### PR TITLE
fix: add explicit UTF-8 encoding for file writes on Windows

### DIFF
--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -966,29 +966,29 @@ def write_outputs(
     ensure_output_dir()
 
     # report.json
-    with open(OUTPUT_DIR / "report.json", 'w') as f:
-        json.dump(report.to_dict(), f, indent=2)
+    with open(OUTPUT_DIR / "report.json", 'w', encoding='utf-8') as f:
+        json.dump(report.to_dict(), f, indent=2, ensure_ascii=False)
 
     # report.md
-    with open(OUTPUT_DIR / "report.md", 'w') as f:
+    with open(OUTPUT_DIR / "report.md", 'w', encoding='utf-8') as f:
         f.write(render_full_report(report))
 
     # last30days.context.md
-    with open(OUTPUT_DIR / "last30days.context.md", 'w') as f:
+    with open(OUTPUT_DIR / "last30days.context.md", 'w', encoding='utf-8') as f:
         f.write(render_context_snippet(report))
 
     # Raw responses
     if raw_openai:
-        with open(OUTPUT_DIR / "raw_openai.json", 'w') as f:
-            json.dump(raw_openai, f, indent=2)
+        with open(OUTPUT_DIR / "raw_openai.json", 'w', encoding='utf-8') as f:
+            json.dump(raw_openai, f, indent=2, ensure_ascii=False)
 
     if raw_xai:
-        with open(OUTPUT_DIR / "raw_xai.json", 'w') as f:
-            json.dump(raw_xai, f, indent=2)
+        with open(OUTPUT_DIR / "raw_xai.json", 'w', encoding='utf-8') as f:
+            json.dump(raw_xai, f, indent=2, ensure_ascii=False)
 
     if raw_reddit_enriched:
-        with open(OUTPUT_DIR / "raw_reddit_threads_enriched.json", 'w') as f:
-            json.dump(raw_reddit_enriched, f, indent=2)
+        with open(OUTPUT_DIR / "raw_reddit_threads_enriched.json", 'w', encoding='utf-8') as f:
+            json.dump(raw_reddit_enriched, f, indent=2, ensure_ascii=False)
 
 
 def get_context_path() -> str:


### PR DESCRIPTION
## Summary
- Fixed `UnicodeEncodeError` on Windows with non-English (e.g., Chinese/GBK) locale
- Added explicit `encoding='utf-8'` to all `open()` calls in `render.py`'s `write_outputs()` function
- Added `ensure_ascii=False` to `json.dump()` calls so non-ASCII characters are preserved correctly

## Problem
On Windows systems with Chinese locale, the default file encoding is GBK. When research output contains non-breaking spaces (`\xa0`) or other non-ASCII characters, the script crashes with:
```
UnicodeEncodeError: 'gbk' codec can't encode character '\xa0' in position 20457: illegal multibyte sequence
```

## Test plan
- [x] Tested on Windows 11 Home China (GBK default encoding)
- [x] Verified research output saves correctly to `~/Documents/Last30Days/` after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)