### PR TITLE
fix: tighten recency filtering and mode display

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1774,24 +1774,30 @@ def main():
     normalized_pm = normalize.normalize_polymarket_items(polymarket_items, from_date, to_date) if polymarket_items else []
     normalized_web = websearch.normalize_websearch_items(web_items, from_date, to_date) if web_items else []
 
-    # Hard date filter: exclude items with verified dates outside the range
-    # This is the safety net - even if prompts let old content through, this filters it
-    filtered_reddit = normalize.filter_by_date_range(normalized_reddit, from_date, to_date)
-    filtered_x = normalize.filter_by_date_range(normalized_x, from_date, to_date)
-    # YouTube: skip hard date filter — youtube_yt.py already applies a soft filter
-    # that prefers recent videos but keeps older ones for evergreen topics.
-    # YouTube content has a longer shelf life than tweets/posts.
-    filtered_youtube = normalized_youtube
-    # TikTok: hard date filter (tiktok.py already pre-filters, but safety net)
-    filtered_tiktok = normalize.filter_by_date_range(normalized_tiktok, from_date, to_date) if normalized_tiktok else []
-    # Instagram: hard date filter (instagram.py already pre-filters, but safety net)
-    filtered_ig = normalize.filter_by_date_range(normalized_ig, from_date, to_date) if normalized_ig else []
-    filtered_hn = normalize.filter_by_date_range(normalized_hn, from_date, to_date) if normalized_hn else []
-    filtered_bsky = normalize.filter_by_date_range(normalized_bsky, from_date, to_date) if normalized_bsky else []
-    filtered_ts = normalize.filter_by_date_range(normalized_ts, from_date, to_date) if normalized_ts else []
-    # Polymarket: skip hard date filter - markets are active/traded, updatedAt is fine
-    filtered_pm = normalized_pm
-    filtered_web = normalize.filter_by_date_range(normalized_web, from_date, to_date) if normalized_web else []
+    filtered_items = apply_date_safety_filters(
+        reddit_items=normalized_reddit,
+        x_items=normalized_x,
+        youtube_items=normalized_youtube,
+        tiktok_items=normalized_tiktok,
+        instagram_items=normalized_ig,
+        hackernews_items=normalized_hn,
+        bluesky_items=normalized_bsky,
+        truthsocial_items=normalized_ts,
+        polymarket_items=normalized_pm,
+        web_items=normalized_web,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    filtered_reddit = filtered_items["reddit"]
+    filtered_x = filtered_items["x"]
+    filtered_youtube = filtered_items["youtube"]
+    filtered_tiktok = filtered_items["tiktok"]
+    filtered_ig = filtered_items["instagram"]
+    filtered_hn = filtered_items["hackernews"]
+    filtered_bsky = filtered_items["bluesky"]
+    filtered_ts = filtered_items["truthsocial"]
+    filtered_pm = filtered_items["polymarket"]
+    filtered_web = filtered_items["web"]
 
     # Score items
     scored_reddit = score.score_reddit_items(filtered_reddit)
@@ -2074,6 +2080,37 @@ def output_result(
         print("results above. WebSearch items should rank LOWER than comparable")
         print("Reddit/X items (they lack engagement metrics).")
         print("="*60)
+
+
+def apply_date_safety_filters(
+    *,
+    reddit_items=None,
+    x_items=None,
+    youtube_items=None,
+    tiktok_items=None,
+    instagram_items=None,
+    hackernews_items=None,
+    bluesky_items=None,
+    truthsocial_items=None,
+    polymarket_items=None,
+    web_items=None,
+    from_date: str,
+    to_date: str,
+):
+    """Apply final date safety filters before scoring and rendering."""
+    return {
+        "reddit": normalize.filter_by_date_range(reddit_items, from_date, to_date) if reddit_items else [],
+        "x": normalize.filter_by_date_range(x_items, from_date, to_date) if x_items else [],
+        "youtube": normalize.filter_by_date_range(youtube_items, from_date, to_date) if youtube_items else [],
+        "tiktok": normalize.filter_by_date_range(tiktok_items, from_date, to_date) if tiktok_items else [],
+        "instagram": normalize.filter_by_date_range(instagram_items, from_date, to_date) if instagram_items else [],
+        "hackernews": normalize.filter_by_date_range(hackernews_items, from_date, to_date) if hackernews_items else [],
+        "bluesky": normalize.filter_by_date_range(bluesky_items, from_date, to_date) if bluesky_items else [],
+        "truthsocial": normalize.filter_by_date_range(truthsocial_items, from_date, to_date) if truthsocial_items else [],
+        # Markets stay visible even when created before the window if they are still active.
+        "polymarket": polymarket_items or [],
+        "web": normalize.filter_by_date_range(web_items, from_date, to_date) if web_items else [],
+    }
 
 
 if __name__ == "__main__":

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -84,6 +84,11 @@ def _assess_data_freshness(report: schema.Report) -> dict:
     }
 
 
+def _mode_label(report: schema.Report) -> str:
+    """Human-facing mode label that includes auxiliary sources with signal."""
+    return report.display_mode()
+
+
 def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "none") -> str:
     """Render compact output for the assistant to synthesize.
 
@@ -129,7 +134,7 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
         lines.append("")
 
     lines.append(f"**Date Range:** {report.range_from} to {report.range_to}")
-    lines.append(f"**Mode:** {report.mode}")
+    lines.append(f"**Mode:** {_mode_label(report)}")
     if report.openai_model_used:
         lines.append(f"**OpenAI Model:** {report.openai_model_used}")
     if report.xai_model_used:
@@ -715,7 +720,7 @@ def render_full_report(report: schema.Report) -> str:
     lines.append("")
     lines.append(f"**Generated:** {report.generated_at}")
     lines.append(f"**Date Range:** {report.range_from} to {report.range_to}")
-    lines.append(f"**Mode:** {report.mode}")
+    lines.append(f"**Mode:** {_mode_label(report)}")
     lines.append("")
 
     # Models

--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -514,6 +514,28 @@ class Report:
     from_cache: bool = False
     cache_age_hours: Optional[float] = None
 
+    def display_mode(self) -> str:
+        """Human-facing mode label that includes auxiliary sources with signal."""
+        label = self.mode
+        extras = []
+        if (self.youtube or self.youtube_error) and "youtube" not in label:
+            extras.append("youtube")
+        if (self.hackernews or self.hackernews_error) and "hn" not in label:
+            extras.append("hn")
+        if (self.tiktok or self.tiktok_error) and "tiktok" not in label:
+            extras.append("tiktok")
+        if (self.instagram or self.instagram_error) and "instagram" not in label:
+            extras.append("instagram")
+        if (self.bluesky or self.bluesky_error) and "bluesky" not in label:
+            extras.append("bluesky")
+        if (self.truthsocial or self.truthsocial_error) and "truthsocial" not in label:
+            extras.append("truthsocial")
+        if (self.polymarket or self.polymarket_error) and "polymarket" not in label:
+            extras.append("polymarket")
+        if extras:
+            label = f"{label} + " + " + ".join(extras)
+        return label
+
     def to_dict(self) -> Dict[str, Any]:
         d = {
             'topic': self.topic,
@@ -523,6 +545,7 @@ class Report:
             },
             'generated_at': self.generated_at,
             'mode': self.mode,
+            'display_mode': self.display_mode(),
             'openai_model_used': self.openai_model_used,
             'xai_model_used': self.xai_model_used,
             'reddit': [r.to_dict() for r in self.reddit],

--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -219,9 +219,10 @@ def search_youtube(
             "why_relevant": f"YouTube: {video.get('title', core_topic)[:60]}",
         })
 
-    # Soft date filter: prefer recent items but fall back to all if too few
+    # Soft date filter: if we found any in-range videos, keep only those.
+    # Fall back to all results only when YouTube returns zero recent matches.
     recent = [i for i in items if i["date"] and i["date"] >= from_date]
-    if len(recent) >= 3:
+    if recent:
         items = recent
         _log(f"Found {len(items)} videos within date range")
     else:

--- a/tests/test_last30days_youtube_dates.py
+++ b/tests/test_last30days_youtube_dates.py
@@ -1,0 +1,42 @@
+"""Tests for date safety filters in the main last30days pipeline."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import last30days
+from lib import schema
+
+
+class TestDateSafetyFilters(unittest.TestCase):
+    def test_youtube_items_outside_range_are_removed_before_report(self):
+        youtube_items = [
+            schema.YouTubeItem(
+                id="recent",
+                title="Recent video",
+                url="https://youtube.com/watch?v=recent",
+                channel_name="ch",
+                date="2026-03-27",
+            ),
+            schema.YouTubeItem(
+                id="old",
+                title="Old video",
+                url="https://youtube.com/watch?v=old",
+                channel_name="ch",
+                date="2025-09-20",
+            ),
+        ]
+
+        filtered = last30days.apply_date_safety_filters(
+            youtube_items=youtube_items,
+            from_date="2026-02-26",
+            to_date="2026-03-28",
+        )
+
+        self.assertEqual([item.id for item in filtered["youtube"]], ["recent"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -69,6 +69,39 @@ class TestRenderCompact(unittest.TestCase):
 
         self.assertIn("xAI key", result)
 
+    def test_mode_line_includes_auxiliary_sources_present_in_report(self):
+        report = schema.Report(
+            topic="test",
+            range_from="2026-01-01",
+            range_to="2026-01-31",
+            generated_at="2026-01-31T12:00:00Z",
+            mode="reddit-only",
+            youtube=[
+                schema.YouTubeItem(
+                    id="Y1",
+                    title="Video",
+                    url="https://youtube.com/watch?v=1",
+                    channel_name="ch",
+                    date="2026-01-15",
+                )
+            ],
+            hackernews=[
+                schema.HackerNewsItem(
+                    id="HN1",
+                    title="Story",
+                    url="https://example.com/story",
+                    hn_url="https://news.ycombinator.com/item?id=1",
+                    author="hn",
+                    date="2026-01-16",
+                    engagement=schema.Engagement(score=10, num_comments=2),
+                )
+            ],
+        )
+
+        result = render.render_compact(report)
+
+        self.assertIn("**Mode:** reddit-only + youtube + hn", result)
+
 
 class TestRenderContextSnippet(unittest.TestCase):
     def test_renders_snippet(self):

--- a/tests/test_schema_roundtrip.py
+++ b/tests/test_schema_roundtrip.py
@@ -138,5 +138,38 @@ class TestPolymarketItem(unittest.TestCase):
         self.assertEqual(d["question"], "Who wins?")
 
 
+class TestReport(unittest.TestCase):
+    def test_to_dict_includes_display_mode_for_auxiliary_sources(self):
+        report = schema.Report(
+            topic="test",
+            range_from="2026-01-01",
+            range_to="2026-01-31",
+            generated_at="2026-01-31T12:00:00Z",
+            mode="reddit-only",
+            youtube=[
+                schema.YouTubeItem(
+                    id="YT1",
+                    title="Video",
+                    url="http://youtube.com/1",
+                    channel_name="chan",
+                    date="2026-01-15",
+                )
+            ],
+            hackernews=[
+                schema.HackerNewsItem(
+                    id="HN1",
+                    title="Story",
+                    url="http://example.com/story",
+                    hn_url="http://news.ycombinator.com/item?id=1",
+                    author="pg",
+                    date="2026-01-16",
+                )
+            ],
+        )
+
+        d = report.to_dict()
+        self.assertEqual(d["display_mode"], "reddit-only + youtube + hn")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -23,6 +23,19 @@ class _DummyProc:
         return 0
 
 
+class _JsonProc:
+    def __init__(self, lines):
+        self.pid = 12345
+        self.returncode = 0
+        self._stdout = "\n".join(lines)
+
+    def communicate(self, timeout=None):
+        return self._stdout, ""
+
+    def wait(self, timeout=None):
+        return 0
+
+
 class TestYtDlpFlags(unittest.TestCase):
     def test_search_ignores_global_config_and_browser_cookies(self):
         proc = _DummyProc()
@@ -33,6 +46,27 @@ class TestYtDlpFlags(unittest.TestCase):
         cmd = popen_mock.call_args.args[0]
         self.assertIn("--ignore-config", cmd)
         self.assertIn("--no-cookies-from-browser", cmd)
+
+    def test_search_prefers_only_in_range_results_when_recent_exist(self):
+        recent = (
+            '{"id":"recent1","title":"Recent video","channel":"ch",'
+            '"view_count":100,"like_count":10,"comment_count":1,"upload_date":"20260327"}'
+        )
+        old_1 = (
+            '{"id":"old1","title":"Old video 1","channel":"ch",'
+            '"view_count":9999,"like_count":500,"comment_count":50,"upload_date":"20250920"}'
+        )
+        old_2 = (
+            '{"id":"old2","title":"Old video 2","channel":"ch",'
+            '"view_count":8888,"like_count":400,"comment_count":40,"upload_date":"20250820"}'
+        )
+        proc = _JsonProc([recent, old_1, old_2])
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True), \
+             mock.patch.object(youtube_yt.subprocess, "Popen", return_value=proc):
+            result = youtube_yt.search_youtube("AI video tools", "2026-02-26", "2026-03-28", depth="quick")
+
+        self.assertEqual(len(result["items"]), 1)
+        self.assertEqual(result["items"][0]["video_id"], "recent1")
 
     def test_transcript_fetch_ignores_global_config_and_browser_cookies(self):
         proc = _DummyProc()


### PR DESCRIPTION
## Summary
- tighten YouTube recency handling so in-range videos are preferred and final report filtering drops out-of-window results
- make compact mode display include auxiliary sources like YouTube and HN when they contribute signal
- add display_mode to JSON output while keeping raw mode for internal/source-gating semantics

## Verification
- python3 -m unittest tests.test_youtube_yt tests.test_last30days_youtube_dates tests.test_schema_roundtrip tests.test_render tests.test_smoke.TestMockMode -v
- python3 ~/.agents/skills/last30days/scripts/last30days.py "AI video tools" --quick --emit=compact
- python3 ~/.agents/skills/last30days/scripts/last30days.py "AI video tools" --quick --emit=json