### PR TITLE
fix: hardcoded paths, import check, UTC datetime

### DIFF
--- a/scripts/lib/websearch.py
+++ b/scripts/lib/websearch.py
@@ -11,7 +11,7 @@ The typical flow is:
 """
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -128,7 +128,7 @@ def extract_date_from_snippet(text: str) -> Optional[str]:
             return f"{year}-{month}-{day}"
 
     # Pattern 4: Relative dates ("3 days ago", "yesterday", etc.)
-    today = datetime.now()
+    today = datetime.now(timezone.utc)
 
     if "yesterday" in text_lower:
         date = today - timedelta(days=1)

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -38,8 +38,26 @@ for t in "${TARGETS[@]}"; do
   mod_count=$(ls "$t/scripts/lib/"*.py 2>/dev/null | wc -l | tr -d ' ')
   echo "  Copied $mod_count modules"
 
-  # Verify imports
-  if (cd "$t/scripts" && python3 -c "from lib import youtube_yt, bird_x, render, ui; print('  Import check: OK')" 2>&1); then
+  # Verify imports — dynamically checks every module in lib/
+  if (cd "$t/scripts" && python3 - <<'PYEOF'
+import importlib, pathlib, sys
+failed = []
+for p in sorted(pathlib.Path("lib").glob("*.py")):
+    if p.stem == "__init__":
+        continue
+    try:
+        importlib.import_module(f"lib.{p.stem}")
+    except Exception as e:
+        failed.append(f"{p.stem}: {e}")
+if failed:
+    print("  Import check FAILED:")
+    for f in failed:
+        print(f"    {f}")
+    sys.exit(1)
+else:
+    print(f"  Import check: OK ({len(list(pathlib.Path('lib').glob('*.py'))) - 1} modules)")
+PYEOF
+  ); then
     true
   else
     echo "  Import check FAILED"

--- a/scripts/test-v1-vs-v2.sh
+++ b/scripts/test-v1-vs-v2.sh
@@ -6,7 +6,13 @@ set -euo pipefail
 # using `claude --print` to capture real end-to-end output.
 
 SKILL_DIR="$HOME/.claude/skills/last30days"
-REPO_DIR="/Users/mvanhorn/last30days-skill"
+REPO_DIR="${REPO_DIR:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || true)}"
+
+if [ -z "$CLAUDE_BIN" ]; then
+  echo "❌ claude not found in PATH. Set CLAUDE_BIN=/path/to/claude and retry." >&2
+  exit 1
+fi
 
 # Safety: always restore V2 SKILL.md on exit/crash
 cleanup() {
@@ -101,7 +107,7 @@ run_version() {
 
     # Run claude --print with the skill invocation
     # No timeout — claude --print exits on its own; kill manually if stuck
-    if /Users/mvanhorn/.local/bin/claude --print \
+    if "$CLAUDE_BIN" --print \
       "/last30days $query" \
       > "$outfile" 2>"$errfile"; then
       local end_time


### PR DESCRIPTION
Fixed three low-severity bugs:

- Replaced hardcoded `/Users/mvanhorn/...` paths in `test-v1-vs-v2.sh` with auto-detected values via `git rev-parse` and `command -v claude`, with env var overrides
- Expanded `sync.sh` import verification to dynamically check all modules in `lib/` instead of just 4
- Fixed `websearch.py` to use `datetime.now(timezone.utc)` instead of naive local time

Closes #94, #96, #98