### PR TITLE
feat: add SessionStart hook for config check

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,5 +21,6 @@
     "prompts",
     "polymarket"
   ],
-  "skills": ["./"]
+  "skills": ["./"],
+  "hooks": ["./hooks/"]
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check if last30days has any configuration source available.
+# Priority: .claude/last30days.env > ~/.config/last30days/.env > env vars
+
+PROJECT_ENV=".claude/last30days.env"
+GLOBAL_ENV="$HOME/.config/last30days/.env"
+
+# Helper: warn if file permissions are too open
+check_perms() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then return; fi
+  local perms
+  perms=$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file" 2>/dev/null || echo "")
+  if [[ -n "$perms" && "$perms" != "600" && "$perms" != "400" ]]; then
+    echo "/last30days: WARNING — $file has permissions $perms (should be 600)."
+    echo "  Fix: chmod 600 $file"
+  fi
+}
+
+# Check per-project config
+if [[ -f "$PROJECT_ENV" ]]; then
+  check_perms "$PROJECT_ENV"
+  exit 0
+fi
+
+# Check global config
+if [[ -f "$GLOBAL_ENV" ]]; then
+  check_perms "$GLOBAL_ENV"
+  exit 0
+fi
+
+# Check if OPENAI_API_KEY is set in environment (minimum requirement)
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  exit 0
+fi
+
+# Check if SCRAPECREATORS_API_KEY is set (also sufficient)
+if [[ -n "${SCRAPECREATORS_API_KEY:-}" ]]; then
+  exit 0
+fi
+
+# No config found — inform user
+cat <<'EOF'
+/last30days: No API keys configured.
+
+Create .claude/last30days.env with your API keys, or create
+~/.config/last30days/.env globally. At minimum, SCRAPECREATORS_API_KEY
+or OPENAI_API_KEY is required. See the README for setup instructions.
+EOF


### PR DESCRIPTION
## Summary
- Adds a `SessionStart` hook that checks for API key configuration when a session begins
- Warns users if no config source is found (project `.env`, global `.env`, or env vars)
- Checks file permissions on existing config files and warns if they're too open (should be `chmod 600`)
- Registers the hook in `plugin.json`

## Motivation
When users install via the plugin marketplace, there's no feedback about missing config until they actually run `/last30days`. This hook provides immediate, actionable guidance at session start — either confirming config is found (silently) or telling users exactly what to do.

## Changes
- `hooks/hooks.json`: SessionStart hook definition (5s timeout)
- `hooks/scripts/check-config.sh`: Config detection + permission check script
- `.claude-plugin/plugin.json`: registers hooks directory

## Behavior
- If config exists: silent (no output), exits 0
- If config has bad permissions: warns with fix command, exits 0
- If no config at all: prints setup instructions, exits 0

## Test plan
- [ ] Install plugin, start session without config → see warning message
- [ ] Create `.claude/last30days.env` with a key → warning disappears
- [ ] Set file to `chmod 644` → see permission warning
- [ ] Set `OPENAI_API_KEY` in env → warning disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)