### PR TITLE
feat(reddit): intent-aware query expansion for product queries

### DIFF
--- a/scripts/lib/reddit.py
+++ b/scripts/lib/reddit.py
@@ -102,16 +102,66 @@ def _extract_core_subject(topic: str) -> str:
     return result.rstrip('?!.')
 
 
+# Pre-compiled pattern for comparison intent detection
+_COMPARISON_RE = re.compile(
+    r'\bvs\.?\b|\bversus\b|\bcompared?\s+to\b|\bcomparison\b|\bbetter\s+than\b'
+)
+
+
+def _infer_query_intent(topic: str) -> str:
+    """Classify a search topic into an intent category.
+
+    Categories:
+        product    - buying, reviewing, or recommending a product/service
+        comparison - comparing two or more products/options
+        opinion    - seeking community opinion or experience
+        how_to     - procedural/instructional query
+        factual    - news, events, or factual lookup
+
+    Returns one of the above category strings.
+    """
+    text = topic.lower().strip()
+
+    # Comparison signals: "vs", "versus", "compared to", etc.
+    if _COMPARISON_RE.search(text):
+        return "comparison"
+
+    # Product signals: "best", "budget", "buy", "recommend", "review", price-like
+    product_words = {
+        'best', 'budget', 'buy', 'buying', 'purchase', 'recommend',
+        'recommendation', 'recommendations', 'review', 'reviews',
+        'worth', 'affordable', 'cheap', 'expensive', 'price',
+        'upgrade', 'alternative', 'alternatives',
+    }
+    words = set(re.findall(r'\b\w+\b', text))
+    if words & product_words:
+        return "product"
+
+    # How-to signals
+    if text.startswith(('how to ', 'how do ', 'how can ', 'how should ')):
+        return "how_to"
+
+    # Opinion signals ('worth' deliberately omitted -- caught by product_words above)
+    opinion_words = {
+        'think', 'opinion', 'opinions', 'thoughts', 'experience',
+        'experiences', 'feel', 'feeling',
+    }
+    if words & opinion_words:
+        return "opinion"
+
+    return "factual"
+
+
 def expand_reddit_queries(topic: str, depth: str) -> List[str]:
     """Generate multiple Reddit search queries from a topic.
 
     Uses local logic (no LLM call needed):
     1. Extract core subject (strip noise words)
     2. Include original topic if different from core
-    3. For default/deep: add casual/review variant
-    4. For deep: add problem/issues variant
+    3. Intent-aware variants (product, comparison, opinion, how_to)
+    4. Depth-gated problem/issues variant
 
-    Returns 1-4 query strings depending on depth.
+    Returns 1-5 query strings depending on depth and intent.
     """
     core = _extract_core_subject(topic)
     queries = [core]
@@ -121,7 +171,20 @@ def expand_reddit_queries(topic: str, depth: str) -> List[str]:
     if core.lower() != original_clean.lower() and len(original_clean.split()) <= 8:
         queries.append(original_clean)
 
-    if depth in ("default", "deep"):
+    qtype = _infer_query_intent(topic)
+
+    # Product queries: always include review-oriented variant (all depths)
+    if qtype == "product":
+        queries.append(f"{core} review OR recommendation OR best")
+
+    # Product/comparison: add comparison-oriented variant
+    if qtype in ("product", "comparison"):
+        queries.append(f"{core} worth it OR vs OR compared")
+
+    # Review/opinion variant: always for product/opinion, depth-gated for others
+    if qtype in ("product", "opinion"):
+        queries.append(f"{core} worth it OR thoughts OR review")
+    elif depth in ("default", "deep"):
         queries.append(f"{core} worth it OR thoughts OR review")
 
     if depth == "deep":

--- a/tests/test_reddit_sc.py
+++ b/tests/test_reddit_sc.py
@@ -39,6 +39,50 @@ class TestExtractCoreSubject(unittest.TestCase):
         self.assertEqual(result, "react server components")
 
 
+class TestInferQueryIntent(unittest.TestCase):
+    """Tests for _infer_query_intent()."""
+
+    def test_product_best_budget(self):
+        result = reddit._infer_query_intent("best budget noise cancelling headphones 2026")
+        self.assertEqual(result, "product")
+
+    def test_product_recommend(self):
+        result = reddit._infer_query_intent("recommend a good laptop for coding")
+        self.assertEqual(result, "product")
+
+    def test_product_review(self):
+        result = reddit._infer_query_intent("Sony WH-1000XM5 review")
+        self.assertEqual(result, "product")
+
+    def test_product_alternative(self):
+        result = reddit._infer_query_intent("cheap alternative to AirPods Pro")
+        self.assertEqual(result, "product")
+
+    def test_comparison_vs(self):
+        result = reddit._infer_query_intent("iPhone 16 vs Pixel 9")
+        self.assertEqual(result, "comparison")
+
+    def test_comparison_versus(self):
+        result = reddit._infer_query_intent("React versus Vue for new projects")
+        self.assertEqual(result, "comparison")
+
+    def test_comparison_compared_to(self):
+        result = reddit._infer_query_intent("M4 MacBook compared to M3")
+        self.assertEqual(result, "comparison")
+
+    def test_how_to(self):
+        result = reddit._infer_query_intent("how to set up a home server")
+        self.assertEqual(result, "how_to")
+
+    def test_opinion(self):
+        result = reddit._infer_query_intent("what do you think about Rust")
+        self.assertEqual(result, "opinion")
+
+    def test_factual_default(self):
+        result = reddit._infer_query_intent("Claude 4 release date")
+        self.assertEqual(result, "factual")
+
+
 class TestExpandRedditQueries(unittest.TestCase):
     """Tests for expand_reddit_queries()."""
 
@@ -58,6 +102,48 @@ class TestExpandRedditQueries(unittest.TestCase):
         quick = reddit.expand_reddit_queries("cursor IDE", "quick")
         deep = reddit.expand_reddit_queries("cursor IDE", "deep")
         self.assertGreater(len(deep), len(quick))
+
+    def test_product_always_includes_review_variant(self):
+        """Product queries include review-oriented variant at all depths."""
+        for depth in ("quick", "default", "deep"):
+            queries = reddit.expand_reddit_queries(
+                "best budget noise cancelling headphones 2026", depth
+            )
+            has_review = any(
+                "review" in q or "recommendation" in q for q in queries
+            )
+            self.assertTrue(
+                has_review,
+                f"Product query at depth={depth} missing review variant: {queries}"
+            )
+
+    def test_product_quick_includes_opinion_variant(self):
+        """Product queries include 'worth it OR thoughts' even at quick depth."""
+        queries = reddit.expand_reddit_queries(
+            "best budget noise cancelling headphones 2026", "quick"
+        )
+        has_opinion = any("worth it" in q or "thoughts" in q for q in queries)
+        self.assertTrue(
+            has_opinion,
+            f"Product query at quick depth missing opinion variant: {queries}"
+        )
+
+    def test_comparison_includes_vs_variant(self):
+        """Comparison queries include 'vs OR compared' variant."""
+        queries = reddit.expand_reddit_queries("iPhone 16 vs Pixel 9", "default")
+        has_vs = any("vs" in q or "compared" in q for q in queries)
+        self.assertTrue(
+            has_vs,
+            f"Comparison query missing vs variant: {queries}"
+        )
+
+    def test_factual_query_minimal_variants(self):
+        """Factual queries don't get product/comparison variants."""
+        queries = reddit.expand_reddit_queries("Claude 4 release date", "quick")
+        has_review = any("review" in q or "recommendation" in q for q in queries)
+        has_vs = any("vs OR compared" in q for q in queries)
+        self.assertFalse(has_review, f"Factual query got review variant: {queries}")
+        self.assertFalse(has_vs, f"Factual query got vs variant: {queries}")
 
 
 class TestDiscoverSubreddits(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds _infer_query_intent() to classify Reddit search topics by intent (product, comparison, opinion, how_to, factual)
- Product queries now always include review-oriented and comparison-oriented search variants, even at quick depth
- Backward-compatible: non-product queries at default/deep depth retain existing review variant behavior

## Context
Reddit product queries like best budget noise cancelling headphones 2026 returned 13% relevance (2/15 items grade >= 2) because generic keyword matching hit unrelated subreddits. The intent-aware expansion biases search toward review-oriented communities.

## Test plan
- [x] New tests for _infer_query_intent() covering all 5 intent categories
- [x] New tests for expand_reddit_queries() verifying product/comparison/factual behavior
- [x] Existing tests pass with no regressions (39/39 in test_reddit_sc.py)