### PR TITLE
Fix UnicodeEncodeError on Windows (cp1252 emoji crash)

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -275,6 +275,11 @@ def run_research(
 
 
 def main():
+    # Fix Unicode output on Windows (cp1252 can't encode emoji)
+    if sys.platform == "win32":
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
     parser = argparse.ArgumentParser(
         description="Research a topic from the last 30 days on Reddit + X"
     )


### PR DESCRIPTION
## Summary
- On Windows, Python defaults to cp1252 encoding for stdio, which crashes on the emoji characters used in `render.py` and `ui.py` output
- Adds `sys.stdout/stderr.reconfigure(encoding='utf-8', errors='replace')` at the top of `main()`, guarded by `sys.platform == 'win32'`
- 2-line fix (plus guard + comment), zero impact on non-Windows platforms

## Reproduction
```
python3 ~/.claude/skills/last30days/scripts/last30days.py "any topic" --emit=compact
```
Crashes with:
```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 50-51: character maps to <undefined>
```
at `render.render_compact()` → `print()` → `cp1252.py:encode()`

## Fix
```python
if sys.platform == "win32":
    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
```

## Test plan
- [x] Verified fix renders emoji correctly on Windows 11 (Python 3.14.2)
- [x] Verified `--mock --emit=compact` produces full output without crash
- [x] Ran existing test suite: 83 passed (4 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)