### PR TITLE
fix: add AttributeError to subprocess cleanup (Windows compatibility)

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -102,7 +102,7 @@ def _cleanup_children():
     for pid in pids:
         try:
             os.killpg(os.getpgid(pid), signal.SIGTERM)
-        except (ProcessLookupError, PermissionError, OSError):
+        except (ProcessLookupError, PermissionError, OSError, AttributeError):
             pass
 
 

--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -192,7 +192,7 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
             # Kill the entire process group
             try:
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
+            except (ProcessLookupError, PermissionError, OSError, AttributeError):
                 proc.kill()
             proc.wait(timeout=5)
             return {"error": f"Search timed out after {timeout}s", "items": []}
@@ -341,7 +341,7 @@ def search_handles(
             except subprocess.TimeoutExpired:
                 try:
                     os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-                except (ProcessLookupError, PermissionError, OSError):
+                except (ProcessLookupError, PermissionError, OSError, AttributeError):
                     proc.kill()
                 proc.wait(timeout=5)
                 _log(f"Handle search timed out for @{handle}")


### PR DESCRIPTION
## Fix Issue #110: Windows subprocess timeout cleanup still breaks

**Problem:** On Windows, `os.killpg` and `os.getpgid` are not available (or may not work correctly). When these Unix-only functions are called, they raise `AttributeError`, which was not being caught. This caused subprocess timeout cleanup to fail on Windows.

**Root Cause:** The existing YouTube fix added exception handling for `ProcessLookupError, PermissionError, OSError`, but did not include `AttributeError`. On Windows, calling `os.killpg` or `os.getpgid` raises `AttributeError` since these functions don't exist on Windows.

**Fix:** Add `AttributeError` to the exception tuple in all three remaining spots that still used the Unix-only pattern:
- `scripts/last30days.py` (`_cleanup_children` function)
- `scripts/lib/bird_x.py` (`_run_bird_search` function)
- `scripts/lib/bird_x.py` (`search_handles` function)

This matches the pattern already used in `scripts/lib/youtube_yt.py` and ensures the fallback `proc.kill()` is called on Windows instead of crashing.