### PR TITLE
Fix missing metadata files in skill upload bundle

### DIFF
--- a/.clawhubignore
+++ b/.clawhubignore
@@ -11,7 +11,6 @@ SPEC.md
 TASKS.md
 SKILL-original.md
 *.jsonl
-*.json
 *.mp3
 *.jpeg
 *.jpg


### PR DESCRIPTION
Fixes #46. The *.json pattern in .clawhubignore was excluding critical .claude-plugin/marketplace.json and .claude-plugin/plugin.json metadata files required for skill upload, causing the 'invalid characters' error when uploading to the marketplace.