### PR TITLE
refactor(store): extract _item_to_finding, fix TikTok data loss

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1938,87 +1938,13 @@ def main():
         topic_id = topic_row["id"]
         run_id = store_mod.record_run(topic_id, source_mode=mode, status="completed")
 
-        findings = []
-        for item in deduped_reddit:
-            findings.append({
-                "source": "reddit",
-                "url": item.url,
-                "title": item.title,
-                "author": item.subreddit,
-                "content": item.title,
-                "engagement_score": item.engagement.score if item.engagement else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_x:
-            findings.append({
-                "source": "x",
-                "url": item.url,
-                "title": item.text[:100],
-                "author": item.author_handle,
-                "content": item.text,
-                "engagement_score": item.engagement.likes if item.engagement else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_youtube:
-            findings.append({
-                "source": "youtube",
-                "url": item.url,
-                "title": item.title,
-                "author": item.channel_name,
-                "content": item.transcript_snippet[:500] if item.transcript_snippet else item.title,
-                "engagement_score": item.engagement.views if item.engagement and item.engagement.views else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_hn:
-            findings.append({
-                "source": "hackernews",
-                "url": item.hn_url,
-                "title": item.title,
-                "author": item.author,
-                "content": item.title,
-                "engagement_score": item.engagement.score if item.engagement else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_bsky:
-            findings.append({
-                "source": "bluesky",
-                "url": item.url,
-                "title": item.text[:100],
-                "author": item.author_handle,
-                "content": item.text,
-                "engagement_score": item.engagement.likes if item.engagement else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_pm:
-            findings.append({
-                "source": "polymarket",
-                "url": item.url,
-                "title": item.question,
-                "author": "polymarket",
-                "content": item.title,
-                "engagement_score": item.engagement.volume if item.engagement and item.engagement.volume else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_ig:
-            findings.append({
-                "source": "instagram",
-                "url": item.url,
-                "title": item.text[:100],
-                "author": item.author_name,
-                "content": item.caption_snippet[:500] if item.caption_snippet else item.text,
-                "engagement_score": item.engagement.views if item.engagement and item.engagement.views else 0,
-                "relevance_score": item.relevance,
-            })
-        for item in deduped_web:
-            findings.append({
-                "source": "web",
-                "url": item.url,
-                "title": item.title,
-                "author": item.source_domain,
-                "content": item.snippet,
-                "engagement_score": 0,
-                "relevance_score": item.relevance,
-            })
+        all_deduped = (
+            list(deduped_reddit) + list(deduped_x) + list(deduped_youtube)
+            + list(deduped_tiktok) + list(deduped_hn) + list(deduped_bsky)
+            + list(deduped_ts) + list(deduped_pm) + list(deduped_ig)
+            + list(deduped_web)
+        )
+        findings = [_item_to_finding(item) for item in all_deduped]
 
         counts = store_mod.store_findings(run_id, topic_id, findings)
         store_mod.update_run(
@@ -2031,6 +1957,120 @@ def main():
             f"[store] Saved {counts['new']} new, {counts['updated']} updated findings\n"
         )
         sys.stderr.flush()
+
+
+def _item_to_finding(item) -> dict:
+    """Convert any schema item to a flat finding dict for SQLite storage."""
+    if isinstance(item, schema.RedditItem):
+        return {
+            "source": "reddit",
+            "url": item.url,
+            "title": item.title,
+            "author": item.subreddit,
+            "content": item.title,
+            "engagement_score": item.engagement.score if item.engagement else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.XItem):
+        return {
+            "source": "x",
+            "url": item.url,
+            "title": item.text[:100],
+            "author": item.author_handle,
+            "content": item.text,
+            "engagement_score": item.engagement.likes if item.engagement else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.YouTubeItem):
+        return {
+            "source": "youtube",
+            "url": item.url,
+            "title": item.title,
+            "author": item.channel_name,
+            "content": item.transcript_snippet[:500] if item.transcript_snippet else item.title,
+            "engagement_score": item.engagement.views if item.engagement and item.engagement.views else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.HackerNewsItem):
+        return {
+            "source": "hackernews",
+            "url": item.hn_url,
+            "title": item.title,
+            "author": item.author,
+            "content": item.title,
+            "engagement_score": item.engagement.score if item.engagement else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.BlueskyItem):
+        return {
+            "source": "bluesky",
+            "url": item.url,
+            "title": item.text[:100],
+            "author": item.author_handle,
+            "content": item.text,
+            "engagement_score": item.engagement.likes if item.engagement else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.TruthSocialItem):
+        return {
+            "source": "truthsocial",
+            "url": item.url,
+            "title": item.text[:100],
+            "author": item.author_handle,
+            "content": item.text,
+            "engagement_score": item.engagement.likes if item.engagement else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.PolymarketItem):
+        return {
+            "source": "polymarket",
+            "url": item.url,
+            "title": item.question,
+            "author": "polymarket",
+            "content": item.title,
+            "engagement_score": item.engagement.volume if item.engagement and item.engagement.volume else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.TikTokItem):
+        return {
+            "source": "tiktok",
+            "url": item.url,
+            "title": item.text[:100],
+            "author": item.author_name,
+            "content": item.caption_snippet[:500] if item.caption_snippet else item.text,
+            "engagement_score": item.engagement.views if item.engagement and item.engagement.views else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.InstagramItem):
+        return {
+            "source": "instagram",
+            "url": item.url,
+            "title": item.text[:100],
+            "author": item.author_name,
+            "content": item.caption_snippet[:500] if item.caption_snippet else item.text,
+            "engagement_score": item.engagement.views if item.engagement and item.engagement.views else 0,
+            "relevance_score": item.relevance,
+        }
+    elif isinstance(item, schema.WebSearchItem):
+        return {
+            "source": "web",
+            "url": item.url,
+            "title": item.title,
+            "author": item.source_domain,
+            "content": item.snippet,
+            "engagement_score": 0,
+            "relevance_score": item.relevance,
+        }
+    else:
+        return {
+            "source": "unknown",
+            "url": getattr(item, 'url', ''),
+            "title": getattr(item, 'title', str(item)[:100]),
+            "author": "",
+            "content": str(item)[:500],
+            "engagement_score": 0,
+            "relevance_score": getattr(item, 'relevance', 0),
+        }
 
 
 def output_result(

--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -30,29 +30,7 @@ class Engagement:
     liquidity: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        d = {}
-        if self.score is not None:
-            d['score'] = self.score
-        if self.num_comments is not None:
-            d['num_comments'] = self.num_comments
-        if self.upvote_ratio is not None:
-            d['upvote_ratio'] = self.upvote_ratio
-        if self.likes is not None:
-            d['likes'] = self.likes
-        if self.reposts is not None:
-            d['reposts'] = self.reposts
-        if self.replies is not None:
-            d['replies'] = self.replies
-        if self.quotes is not None:
-            d['quotes'] = self.quotes
-        if self.views is not None:
-            d['views'] = self.views
-        if self.shares is not None:
-            d['shares'] = self.shares
-        if self.volume is not None:
-            d['volume'] = self.volume
-        if self.liquidity is not None:
-            d['liquidity'] = self.liquidity
+        d = {k: v for k, v in asdict(self).items() if v is not None}
         return d if d else None
 
 


### PR DESCRIPTION
## Summary

### Bug fix: TikTok and TruthSocial findings silently lost in `--store` mode

When a user runs `--store` to persist research findings to SQLite, the code at `last30days.py:1941-2021` iterates over each source's deduped items and builds a `findings` list for `store_mod.store_findings()`. There are 8 separate for-loops, one per source — but **TikTok and TruthSocial were never included**. Their deduped items (`deduped_tiktok`, `deduped_ts`) simply aren't iterated over, so they're silently dropped.

This means any user relying on `--store` for watchlist/briefing workflows (the variants/ use case) has been accumulating an incomplete dataset — TikTok and TruthSocial results appear in the CLI output but never make it to the database.

**Root cause:** The 8 for-loops were likely copy-pasted as new sources were added, and TikTok/TruthSocial were missed when they were introduced. The repetitive structure made it easy to overlook.

### Refactor: Extract `_item_to_finding()` dispatch function

To prevent this class of bug from recurring, this PR replaces the 8 for-loops with:
1. A single `_item_to_finding(item)` function that dispatches on `isinstance()` to map any schema item type to the flat dict format expected by the store module
2. A single loop: `findings = [_item_to_finding(item) for item in all_deduped]` where `all_deduped` explicitly concatenates all 10 source lists

Adding a new source now requires adding one `elif` branch to `_item_to_finding()` and one `list()` entry to `all_deduped` — rather than copy-pasting an entire for-loop block. The fallback `else` branch also handles unknown item types gracefully.

### Cleanup: `Engagement.to_dict()` simplified

Replaces 11 manual `if self.field is not None` checks with `{k: v for k, v in asdict(self).items() if v is not None}`. This means new engagement fields (like `shares`, `volume`, `liquidity` which were added after the original code) are automatically included in serialization without requiring a corresponding manual check. The `asdict()` call is safe here because `Engagement` is a flat dataclass with only scalar fields.

## Test plan
- [x] Existing test suite passes (461/465, 4 pre-existing model-name failures unrelated to this PR)
- [x] All 10 source types (including TikTok and TruthSocial) produce correct findings via `_item_to_finding()`
- [x] `Engagement.to_dict()` output is identical before/after for all field combinations (all-None, single field, mixed sources, zero values, all fields populated)
- [x] The `else` fallback in `_item_to_finding()` handles unexpected item types without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)