### PR TITLE
fix: handle 403 model access errors + broaden model fallbacks

### DIFF
--- a/scripts/lib/models.py
+++ b/scripts/lib/models.py
@@ -7,7 +7,7 @@ from . import cache, http
 
 # OpenAI API
 OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
-OPENAI_FALLBACK_MODELS = ["gpt-5.2", "gpt-5.1", "gpt-5", "gpt-4o"]
+OPENAI_FALLBACK_MODELS = ["gpt-5.2", "gpt-5.1", "gpt-5", "gpt-4.1", "gpt-4o"]
 
 # xAI API - Agent Tools API requires grok-4 family
 XAI_MODELS_URL = "https://api.x.ai/v1/models"
@@ -35,8 +35,8 @@ def is_mainline_openai_model(model_id: str) -> bool:
     """Check if model is a mainline GPT model (not mini/nano/chat/codex/pro)."""
     model_lower = model_id.lower()
 
-    # Must be gpt-5 series
-    if not re.match(r'^gpt-5(\.\d+)*$', model_lower):
+    # Must be gpt-4o, gpt-4.1+, or gpt-5+ series (mainline, not mini/nano/etc)
+    if not re.match(r'^gpt-(?:4o|4\.1|5)(\.\d+)*$', model_lower):
         return False
 
     # Exclude variants

--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 from . import http
 
 # Fallback models when the selected model isn't accessible (e.g., org not verified for GPT-5)
-MODEL_FALLBACK_ORDER = ["gpt-4o", "gpt-4o-mini"]
+MODEL_FALLBACK_ORDER = ["gpt-4.1", "gpt-4o", "gpt-4o-mini"]
 
 
 def _log_error(msg: str):
@@ -25,7 +25,7 @@ def _log_info(msg: str):
 
 def _is_model_access_error(error: http.HTTPError) -> bool:
     """Check if error is due to model access/verification issues."""
-    if error.status_code != 400:
+    if error.status_code not in (400, 403):
         return False
     if not error.body:
         return False


### PR DESCRIPTION
## Problem

Users whose OpenAI API keys return HTTP 403 for newer models (e.g., gpt-5.2 requires specific project-level access) see a hard failure instead of graceful fallback. The `_is_model_access_error` function only checks for HTTP 400, missing the 403 case.

Additionally, the mainline model detection only recognizes the gpt-5 series, so users with gpt-4o or gpt-4.1 as their highest available models get no auto-selection.

## Changes

### 403 Fallback Fix (`openai_reddit.py`)
- `_is_model_access_error` now handles HTTP 403 in addition to 400
- Added gpt-4.1 to `MODEL_FALLBACK_ORDER`

### Model Detection (`models.py`)
- Added gpt-4.1 to `OPENAI_FALLBACK_MODELS`
- Broadened `is_mainline_openai_model` regex to recognize gpt-4o and gpt-4.1 series alongside gpt-5

## Context

Discovered while using the skill with a standard OpenAI project API key that had access to gpt-4.1 and gpt-4o but not gpt-5.2. The skill crashed with a 403 error instead of falling back. With this fix, it gracefully falls through to the next available model.

Thanks for building this skill! 🎉