### PR TITLE
Normalize Reddit subreddit names before rendering

### DIFF
--- a/scripts/lib/entity_extract.py
+++ b/scripts/lib/entity_extract.py
@@ -106,7 +106,12 @@ def _extract_subreddits(reddit_items: List[Dict[str, Any]]) -> List[str]:
 
     for item in reddit_items:
         # Primary subreddit
-        sub = item.get("subreddit", "").strip().lstrip("r/")
+        raw_sub = item.get("subreddit", "")
+        if isinstance(raw_sub, dict):
+            sub = raw_sub.get("name") or raw_sub.get("display_name") or raw_sub.get("subreddit") or ""
+        else:
+            sub = raw_sub
+        sub = str(sub).strip().lstrip("r/")
         if sub:
             sub_counts[sub] += 1
 

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -7,6 +7,18 @@ from . import dates, schema
 T = TypeVar("T", schema.RedditItem, schema.XItem, schema.WebSearchItem, schema.YouTubeItem, schema.TikTokItem, schema.InstagramItem, schema.HackerNewsItem, schema.BlueskyItem, schema.PolymarketItem)
 
 
+def _coerce_subreddit_name(value: Any) -> str:
+    """Normalize subreddit values into a clean subreddit name."""
+    if isinstance(value, str):
+        return value.strip().lstrip("r/")
+    if isinstance(value, dict):
+        for key in ("name", "display_name", "subreddit", "title", "id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip().lstrip("r/")
+    return ""
+
+
 def filter_by_date_range(
     items: List[T],
     from_date: str,
@@ -94,7 +106,7 @@ def normalize_reddit_items(
             id=item.get("id", ""),
             title=item.get("title", ""),
             url=item.get("url", ""),
-            subreddit=item.get("subreddit", ""),
+            subreddit=_coerce_subreddit_name(item.get("subreddit", "")),
             date=date_str,
             date_confidence=date_confidence,
             engagement=engagement,

--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -25,6 +25,18 @@ def _log_info(msg: str):
     sys.stderr.flush()
 
 
+def _coerce_subreddit_name(value: Any) -> str:
+    """Normalize subreddit values into a clean subreddit name."""
+    if isinstance(value, str):
+        return value.strip().lstrip("r/")
+    if isinstance(value, dict):
+        for key in ("name", "display_name", "subreddit", "title", "id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip().lstrip("r/")
+    return ""
+
+
 def _is_model_access_error(error: http.HTTPError) -> bool:
     """Check if error is due to model access/verification issues."""
     if error.status_code not in (400, 403):
@@ -427,7 +439,7 @@ def search_reddit_public(
                     "id": f"R{len(all_items)+1}",
                     "title": str(post.get("title", "")).strip(),
                     "url": full_url,
-                    "subreddit": str(post.get("subreddit", "")).strip(),
+                    "subreddit": _coerce_subreddit_name(post.get("subreddit", "")),
                     "date": date_value,
                     "why_relevant": "Found via Reddit public search",
                     "relevance": _public_relevance(score, num_comments),
@@ -508,7 +520,7 @@ def search_subreddits(
                     "id": f"RS{len(all_items)+1}",
                     "title": str(post.get("title", "")).strip(),
                     "url": f"https://www.reddit.com{permalink}",
-                    "subreddit": str(post.get("subreddit", sub)).strip(),
+                    "subreddit": _coerce_subreddit_name(post.get("subreddit", sub)) or sub.lstrip("r/"),
                     "date": None,
                     "why_relevant": f"Found in r/{sub} supplemental search",
                     "relevance": 0.65,  # Slightly lower default for supplemental
@@ -615,7 +627,7 @@ def parse_reddit_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
             "id": f"R{i+1}",
             "title": str(item.get("title", "")).strip(),
             "url": url,
-            "subreddit": str(item.get("subreddit", "")).strip().lstrip("r/"),
+            "subreddit": _coerce_subreddit_name(item.get("subreddit", "")),
             "date": item.get("date"),
             "why_relevant": str(item.get("why_relevant", "")).strip(),
             "relevance": min(1.0, max(0.0, float(item.get("relevance", 0.5)))),

--- a/scripts/lib/reddit.py
+++ b/scripts/lib/reddit.py
@@ -73,6 +73,18 @@ def _log(msg: str):
     sys.stderr.flush()
 
 
+def _coerce_subreddit_name(value: Any) -> str:
+    """Normalize subreddit values from APIs into a clean subreddit name."""
+    if isinstance(value, str):
+        return value.strip().lstrip("r/")
+    if isinstance(value, dict):
+        for key in ("name", "display_name", "subreddit", "title", "id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip().lstrip("r/")
+    return ""
+
+
 def _sc_headers(token: str) -> Dict[str, str]:
     """Build ScrapeCreators request headers."""
     return {
@@ -153,7 +165,7 @@ def discover_subreddits(
 
     scores = Counter()
     for post in results:
-        sub = post.get("subreddit", "")
+        sub = _coerce_subreddit_name(post.get("subreddit", ""))
         if not sub:
             continue
 
@@ -211,7 +223,7 @@ def _normalize_post(post: Dict[str, Any], idx: int, source_label: str = "global"
         "reddit_id": post.get("id", ""),
         "title": title,
         "url": url,
-        "subreddit": str(post.get("subreddit", "")).strip(),
+        "subreddit": _coerce_subreddit_name(post.get("subreddit", "")),
         "date": _parse_date(post.get("created_utc")),
         "engagement": {
             "score": post.get("ups") or post.get("score", 0),


### PR DESCRIPTION
## Summary

This fixes a Reddit formatting bug where subreddit values can show up as object/dict strings in the rendered output instead of clean subreddit names.

For example, instead of rendering something like `r/openclaw`, the output could render `r/{'id': 't5_...', 'name': 'openclaw', ...}` when the upstream Reddit result returned a structured subreddit object.

## What changed

- Normalize Reddit subreddit values to a clean subreddit name before rendering
- Handle both string and dict/object-shaped subreddit values
- Apply the normalization across the Reddit search/parse/normalize path so downstream rendering and entity extraction stay consistent

## Why

Issue #100 mentions cases where subreddit names are rendered incorrectly in the output. This PR fixes that user-visible formatting bug directly.
