### PR TITLE
Fix double Keychain prompt; forward AUTH_TOKEN/CT0 to Node subprocesses

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -940,7 +940,7 @@ def main():
     from_date, to_date = dates.get_date_range(args.days)
 
     # Check what keys are missing for promo messaging
-    missing_keys = env.get_missing_keys(config)
+    missing_keys = env.get_missing_keys(config, x_source_status=x_source_status)
 
     # Show NUX / promo for missing keys BEFORE research
     if missing_keys != 'none':

--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -31,6 +31,29 @@ def _log(msg: str):
     sys.stderr.flush()
 
 
+def _node_env() -> Optional[Dict[str, str]]:
+    """Build environment dict for Node subprocesses.
+
+    Forwards AUTH_TOKEN / CT0 from the last30days config into the subprocess
+    so that resolveCredentials() in cookies.js finds them and skips browser
+    cookie extraction (which triggers macOS Keychain prompts).
+
+    Returns None (inherit parent env) when no config tokens are set.
+    """
+    from . import env as _env
+    config = _env.get_config()
+    auth_token = config.get('AUTH_TOKEN')
+    ct0 = config.get('CT0')
+    if not auth_token and not ct0:
+        return None
+    child_env = os.environ.copy()
+    if auth_token:
+        child_env.setdefault('AUTH_TOKEN', auth_token)
+    if ct0:
+        child_env.setdefault('CT0', ct0)
+    return child_env
+
+
 def _extract_core_subject(topic: str) -> str:
     """Extract core subject from verbose query for X search.
 
@@ -112,6 +135,7 @@ def is_bird_authenticated() -> Optional[str]:
             capture_output=True,
             text=True,
             timeout=15,
+            env=_node_env(),
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip().split('\n')[0]
@@ -187,6 +211,7 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
             stderr=subprocess.PIPE,
             text=True,
             preexec_fn=preexec,
+            env=_node_env(),
         )
 
         # Register for cleanup tracking (if available)
@@ -313,6 +338,7 @@ def search_handles(
                 stderr=subprocess.PIPE,
                 text=True,
                 preexec_fn=preexec,
+                env=_node_env(),
             )
 
             try:

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -60,6 +60,9 @@ def get_config() -> Dict[str, Any]:
         ('OPENAI_MODEL_PIN', None),
         ('XAI_MODEL_POLICY', 'latest'),
         ('XAI_MODEL_PIN', None),
+        # X/Twitter cookie auth (skips browser cookie extraction / Keychain prompts)
+        ('AUTH_TOKEN', None),
+        ('CT0', None),
     ]
 
     config = {}
@@ -116,8 +119,14 @@ def get_web_search_source(config: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def get_missing_keys(config: Dict[str, Any]) -> str:
+def get_missing_keys(config: Dict[str, Any], x_source_status: Optional[Dict[str, Any]] = None) -> str:
     """Determine which sources are missing (accounting for Bird).
+
+    Args:
+        config: Configuration dict from get_config().
+        x_source_status: Pre-fetched result from get_x_source_status() to avoid
+            redundant bird-search --whoami calls (each may trigger a Keychain
+            prompt on macOS).
 
     Returns: 'all', 'both', 'reddit', 'x', 'web', or 'none'
     """
@@ -125,9 +134,11 @@ def get_missing_keys(config: Dict[str, Any]) -> str:
     has_xai = bool(config.get('XAI_API_KEY'))
     has_web = has_web_search_keys(config)
 
-    # Check if Bird provides X access (import here to avoid circular dependency)
-    from . import bird_x
-    has_bird = bird_x.is_bird_installed() and bird_x.is_bird_authenticated()
+    if x_source_status is not None:
+        has_bird = x_source_status.get("bird_authenticated", False)
+    else:
+        from . import bird_x
+        has_bird = bird_x.is_bird_installed() and bird_x.is_bird_authenticated()
 
     has_x = has_xai or has_bird
 


### PR DESCRIPTION
## Summary

- **Eliminate redundant `bird-search --whoami` call**: `is_bird_authenticated()` was invoked twice per run (via `get_x_source_status()` at startup, then again inside `get_missing_keys()`). Each call triggers a macOS Keychain prompt when sweet-cookie reads Safari cookies. `get_missing_keys()` now accepts a pre-fetched `x_source_status` dict so the second probe is skipped.

- **Forward AUTH_TOKEN/CT0 from config to Node subprocesses**: `resolveCredentials()` in `cookies.js` checks `process.env.AUTH_TOKEN` + `process.env.CT0` and returns immediately when both are present (no browser cookie extraction, no Keychain). But the Python layer loaded these from `~/.config/last30days/.env` into a dict without exporting them. New `bird_x._node_env()` helper builds a subprocess env that includes these tokens. Users can now set `AUTH_TOKEN` and `CT0` in their `.env` to bypass Keychain prompts entirely.

## Test plan

- [x] `python3 -c` unit assertions for `get_missing_keys` with/without `x_source_status`, `_node_env()` returns `None` when no tokens set, config schema includes new keys
- [x] End-to-end mock test: `python3 scripts/last30days.py "test" --mock --emit=json` produces valid output
- [ ] Manual: set `AUTH_TOKEN`/`CT0` in `~/.config/last30days/.env`, verify zero Keychain prompts on macOS
- [ ] Manual: remove `AUTH_TOKEN`/`CT0`, verify fallback to Safari cookies still works (one prompt, not two)