### PR TITLE
feat: add --days flag for configurable date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ chmod 600 ~/.config/last30days/.env
 ```
 /last30days [topic]
 /last30days [topic] for [tool]
+/last30days [topic] --days=7
 ```
 
 Examples:
@@ -33,6 +34,7 @@ Examples:
 - `/last30days iOS app mockups for Nano Banana Pro`
 - `/last30days What are the best rap songs lately`
 - `/last30days remotion animations for Claude Code`
+- `/last30days AI news --days=7` — weekly roundup instead of full month
 
 ## What It Does
 
@@ -693,6 +695,7 @@ This example shows /last30days discovering **emerging developer workflows** - re
 
 | Flag | Description |
 |------|-------------|
+| `--days=N` | Look back N days instead of 30 (1-30, e.g., `--days=7` for weekly) |
 | `--quick` | Faster research, fewer sources (8-12 each) |
 | `--deep` | Comprehensive research (50-70 Reddit, 40-60 X) |
 | `--debug` | Verbose logging for troubleshooting |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: last30days
 description: Research a topic from the last 30 days on Reddit + X + Web, become an expert, and write copy-paste-ready prompts for the user's target tool.
-argument-hint: "[topic] for [tool]" or "[topic]"
+argument-hint: "[topic]" or "[topic] --days=7"
 context: fork
 agent: Explore
 disable-model-invocation: true
@@ -144,7 +144,8 @@ For ALL query types:
 **Step 3: Wait for background script to complete**
 Use TaskOutput to get the script results before proceeding to synthesis.
 
-**Depth options** (passed through from user's command):
+**Options** (passed through from user's command):
+- `--days=N` → Look back N days instead of 30 (e.g., `--days=7` for weekly roundup)
 - `--quick` → Faster, fewer sources (8-12 each)
 - (default) → Balanced (20-30 each)
 - `--deep` → Comprehensive (50-70 Reddit, 40-60 X)

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-last30days - Research a topic from the last 30 days on Reddit + X.
+last30days - Research a topic from the last N days on Reddit + X.
 
 Usage:
     python3 last30days.py <topic> [options]
@@ -12,6 +12,7 @@ Options:
     --quick             Faster research with fewer sources (8-12 each)
     --deep              Comprehensive research with more sources (50-70 Reddit, 40-60 X)
     --debug             Enable verbose debug logging
+    --days=N            Number of days to look back (1-30, default: 30)
 """
 
 import argparse
@@ -312,6 +313,14 @@ def main():
         action="store_true",
         help="Include general web search alongside Reddit/X (lower weighted)",
     )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        choices=range(1, 31),
+        metavar="N",
+        help="Number of days to look back (1-30, default: 30)",
+    )
 
     args = parser.parse_args()
 
@@ -362,7 +371,7 @@ def main():
                 sys.exit(1)
 
     # Get date range
-    from_date, to_date = dates.get_date_range(30)
+    from_date, to_date = dates.get_date_range(args.days)
 
     # Check what keys are missing for promo messaging
     missing_keys = env.get_missing_keys(config)
@@ -475,7 +484,7 @@ def main():
         progress.show_complete(len(deduped_reddit), len(deduped_x))
 
     # Output result
-    output_result(report, args.emit, web_needed, args.topic, from_date, to_date, missing_keys)
+    output_result(report, args.emit, web_needed, args.topic, from_date, to_date, missing_keys, args.days)
 
 
 def output_result(
@@ -486,6 +495,7 @@ def output_result(
     from_date: str = "",
     to_date: str = "",
     missing_keys: str = "none",
+    days: int = 30,
 ):
     """Output the result based on emit mode."""
     if emit_mode == "compact":
@@ -509,7 +519,7 @@ def output_result(
         print("")
         print("Claude: Use your WebSearch tool to find 8-15 relevant web pages.")
         print("EXCLUDE: reddit.com, x.com, twitter.com (already covered above)")
-        print("INCLUDE: blogs, docs, news, tutorials from the last 30 days")
+        print(f"INCLUDE: blogs, docs, news, tutorials from the last {days} days")
         print("")
         print("After searching, synthesize WebSearch results WITH the Reddit/X")
         print("results above. WebSearch items should rank LOWER than comparable")


### PR DESCRIPTION
## Summary

Adds a `--days` argument (1-30) to customize the lookback period, defaulting to 30 for backward compatibility.

## Use Cases

- `/last30days AI news --days=7` — weekly roundups
- `/last30days trending topics --days=14` — biweekly research  
- `/last30days breaking news --days=3` — very recent only

## Changes

- **scripts/last30days.py**: Add `--days` argument with validation (1-30), pass to date range function
- **SKILL.md**: Document `--days` in argument-hint and options section
- **README.md**: Add `--days` to usage examples and options table

## Backward Compatible

The default remains 30 days, so existing usage is unchanged.

## Test plan

- [x] `python3 last30days.py "test" --days=7` uses 7-day range
- [x] `python3 last30days.py "test"` still defaults to 30 days
- [x] `python3 last30days.py "test" --days=0` rejected (out of range)
- [x] `python3 last30days.py "test" --days=31` rejected (out of range)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)