### PR TITLE
Fix OpenAI 429 rate limiting with exponential backoff

### DIFF
--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List, Optional
 from . import http
 
 # Fallback models when the selected model isn't accessible (e.g., org not verified for GPT-5)
-MODEL_FALLBACK_ORDER = ["gpt-4.1", "gpt-4o", "gpt-4o-mini"]
+# Note: gpt-4o-mini does NOT support web_search with filters param, so exclude it
+MODEL_FALLBACK_ORDER = ["gpt-4.1", "gpt-4o"]
 
 
 def _log_error(msg: str):
@@ -187,6 +188,9 @@ def search_reddit(
             last_error = e
             if _is_model_access_error(e):
                 _log_info(f"Model {current_model} not accessible, trying fallback...")
+                continue
+            if e.status_code == 429:
+                _log_info(f"Rate limited on {current_model}, trying fallback model...")
                 continue
             # Non-access error, don't retry with different model
             raise


### PR DESCRIPTION
## Summary

- Reddit search consistently fails with `HTTP 429: Too Many Requests` from the OpenAI Responses API
- The current retry logic in `http.py` uses linear backoff (1s, 2s, 3s) which is too fast for OpenAI's rate limiter (often needs 10-60s waits)
- After exhausting retries, the error propagates and Reddit returns 0 threads

## Changes

**`scripts/lib/http.py`**
- Increase max retries from 3 → 5
- Switch from linear to exponential backoff: `2s, 5s, 9s, 17s, 33s` (was `1s, 2s, 3s`)
- Parse and respect `Retry-After` header from OpenAI 429 responses
- Non-429 errors still use exponential backoff without the +1s offset

**`scripts/lib/openai_reddit.py`**
- Model fallback now triggers on 429 errors, not just 400/403 access errors
- If `gpt-5` is rate-limited, falls back through `gpt-4.1` → `gpt-4o`
- Remove `gpt-4o-mini` from fallback chain — it doesn't support `web_search` with the `filters` parameter (crashes with `"Parameter 'filters' not supported with model 'gpt-4o-mini'"`)

## Test plan

- [x] Verified exponential backoff fires correctly: `3s → 5s → 9s → 17s` (via `LAST30DAYS_DEBUG=1`)
- [x] Verified model fallback on 429: `gpt-5.2 → gpt-4.1 → gpt-4o` (confirmed in debug logs)
- [x] Confirmed `gpt-4o-mini` crash — now excluded from fallback chain
- [ ] Run `/last30days` with sufficient OpenAI quota to confirm Reddit results return

🤖 Generated with [Claude Code](https://claude.com/claude-code)