### PR TITLE
fix(watchlist): store HN and Polymarket findings from research runs

### DIFF
--- a/scripts/watchlist.py
+++ b/scripts/watchlist.py
@@ -221,6 +221,35 @@ def _run_topic(topic: dict) -> dict:
                 "engagement_score": (item.get("engagement") or {}).get("views", 0),
                 "relevance_score": item.get("relevance", 0),
             })
+        for item in data.get("hn", []):
+            findings.append({
+                "source": "hackernews",
+                "url": item.get("hn_url", item.get("url", "")),
+                "title": item.get("title", ""),
+                "author": item.get("author", ""),
+                "content": item.get("title", ""),
+                "summary": item.get("comment_insights_summary", ""),
+                "engagement_score": (item.get("engagement") or {}).get("points", 0) + (item.get("engagement") or {}).get("num_comments", 0),
+                "relevance_score": item.get("relevance", 0),
+            })
+        for item in data.get("polymarket", []):
+            # Format outcomes for content field
+            outcomes = item.get("outcomes", [])
+            outcomes_text = " / ".join([
+                f"{o.get('title', '')}: {o.get('probability', o.get('price', 0)):.0%}"
+                for o in outcomes[:3]
+            ]) if outcomes else ""
+            
+            findings.append({
+                "source": "polymarket",
+                "url": item.get("url", ""),
+                "title": item.get("title", item.get("question", "")),
+                "author": "polymarket",
+                "content": f"{item.get('title', '')} | {outcomes_text}",
+                "summary": item.get("why_relevant", ""),
+                "engagement_score": item.get("volume24hr", item.get("liquidity", 0)),
+                "relevance_score": item.get("relevance", 0),
+            })
 
         # Store with dedup
         counts = store.store_findings(run_id, topic_id, findings)


### PR DESCRIPTION
Fixes data quality gap where HN and Polymarket items were researched but never stored in the watchlist database.

## Problem

When `last30days.py` runs as part of watchlist, it searches HN and Polymarket (added in v2.5) but `watchlist.py` only stored reddit, x, youtube, tiktok, and instagram findings. HN discussions and Polymarket odds were silently dropped, creating a significant gap in the persistent knowledge base.

## Impact

- **HN:** Highest-signal developer community discussions (free, no API key)
- **Polymarket:** Real-money prediction markets (highest-signal odds data)  
- Both sources are valuable for research but were being discarded

## Changes

**Added HN findings loop** in `_run_topic()` (lines 224-233):
- Uses `hn_url` for deduplication (stable HN item IDs)
- Combines `points + num_comments` for engagement_score
- Preserves `comment_insights_summary` in summary field

**Added Polymarket findings loop** in `_run_topic()` (lines 234-247):
- Formats outcomes with probabilities in content field
- Uses `volume24hr` or `liquidity` for engagement_score
- Deduplicates on Polymarket event URLs (stable)

## Testing

- ✅ Python syntax validation: passed
- ✅ Logic test with sample data: passed  
- ✅ Verified engagement scoring: HN (points+comments), PM (volume)
- ✅ Confirmed probability formatting: "Yes: 64% / No: 36%"

## Deduplication

Both sources use stable URLs that work with existing `source_url UNIQUE` constraint:
- HN: `https://news.ycombinator.com/item?id={object_id}`
- Polymarket: `https://polymarket.com/event/{slug}`

The SQLite FTS5 virtual table will automatically index the new source types via existing INSERT trigger.

## Open Questions

**For maintainer:**
1. Confirm exact JSON field names for HN/Polymarket in `--emit=json` output match expectations
2. Is the engagement scoring approach correct? (HN: points+comments, PM: volume24hr)
3. Should Polymarket use `liquidity` as fallback if `volume24hr` is missing?

---

**Related:** Complements PR #84 (90-day window extension) — more data + longer window = better research quality! 🎯