### PR TITLE
Warn about unreliable YouTube auto-captions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -240,7 +240,7 @@ The script will automatically:
 
 **Read the ENTIRE output.** It contains EIGHT data sections in this order: Reddit items, X items, YouTube items, TikTok items, Instagram Reels items, Hacker News items, Polymarket items, and WebSearch items. If you miss sections, you will produce incomplete stats.
 
-**YouTube items in the output look like:** `**{video_id}** (score:N) {channel_name} [N views, N likes]` followed by a title, URL, **transcript highlights** (pre-extracted quotable excerpts from the video), and an optional full transcript in a collapsible section. **Quote the highlights directly in your synthesis** - they are the YouTube equivalent of Reddit top comments. Attribute quotes to the channel name. Count them and include them in your synthesis and stats block.
+**YouTube items in the output look like:** `**{video_id}** (score:N) {channel_name} [N views, N likes]` followed by a title, URL, **auto-caption transcript highlights** (pre-extracted quotable excerpts from the video), and an optional full transcript in a collapsible section. **Use the highlights in your synthesis, but treat them as auto-generated captions that can be wrong.** Attribute quotes to the channel name, and if a phrase looks unusual or domain-incorrect, frame it as tentative or skip it unless corroborated elsewhere. Count YouTube items in your synthesis and stats block.
 
 **TikTok items in the output look like:** `**{TK_id}** (score:N) @{creator} [N views, N likes]` followed by a caption, URL, hashtags, and optional caption snippet. Count them and include them in your synthesis and stats block.
 
@@ -303,7 +303,7 @@ The Judge Agent must:
 3. Weight TikTok sources HIGH (they have views, likes, and caption content — viral signal)
 4. Weight WebSearch sources LOWER (no engagement data)
 5. **For Reddit: Pay special attention to top comments** — they often contain the wittiest, most insightful, or funniest take. When a top comment has high upvotes (shown as `💬 Top comment (N upvotes)`), quote it directly in your synthesis. Reddit's value is in the comments.
-6. **For YouTube: Quote transcript highlights directly in your synthesis.** These are pre-extracted key moments from the video - treat them like Reddit top comments. Attribute to the channel name and include the actual quote. YouTube's value is in what creators SAY, not just their view counts.
+6. **For YouTube: Use transcript highlights carefully in your synthesis.** These are pre-extracted key moments from auto-generated captions, so they can contain homophone/speech-to-text mistakes. Quote them only when they make sense in context, attribute them to the channel name, and avoid building a theory around a weird phrase unless another source supports it. YouTube's value is in what creators SAY, not just their view counts.
 7. Identify patterns that appear across ALL sources (strongest signals)
 8. Note any contradictions between sources
 9. Extract the top 3-5 actionable insights
@@ -346,6 +346,8 @@ Read the research output carefully. Pay attention to:
 - **What the sources actually say**, not what you assume the topic is about
 
 **ANTI-PATTERN TO AVOID**: If user asks about "clawdbot skills" and research returns ClawdBot content (self-hosted AI agent), do NOT synthesize this as "Claude Code skills" just because both involve "skills". Read what the research actually says.
+
+**ANTI-PATTERN TO AVOID**: If a YouTube auto-caption says something odd like a strange term, brand, or phrase that does not fit the rest of the research, do NOT rationalize it into a concept. Treat it as a likely transcription error first, especially for homophones. Prefer corroborated language from Reddit/X/web sources or the surrounding transcript context.
 
 ### If QUERY_TYPE = RECOMMENDATIONS
 

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -240,6 +240,8 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
     elif report.youtube:
         lines.append("### YouTube Videos")
         lines.append("")
+        lines.append("*Note: YouTube transcripts/highlights come from auto-generated captions and may contain speech-to-text mistakes. Treat odd phrases as unverified until corroborated elsewhere.*")
+        lines.append("")
         for item in report.youtube[:limit]:
             eng_str = ""
             if item.engagement:
@@ -258,12 +260,12 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
             lines.append(f"  {item.title}")
             lines.append(f"  {item.url}")
             if item.transcript_highlights:
-                lines.append("  Highlights:")
+                lines.append("  Auto-caption highlights:")
                 for hl in item.transcript_highlights[:5]:
                     lines.append(f'    - "{hl}"')
             if item.transcript_snippet:
                 word_count = len(item.transcript_snippet.split())
-                lines.append(f"  <details><summary>Full transcript ({word_count} words)</summary>")
+                lines.append(f"  <details><summary>Auto-generated transcript ({word_count} words, may contain errors)</summary>")
                 lines.append(f"  {item.transcript_snippet}")
                 lines.append("  </details>")
             lines.append(f"  *{item.why_relevant}*")

--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -90,6 +90,34 @@ def _log(msg: str):
     sys.stderr.flush()
 
 
+def _terminate_process(proc: subprocess.Popen) -> None:
+    """Terminate a spawned yt-dlp process safely across platforms."""
+    try:
+        if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.kill()
+    except (ProcessLookupError, PermissionError, OSError, AttributeError):
+        proc.kill()
+
+
+def _get_proxy_url() -> Optional[str]:
+    """Return the first configured proxy URL from common environment variables."""
+    for key in ("ALL_PROXY", "all_proxy", "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"):
+        value = os.environ.get(key)
+        if value:
+            return value
+    return None
+
+
+def _build_ytdlp_command(base_cmd: List[str]) -> List[str]:
+    """Inject proxy args into a yt-dlp command when proxy env vars are set."""
+    proxy_url = _get_proxy_url()
+    if proxy_url:
+        return [base_cmd[0], "--proxy", proxy_url, *base_cmd[1:]]
+    return base_cmd
+
+
 def is_ytdlp_installed() -> bool:
     """Check if yt-dlp is available in PATH."""
     return shutil.which("yt-dlp") is not None
@@ -144,7 +172,7 @@ def search_youtube(
     # NOTE: --dateafter intentionally omitted — YouTube search returns
     # relevance-sorted results and strict date filtering returns 0 for
     # evergreen topics. Python soft filter (below) handles date filtering.
-    cmd = [
+    cmd = _build_ytdlp_command([
         "yt-dlp",
         "--ignore-config",
         "--no-cookies-from-browser",
@@ -152,7 +180,7 @@ def search_youtube(
         "--dump-json",
         "--no-warnings",
         "--no-download",
-    ]
+    ])
 
     preexec = os.setsid if hasattr(os, 'setsid') else None
 
@@ -167,10 +195,7 @@ def search_youtube(
         try:
             stdout, stderr = proc.communicate(timeout=120)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
-                proc.kill()
+            _terminate_process(proc)
             proc.wait(timeout=5)
             _log("YouTube search timed out (120s)")
             return {"items": [], "error": "Search timed out"}
@@ -265,7 +290,7 @@ def fetch_transcript(video_id: str, temp_dir: str) -> Optional[str]:
     Returns:
         Plaintext transcript string, or None if no captions available.
     """
-    cmd = [
+    cmd = _build_ytdlp_command([
         "yt-dlp",
         "--ignore-config",
         "--no-cookies-from-browser",
@@ -276,7 +301,7 @@ def fetch_transcript(video_id: str, temp_dir: str) -> Optional[str]:
         "--no-warnings",
         "-o", f"{temp_dir}/%(id)s",
         f"https://www.youtube.com/watch?v={video_id}",
-    ]
+    ])
 
     preexec = os.setsid if hasattr(os, 'setsid') else None
 
@@ -291,10 +316,7 @@ def fetch_transcript(video_id: str, temp_dir: str) -> Optional[str]:
         try:
             proc.communicate(timeout=30)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
-                proc.kill()
+            _terminate_process(proc)
             proc.wait(timeout=5)
             return None
     except FileNotFoundError:

--- a/variants/open/references/research.md
+++ b/variants/open/references/research.md
@@ -86,6 +86,7 @@ Rules:
 4. Identify cross-source patterns (strongest signals)
 5. Extract top 3-5 actionable insights
 6. **Prediction markets are high-signal when relevant** - real money on outcomes cuts through opinion. Prefer structural/long-term markets (championship > regular season, regime change > near-term deadline). When the topic is an outcome in a multi-outcome market, call out that specific outcome's odds and movement. Weave odds into narrative: "Polymarket has X at Y% (up/down Z%)"
+7. **Treat YouTube transcript text as auto-generated captions, not ground truth.** If a quoted phrase looks odd, domain-incorrect, or suspiciously homophonic, do not build your synthesis around it unless the broader transcript or another source confirms it.
 
 **Ground synthesis in ACTUAL research, not pre-existing knowledge.**
 


### PR DESCRIPTION
## Summary

This PR adds guardrails for unreliable YouTube auto-captions.

It updates the rendered output to clearly label YouTube transcript text as auto-generated and potentially error-prone, and updates the synthesis instructions to avoid treating suspicious caption phrases as real concepts unless they are corroborated elsewhere.

It also makes `yt-dlp` respect common proxy environment variables and fixes Windows timeout cleanup in the YouTube subprocess path.

## Why

Issue #82 describes a case where a YouTube auto-caption misheard `basal fears` as `basil fears`, and the downstream synthesis treated the mistaken phrase like a real concept.

I was able to reproduce the caption issue on the `Guryan Tighe` query, so this PR focuses on making those transcript artifacts more explicit and less likely to be over-interpreted.
