### PR TITLE
adding codex compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ bird login
 
 Bird is free and doesn't require an xAI key. If both Bird and an xAI key are available, Bird is preferred.
 
+## Codex Compatibility
+
+This repo now supports both Claude Code and Codex workflows:
+
+- Claude Code: use `SKILL.md` and `.claude-plugin/` metadata.
+- Codex: use `agents/openai.yaml` metadata.
+- Shared engine: both paths use the same Python runtime under `scripts/`.
+
+| Feature | Claude Code | Codex | Notes |
+|---|---|---|---|
+| Skill instructions | `SKILL.md` | `SKILL.md` | Unified instructions with portable script path lookup |
+| Discovery metadata | `.claude-plugin/*` | `agents/openai.yaml` | Additive, no runtime fork |
+| Research runtime | `scripts/` | `scripts/` | Same Python entrypoint and libs |
+
+If running the script directly in either environment:
+
+```bash
+python3 scripts/last30days.py "your topic" --emit=compact
+```
+
 ## Usage
 
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,7 @@ Common patterns:
 - `TOPIC = [extracted topic]`
 - `TARGET_TOOL = [extracted tool, or "unknown" if not specified]`
 - `QUERY_TYPE = [RECOMMENDATIONS | NEWS | HOW-TO | GENERAL]`
+- `OPTIONAL_FLAGS = [any explicit flags user requested, e.g. "--days=7 --quick", or empty]`
 
 **DISPLAY your parsing to the user.** Before running any tools, output:
 
@@ -60,7 +61,21 @@ This text MUST appear before you call any tools. It confirms to the user that yo
 
 **Step 1: Run the research script**
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/last30days}/scripts/last30days.py" "$ARGUMENTS" --emit=compact 2>&1
+if [ -f "scripts/last30days.py" ]; then
+  SKILL_ROOT="."
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/last30days.py" ]; then
+  SKILL_ROOT="${CLAUDE_PLUGIN_ROOT}"
+elif [ -f "$HOME/.claude/skills/last30days/scripts/last30days.py" ]; then
+  SKILL_ROOT="$HOME/.claude/skills/last30days"
+elif [ -f "$HOME/.codex/skills/last30days/scripts/last30days.py" ]; then
+  SKILL_ROOT="$HOME/.codex/skills/last30days"
+else
+  echo "ERROR: Could not find scripts/last30days.py in repo, CLAUDE_PLUGIN_ROOT, ~/.claude/skills/last30days, or ~/.codex/skills/last30days" >&2
+  exit 1
+fi
+
+EXTRA_FLAGS="${OPTIONAL_FLAGS:-}"
+python3 "${SKILL_ROOT}/scripts/last30days.py" "${TOPIC}" --emit=compact ${EXTRA_FLAGS} 2>&1
 ```
 
 The script will automatically:

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Last30Days
+short_description: Research last-30-day trends from Reddit, X, and web, then synthesize actionable output.
+default_prompt: Research this topic from the last 30 days across Reddit, X, and web, summarize what matters now, and suggest next actions.

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -346,8 +346,8 @@ def run_research(
     Returns:
         Tuple of (reddit_items, x_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error)
 
-    Note: web_needed is True when WebSearch should be performed by Claude.
-    The script outputs a marker and Claude handles WebSearch in its session.
+    Note: web_needed is True when web search should be performed by the assistant.
+    The script outputs a marker and the assistant handles web search in its session.
     """
     reddit_items = []
     x_items = []
@@ -360,7 +360,7 @@ def run_research(
     # Check if WebSearch is needed (always needed in web-only mode)
     web_needed = sources in ("all", "web", "reddit-web", "x-web")
 
-    # Web-only mode: no API calls needed, Claude handles everything
+    # Web-only mode: no API calls needed, assistant handles everything
     if sources == "web":
         if progress:
             progress.start_web_only()
@@ -725,7 +725,7 @@ def output_result(
         print(f"Topic: {topic}")
         print(f"Date range: {from_date} to {to_date}")
         print("")
-        print("Claude: Use your WebSearch tool to find 8-15 relevant web pages.")
+        print("Assistant: Use your web search tool to find 8-15 relevant web pages.")
         print("EXCLUDE: reddit.com, x.com, twitter.com (already covered above)")
         print(f"INCLUDE: blogs, docs, news, tutorials from the last {days} days")
         print("")

--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -61,9 +61,11 @@ def _extract_core_subject(topic: str) -> str:
         # Research/meta descriptors
         'best', 'top', 'good', 'great', 'awesome', 'killer',
         'latest', 'new', 'news', 'update', 'updates',
+        'trendiest', 'trending', 'hottest', 'hot', 'popular', 'viral',
         'practices', 'features', 'guide', 'tutorial',
         'recommendations', 'advice', 'review', 'reviews',
         'usecases', 'examples', 'comparison', 'versus', 'vs',
+        'plugin', 'plugins', 'skill', 'skills', 'tool', 'tools',
         # Prompting meta words
         'prompt', 'prompts', 'prompting', 'techniques', 'tips',
         'tricks', 'methods', 'strategies', 'approaches',
@@ -244,6 +246,21 @@ def search_x(
         _log(f"0 results for '{core_topic}', retrying with '{shorter}'")
         query = f"{shorter} since:{from_date}"
         response = _run_bird_search(query, count, timeout)
+        items = parse_bird_response(response)
+
+    # Last-chance retry: use strongest remaining token (often the product name)
+    if not items and core_words:
+        low_signal = {
+            'trendiest', 'trending', 'hottest', 'hot', 'popular', 'viral',
+            'best', 'top', 'latest', 'new', 'plugin', 'plugins',
+            'skill', 'skills', 'tool', 'tools',
+        }
+        candidates = [w for w in core_words if w not in low_signal]
+        if candidates:
+            strongest = max(candidates, key=len)
+            _log(f"0 results for '{core_topic}', retrying with strongest token '{strongest}'")
+            query = f"{strongest} since:{from_date}"
+            response = _run_bird_search(query, count, timeout)
 
     return response
 

--- a/scripts/lib/http.py
+++ b/scripts/lib/http.py
@@ -20,7 +20,7 @@ def log(msg: str):
         sys.stderr.flush()
 MAX_RETRIES = 3
 RETRY_DELAY = 1.0
-USER_AGENT = "last30days-skill/2.0 (Claude Code Skill)"
+USER_AGENT = "last30days-skill/2.0 (Assistant Skill)"
 
 
 class HTTPError(Exception):

--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -56,7 +56,7 @@ STEP 1: EXTRACT THE CORE SUBJECT
 Get the MAIN NOUN/PRODUCT/TOPIC:
 - "best nano banana prompting practices" → "nano banana"
 - "killer features of clawdbot" → "clawdbot"
-- "top Claude Code skills" → "Claude Code"
+- "top coding assistant skills" → "coding assistant"
 DO NOT include "best", "top", "tips", "practices", "features" in your search.
 
 STEP 2: SEARCH BROADLY

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -1,6 +1,8 @@
 """Output rendering for last30days skill."""
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -11,7 +13,17 @@ OUTPUT_DIR = Path.home() / ".local" / "share" / "last30days" / "out"
 
 def ensure_output_dir():
     """Ensure output directory exists."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    global OUTPUT_DIR
+    env_dir = os.environ.get("LAST30DAYS_OUTPUT_DIR")
+    if env_dir:
+        OUTPUT_DIR = Path(env_dir)
+
+    try:
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        # Fall back when default output paths are unavailable in sandboxed envs.
+        OUTPUT_DIR = Path(tempfile.gettempdir()) / "last30days" / "out"
+        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _assess_data_freshness(report: schema.Report) -> dict:
@@ -35,7 +47,7 @@ def _assess_data_freshness(report: schema.Report) -> dict:
 
 
 def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "none") -> str:
-    """Render compact output for Claude to synthesize.
+    """Render compact output for the assistant to synthesize.
 
     Args:
         report: Report data
@@ -61,7 +73,7 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
 
     # Web-only mode banner (when no API keys)
     if report.mode == "web-only":
-        lines.append("**🌐 WEB SEARCH MODE** - Claude will search blogs, docs & news")
+        lines.append("**🌐 WEB SEARCH MODE** - assistant will search blogs, docs & news")
         lines.append("")
         lines.append("---")
         lines.append("**⚡ Want better results?** Add API keys to unlock Reddit & X data:")
@@ -86,10 +98,10 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
     lines.append("")
 
     # Coverage note for partial coverage
-    if report.mode == "reddit-only" and missing_keys == "x":
-        lines.append("*💡 Tip: Add XAI_API_KEY for X/Twitter data and better triangulation.*")
+    if report.mode == "reddit-only" and missing_keys in ("x", "none"):
+        lines.append("*💡 Tip: Add an xAI key (`XAI_API_KEY`) for X/Twitter data and better triangulation.*")
         lines.append("")
-    elif report.mode == "x-only" and missing_keys == "reddit":
+    elif report.mode == "x-only" and missing_keys in ("reddit", "none"):
         lines.append("*💡 Tip: Add OPENAI_API_KEY for Reddit data and better triangulation.*")
         lines.append("")
 
@@ -170,7 +182,7 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
             lines.append(f"  *{item.why_relevant}*")
             lines.append("")
 
-    # Web items (if any - populated by Claude)
+    # Web items (if any - populated by the assistant)
     if report.web_error:
         lines.append("### Web Results")
         lines.append("")
@@ -322,15 +334,15 @@ def render_full_report(report: schema.Report) -> str:
             lines.append(f"> {item.snippet}")
             lines.append("")
 
-    # Placeholders for Claude synthesis
+    # Placeholders for assistant synthesis
     lines.append("## Best Practices")
     lines.append("")
-    lines.append("*To be synthesized by Claude*")
+    lines.append("*To be synthesized by assistant*")
     lines.append("")
 
     lines.append("## Prompt Pack")
     lines.append("")
-    lines.append("*To be synthesized by Claude*")
+    lines.append("*To be synthesized by assistant*")
     lines.append("")
 
     return "\n".join(lines)

--- a/scripts/lib/ui.py
+++ b/scripts/lib/ui.py
@@ -7,7 +7,7 @@ import threading
 import random
 from typing import Optional
 
-# Check if we're in a real terminal (not captured by Claude Code)
+# Check if we're in a real terminal (not captured by an assistant UI)
 IS_TTY = sys.stderr.isatty()
 
 # ANSI color codes
@@ -201,7 +201,7 @@ class Spinner:
             self.thread = threading.Thread(target=self._spin, daemon=True)
             self.thread.start()
         else:
-            # Not a TTY (Claude Code) - just print once
+            # Not a TTY (assistant UI) - just print once
             if not self.shown_static:
                 sys.stderr.write(f"⏳ {self.message}\n")
                 sys.stderr.flush()
@@ -321,7 +321,7 @@ class ProgressDisplay:
     def end_web_only(self):
         """End web-only spinner."""
         if self.spinner:
-            self.spinner.stop(f"{Colors.GREEN}Web{Colors.RESET} Claude will search the web")
+            self.spinner.stop(f"{Colors.GREEN}Web{Colors.RESET} assistant will search the web")
 
     def show_web_only_complete(self):
         """Show completion for web-only mode."""
@@ -329,7 +329,7 @@ class ProgressDisplay:
         if IS_TTY:
             sys.stderr.write(f"\n{Colors.GREEN}{Colors.BOLD}✓ Ready for web search{Colors.RESET} ")
             sys.stderr.write(f"{Colors.DIM}({elapsed:.1f}s){Colors.RESET}\n")
-            sys.stderr.write(f"  {Colors.GREEN}Web:{Colors.RESET} Claude will search blogs, docs & news\n\n")
+            sys.stderr.write(f"  {Colors.GREEN}Web:{Colors.RESET} assistant will search blogs, docs & news\n\n")
         else:
             sys.stderr.write(f"✓ Ready for web search ({elapsed:.1f}s)\n")
         sys.stderr.flush()

--- a/scripts/lib/websearch.py
+++ b/scripts/lib/websearch.py
@@ -1,12 +1,12 @@
 """WebSearch module for last30days skill.
 
-NOTE: WebSearch uses Claude's built-in WebSearch tool, which runs INSIDE Claude Code.
-Unlike Reddit/X which use external APIs, WebSearch results are obtained by Claude
-directly and passed to this module for normalization and scoring.
+NOTE: WebSearch uses the assistant's built-in web search tool.
+Unlike Reddit/X which use external APIs, web results are obtained by the
+assistant directly and passed to this module for normalization and scoring.
 
 The typical flow is:
-1. Claude invokes WebSearch tool with the topic
-2. Claude passes results to parse_websearch_results()
+1. Assistant invokes web search tool with the topic
+2. Assistant passes results to parse_websearch_results()
 3. Results are normalized into WebSearchItem objects
 """
 
@@ -259,7 +259,7 @@ def parse_websearch_results(
 ) -> List[Dict[str, Any]]:
     """Parse WebSearch results into normalized format.
 
-    This function expects results from Claude's WebSearch tool.
+    This function expects results from the assistant's web search tool.
     Each result should have: title, url, snippet, and optionally date/relevance.
 
     Uses "Date Detective" approach:

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -1,0 +1,31 @@
+"""Tests for bird_x module."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Add lib to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from lib import bird_x
+
+
+class TestBirdSearchRetries(unittest.TestCase):
+    def test_uses_strongest_token_on_last_chance_retry(self):
+        with mock.patch.object(bird_x, "_extract_core_subject", return_value="best codex skill plugin"), \
+             mock.patch.object(bird_x, "_run_bird_search", side_effect=[{"items": []}, {"items": []}, {"items": []}]) as run_mock:
+            bird_x.search_x("best codex skill plugin", "2026-01-01", "2026-01-31", depth="quick")
+
+        self.assertEqual(run_mock.call_count, 3)
+        first_query = run_mock.call_args_list[0].args[0]
+        second_query = run_mock.call_args_list[1].args[0]
+        third_query = run_mock.call_args_list[2].args[0]
+
+        self.assertEqual(first_query, "best codex skill plugin since:2026-01-01")
+        self.assertEqual(second_query, "best codex since:2026-01-01")
+        self.assertEqual(third_query, "codex since:2026-01-01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,11 @@
 """Tests for cache module."""
 
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 # Add lib to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
@@ -53,6 +56,44 @@ class TestModelCache(unittest.TestCase):
         result = cache.get_cached_model("nonexistent_provider")
         # May be None or a cached value, but should not error
         self.assertTrue(result is None or isinstance(result, str))
+
+
+class TestCacheDirSelection(unittest.TestCase):
+    def setUp(self):
+        self.orig_cache_dir = cache.CACHE_DIR
+        self.orig_model_cache = cache.MODEL_CACHE_FILE
+
+    def tearDown(self):
+        cache.CACHE_DIR = self.orig_cache_dir
+        cache.MODEL_CACHE_FILE = self.orig_model_cache
+        os.environ.pop("LAST30DAYS_CACHE_DIR", None)
+
+    def test_respects_env_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["LAST30DAYS_CACHE_DIR"] = td
+            cache.ensure_cache_dir()
+            self.assertEqual(cache.CACHE_DIR, Path(td))
+            self.assertEqual(cache.MODEL_CACHE_FILE, Path(td) / "model_selection.json")
+
+    def test_falls_back_to_temp_on_permission_error(self):
+        original = Path("/tmp/should-not-exist")
+        cache.CACHE_DIR = original
+        cache.MODEL_CACHE_FILE = original / "model_selection.json"
+
+        original_mkdir = Path.mkdir
+        calls = {"count": 0}
+
+        def fake_mkdir(self, *args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise PermissionError("no write access")
+            return original_mkdir(self, *args, **kwargs)
+
+        with mock.patch.object(Path, "mkdir", new=fake_mkdir):
+            cache.ensure_cache_dir()
+
+        self.assertIn("last30days/cache", str(cache.CACHE_DIR))
+        self.assertEqual(cache.MODEL_CACHE_FILE, cache.CACHE_DIR / "model_selection.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  This PR adds Codex compatibility to `last30days` while keeping a single shared runtime
  and preserving Claude Code support.

  The goal is to make the skill work in both environments without maintaining a forked
  implementation.

  ## What changed

  - Added Codex discovery metadata:
    - `agents/openai.yaml`
  - Unified skill execution path in `SKILL.md`:
    - Portable script path resolution across repo-local, Claude skill install, and Codex
  skill install.
    - Support for optional runtime flags passed by the user.
  - Made runtime UX text platform-neutral (`assistant` instead of Claude-specific wording):
    - `scripts/last30days.py`
    - `scripts/lib/ui.py`
    - `scripts/lib/websearch.py`
    - `scripts/lib/render.py`
    - `scripts/lib/http.py` (user-agent label)
  - Improved robustness in constrained/sandboxed environments:
    - Cache dir override + fallback (`LAST30DAYS_CACHE_DIR`) in `scripts/lib/cache.py`
    - Output dir override + fallback (`LAST30DAYS_OUTPUT_DIR`) in `scripts/lib/render.py`
  - Improved X/Bird retrieval resilience:
    - Better query noise stripping
    - Last-chance retry using strongest remaining token in `scripts/lib/bird_x.py`
  - Added coverage for new behavior:
    - `tests/test_bird_x.py`
    - `tests/test_cache.py`
    - `tests/test_render.py`
  - Added README section documenting Claude + Codex compatibility.

  ## Compatibility

  - Claude Code behavior is preserved.
  - Codex support is additive (no runtime fork).
  - Python research engine remains shared for both workflows.

  ## Validation

  Run:
  - `python3 scripts/last30days.py "nano banana pro prompting" --mock --emit=compact`
  - `python3 -m unittest discover -s tests -p 'test_*.py'`