### PR TITLE
feat: extend scanning window from 30 to 90 days

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1455,9 +1455,9 @@ def main():
         "--days",
         type=int,
         default=30,
-        choices=range(1, 31),
+        choices=range(1, 91),
         metavar="N",
-        help="Number of days to look back (1-30, default: 30)",
+        help="Number of days to look back (1-90, default: 30)",
     )
     parser.add_argument(
         "--store",


### PR DESCRIPTION
Allows `--days` argument to accept values from 1-90 (previously 1-30) for pre-event deep research requiring longer historical windows.

## Changes
- Updated argparse `choices` from `range(1, 31)` to `range(1, 91)`
- Updated help text to reflect new 1-90 range
- Default remains 30 days (no breaking change)

## Implementation Notes

The `recency_score` function in `scripts/lib/dates.py` already accepts a `max_days` parameter, so this change only required updating the CLI validation to allow larger values. No changes to scoring logic were needed.

## Testing

```bash
$ python3 scripts/last30days.py --help | grep days
  --days N              Number of days to look back (1-90, default: 30)
```

✅ Argparse accepts values 1-90  
✅ Help text updated  
✅ Default remains 30

Fixes #79