### PR TITLE
feat(observability): SourceHealth tracking, logging and retry infra

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -23,6 +23,7 @@ import os
 import signal
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -932,6 +933,7 @@ def run_research(
     polymarket_error = None
     web_error = None
     xiaohongshu_error = None
+    health: list = []  # List[schema.SourceHealth]
 
     # Determine web search mode
     do_web = sources in ("all", "web", "reddit-web", "x-web")
@@ -1013,7 +1015,7 @@ def run_research(
                     progress.show_error(f"Instagram error: {e}")
             if progress:
                 progress.end_instagram(len(instagram_items))
-        return reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error
+        return reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error, health
 
     # Determine which searches to run
     do_reddit = sources in ("both", "reddit", "all", "reddit-web")
@@ -1124,9 +1126,15 @@ def run_research(
             )
 
         # Collect results (with timeouts to prevent indefinite blocking)
+        # Each source records SourceHealth timing for observability
+        def _health_status(error: str = None) -> str:
+            if not error: return "ok"
+            return "timeout" if "timed out" in error else "error"
+
         reddit_used_sc = False  # Track if ScrapeCreators was used for Reddit
         if reddit_future:
             reddit_timeout = timeouts.get("reddit_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 reddit_items, raw_openai, reddit_error, reddit_used_sc = reddit_future.result(timeout=reddit_timeout)
                 if reddit_error and progress:
@@ -1139,10 +1147,17 @@ def run_research(
                 reddit_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Reddit error: {e}")
+            health.append(schema.SourceHealth(
+                source="reddit", item_count=len(reddit_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(reddit_error), error=reddit_error,
+                backend="scrapecreators" if reddit_used_sc else "openai",
+            ))
             if progress:
                 progress.end_reddit(len(reddit_items))
 
         if x_future:
+            _t0 = time.monotonic()
             try:
                 x_items, raw_xai, x_error = x_future.result(timeout=future_timeout)
                 if x_error and progress:
@@ -1155,11 +1170,17 @@ def run_research(
                 x_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"X error: {e}")
+            health.append(schema.SourceHealth(
+                source="x", item_count=len(x_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(x_error), error=x_error, backend=x_source,
+            ))
             if progress:
                 progress.end_x(len(x_items))
 
         if youtube_future:
             yt_timeout = timeouts.get("youtube_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 youtube_items, youtube_error = youtube_future.result(timeout=yt_timeout)
                 if youtube_error and progress:
@@ -1172,11 +1193,17 @@ def run_research(
                 youtube_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"YouTube error: {e}")
+            health.append(schema.SourceHealth(
+                source="youtube", item_count=len(youtube_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(youtube_error), error=youtube_error, backend="yt-dlp",
+            ))
             if progress:
                 progress.end_youtube(len(youtube_items))
 
         if tiktok_future:
             tk_timeout = timeouts.get("tiktok_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 tiktok_items, tiktok_error = tiktok_future.result(timeout=tk_timeout)
                 if tiktok_error and progress:
@@ -1189,11 +1216,17 @@ def run_research(
                 tiktok_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"TikTok error: {e}")
+            health.append(schema.SourceHealth(
+                source="tiktok", item_count=len(tiktok_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(tiktok_error), error=tiktok_error, backend="scrapecreators",
+            ))
             if progress:
                 progress.end_tiktok(len(tiktok_items))
 
         if instagram_future:
             ig_timeout = timeouts.get("instagram_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 instagram_items, instagram_error = instagram_future.result(timeout=ig_timeout)
                 if instagram_error and progress:
@@ -1206,6 +1239,11 @@ def run_research(
                 instagram_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Instagram error: {e}")
+            health.append(schema.SourceHealth(
+                source="instagram", item_count=len(instagram_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(instagram_error), error=instagram_error, backend="scrapecreators",
+            ))
             if progress:
                 progress.end_instagram(len(instagram_items))
 
@@ -1226,6 +1264,7 @@ def run_research(
 
         if hackernews_future:
             hn_timeout = timeouts.get("hackernews_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 hackernews_items, hackernews_error = hackernews_future.result(timeout=hn_timeout)
                 if hackernews_error and progress:
@@ -1238,11 +1277,17 @@ def run_research(
                 hackernews_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"HN error: {e}")
+            health.append(schema.SourceHealth(
+                source="hackernews", item_count=len(hackernews_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(hackernews_error), error=hackernews_error, backend="algolia",
+            ))
             if progress:
                 progress.end_hackernews(len(hackernews_items))
 
         if bluesky_future:
             bsky_timeout = timeouts.get("bluesky_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 bluesky_items, bluesky_error = bluesky_future.result(timeout=bsky_timeout)
                 if bluesky_error and progress:
@@ -1255,9 +1300,15 @@ def run_research(
                 bluesky_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Bluesky error: {e}")
+            health.append(schema.SourceHealth(
+                source="bluesky", item_count=len(bluesky_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(bluesky_error), error=bluesky_error, backend="atproto",
+            ))
 
         if truthsocial_future:
             ts_timeout = timeouts.get("truthsocial_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 truthsocial_items, truthsocial_error = truthsocial_future.result(timeout=ts_timeout)
                 if truthsocial_error and progress:
@@ -1270,9 +1321,15 @@ def run_research(
                 truthsocial_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Truth Social error: {e}")
+            health.append(schema.SourceHealth(
+                source="truthsocial", item_count=len(truthsocial_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(truthsocial_error), error=truthsocial_error, backend="mastodon",
+            ))
 
         if polymarket_future:
             pm_timeout = timeouts.get("polymarket_future", future_timeout)
+            _t0 = time.monotonic()
             try:
                 polymarket_items, polymarket_error = polymarket_future.result(timeout=pm_timeout)
                 if polymarket_error and progress:
@@ -1285,10 +1342,16 @@ def run_research(
                 polymarket_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Polymarket error: {e}")
+            health.append(schema.SourceHealth(
+                source="polymarket", item_count=len(polymarket_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(polymarket_error), error=polymarket_error, backend="gamma",
+            ))
             if progress:
                 progress.end_polymarket(len(polymarket_items))
 
         if web_future:
+            _t0 = time.monotonic()
             try:
                 web_items, web_error = web_future.result(timeout=future_timeout)
                 if web_error and progress:
@@ -1301,6 +1364,11 @@ def run_research(
                 web_error = f"{type(e).__name__}: {e}"
                 if progress:
                     progress.show_error(f"Web error: {e}")
+            health.append(schema.SourceHealth(
+                source="web", item_count=len(web_items),
+                duration_ms=int((time.monotonic() - _t0) * 1000),
+                status=_health_status(web_error), error=web_error, backend=web_backend,
+            ))
             sys.stderr.write(f"[web] {len(web_items)} results\n")
             sys.stderr.flush()
 
@@ -1405,7 +1473,7 @@ def run_research(
         if sup_x:
             x_items.extend(sup_x)
 
-    return reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error
+    return reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error, health
 
 
 def main():
@@ -1735,7 +1803,7 @@ def main():
             sources = "web"  # hn/polymarket only; no Reddit/X
 
     # Run research
-    reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error = run_research(
+    reddit_items, x_items, youtube_items, tiktok_items, instagram_items, hackernews_items, bluesky_items, truthsocial_items, polymarket_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, tiktok_error, instagram_error, hackernews_error, bluesky_error, truthsocial_error, polymarket_error, web_error, source_health = run_research(
         args.topic,
         sources,
         config,
@@ -1877,6 +1945,7 @@ def main():
     report.polymarket_error = polymarket_error
     report.web_error = web_error
     report.resolved_x_handle = args.x_handle
+    report.source_health = source_health
 
     # Generate context snippet
     report.context_snippet_md = render.render_context_snippet(report)

--- a/scripts/lib/log.py
+++ b/scripts/lib/log.py
@@ -1,0 +1,38 @@
+"""Structured logging for last30days skill.
+
+Provides a configured logger that preserves the existing [Source] prefix
+style while enabling level-based filtering via --debug.
+
+Usage:
+    from lib.log import logger
+    logger.info("[Reddit] Using ScrapeCreators API")
+    logger.debug("[Reddit] Raw response: %s", data)
+    logger.warning("[Reddit] Rate limited, backing off")
+    logger.error("[Reddit] ScrapeCreators failed: %s", err)
+"""
+
+import logging
+import sys
+
+# Single named logger for the entire skill
+logger = logging.getLogger("last30days")
+
+# Bare formatter: message only, matching existing stderr output style
+_formatter = logging.Formatter("%(message)s")
+
+# stderr handler (matches existing sys.stderr.write behavior)
+_handler = logging.StreamHandler(sys.stderr)
+_handler.setFormatter(_formatter)
+
+# Prevent duplicate handlers if module is re-imported
+if not logger.handlers:
+    logger.addHandler(_handler)
+    logger.setLevel(logging.INFO)
+
+# Prevent propagation to root logger
+logger.propagate = False
+
+
+def set_debug(enabled: bool = True) -> None:
+    """Enable or disable debug-level logging."""
+    logger.setLevel(logging.DEBUG if enabled else logging.INFO)

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -639,6 +639,31 @@ def render_source_status(report: schema.Report, source_info: dict = None) -> str
         reason = source_info.get("web_skip_reason", "assistant will use WebSearch")
         lines.append(f"  ⚡ Web: {reason}")
 
+    # Source health timing (if available)
+    _src_display = {
+        "reddit": "Reddit", "x": "X", "youtube": "YouTube",
+        "tiktok": "TikTok", "instagram": "Instagram",
+        "hackernews": "HN", "bluesky": "Bluesky",
+        "truthsocial": "Truth Social", "polymarket": "Polymarket",
+        "web": "Web",
+    }
+    if report.source_health:
+        active = [sh for sh in report.source_health if sh.status != "skipped"]
+        if active:
+            timings = []
+            for sh in sorted(active, key=lambda s: s.duration_ms, reverse=True):
+                secs = sh.duration_ms / 1000
+                name = _src_display.get(sh.source, sh.source.capitalize())
+                if sh.backend:
+                    name += f"/{sh.backend}"
+                if sh.status == "error":
+                    timings.append(f"{name}: ERR")
+                elif sh.status == "timeout":
+                    timings.append(f"{name}: T/O")
+                else:
+                    timings.append(f"{name}: {secs:.1f}s")
+            lines.append(f"  ⏱️ Timing: {' | '.join(timings)}")
+
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/lib/retry.py
+++ b/scripts/lib/retry.py
@@ -1,0 +1,98 @@
+"""Retry decorator for source-level search functions.
+
+Provides exponential backoff for transient errors (429, 503, connection
+errors) without retrying permanent client errors (4xx except 429).
+
+Usage:
+    from lib.retry import retry
+
+    @retry(max_attempts=2, backoff_base=1.5)
+    def _search_reddit(topic, ...):
+        ...
+"""
+
+import functools
+import time
+
+from lib.http import HTTPError
+from lib.log import logger
+
+
+# Exceptions that indicate transient failures worth retrying
+_TRANSIENT_EXCEPTIONS = (
+    ConnectionError,
+    ConnectionResetError,
+    TimeoutError,
+    OSError,
+)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """Determine if an exception represents a transient failure."""
+    # Direct transient exceptions
+    if isinstance(exc, _TRANSIENT_EXCEPTIONS):
+        return True
+
+    # HTTP errors: retry 429 (rate limit) and 5xx, not other 4xx
+    if isinstance(exc, HTTPError):
+        if exc.status_code is None:
+            return True  # Connection-level error
+        if exc.status_code == 429:
+            return True
+        if exc.status_code >= 500:
+            return True
+        return False  # 4xx client errors are permanent
+
+    return False
+
+
+def retry(max_attempts: int = 2, backoff_base: float = 1.5):
+    """Decorator that retries a function on transient failures.
+
+    Args:
+        max_attempts: Total attempts (1 = no retry, 2 = one retry). Max 5.
+        backoff_base: Base for exponential backoff in seconds. Max 10.
+            Delay = backoff_base * (2 ** attempt_index), so:
+            attempt 1 retry: 1.5s, attempt 2 retry: 3.0s
+
+    Non-transient errors (4xx except 429) are raised immediately.
+
+    Note: Functions that call http.request() already have HTTP-level retries.
+    This decorator is for source-level retries (e.g., retrying the entire
+    search function when the API backend itself is down).
+    """
+    if max_attempts < 1 or max_attempts > 5:
+        raise ValueError("max_attempts must be between 1 and 5")
+    if backoff_base < 0 or backoff_base > 10:
+        raise ValueError("backoff_base must be between 0 and 10")
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exc = None
+            for attempt in range(max_attempts):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:
+                    last_exc = exc
+                    if not _is_transient(exc):
+                        raise  # Permanent error, don't retry
+
+                    if attempt < max_attempts - 1:
+                        delay = backoff_base * (2 ** attempt)
+                        logger.warning(
+                            "[retry] %s failed (attempt %d/%d): %s. "
+                            "Retrying in %.1fs",
+                            func.__name__, attempt + 1, max_attempts,
+                            exc, delay,
+                        )
+                        time.sleep(delay)
+                    else:
+                        logger.warning(
+                            "[retry] %s failed (attempt %d/%d): %s. "
+                            "No more retries.",
+                            func.__name__, attempt + 1, max_attempts, exc,
+                        )
+            raise last_exc
+        return wrapper
+    return decorator

--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -473,6 +473,31 @@ class PolymarketItem:
 
 
 @dataclass
+@dataclass
+class SourceHealth:
+    """Per-source health metrics from a research run."""
+    source: str               # e.g. "reddit", "x", "youtube"
+    status: str = "ok"        # "ok", "error", "timeout", "skipped"
+    item_count: int = 0
+    duration_ms: int = 0      # wall-clock milliseconds
+    error: Optional[str] = None
+    backend: Optional[str] = None  # e.g. "bird", "xai", "scrapecreators"
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            'source': self.source,
+            'status': self.status,
+            'item_count': self.item_count,
+            'duration_ms': self.duration_ms,
+        }
+        if self.error:
+            d['error'] = self.error
+        if self.backend:
+            d['backend'] = self.backend
+        return d
+
+
+@dataclass
 class Report:
     """Full research report."""
     topic: str
@@ -508,6 +533,8 @@ class Report:
     polymarket_error: Optional[str] = None
     # Handle resolution
     resolved_x_handle: Optional[str] = None
+    # Source health tracking
+    source_health: List[SourceHealth] = field(default_factory=list)
     # Cache info
     from_cache: bool = False
     cache_age_hours: Optional[float] = None
@@ -537,6 +564,8 @@ class Report:
             'prompt_pack': self.prompt_pack,
             'context_snippet_md': self.context_snippet_md,
         }
+        if self.source_health:
+            d['source_health'] = [sh.to_dict() for sh in self.source_health]
         if self.resolved_x_handle:
             d['resolved_x_handle'] = self.resolved_x_handle
         if self.reddit_error:
@@ -814,6 +843,16 @@ class Report:
             hackernews_error=data.get('hackernews_error'),
             truthsocial_error=data.get('truthsocial_error'),
             polymarket_error=data.get('polymarket_error'),
+            source_health=[
+                SourceHealth(
+                    source=sh['source'],
+                    status=sh.get('status', 'ok'),
+                    item_count=sh.get('item_count', 0),
+                    duration_ms=sh.get('duration_ms', 0),
+                    error=sh.get('error'),
+                    backend=sh.get('backend'),
+                ) for sh in data.get('source_health', [])
+            ],
             resolved_x_handle=data.get('resolved_x_handle'),
             from_cache=data.get('from_cache', False),
             cache_age_hours=data.get('cache_age_hours'),


### PR DESCRIPTION
## Summary

### Problem: No visibility into source performance

When a research run completes, the compact output shows what was found per source (e.g., "✅ Reddit: 12 threads") but gives no insight into **how long each source took**, **which backend was used**, or **why a source failed**. This makes it hard to:
- Debug slow runs (was it YouTube taking 90s, or Reddit?)
- Understand which backend was selected (Bird vs xAI vs ScrapeCreators for X)
- Diagnose intermittent failures (timeout vs API error vs auth failure)

### Solution: SourceHealth dataclass + timing instrumentation

**New `SourceHealth` dataclass** (`schema.py`) captures per-source metrics:
- `source`: name (e.g., "reddit", "x", "youtube")
- `status`: "ok", "error", "timeout", or "skipped"
- `item_count`: number of items returned
- `duration_ms`: wall-clock milliseconds spent waiting for this source
- `error`: error message (if any)
- `backend`: which backend was used (e.g., "bird", "scrapecreators", "yt-dlp", "algolia")

**Timing instrumentation** (`last30days.py`): Each source's `future.result()` call is wrapped with `time.monotonic()` to measure wall-clock wait time. A `SourceHealth` entry is appended to a `health` list after each source completes. The list is returned from `run_research()` and attached to the `Report`.

**Timing footer** (`render.py`): The compact output's source status section now includes a timing line, sorted slowest-first:
```
⏱️ Timing: Bluesky/atproto: T/O | YouTube/yt-dlp: 12.3s | Reddit/scrapecreators: 4.1s | HN/algolia: 1.2s | X/bird: ERR
```
Error and timeout sources show `ERR` or `T/O` instead of a time.

**Full serialization**: `SourceHealth` round-trips through `Report.to_dict()` / `Report.from_dict()`, using explicit `.get()` kwargs (not `**kwargs` splatting) for forward-compatibility with future fields.

### Infrastructure modules (not yet wired in)

This PR also adds two new modules that are imported and tested but not yet called from the main pipeline. They provide infrastructure for future improvements:

**`lib/log.py`**: Structured logging using Python's `logging` module with a bare formatter that matches the existing `[Source] message` stderr style. Provides `set_debug()` to flip between INFO and DEBUG levels, replacing the current pattern of `sys.stderr.write` + `if DEBUG` checks scattered across modules.

**`lib/retry.py`**: `@retry(max_attempts=2, backoff_base=1.5)` decorator for source-level retries with exponential backoff. Only retries transient failures (429, 503, connection errors) — permanent client errors (4xx) are raised immediately. Bounds-validated (max 5 attempts, max 10s backoff). Includes documentation about the interaction with `http.py`'s existing request-level retries to prevent surprise delay stacking.

### Note on timing semantics

The `duration_ms` measures time spent in `future.result()`, which is the **wall-clock impact on the user** — how long they waited for that source. Because futures are collected sequentially (not with `as_completed`), a source that finishes quickly but is collected after a slow source will show a low duration. This is intentional: it reflects blocking time, not execution time.

## Test plan
- [x] Existing test suite passes (461/465, 4 pre-existing)
- [x] Timing footer renders correctly with proper source display names, sorted slowest-first, showing ERR/T/O for failed sources
- [x] `SourceHealth` round-trips through `Report.to_dict()` / `Report.from_dict()` with all fields preserved (including error and backend)
- [x] `log.py` and `retry.py` import cleanly; `set_debug()` toggles log level between INFO and DEBUG
- [x] `@retry` raises immediately on 4xx errors (called once, no sleep)
- [x] `@retry` retries on 429 and 503 (called `max_attempts` times with backoff)
- [x] `@retry` recovers on transient-then-success (returns result from second attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)