### PR TITLE
fix(reddit): prevent enrichment timeout from discarding all search results

### DIFF
--- a/scripts/lib/reddit.py
+++ b/scripts/lib/reddit.py
@@ -584,10 +584,23 @@ def search_and_enrich(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    enrich_timeout: int = 45,
 ) -> Dict[str, Any]:
     """Full Reddit pipeline: search + comment enrichment.
 
-    This is the convenience function that does everything.
+    Search results are always returned even if comment enrichment times
+    out or fails.  Previously, the enrichment phase ran synchronously
+    inside this function.  When fetching comments for the top posts was
+    slow (e.g. ScrapeCreators latency spikes), the entire function
+    could exceed the caller's 90-second future timeout, causing a
+    TimeoutError that discarded *all* search results — even though the
+    search itself had already completed successfully.
+
+    The fix runs enrichment in a dedicated thread with its own timeout
+    (default 45 s), leaving ~45 s of budget for the search phase within
+    the caller's 90-second window.  If enrichment times out or raises,
+    the search results are returned without comments rather than being
+    thrown away.
 
     Args:
         topic: Search topic
@@ -595,16 +608,34 @@ def search_and_enrich(
         to_date: End date (YYYY-MM-DD)
         depth: 'quick', 'default', or 'deep'
         token: ScrapeCreators API key
+        enrich_timeout: Max seconds for the comment-enrichment phase
+            (default 45).  Set to 0 to skip enrichment entirely.
 
     Returns:
-        Dict with 'items' list. Items include top_comments and comment_insights.
+        Dict with 'items' list. Items include top_comments and
+        comment_insights when enrichment succeeds; plain search
+        results otherwise.
     """
     result = search_reddit(topic, from_date, to_date, depth, token)
     items = result.get("items", [])
 
-    if items and token:
-        items = enrich_with_comments(items, token, depth)
-        result["items"] = items
+    if items and token and enrich_timeout > 0:
+        try:
+            from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(enrich_with_comments, items, token, depth)
+                items = future.result(timeout=enrich_timeout)
+                result["items"] = items
+        except FutureTimeout:
+            _log(
+                f"Comment enrichment timed out after {enrich_timeout}s "
+                f"— returning {len(items)} posts without comments"
+            )
+        except Exception as e:
+            _log(
+                f"Comment enrichment failed ({type(e).__name__}: {e}) "
+                f"— returning {len(items)} posts without comments"
+            )
 
     return result
 


### PR DESCRIPTION
## Summary

- **Bug:** When ScrapeCreators comment enrichment is slow, `search_and_enrich()` exceeds the caller's 90-second `ThreadPoolExecutor` timeout. The resulting `TimeoutError` discards **all** search results — even though the search phase already completed successfully (e.g. 116 posts found and deduped). The user sees `✓ Reddit Found 0 threads` despite logs showing 116 posts were found.
- **Fix:** Run `enrich_with_comments()` in a dedicated thread with its own 45-second timeout. If enrichment times out or fails, search results are returned **without comments** instead of being thrown away. Backward-compatible — no caller changes needed.

## How to reproduce

1. Run `/last30days` with a broad topic that returns many Reddit results (e.g. "best local AI models across different use cases")
2. If ScrapeCreators comment-fetch latency is high (network conditions, API load), the enrichment phase for 5 posts can take >45 seconds
3. The search phase (~30s) + enrichment (~60s) exceeds the 90s `reddit_future.result(timeout=90)` deadline in `last30days.py`
4. All Reddit results are silently discarded — output shows `**ERROR:** Reddit search timed out after 90s` and `Reddit: 0 threads`

## Root cause

`search_and_enrich()` ran `enrich_with_comments()` **synchronously** in the same call stack as the search. There was no timeout boundary between the two phases, so slow enrichment consumed the entire budget:

```
0s   — search starts (ScrapeCreators API)
~30s — search completes: 116 posts ✓
~30s — enrichment starts: fetching comments for top 5 posts
~90s — ⚡ caller's 90s timeout fires DURING enrichment
       └─ TimeoutError raised
       └─ reddit_items stays as initialized [] 
       └─ ALL 116 posts discarded
```

## Changes

**`scripts/lib/reddit.py` — `search_and_enrich()`**

- Enrichment now runs in a `ThreadPoolExecutor(max_workers=1)` with a 45-second timeout
- On `TimeoutError` or any exception: search results are preserved, a log message is emitted
- New optional `enrich_timeout` parameter (default 45s, set to 0 to skip enrichment)
- No changes to any callers required

## Test plan

- [ ] Run `/last30days` with a topic that triggers Reddit search — verify Reddit results appear in output
- [ ] Simulate slow enrichment (e.g. add `time.sleep(60)` at top of `enrich_with_comments`) — verify search results are returned without comments and log shows timeout message
- [ ] Verify `enrich_timeout=0` skips enrichment entirely
- [ ] Verify normal fast enrichment still attaches comments as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)