### PR TITLE
Fix hardcoded paths with environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,6 +1204,14 @@ Your research topic is included in all outbound API requests. If you research se
 - Watchlist database: `~/.local/share/last30days/research.db` (SQLite)
 - Briefings: `~/.local/share/last30days/briefs/`
 
+**Path customization:** All paths can be overridden via environment variables:
+- `LAST30DAYS_CONFIG_DIR` — Config directory (default: `~/.config/last30days`)
+- `LAST30DAYS_DATA_DIR` — Data directory for database (default: `~/.local/share/last30days`)
+- `LAST30DAYS_DATABASE_PATH` — Full database path (overrides `LAST30DAYS_DATA_DIR`)
+- `LAST30DAYS_CACHE_DIR` — Cache directory (default: `~/.cache/last30days`)
+- `LAST30DAYS_OUTPUT_DIR` — Output directory for reports (default: `~/.local/share/last30days/out`)
+- `LAST30DAYS_BRIEFS_DIR` — Briefings directory (default: `~/.local/share/last30days/briefs`)
+
 ### API key isolation
 
 Each API key is transmitted only to its respective endpoint. Your OpenAI key is never sent to xAI, Brave, or any other provider. Browser cookies for X are read locally and used only for Twitter GraphQL requests.

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -21,7 +21,21 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
 import store
+from lib.env import get_briefs_dir
 
+
+def _get_briefs_dir() -> Path:
+    """Get the briefs directory, using centralized config with fallbacks.
+    
+    Priority:
+    1. LAST30DAYS_BRIEFS_DIR environment variable
+    2. ~/.local/share/last30days/briefs (XDG default)
+    3. System temp directory as fallback
+    """
+    return get_briefs_dir()
+
+
+# Legacy module-level variable for backward compatibility
 BRIEFS_DIR = Path.home() / ".local" / "share" / "last30days" / "briefs"
 
 
@@ -204,10 +218,11 @@ def show_briefing(date: str = None) -> dict:
     if not date:
         date = datetime.now().strftime("%Y-%m-%d")
 
-    path = BRIEFS_DIR / f"{date}.json"
+    briefs_dir = _get_briefs_dir()
+    path = briefs_dir / f"{date}.json"
     if not path.exists():
         # Try weekly
-        path = BRIEFS_DIR / f"{date}-weekly.json"
+        path = briefs_dir / f"{date}-weekly.json"
 
     if not path.exists():
         return {"status": "not_found", "message": f"No briefing found for {date}."}
@@ -218,9 +233,10 @@ def show_briefing(date: str = None) -> dict:
 
 def _save_briefing(data: dict, suffix: str = ""):
     """Save briefing data to local archive."""
-    BRIEFS_DIR.mkdir(parents=True, exist_ok=True)
+    briefs_dir = _get_briefs_dir()
+    briefs_dir.mkdir(parents=True, exist_ok=True)
     date = datetime.now().strftime("%Y-%m-%d")
-    path = BRIEFS_DIR / f"{date}{suffix}.json"
+    path = briefs_dir / f"{date}{suffix}.json"
     with open(path, "w") as f:
         json.dump(data, f, indent=2, default=str)
 

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1462,7 +1462,8 @@ def main():
     parser.add_argument(
         "--store",
         action="store_true",
-        help="Persist findings to SQLite database (~/.local/share/last30days/research.db)",
+        help="Persist findings to SQLite database (default: ~/.local/share/last30days/research.db, "
+             "override with LAST30DAYS_DATABASE_PATH)",
     )
     parser.add_argument(
         "--diagnose",

--- a/scripts/lib/cache.py
+++ b/scripts/lib/cache.py
@@ -8,26 +8,43 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-CACHE_DIR = Path.home() / ".cache" / "last30days"
+# Import path configuration from env module
+from . import env
+
 DEFAULT_TTL_HOURS = 24
 MODEL_CACHE_TTL_DAYS = 7
+
+
+def _get_cache_dir() -> Path:
+    """Get the cache directory, using centralized config with fallbacks.
+    
+    Priority:
+    1. LAST30DAYS_CACHE_DIR environment variable
+    2. ~/.cache/last30days (XDG default)
+    3. System temp directory as fallback
+    """
+    return env.get_cache_dir()
+
+
+def _get_model_cache_file() -> Path:
+    """Get the model cache file path."""
+    return _get_cache_dir() / "model_selection.json"
+
+
+# Legacy module-level variables for backward compatibility
+CACHE_DIR = Path.home() / ".cache" / "last30days"
 MODEL_CACHE_FILE = CACHE_DIR / "model_selection.json"
 
 
 def ensure_cache_dir():
-    """Ensure cache directory exists. Supports env override and sandbox fallback."""
-    global CACHE_DIR, MODEL_CACHE_FILE
-    env_dir = os.environ.get("LAST30DAYS_CACHE_DIR")
-    if env_dir:
-        CACHE_DIR = Path(env_dir)
-        MODEL_CACHE_FILE = CACHE_DIR / "model_selection.json"
-
-    try:
-        CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        CACHE_DIR = Path(tempfile.gettempdir()) / "last30days" / "cache"
-        MODEL_CACHE_FILE = CACHE_DIR / "model_selection.json"
-        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    """Ensure cache directory exists. Uses centralized config with fallbacks.
+    
+    The actual path is determined by _get_cache_dir() which supports:
+    - LAST30DAYS_CACHE_DIR environment variable
+    - XDG default: ~/.cache/last30days
+    - Temp directory fallback
+    """
+    _get_cache_dir()  # This creates the directory via get_cache_dir()
 
 
 def get_cache_key(topic: str, from_date: str, to_date: str, sources: str) -> str:
@@ -37,8 +54,8 @@ def get_cache_key(topic: str, from_date: str, to_date: str, sources: str) -> str
 
 
 def get_cache_path(cache_key: str) -> Path:
-    """Get path to cache file."""
-    return CACHE_DIR / f"{cache_key}.json"
+    """Get path to cache file. Uses centralized cache directory config."""
+    return _get_cache_dir() / f"{cache_key}.json"
 
 
 def is_cache_valid(cache_path: Path, ttl_hours: int = DEFAULT_TTL_HOURS) -> bool:
@@ -116,36 +133,38 @@ def save_cache(cache_key: str, data: dict):
 
 
 def clear_cache():
-    """Clear all cache files."""
-    if CACHE_DIR.exists():
-        for f in CACHE_DIR.glob("*.json"):
+    """Clear all cache files. Uses centralized cache directory config."""
+    cache_dir = _get_cache_dir()
+    if cache_dir.exists():
+        for f in cache_dir.glob("*.json"):
             try:
                 f.unlink()
             except OSError:
                 pass
 
 
-# Model selection cache (longer TTL) — MODEL_CACHE_FILE is set at module level
-# and updated by ensure_cache_dir() if env override or fallback is needed.
+# Model selection cache (longer TTL)
 
 
 def load_model_cache() -> dict:
-    """Load model selection cache."""
-    if not is_cache_valid(MODEL_CACHE_FILE, MODEL_CACHE_TTL_DAYS * 24):
+    """Load model selection cache. Uses centralized cache directory config."""
+    model_cache_file = _get_model_cache_file()
+    if not is_cache_valid(model_cache_file, MODEL_CACHE_TTL_DAYS * 24):
         return {}
 
     try:
-        with open(MODEL_CACHE_FILE, 'r') as f:
+        with open(model_cache_file, 'r') as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError):
         return {}
 
 
 def save_model_cache(data: dict):
-    """Save model selection cache."""
+    """Save model selection cache. Uses centralized cache directory config."""
     ensure_cache_dir()
+    model_cache_file = _get_model_cache_file()
     try:
-        with open(MODEL_CACHE_FILE, 'w') as f:
+        with open(model_cache_file, 'w') as f:
             json.dump(data, f)
     except OSError:
         pass

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -3,27 +3,174 @@
 import base64
 import json
 import os
+import tempfile
 import time
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Any, Literal
 
-# Allow override via environment variable for testing
-# Set LAST30DAYS_CONFIG_DIR="" for clean/no-config mode
-# Set LAST30DAYS_CONFIG_DIR="/path/to/dir" for custom config location
+
+# =============================================================================
+# Path Configuration
+# =============================================================================
+# Supports environment variable overrides for all paths.
+# Follows XDG Base Directory specification where applicable.
+# Falls back to temp directories if permission denied.
+
+def _get_path_with_override(env_var: str, default_parts: list, temp_suffix: str = None) -> Path:
+    """Get a path with environment variable override support.
+    
+    Args:
+        env_var: Environment variable name to check for override
+        default_parts: List of path parts for default path (e.g., [".config", "last30days"])
+        temp_suffix: Suffix for temp directory fallback (e.g., "last30days/config")
+    
+    Returns:
+        Path object with the resolved location
+    """
+    env_value = os.environ.get(env_var)
+    if env_value:
+        return Path(env_value)
+    return Path.home().joinpath(*default_parts)
+
+
+def _ensure_dir_with_fallback(path: Path, temp_suffix: str) -> Path:
+    """Ensure directory exists, falling back to temp if permission denied.
+    
+    Args:
+        path: Primary path to try
+        temp_suffix: Suffix for temp directory fallback
+    
+    Returns:
+        The path that was successfully created (may be fallback)
+    """
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except PermissionError:
+        fallback = Path(tempfile.gettempdir()) / temp_suffix
+        fallback.mkdir(parents=True, exist_ok=True)
+        warnings.warn(
+            f"Permission denied for {path}, using fallback: {fallback}",
+            RuntimeWarning,
+            stacklevel=3
+        )
+        return fallback
+
+
+# Config directory: ~/.config/last30days or LAST30DAYS_CONFIG_DIR
 _config_override = os.environ.get('LAST30DAYS_CONFIG_DIR')
 if _config_override == "":
     # Empty string = no config file (clean mode)
-    CONFIG_DIR = None
-    CONFIG_FILE = None
+    CONFIG_DIR: Optional[Path] = None
+    CONFIG_FILE: Optional[Path] = None
 elif _config_override:
     CONFIG_DIR = Path(_config_override)
     CONFIG_FILE = CONFIG_DIR / ".env"
 else:
-    CONFIG_DIR = Path.home() / ".config" / "last30days"
+    CONFIG_DIR = _get_path_with_override(
+        'LAST30DAYS_CONFIG_DIR',
+        ['.config', 'last30days']
+    )
     CONFIG_FILE = CONFIG_DIR / ".env"
 
+
+def get_config_dir() -> Path:
+    """Get the config directory path, creating it if needed."""
+    if CONFIG_DIR is None:
+        raise RuntimeError("Config directory is disabled (clean mode)")
+    return _ensure_dir_with_fallback(CONFIG_DIR, "last30days/config")
+
+
+def get_config_file() -> Optional[Path]:
+    """Get the config file path."""
+    return CONFIG_FILE
+
+
+# Data directory: ~/.local/share/last30days or LAST30DAYS_DATA_DIR
+def get_data_dir() -> Path:
+    """Get the data directory for database and persistent storage.
+    
+    Priority:
+    1. LAST30DAYS_DATA_DIR environment variable
+    2. ~/.local/share/last30days (XDG default)
+    3. System temp directory as fallback
+    """
+    path = _get_path_with_override(
+        'LAST30DAYS_DATA_DIR',
+        ['.local', 'share', 'last30days']
+    )
+    return _ensure_dir_with_fallback(path, "last30days/data")
+
+
+def get_database_path() -> Path:
+    """Get the SQLite database path.
+    
+    Override with LAST30DAYS_DATABASE_PATH for full path control.
+    """
+    env_path = os.environ.get('LAST30DAYS_DATABASE_PATH')
+    if env_path:
+        return Path(env_path)
+    return get_data_dir() / "research.db"
+
+
+# Cache directory: ~/.cache/last30days or LAST30DAYS_CACHE_DIR
+def get_cache_dir() -> Path:
+    """Get the cache directory for temporary cached data.
+    
+    Priority:
+    1. LAST30DAYS_CACHE_DIR environment variable
+    2. ~/.cache/last30days (XDG default)
+    3. System temp directory as fallback
+    """
+    path = _get_path_with_override(
+        'LAST30DAYS_CACHE_DIR',
+        ['.cache', 'last30days']
+    )
+    return _ensure_dir_with_fallback(path, "last30days/cache")
+
+
+# Output directory: ~/.local/share/last30days/out or LAST30DAYS_OUTPUT_DIR
+def get_output_dir() -> Path:
+    """Get the output directory for generated reports.
+    
+    Priority:
+    1. LAST30DAYS_OUTPUT_DIR environment variable
+    2. ~/.local/share/last30days/out (XDG default)
+    3. System temp directory as fallback
+    """
+    path = _get_path_with_override(
+        'LAST30DAYS_OUTPUT_DIR',
+        ['.local', 'share', 'last30days', 'out']
+    )
+    return _ensure_dir_with_fallback(path, "last30days/out")
+
+
+# Briefs directory: ~/.local/share/last30days/briefs or LAST30DAYS_BRIEFS_DIR
+def get_briefs_dir() -> Path:
+    """Get the briefs directory for saved briefings.
+    
+    Priority:
+    1. LAST30DAYS_BRIEFS_DIR environment variable
+    2. ~/.local/share/last30days/briefs (XDG default)
+    3. System temp directory as fallback
+    """
+    path = _get_path_with_override(
+        'LAST30DAYS_BRIEFS_DIR',
+        ['.local', 'share', 'last30days', 'briefs']
+    )
+    return _ensure_dir_with_fallback(path, "last30days/briefs")
+
+
+# Codex auth file: ~/.codex/auth.json or CODEX_AUTH_FILE
 CODEX_AUTH_FILE = Path(os.environ.get("CODEX_AUTH_FILE", str(Path.home() / ".codex" / "auth.json")))
+
+
+# Legacy module-level variables for backward compatibility
+# These will be removed in a future version
+_DB_DIR_LEGACY = Path.home() / ".local" / "share" / "last30days"
+_DB_PATH_LEGACY = _DB_DIR_LEGACY / "research.db"
 
 AuthSource = Literal["api_key", "codex", "none"]
 AuthStatus = Literal["ok", "missing", "expired", "missing_account_id"]
@@ -218,7 +365,13 @@ def get_config() -> Dict[str, Any]:
     Priority (highest wins):
       1. Environment variables (os.environ)
       2. .claude/last30days.env (per-project config)
-      3. ~/.config/last30days/.env (global config)
+      3. Global config file (default: ~/.config/last30days/.env, 
+         override with LAST30DAYS_CONFIG_DIR environment variable)
+    
+    See also:
+      - get_config_dir() for config directory path
+      - get_data_dir() for data/database directory path  
+      - get_cache_dir() for cache directory path
     """
     # Load from global config file
     file_env = load_env_file(CONFIG_FILE) if CONFIG_FILE else {}

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -7,7 +7,21 @@ from pathlib import Path
 from typing import Optional
 
 from . import schema
+from . import env
 
+
+def _get_output_dir() -> Path:
+    """Get the output directory, using centralized config with fallbacks.
+    
+    Priority:
+    1. LAST30DAYS_OUTPUT_DIR environment variable
+    2. ~/.local/share/last30days/out (XDG default)
+    3. System temp directory as fallback
+    """
+    return env.get_output_dir()
+
+
+# Legacy module-level variable for backward compatibility
 OUTPUT_DIR = Path.home() / ".local" / "share" / "last30days" / "out"
 
 
@@ -44,17 +58,14 @@ def _xref_tag(item) -> str:
 
 
 def ensure_output_dir():
-    """Ensure output directory exists. Supports env override and sandbox fallback."""
-    global OUTPUT_DIR
-    env_dir = os.environ.get("LAST30DAYS_OUTPUT_DIR")
-    if env_dir:
-        OUTPUT_DIR = Path(env_dir)
-
-    try:
-        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        OUTPUT_DIR = Path(tempfile.gettempdir()) / "last30days" / "out"
-        OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    """Ensure output directory exists. Uses centralized config with fallbacks.
+    
+    The actual path is determined by _get_output_dir() which supports:
+    - LAST30DAYS_OUTPUT_DIR environment variable
+    - XDG default: ~/.local/share/last30days/out
+    - Temp directory fallback
+    """
+    _get_output_dir()  # This creates the directory via get_output_dir()
 
 
 def _assess_data_freshness(report: schema.Report) -> dict:
@@ -118,7 +129,10 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
         lines.append("- `SCRAPECREATORS_API_KEY` → Reddit + TikTok + Instagram (one key, all three!) — real upvotes, comments, views")
         lines.append("- `XAI_API_KEY` → X posts with real likes & reposts")
         lines.append("- `OPENAI_API_KEY` (legacy) → Reddit threads (slower, higher cost)")
-        lines.append("- Edit `~/.config/last30days/.env` to add keys")
+        # Show actual config path
+        config_file = env.get_config_file()
+        config_path = str(config_file) if config_file else "~/.config/last30days/.env"
+        lines.append(f"- Edit `{config_path}` to add keys")
         lines.append("---")
         lines.append("")
 
@@ -964,33 +978,34 @@ def write_outputs(
         raw_reddit_enriched: Raw enriched Reddit thread data
     """
     ensure_output_dir()
+    output_dir = _get_output_dir()
 
     # report.json
-    with open(OUTPUT_DIR / "report.json", 'w') as f:
+    with open(output_dir / "report.json", 'w') as f:
         json.dump(report.to_dict(), f, indent=2)
 
     # report.md
-    with open(OUTPUT_DIR / "report.md", 'w') as f:
+    with open(output_dir / "report.md", 'w') as f:
         f.write(render_full_report(report))
 
     # last30days.context.md
-    with open(OUTPUT_DIR / "last30days.context.md", 'w') as f:
+    with open(output_dir / "last30days.context.md", 'w') as f:
         f.write(render_context_snippet(report))
 
     # Raw responses
     if raw_openai:
-        with open(OUTPUT_DIR / "raw_openai.json", 'w') as f:
+        with open(output_dir / "raw_openai.json", 'w') as f:
             json.dump(raw_openai, f, indent=2)
 
     if raw_xai:
-        with open(OUTPUT_DIR / "raw_xai.json", 'w') as f:
+        with open(output_dir / "raw_xai.json", 'w') as f:
             json.dump(raw_xai, f, indent=2)
 
     if raw_reddit_enriched:
-        with open(OUTPUT_DIR / "raw_reddit_threads_enriched.json", 'w') as f:
+        with open(output_dir / "raw_reddit_threads_enriched.json", 'w') as f:
             json.dump(raw_reddit_enriched, f, indent=2)
 
 
 def get_context_path() -> str:
-    """Get path to context file."""
-    return str(OUTPUT_DIR / "last30days.context.md")
+    """Get path to context file. Uses centralized output directory config."""
+    return str(_get_output_dir() / "last30days.context.md")

--- a/scripts/lib/ui.py
+++ b/scripts/lib/ui.py
@@ -6,6 +6,9 @@ import threading
 import random
 from typing import Optional
 
+# Import path configuration for dynamic path display
+from . import env
+
 # Check if we're in a real terminal (not captured by Claude Code)
 IS_TTY = sys.stderr.isatty()
 
@@ -146,7 +149,46 @@ PROMO_SINGLE_KEY = {
     "x": "\n💡 You can unlock X with AUTH_TOKEN/CT0 or XAI_API_KEY - just ask me how.\n",
 }
 
-# Bird auth help (for local users with vendored Bird CLI)
+
+def _get_config_path_display() -> str:
+    """Get a display-friendly config path for UI messages.
+    
+    Returns the actual config file path if available, or a fallback string.
+    """
+    config_file = env.get_config_file()
+    if config_file:
+        return str(config_file)
+    return "~/.config/last30days/.env"
+
+
+def _get_bird_auth_help(use_colors: bool = True) -> str:
+    """Generate Bird auth help text with the actual config path.
+    
+    Args:
+        use_colors: If True, use ANSI color codes
+    
+    Returns:
+        Help text string with the actual config path
+    """
+    config_path = _get_config_path_display()
+    if use_colors:
+        return f"""
+{Colors.YELLOW}Bird authentication failed.{Colors.RESET}
+
+To fix this:
+1. Add AUTH_TOKEN and CT0 to {config_path} or .claude/last30days.env
+2. Or set XAI_API_KEY for the xAI fallback backend
+"""
+    return f"""
+Bird authentication failed.
+
+To fix this:
+1. Add AUTH_TOKEN and CT0 to {config_path} or .claude/last30days.env
+2. Or set XAI_API_KEY for the xAI fallback backend
+"""
+
+
+# Legacy constants for backward compatibility (use functions above instead)
 BIRD_AUTH_HELP = f"""
 {Colors.YELLOW}Bird authentication failed.{Colors.RESET}
 
@@ -409,11 +451,8 @@ class ProgressDisplay:
         sys.stderr.flush()
 
     def show_bird_auth_help(self):
-        """Show Bird authentication help."""
-        if IS_TTY:
-            sys.stderr.write(BIRD_AUTH_HELP)
-        else:
-            sys.stderr.write(BIRD_AUTH_HELP_PLAIN)
+        """Show Bird authentication help with actual config path."""
+        sys.stderr.write(_get_bird_auth_help(use_colors=IS_TTY))
         sys.stderr.flush()
 
 
@@ -437,6 +476,14 @@ def show_diagnostic_banner(diag: dict):
     if has_reddit and has_x and has_youtube and has_web:
         return
 
+    # Get the actual config path for display
+    config_path = _get_config_path_display()
+    
+    # Truncate config path if too long for banner width
+    max_config_len = 30
+    if len(config_path) > max_config_len:
+        config_path = "..." + config_path[-(max_config_len-3):]
+
     lines = []
 
     if IS_TTY:
@@ -451,7 +498,8 @@ def show_diagnostic_banner(diag: dict):
             lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.GREEN}✅ Reddit{Colors.RESET}    — Public Reddit search (no key)       {Colors.DIM}│{Colors.RESET}")
         else:
             lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.RED}❌ Reddit{Colors.RESET}    — No OPENAI_API_KEY                    {Colors.DIM}│{Colors.RESET}")
-            lines.append(f"{Colors.DIM}│{Colors.RESET}     └─ Add to ~/.config/last30days/.env            {Colors.DIM}│{Colors.RESET}")
+            add_msg = f"Add to {config_path}"
+            lines.append(f"{Colors.DIM}│{Colors.RESET}     └─ {add_msg:<38}{Colors.DIM}│{Colors.RESET}")
 
         # X/Twitter
         if has_x:
@@ -487,7 +535,8 @@ def show_diagnostic_banner(diag: dict):
             lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.YELLOW}⚡ Web{Colors.RESET}       — Using assistant's search tool       {Colors.DIM}│{Colors.RESET}")
 
         lines.append(f"{Colors.DIM}│{Colors.RESET}                                                     {Colors.DIM}│{Colors.RESET}")
-        lines.append(f"{Colors.DIM}│{Colors.RESET}  Config: {Colors.BOLD}~/.config/last30days/.env{Colors.RESET}                  {Colors.DIM}│{Colors.RESET}")
+        config_line = f"Config: {config_path}"
+        lines.append(f"{Colors.DIM}│{Colors.RESET}  {config_line:<43}{Colors.DIM}│{Colors.RESET}")
         lines.append(f"{Colors.DIM}└─────────────────────────────────────────────────────┘{Colors.RESET}")
     else:
         # Plain text for non-TTY (Claude Code / Codex)
@@ -501,7 +550,8 @@ def show_diagnostic_banner(diag: dict):
             lines.append("│  ✅ Reddit    — Public Reddit search (no key)       │")
         else:
             lines.append("│  ❌ Reddit    — No OPENAI_API_KEY                    │")
-            lines.append("│     └─ Add to ~/.config/last30days/.env            │")
+            add_msg = f"Add to {config_path}"
+            lines.append(f"│     └─ {add_msg:<38}│")
 
         if has_x:
             lines.append("│  ✅ X/Twitter — available                            │")
@@ -529,7 +579,7 @@ def show_diagnostic_banner(diag: dict):
             lines.append("│  ⚡ Web       — Using assistant's search tool       │")
 
         lines.append("│                                                     │")
-        lines.append("│  Config: ~/.config/last30days/.env                  │")
+        lines.append(f"│  Config: {config_path:<43}│")
         lines.append("└─────────────────────────────────────────────────────┘")
 
     sys.stderr.write("\n".join(lines) + "\n\n")

--- a/scripts/store.py
+++ b/scripts/store.py
@@ -7,7 +7,8 @@ Stores topics, research runs, and findings with:
 - URL-based dedup with engagement metric updates on re-sighting
 - Lightweight schema migrations without external dependencies
 
-Database location: ~/.local/share/last30days/research.db
+Database location: Configurable via LAST30DAYS_DATABASE_PATH or LAST30DAYS_DATA_DIR
+                   Default: ~/.local/share/last30days/research.db
 """
 
 import argparse
@@ -18,6 +19,10 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# Import path configuration from env module
+from lib.env import get_database_path, get_data_dir
+
+# Module-level defaults for backward compatibility
 DB_DIR = Path.home() / ".local" / "share" / "last30days"
 DB_PATH = DB_DIR / "research.db"
 
@@ -26,7 +31,17 @@ _db_override = None
 
 
 def _get_db_path() -> Path:
-    return _db_override or DB_PATH
+    """Get the database path, using override or centralized config.
+    
+    Priority:
+    1. Test override (_db_override)
+    2. LAST30DAYS_DATABASE_PATH environment variable
+    3. LAST30DAYS_DATA_DIR environment variable + /research.db
+    4. Default: ~/.local/share/last30days/research.db
+    """
+    if _db_override:
+        return _db_override
+    return get_database_path()
 
 
 SCHEMA_V1 = """


### PR DESCRIPTION
## Summary

This PR fixes hardcoded path issues throughout the codebase by implementing a centralized path configuration system with environment variable support.

## Changes

### Core Path Configuration (`scripts/lib/env.py`)
- Added centralized path functions that support environment variable overrides
- Implemented XDG Base Directory specification compliance
- Added fallback to temp directories when permission denied

### Environment Variables Supported
| Variable | Default | Description |
|----------|---------|-------------|
| `LAST30DAYS_CONFIG_DIR` | `~/.config/last30days` | Config directory |
| `LAST30DAYS_DATA_DIR` | `~/.local/share/last30days` | Data directory for database |
| `LAST30DAYS_DATABASE_PATH` | `{DATA_DIR}/research.db` | Full database path |
| `LAST30DAYS_CACHE_DIR` | `~/.cache/last30days` | Cache directory |
| `LAST30DAYS_OUTPUT_DIR` | `~/.local/share/last30days/out` | Output directory |
| `LAST30DAYS_BRIEFS_DIR` | `~/.local/share/last30days/briefs` | Briefings directory |

### Files Modified
- `scripts/lib/env.py` - Added path configuration functions
- `scripts/store.py` - Updated to use `get_database_path()`
- `scripts/lib/cache.py` - Updated to use `get_cache_dir()`
- `scripts/lib/render.py` - Updated to use `get_output_dir()`
- `scripts/last30days.py` - Updated help string for `--store`
- `scripts/lib/ui.py` - Updated to dynamically show config paths
- `scripts/briefing.py` - Updated to use `get_briefs_dir()`
- `README.md` - Added path customization documentation

## Benefits
1. **Portability** - Users can now customize storage locations for different environments (containers, shared systems, etc.)
2. **XDG Compliance** - Follows the XDG Base Directory specification
3. **Graceful Fallback** - Automatically falls back to temp directories if permission denied
4. **Backward Compatible** - All existing defaults are preserved

## Testing
All modified Python files compile successfully without errors.