### PR TITLE
fix: invalid YAML in argument-hint breaks skill discovery

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: last30days
 description: Research a topic from the last 30 days on Reddit + X + Web, become an expert, and write copy-paste-ready prompts for the user's target tool.
-argument-hint: "[topic] for [tool]" or "[topic]"
+argument-hint: "[topic] for [tool]"
 context: fork
 agent: Explore
 disable-model-invocation: true


### PR DESCRIPTION
## Problem

The current `argument-hint` line in SKILL.md:

```yaml
argument-hint: "[topic] for [tool]" or "[topic]"
```

is invalid YAML. The `or "[topic]"` part after the quoted string breaks YAML parsing, which causes Claude Code to silently skip the skill when building the skills list.

The skill still works when invoked directly with `/last30days`, but it won't appear in Claude's context and Claude can't invoke it autonomously.

## Fix

Simplify to valid YAML:

```yaml
argument-hint: "[topic] for [tool]"
```

## How I found this

Spent an hour debugging why the skill wasn't showing up after removing `disable-model-invocation: true`. Turned out the YAML was silently failing to parse.