### PR TITLE
chore: normalize skills-ref frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,33 +1,6 @@
 ---
 name: last30days
-version: "2.8"
 description: "Research a topic from the last 30 days. Also triggered by 'last30'. Sources: Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, web. Become an expert and write copy-paste-ready prompts."
-argument-hint: 'last30 AI video tools, last30 best project management tools'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
-homepage: https://github.com/mvanhorn/last30days-skill
-user-invocable: true
-metadata:
-  clawdbot:
-    emoji: "📰"
-    requires:
-      env:
-        - OPENAI_API_KEY
-      bins:
-        - node
-        - python3
-    primaryEnv: OPENAI_API_KEY
-    files:
-      - "scripts/*"
-    homepage: https://github.com/mvanhorn/last30days-skill
-    tags:
-      - research
-      - reddit
-      - x
-      - youtube
-      - tiktok
-      - hackernews
-      - trends
-      - prompts
 ---
 
 # last30days v2.8: Research Any Topic from the Last 30 Days

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: last30days
+name: open
 version: "2.1-open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
 argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: open
-version: "2.1-open"
+name: "open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
-argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+allowed-tools: "Bash, Read, Write, AskUserQuestion, WebSearch"
+metadata:
+  version: "2.1-open"
+  argument-hint: "last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing"
 ---
 
 # last30days (open variant): Research + Watchlist + Briefings


### PR DESCRIPTION
Normalize SKILL frontmatter to pass the official skills-ref validator.\n\n- remove unsupported top-level fields from frontmatter\n- preserve metadata within supported fields\n- keep skill behavior unchanged\n\nValidation:\n- skills-ref validate .\n- skills-ref validate variants/open\n