### PR TITLE
fix: include youtube in freshness calculation (#108)

### DIFF
--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -69,9 +69,10 @@ def _assess_data_freshness(report: schema.Report) -> dict:
 
     tiktok_recent = sum(1 for t in report.tiktok if t.date and t.date >= report.range_from)
     ig_recent = sum(1 for ig in report.instagram if ig.date and ig.date >= report.range_from)
+    yt_recent = sum(1 for yt in report.youtube if yt.date and yt.date >= report.range_from)
 
-    total_recent = reddit_recent + x_recent + web_recent + hn_recent + bsky_recent + ts_recent + pm_recent + tiktok_recent + ig_recent
-    total_items = len(report.reddit) + len(report.x) + len(report.web) + len(report.hackernews) + len(report.bluesky) + len(report.truthsocial) + len(report.polymarket) + len(report.tiktok) + len(report.instagram)
+    total_recent = reddit_recent + x_recent + web_recent + yt_recent + hn_recent + bsky_recent + ts_recent + pm_recent + tiktok_recent + ig_recent
+    total_items = len(report.reddit) + len(report.x) + len(report.web) + len(report.youtube) + len(report.hackernews) + len(report.bluesky) + len(report.truthsocial) + len(report.polymarket) + len(report.tiktok) + len(report.instagram)
 
     return {
         "reddit_recent": reddit_recent,


### PR DESCRIPTION
## Summary

Fixes #108 by including YouTube items in the data freshness evaluation.

## Changes

- Added `yt_recent` to calculate recent YouTube videos
- Included `yt_recent` in `total_recent` sum
- Included `len(report.youtube)` in `total_items` sum

Fixes mvanhorn/last30days-skill#108