### PR TITLE
Fix Windows encoding crash in render.py and cache.py

### DIFF
--- a/scripts/lib/cache.py
+++ b/scripts/lib/cache.py
@@ -51,7 +51,7 @@ def load_cache(cache_key: str, ttl_hours: int = DEFAULT_TTL_HOURS) -> Optional[d
         return None
 
     try:
-        with open(cache_path, 'r') as f:
+        with open(cache_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError):
         return None
@@ -84,7 +84,7 @@ def load_cache_with_age(cache_key: str, ttl_hours: int = DEFAULT_TTL_HOURS) -> t
     age = get_cache_age_hours(cache_path)
 
     try:
-        with open(cache_path, 'r') as f:
+        with open(cache_path, 'r', encoding='utf-8') as f:
             return json.load(f), age
     except (json.JSONDecodeError, OSError):
         return None, None
@@ -96,7 +96,7 @@ def save_cache(cache_key: str, data: dict):
     cache_path = get_cache_path(cache_key)
 
     try:
-        with open(cache_path, 'w') as f:
+        with open(cache_path, 'w', encoding='utf-8') as f:
             json.dump(data, f)
     except OSError:
         pass  # Silently fail on cache write errors
@@ -122,7 +122,7 @@ def load_model_cache() -> dict:
         return {}
 
     try:
-        with open(MODEL_CACHE_FILE, 'r') as f:
+        with open(MODEL_CACHE_FILE, 'r', encoding='utf-8') as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError):
         return {}
@@ -132,7 +132,7 @@ def save_model_cache(data: dict):
     """Save model selection cache."""
     ensure_cache_dir()
     try:
-        with open(MODEL_CACHE_FILE, 'w') as f:
+        with open(MODEL_CACHE_FILE, 'w', encoding='utf-8') as f:
             json.dump(data, f)
     except OSError:
         pass

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -353,28 +353,28 @@ def write_outputs(
     ensure_output_dir()
 
     # report.json
-    with open(OUTPUT_DIR / "report.json", 'w') as f:
+    with open(OUTPUT_DIR / "report.json", 'w', encoding='utf-8') as f:
         json.dump(report.to_dict(), f, indent=2)
 
     # report.md
-    with open(OUTPUT_DIR / "report.md", 'w') as f:
+    with open(OUTPUT_DIR / "report.md", 'w', encoding='utf-8') as f:
         f.write(render_full_report(report))
 
     # last30days.context.md
-    with open(OUTPUT_DIR / "last30days.context.md", 'w') as f:
+    with open(OUTPUT_DIR / "last30days.context.md", 'w', encoding='utf-8') as f:
         f.write(render_context_snippet(report))
 
     # Raw responses
     if raw_openai:
-        with open(OUTPUT_DIR / "raw_openai.json", 'w') as f:
+        with open(OUTPUT_DIR / "raw_openai.json", 'w', encoding='utf-8') as f:
             json.dump(raw_openai, f, indent=2)
 
     if raw_xai:
-        with open(OUTPUT_DIR / "raw_xai.json", 'w') as f:
+        with open(OUTPUT_DIR / "raw_xai.json", 'w', encoding='utf-8') as f:
             json.dump(raw_xai, f, indent=2)
 
     if raw_reddit_enriched:
-        with open(OUTPUT_DIR / "raw_reddit_threads_enriched.json", 'w') as f:
+        with open(OUTPUT_DIR / "raw_reddit_threads_enriched.json", 'w', encoding='utf-8') as f:
             json.dump(raw_reddit_enriched, f, indent=2)
 
 


### PR DESCRIPTION
## Summary

- Adds explicit `encoding='utf-8'` to all 11 `open()` calls across `render.py` (6 calls) and `cache.py` (5 calls)
- On Windows, Python defaults to `cp1252` encoding, which crashes with `UnicodeEncodeError` when writing research results containing Unicode characters (arrows, emoji, non-ASCII text from Reddit/X posts)
- Zero-risk change on Linux/macOS where UTF-8 is already the default

## Files Changed

| File | Calls Fixed | Type |
|------|------------|------|
| `scripts/lib/render.py` | 6 | All file writes in `write_outputs()` |
| `scripts/lib/cache.py` | 5 | All reads/writes for query cache and model cache |

## Test plan

- [x] Tested on Windows 11, Python 3.12 — ran `/last30days` end-to-end with topics that produce Unicode in results
- [x] Confirmed the `UnicodeEncodeError` no longer occurs on cache write/read cycles
- [x] No behavior change on systems where UTF-8 is already the default encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)