### PR TITLE
feat: add browser cookie extraction modules

### DIFF
--- a/scripts/lib/chrome_cookies.py
+++ b/scripts/lib/chrome_cookies.py
@@ -1,0 +1,265 @@
+"""Chrome cookie extraction for macOS.
+
+Extracts cookies from Chrome's encrypted SQLite database using only stdlib
+modules and the system openssl CLI (ships with macOS). Zero pip dependencies.
+
+Chrome on macOS uses v10 encryption (AES-128-CBC with Keychain-stored key).
+This is NOT affected by Windows App-Bound Encryption (v20).
+"""
+
+import hashlib
+import logging
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Chrome cookie DB location on macOS
+CHROME_COOKIES_DB = Path.home() / "Library" / "Application Support" / "Google" / "Chrome" / "Default" / "Cookies"
+
+# Chrome v10 encryption constants
+CHROME_SALT = b"saltysalt"
+CHROME_PBKDF2_ITERATIONS = 1003
+CHROME_KEY_LENGTH = 16
+# IV is 16 space characters (0x20)
+CHROME_IV_HEX = "20" * 16
+
+
+def _get_chrome_encryption_key() -> Optional[bytes]:
+    """Retrieve Chrome's encryption passphrase from macOS Keychain.
+
+    Calls `security find-generic-password` which may trigger a system dialog
+    on first access.
+
+    Returns the raw passphrase bytes, or None on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-w", "-s", "Chrome Safe Storage"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            logger.info("Chrome Keychain access denied or Chrome not installed: %s", result.stderr.strip())
+            return None
+        passphrase = result.stdout.strip()
+        if not passphrase:
+            logger.info("Chrome Keychain returned empty passphrase")
+            return None
+        return passphrase.encode("utf-8")
+    except FileNotFoundError:
+        logger.info("'security' command not found — not on macOS?")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.info("Chrome Keychain access timed out")
+        return None
+    except Exception as e:
+        logger.info("Failed to get Chrome encryption key: %s", e)
+        return None
+
+
+def _derive_aes_key(passphrase: bytes) -> bytes:
+    """Derive 16-byte AES key from Chrome's Keychain passphrase via PBKDF2."""
+    return hashlib.pbkdf2_hmac(
+        "sha1",
+        passphrase,
+        CHROME_SALT,
+        CHROME_PBKDF2_ITERATIONS,
+        dklen=CHROME_KEY_LENGTH,
+    )
+
+
+def _decrypt_v10_value(encrypted_value: bytes, aes_key: bytes, db_version: int) -> Optional[str]:
+    """Decrypt a Chrome v10-encrypted cookie value.
+
+    Uses system openssl CLI for AES-128-CBC decryption (zero pip deps).
+    For Chrome 130+ (db_version >= 24), strips 32-byte SHA-256 prefix after decryption.
+
+    Returns decrypted string or None on failure.
+    """
+    # Strip the 'v10' prefix
+    ciphertext = encrypted_value[3:]
+    if not ciphertext:
+        return None
+
+    hex_key = aes_key.hex()
+
+    try:
+        result = subprocess.run(
+            [
+                "openssl", "enc", "-aes-128-cbc", "-d",
+                "-K", hex_key,
+                "-iv", CHROME_IV_HEX,
+                "-nopad",
+            ],
+            input=ciphertext,
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            logger.debug("openssl decryption failed: %s", result.stderr.decode(errors="replace").strip())
+            return None
+
+        decrypted = result.stdout
+        if not decrypted:
+            return None
+
+        # Remove PKCS7 padding
+        decrypted = _remove_pkcs7_padding(decrypted)
+        if decrypted is None:
+            return None
+
+        # Chrome 130+ (db version >= 24): strip 32-byte SHA-256 prefix
+        if db_version >= 24 and len(decrypted) > 32:
+            decrypted = decrypted[32:]
+
+        return decrypted.decode("utf-8", errors="replace")
+
+    except FileNotFoundError:
+        logger.info("openssl not found — cannot decrypt Chrome cookies")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.info("openssl decryption timed out")
+        return None
+    except Exception as e:
+        logger.debug("Chrome cookie decryption error: %s", e)
+        return None
+
+
+def _remove_pkcs7_padding(data: bytes) -> Optional[bytes]:
+    """Remove PKCS7 padding from decrypted data.
+
+    The last byte indicates the number of padding bytes added.
+    All padding bytes must have the same value.
+
+    Returns unpadded data or None if padding is invalid.
+    """
+    if not data:
+        return None
+    pad_len = data[-1]
+    if pad_len < 1 or pad_len > 16:
+        return None
+    # Verify all padding bytes match
+    if data[-pad_len:] != bytes([pad_len]) * pad_len:
+        return None
+    return data[:-pad_len]
+
+
+def _get_db_version(cursor: sqlite3.Cursor) -> int:
+    """Get Chrome cookie database version from the meta table.
+
+    Returns 0 if meta table doesn't exist or version can't be read.
+    """
+    try:
+        cursor.execute("SELECT value FROM meta WHERE key = 'version'")
+        row = cursor.fetchone()
+        if row:
+            return int(row[0])
+    except Exception:
+        pass
+    return 0
+
+
+def extract_chrome_cookies_macos(domain: str, cookie_names: list[str]) -> Optional[dict[str, str]]:
+    """Extract cookies from Chrome on macOS.
+
+    Copies the locked Cookies database to a temp file, reads specified cookies,
+    and decrypts v10-encrypted values using the Keychain-stored key.
+
+    Args:
+        domain: Cookie domain to match (e.g., ".twitter.com", ".x.com")
+        cookie_names: List of cookie names to extract
+
+    Returns:
+        Dict mapping cookie name to decrypted value, or None on failure.
+        Only includes cookies that were successfully found and decrypted.
+    """
+    if not CHROME_COOKIES_DB.exists():
+        logger.info("Chrome cookies database not found at %s", CHROME_COOKIES_DB)
+        return None
+
+    # Get encryption key from Keychain
+    passphrase = _get_chrome_encryption_key()
+    aes_key = _derive_aes_key(passphrase) if passphrase else None
+
+    # Copy DB to temp file (Chrome locks the original)
+    tmp_fd = None
+    tmp_path = None
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
+        shutil.copy2(str(CHROME_COOKIES_DB), tmp_path)
+    except Exception as e:
+        logger.info("Failed to copy Chrome cookies database: %s", e)
+        if tmp_path:
+            try:
+                Path(tmp_path).unlink(missing_ok=True)
+            except Exception:
+                pass
+        return None
+    finally:
+        if tmp_fd is not None:
+            import os
+            os.close(tmp_fd)
+
+    try:
+        conn = sqlite3.connect(tmp_path)
+        cursor = conn.cursor()
+
+        db_version = _get_db_version(cursor)
+        logger.debug("Chrome cookie DB version: %d", db_version)
+
+        # Build query with placeholders for cookie names
+        placeholders = ",".join("?" for _ in cookie_names)
+        query = (
+            f"SELECT name, value, encrypted_value FROM cookies "
+            f"WHERE host_key LIKE ? AND name IN ({placeholders})"
+        )
+        # Use LIKE for domain matching (e.g., %.twitter.com matches .twitter.com)
+        params = [f"%{domain}"] + list(cookie_names)
+        cursor.execute(query, params)
+
+        results: dict[str, str] = {}
+        for name, value, encrypted_value in cursor.fetchall():
+            # Prefer unencrypted value if present
+            if value:
+                results[name] = value
+                continue
+
+            # Handle encrypted value
+            if encrypted_value and encrypted_value[:3] == b"v10":
+                if aes_key is None:
+                    logger.debug("Skipping encrypted cookie %s — no Keychain access", name)
+                    continue
+                decrypted = _decrypt_v10_value(encrypted_value, aes_key, db_version)
+                if decrypted:
+                    results[name] = decrypted
+                else:
+                    logger.debug("Failed to decrypt cookie %s", name)
+            elif encrypted_value:
+                # Unknown encryption version
+                logger.debug("Unknown encryption for cookie %s (prefix: %r)", name, encrypted_value[:3])
+
+        conn.close()
+
+        if not results:
+            logger.info("No matching cookies found in Chrome for domain %s", domain)
+            return None
+
+        return results
+
+    except sqlite3.Error as e:
+        logger.info("Failed to read Chrome cookies database: %s", e)
+        return None
+    except Exception as e:
+        logger.info("Unexpected error reading Chrome cookies: %s", e)
+        return None
+    finally:
+        try:
+            Path(tmp_path).unlink(missing_ok=True)
+        except Exception:
+            pass

--- a/scripts/lib/cookie_extract.py
+++ b/scripts/lib/cookie_extract.py
@@ -1,0 +1,295 @@
+"""Browser cookie extraction for last30days.
+
+Extracts cookies from local browser databases (Firefox, Chrome, Safari)
+to enable zero-config authentication for services like X/Twitter.
+
+Only uses Python stdlib — no external dependencies.
+"""
+
+import configparser
+import logging
+import platform
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_firefox_profiles_dir() -> Optional[Path]:
+    """Return the Firefox profiles directory for the current platform, or None."""
+    system = platform.system()
+    if system == "Darwin":
+        path = Path.home() / "Library" / "Application Support" / "Firefox"
+    elif system == "Linux":
+        path = Path.home() / ".mozilla" / "firefox"
+    else:
+        # Windows: %APPDATA%\Mozilla\Firefox — best-effort
+        appdata = Path.home() / "AppData" / "Roaming" / "Mozilla" / "Firefox"
+        path = appdata
+    return path if path.is_dir() else None
+
+
+def _find_default_profile(profiles_dir: Path) -> Optional[Path]:
+    """Parse profiles.ini to find the default profile directory.
+
+    Looks for a section with Default=1. Falls back to the first profile
+    directory found on disk if profiles.ini is missing or malformed.
+    """
+    ini_path = profiles_dir / "profiles.ini"
+
+    if ini_path.is_file():
+        try:
+            config = configparser.ConfigParser()
+            config.read(str(ini_path), encoding="utf-8")
+
+            # First pass: look for Default=1
+            for section in config.sections():
+                if config.has_option(section, "Default") and config.get(section, "Default") == "1":
+                    return _resolve_profile_path(profiles_dir, config, section)
+
+            # Second pass: first Install* section with Default key (Firefox >= 67 format)
+            for section in config.sections():
+                if section.startswith("Install") and config.has_option(section, "Default"):
+                    raw = config.get(section, "Default")
+                    candidate = profiles_dir / raw
+                    if candidate.is_dir():
+                        return candidate
+
+            # Third pass: first Profile section that exists on disk
+            for section in config.sections():
+                if section.startswith("Profile"):
+                    resolved = _resolve_profile_path(profiles_dir, config, section)
+                    if resolved and resolved.is_dir():
+                        return resolved
+        except (configparser.Error, OSError) as exc:
+            logger.debug("Failed to parse profiles.ini: %s", exc)
+
+    # Fallback: scan directory for anything that looks like a profile
+    return _fallback_find_profile(profiles_dir)
+
+
+def _resolve_profile_path(
+    profiles_dir: Path, config: configparser.ConfigParser, section: str
+) -> Optional[Path]:
+    """Resolve a profile path from a ConfigParser section."""
+    if not config.has_option(section, "Path"):
+        return None
+    raw_path = config.get(section, "Path")
+    is_relative = config.has_option(section, "IsRelative") and config.get(section, "IsRelative") == "1"
+    if is_relative:
+        candidate = profiles_dir / raw_path
+    else:
+        candidate = Path(raw_path)
+    return candidate if candidate.is_dir() else None
+
+
+def _fallback_find_profile(profiles_dir: Path) -> Optional[Path]:
+    """Find the first directory that contains cookies.sqlite."""
+    try:
+        for child in sorted(profiles_dir.iterdir()):
+            if child.is_dir() and (child / "cookies.sqlite").is_file():
+                return child
+    except OSError:
+        pass
+    return None
+
+
+def _query_cookies_db(
+    db_path: Path, domain: str, cookie_names: List[str]
+) -> Optional[Dict[str, str]]:
+    """Copy the cookies database to a temp file and query it.
+
+    Firefox locks cookies.sqlite while running, so we copy first.
+    Returns {name: value} dict or None if no matching cookies found.
+    """
+    if not db_path.is_file():
+        return None
+
+    tmp_fd = None
+    tmp_path = None
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
+        shutil.copy2(str(db_path), tmp_path)
+
+        conn = sqlite3.connect(tmp_path)
+        try:
+            # Build parameterized query — SQLite doesn't support array params,
+            # so we build the IN clause with individual placeholders.
+            placeholders = ",".join("?" for _ in cookie_names)
+            query = (
+                f"SELECT name, value FROM moz_cookies "
+                f"WHERE host LIKE ? AND name IN ({placeholders})"
+            )
+            # domain pattern: match .x.com, x.com, etc.
+            domain_pattern = f"%{domain}"
+            params = [domain_pattern] + list(cookie_names)
+
+            cursor = conn.execute(query, params)
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+
+        if not rows:
+            return None
+        return {name: value for name, value in rows}
+
+    except (sqlite3.Error, OSError) as exc:
+        logger.debug("Failed to query cookies database %s: %s", db_path, exc)
+        return None
+    finally:
+        if tmp_path:
+            try:
+                Path(tmp_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        if tmp_fd is not None:
+            try:
+                import os
+                os.close(tmp_fd)
+            except OSError:
+                pass
+
+
+def extract_firefox_cookies(
+    domain: str, cookie_names: List[str]
+) -> Optional[Dict[str, str]]:
+    """Extract cookies from Firefox for the given domain and cookie names.
+
+    Finds the default Firefox profile, copies cookies.sqlite to a temp file
+    (to avoid lock conflicts), and queries for the requested cookies.
+
+    Args:
+        domain: The cookie domain to match (e.g. ".x.com"). Matched with LIKE %domain.
+        cookie_names: List of cookie names to extract (e.g. ["auth_token", "ct0"]).
+
+    Returns:
+        Dict of {cookie_name: cookie_value} or None if extraction fails.
+    """
+    profiles_dir = _get_firefox_profiles_dir()
+    if profiles_dir is None:
+        logger.debug("Firefox profiles directory not found")
+        return None
+
+    profile_path = _find_default_profile(profiles_dir)
+    if profile_path is None:
+        logger.debug("No Firefox profile found in %s", profiles_dir)
+        return None
+
+    db_path = profile_path / "cookies.sqlite"
+    return _query_cookies_db(db_path, domain, cookie_names)
+
+
+def extract_chrome_cookies(
+    domain: str, cookie_names: List[str]
+) -> Optional[Dict[str, str]]:
+    """Extract cookies from Chrome for the given domain and cookie names.
+
+    macOS only — uses Keychain + system openssl for AES-128-CBC decryption.
+    Linux/Windows not supported (Chrome uses platform-specific encryption).
+
+    Returns:
+        Dict of {cookie_name: cookie_value} or None if extraction fails.
+    """
+    if platform.system() != "Darwin":
+        logger.debug("Chrome cookie extraction only supported on macOS")
+        return None
+    try:
+        from .chrome_cookies import extract_chrome_cookies_macos
+        return extract_chrome_cookies_macos(domain, cookie_names)
+    except Exception as exc:
+        logger.debug("Chrome cookie extraction failed: %s", exc)
+        return None
+
+
+def extract_safari_cookies(
+    domain: str, cookie_names: List[str]
+) -> Optional[Dict[str, str]]:
+    """Extract cookies from Safari for the given domain and cookie names.
+
+    macOS only — parses the unencrypted binary cookie file.
+
+    Returns:
+        Dict of {cookie_name: cookie_value} or None if extraction fails.
+    """
+    if platform.system() != "Darwin":
+        logger.debug("Safari cookie extraction only supported on macOS")
+        return None
+    try:
+        from .safari_cookies import extract_safari_cookies_macos
+        return extract_safari_cookies_macos(domain, cookie_names)
+    except Exception as exc:
+        logger.debug("Safari cookie extraction failed: %s", exc)
+        return None
+
+
+def extract_cookies(
+    browser: str, domain: str, cookie_names: list[str]
+) -> Optional[dict[str, str]]:
+    """Extract cookies from the specified browser.
+
+    Args:
+        browser: One of 'firefox', 'chrome', 'safari', or 'auto'.
+            'auto' tries browsers in platform-appropriate order:
+            - macOS: Chrome -> Firefox -> Safari
+            - Linux: Firefox only
+        domain: The cookie domain to match (e.g. ".x.com").
+        cookie_names: List of cookie names to extract.
+
+    Returns:
+        Dict of {cookie_name: cookie_value} or None if extraction fails.
+    """
+    result = extract_cookies_with_source(browser, domain, cookie_names)
+    if result is None:
+        return None
+    cookies, _browser_name = result
+    return cookies
+
+
+def extract_cookies_with_source(
+    browser: str, domain: str, cookie_names: list[str]
+) -> Optional[tuple[dict[str, str], str]]:
+    """Extract cookies and report which browser they came from.
+
+    Same as extract_cookies() but returns a (cookies, browser_name) tuple
+    so callers can track the source.
+
+    Args:
+        browser: One of 'firefox', 'chrome', 'safari', or 'auto'.
+        domain: The cookie domain to match (e.g. ".x.com").
+        cookie_names: List of cookie names to extract.
+
+    Returns:
+        Tuple of ({cookie_name: cookie_value}, browser_name) or None.
+    """
+    extractors = {
+        "firefox": extract_firefox_cookies,
+        "chrome": extract_chrome_cookies,
+        "safari": extract_safari_cookies,
+    }
+
+    if browser != "auto":
+        extractor = extractors.get(browser)
+        if extractor is None:
+            logger.warning("Unknown browser: %s", browser)
+            return None
+        result = extractor(domain, cookie_names)
+        return (result, browser) if result is not None else None
+
+    # Auto mode: try browsers in platform-appropriate order
+    system = platform.system()
+    if system == "Darwin":
+        order = ["chrome", "firefox", "safari"]
+    elif system == "Linux":
+        order = ["firefox"]
+    else:
+        order = ["firefox"]
+
+    for name in order:
+        result = extractors[name](domain, cookie_names)
+        if result is not None:
+            return (result, name)
+
+    return None

--- a/scripts/lib/safari_cookies.py
+++ b/scripts/lib/safari_cookies.py
@@ -1,0 +1,182 @@
+"""
+Safari binary cookie extractor for macOS.
+
+Parses ~/Library/Cookies/Cookies.binarycookies (unencrypted binary format)
+using only stdlib. Zero pip dependencies.
+
+Reference: github.com/mdegrazia/Safari-Binary-Cookie-Parser
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import sys
+from pathlib import Path
+
+# Mac epoch: 2001-01-01 00:00:00 UTC (not used for filtering, but documented)
+_MAC_EPOCH_OFFSET = 978307200  # seconds between Unix epoch and Mac epoch
+
+_MAGIC = b"cook"
+
+
+def _read_null_terminated(data: bytes, offset: int) -> str:
+    """Read a null-terminated string from data starting at offset."""
+    end = data.find(b"\x00", offset)
+    if end == -1:
+        end = len(data)
+    return data[offset:end].decode("utf-8", errors="replace")
+
+
+def _parse_cookie_record(data: bytes) -> dict | None:
+    """Parse a single cookie record. Returns dict with url, name, value, path or None."""
+    if len(data) < 44:
+        return None
+    try:
+        (size,) = struct.unpack("<I", data[0:4])
+        # flags at offset 4 (4 bytes, little-endian) — not needed for extraction
+        (url_offset,) = struct.unpack("<I", data[16:20])
+        (name_offset,) = struct.unpack("<I", data[20:24])
+        (path_offset,) = struct.unpack("<I", data[24:28])
+        (value_offset,) = struct.unpack("<I", data[28:32])
+        # expiry at offset 40 (8-byte double, little-endian) — not needed for filtering
+        # creation at offset 48 (8-byte double, little-endian) — not needed
+
+        url = _read_null_terminated(data, url_offset)
+        name = _read_null_terminated(data, name_offset)
+        path = _read_null_terminated(data, path_offset)
+        value = _read_null_terminated(data, value_offset)
+
+        return {"url": url, "name": name, "value": value, "path": path}
+    except (struct.error, IndexError, UnicodeDecodeError):
+        return None
+
+
+def _parse_page(page_data: bytes) -> list[dict]:
+    """Parse a single page of cookies. Returns list of cookie dicts."""
+    cookies = []
+    if len(page_data) < 8:
+        return cookies
+
+    # Page header: 4 bytes (always 00 00 01 00), then 4-byte LE cookie count
+    try:
+        (num_cookies,) = struct.unpack("<I", page_data[4:8])
+    except struct.error:
+        return cookies
+
+    # Sanity check
+    if num_cookies > 10000:
+        return cookies
+
+    # Cookie offsets: array of 4-byte LE uint32 starting at offset 8
+    offsets_end = 8 + num_cookies * 4
+    if offsets_end > len(page_data):
+        return cookies
+
+    for i in range(num_cookies):
+        off_start = 8 + i * 4
+        try:
+            (cookie_offset,) = struct.unpack("<I", page_data[off_start : off_start + 4])
+        except struct.error:
+            continue
+
+        if cookie_offset >= len(page_data):
+            continue
+
+        cookie_data = page_data[cookie_offset:]
+        record = _parse_cookie_record(cookie_data)
+        if record:
+            cookies.append(record)
+
+    return cookies
+
+
+def extract_safari_cookies_macos(
+    domain: str, cookie_names: list[str]
+) -> dict[str, str] | None:
+    """
+    Extract cookies from Safari on macOS.
+
+    Args:
+        domain: Domain to match (substring match, e.g. "x.com")
+        cookie_names: List of cookie names to extract (e.g. ["auth_token", "ct0"])
+
+    Returns:
+        Dict mapping cookie name to value for found cookies, or None on failure.
+    """
+    if sys.platform != "darwin":
+        return None
+
+    cookie_path = Path.home() / "Library" / "Cookies" / "Cookies.binarycookies"
+
+    try:
+        raw = cookie_path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        print(
+            "[safari] Permission denied reading Cookies.binarycookies. "
+            "Enable Full Disk Access for Terminal in System Settings > "
+            "Privacy & Security > Full Disk Access.",
+            file=sys.stderr,
+        )
+        return None
+    except OSError:
+        return None
+
+    return _parse_binary_cookies(raw, domain, cookie_names)
+
+
+def _parse_binary_cookies(
+    raw: bytes, domain: str, cookie_names: list[str]
+) -> dict[str, str] | None:
+    """Parse raw binary cookie data. Separated for testability."""
+    if len(raw) < 8:
+        return None
+
+    # Validate magic
+    if raw[:4] != _MAGIC:
+        return None
+
+    try:
+        (num_pages,) = struct.unpack(">I", raw[4:8])
+    except struct.error:
+        return None
+
+    if num_pages > 100000:
+        return None
+
+    # Read page sizes (big-endian uint32 array)
+    page_sizes_end = 8 + num_pages * 4
+    if page_sizes_end > len(raw):
+        return None
+
+    page_sizes = []
+    for i in range(num_pages):
+        off = 8 + i * 4
+        try:
+            (ps,) = struct.unpack(">I", raw[off : off + 4])
+            page_sizes.append(ps)
+        except struct.error:
+            return None
+
+    # Parse each page
+    names_set = set(cookie_names)
+    result: dict[str, str] = {}
+    offset = page_sizes_end
+
+    for ps in page_sizes:
+        if offset + ps > len(raw):
+            break
+        page_data = raw[offset : offset + ps]
+        cookies = _parse_page(page_data)
+        for c in cookies:
+            # Substring match on domain (handles leading dots like ".x.com")
+            if domain in c["url"] and c["name"] in names_set:
+                result[c["name"]] = c["value"]
+        offset += ps
+
+    if not result:
+        return None
+
+    return result

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -1,0 +1,350 @@
+"""Tests for Chrome cookie extraction on macOS."""
+
+import hashlib
+import os
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scripts.lib.chrome_cookies import (
+    CHROME_COOKIES_DB,
+    CHROME_IV_HEX,
+    CHROME_KEY_LENGTH,
+    CHROME_PBKDF2_ITERATIONS,
+    CHROME_SALT,
+    _derive_aes_key,
+    _get_chrome_encryption_key,
+    _get_db_version,
+    _remove_pkcs7_padding,
+    _decrypt_v10_value,
+    extract_chrome_cookies_macos,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — create real encrypted cookie values using known key + system openssl
+# ---------------------------------------------------------------------------
+
+KNOWN_PASSPHRASE = b"test_passphrase_for_unit_tests"
+KNOWN_AES_KEY = _derive_aes_key(KNOWN_PASSPHRASE)
+
+
+def _encrypt_value_v10(plaintext: str, aes_key: bytes) -> bytes:
+    """Encrypt a value the same way Chrome v10 does, using system openssl.
+
+    Returns b'v10' + AES-128-CBC ciphertext with PKCS7 padding.
+    """
+    hex_key = aes_key.hex()
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-aes-128-cbc", "-e",
+            "-K", hex_key,
+            "-iv", CHROME_IV_HEX,
+        ],
+        input=plaintext.encode("utf-8"),
+        capture_output=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"openssl encrypt failed: {result.stderr}"
+    return b"v10" + result.stdout
+
+
+def _encrypt_value_v10_with_sha_prefix(plaintext: str, aes_key: bytes) -> bytes:
+    """Encrypt with a 32-byte SHA-256 prefix (Chrome 130+ style)."""
+    raw = b"\x00" * 32 + plaintext.encode("utf-8")
+    hex_key = aes_key.hex()
+    result = subprocess.run(
+        [
+            "openssl", "enc", "-aes-128-cbc", "-e",
+            "-K", hex_key,
+            "-iv", CHROME_IV_HEX,
+        ],
+        input=raw,
+        capture_output=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"openssl encrypt failed: {result.stderr}"
+    return b"v10" + result.stdout
+
+
+def _create_chrome_cookies_db(path: str, cookies: list[tuple], db_version: int = 20) -> None:
+    """Create a minimal Chrome Cookies SQLite database.
+
+    cookies: list of (host_key, name, value, encrypted_value) tuples
+    """
+    conn = sqlite3.connect(path)
+    c = conn.cursor()
+    c.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    c.execute("INSERT OR REPLACE INTO meta (key, value) VALUES ('version', ?)", (str(db_version),))
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS cookies ("
+        "  host_key TEXT NOT NULL,"
+        "  name TEXT NOT NULL,"
+        "  value TEXT NOT NULL DEFAULT '',"
+        "  encrypted_value BLOB NOT NULL DEFAULT x'',"
+        "  path TEXT NOT NULL DEFAULT '/',"
+        "  expires_utc INTEGER NOT NULL DEFAULT 0,"
+        "  is_secure INTEGER NOT NULL DEFAULT 1,"
+        "  is_httponly INTEGER NOT NULL DEFAULT 1,"
+        "  creation_utc INTEGER NOT NULL DEFAULT 0,"
+        "  last_access_utc INTEGER NOT NULL DEFAULT 0,"
+        "  has_expires INTEGER NOT NULL DEFAULT 1,"
+        "  is_persistent INTEGER NOT NULL DEFAULT 1,"
+        "  priority INTEGER NOT NULL DEFAULT 1,"
+        "  samesite INTEGER NOT NULL DEFAULT 0,"
+        "  source_scheme INTEGER NOT NULL DEFAULT 2,"
+        "  source_port INTEGER NOT NULL DEFAULT 443,"
+        "  last_update_utc INTEGER NOT NULL DEFAULT 0"
+        ")"
+    )
+    for host_key, name, value, encrypted_value in cookies:
+        c.execute(
+            "INSERT INTO cookies (host_key, name, value, encrypted_value) VALUES (?, ?, ?, ?)",
+            (host_key, name, value, encrypted_value),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# PKCS7 padding tests
+# ---------------------------------------------------------------------------
+
+class TestPkcs7Padding:
+    def test_valid_padding_1(self):
+        # 1 byte of padding
+        data = b"hello world!!!!!" + b"\x01"
+        assert _remove_pkcs7_padding(data) == b"hello world!!!!!"
+
+    def test_valid_padding_5(self):
+        data = b"hello world" + b"\x05\x05\x05\x05\x05"
+        assert _remove_pkcs7_padding(data) == b"hello world"
+
+    def test_valid_padding_16(self):
+        # Full block of padding
+        data = b"\x10" * 16
+        assert _remove_pkcs7_padding(data) == b""
+
+    def test_invalid_padding_zero(self):
+        data = b"hello\x00"
+        assert _remove_pkcs7_padding(data) is None
+
+    def test_invalid_padding_mismatch(self):
+        data = b"hello\x03\x03\x02"
+        assert _remove_pkcs7_padding(data) is None
+
+    def test_empty_data(self):
+        assert _remove_pkcs7_padding(b"") is None
+
+
+# ---------------------------------------------------------------------------
+# Key derivation test
+# ---------------------------------------------------------------------------
+
+class TestKeyDerivation:
+    def test_derive_aes_key_deterministic(self):
+        key1 = _derive_aes_key(b"my_passphrase")
+        key2 = _derive_aes_key(b"my_passphrase")
+        assert key1 == key2
+        assert len(key1) == 16
+
+    def test_derive_aes_key_different_passphrases(self):
+        key1 = _derive_aes_key(b"passphrase_a")
+        key2 = _derive_aes_key(b"passphrase_b")
+        assert key1 != key2
+
+
+# ---------------------------------------------------------------------------
+# Decryption test (real openssl, known key)
+# ---------------------------------------------------------------------------
+
+class TestDecryption:
+    def test_decrypt_v10_roundtrip(self):
+        """Encrypt then decrypt — verifies the full pipeline works."""
+        original = "my_secret_cookie_value_12345"
+        encrypted = _encrypt_value_v10(original, KNOWN_AES_KEY)
+        assert encrypted[:3] == b"v10"
+
+        decrypted = _decrypt_v10_value(encrypted, KNOWN_AES_KEY, db_version=20)
+        assert decrypted == original
+
+    def test_decrypt_v10_chrome130_with_sha_prefix(self):
+        """Chrome 130+ (db_version >= 24) strips 32-byte SHA-256 prefix."""
+        original = "session_token_abc"
+        encrypted = _encrypt_value_v10_with_sha_prefix(original, KNOWN_AES_KEY)
+
+        decrypted = _decrypt_v10_value(encrypted, KNOWN_AES_KEY, db_version=24)
+        assert decrypted == original
+
+    def test_decrypt_wrong_key_returns_none_or_garbage(self):
+        """Wrong key should either fail decryption or produce garbage."""
+        original = "secret"
+        encrypted = _encrypt_value_v10(original, KNOWN_AES_KEY)
+        wrong_key = _derive_aes_key(b"wrong_passphrase")
+
+        result = _decrypt_v10_value(encrypted, wrong_key, db_version=20)
+        # Either None (padding check fails) or garbage (not the original)
+        assert result is None or result != original
+
+    def test_decrypt_empty_ciphertext(self):
+        """v10 prefix with no ciphertext should return None."""
+        assert _decrypt_v10_value(b"v10", KNOWN_AES_KEY, db_version=20) is None
+
+
+# ---------------------------------------------------------------------------
+# Chrome not installed → returns None
+# ---------------------------------------------------------------------------
+
+class TestChromeNotInstalled:
+    def test_db_not_found(self):
+        with mock.patch(
+            "scripts.lib.chrome_cookies.CHROME_COOKIES_DB",
+            Path("/nonexistent/path/Cookies"),
+        ):
+            result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Keychain access denied → returns None
+# ---------------------------------------------------------------------------
+
+class TestKeychainDenied:
+    def test_security_command_fails(self):
+        with mock.patch("scripts.lib.chrome_cookies.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=44, stdout="", stderr="security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain."
+            )
+            result = _get_chrome_encryption_key()
+            assert result is None
+
+    def test_security_command_not_found(self):
+        with mock.patch("scripts.lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
+            result = _get_chrome_encryption_key()
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# openssl not found → returns None
+# ---------------------------------------------------------------------------
+
+class TestOpensslNotFound:
+    def test_openssl_missing(self):
+        encrypted = _encrypt_value_v10("test", KNOWN_AES_KEY)
+        with mock.patch("scripts.lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
+            result = _decrypt_v10_value(encrypted, KNOWN_AES_KEY, db_version=20)
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unencrypted cookie values → returned as-is
+# ---------------------------------------------------------------------------
+
+class TestUnencryptedCookies:
+    def test_plain_value_returned(self, tmp_path):
+        """Unencrypted cookies (value column populated) returned without decryption."""
+        db_path = str(tmp_path / "Cookies")
+        _create_chrome_cookies_db(db_path, [
+            (".x.com", "auth_token", "plain_token_value", b""),
+            (".x.com", "ct0", "plain_ct0_value", b""),
+        ])
+
+        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+            # No keychain needed for unencrypted values
+            with mock.patch("scripts.lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+                result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
+
+        assert result == {"auth_token": "plain_token_value", "ct0": "plain_ct0_value"}
+
+
+# ---------------------------------------------------------------------------
+# Full integration: mock DB with real v10 encryption, mock Keychain
+# ---------------------------------------------------------------------------
+
+class TestFullExtraction:
+    def test_encrypted_cookies_extracted(self, tmp_path):
+        """End-to-end: create DB with real v10-encrypted values, extract them."""
+        auth_val = "my_auth_token_123"
+        ct0_val = "my_ct0_csrf_456"
+
+        encrypted_auth = _encrypt_value_v10(auth_val, KNOWN_AES_KEY)
+        encrypted_ct0 = _encrypt_value_v10(ct0_val, KNOWN_AES_KEY)
+
+        db_path = str(tmp_path / "Cookies")
+        _create_chrome_cookies_db(db_path, [
+            (".x.com", "auth_token", "", encrypted_auth),
+            (".x.com", "ct0", "", encrypted_ct0),
+            (".other.com", "other", "", b""),  # unrelated cookie
+        ])
+
+        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+            with mock.patch(
+                "scripts.lib.chrome_cookies._get_chrome_encryption_key",
+                return_value=KNOWN_PASSPHRASE,
+            ):
+                result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == auth_val
+        assert result["ct0"] == ct0_val
+
+    def test_no_matching_cookies_returns_none(self, tmp_path):
+        db_path = str(tmp_path / "Cookies")
+        _create_chrome_cookies_db(db_path, [
+            (".other.com", "session", "val", b""),
+        ])
+
+        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+            with mock.patch("scripts.lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+                result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
+
+        assert result is None
+
+    def test_chrome130_db_version_24(self, tmp_path):
+        """Chrome 130+ with db_version >= 24 strips SHA-256 prefix."""
+        auth_val = "token_for_chrome130"
+        encrypted_auth = _encrypt_value_v10_with_sha_prefix(auth_val, KNOWN_AES_KEY)
+
+        db_path = str(tmp_path / "Cookies")
+        _create_chrome_cookies_db(db_path, [
+            (".x.com", "auth_token", "", encrypted_auth),
+        ], db_version=24)
+
+        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+            with mock.patch(
+                "scripts.lib.chrome_cookies._get_chrome_encryption_key",
+                return_value=KNOWN_PASSPHRASE,
+            ):
+                result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
+
+        assert result is not None
+        assert result["auth_token"] == auth_val
+
+
+# ---------------------------------------------------------------------------
+# DB version detection
+# ---------------------------------------------------------------------------
+
+class TestDbVersion:
+    def test_reads_version_from_meta(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute("CREATE TABLE meta (key TEXT, value TEXT)")
+        c.execute("INSERT INTO meta VALUES ('version', '24')")
+        conn.commit()
+        assert _get_db_version(c) == 24
+        conn.close()
+
+    def test_no_meta_table_returns_zero(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute("CREATE TABLE dummy (x TEXT)")
+        conn.commit()
+        assert _get_db_version(c) == 0
+        conn.close()

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -1,0 +1,293 @@
+"""Tests for browser cookie extraction module."""
+
+import configparser
+import sqlite3
+import textwrap
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from scripts.lib.cookie_extract import (
+    extract_cookies,
+    extract_firefox_cookies,
+    _find_default_profile,
+    _get_firefox_profiles_dir,
+)
+
+
+@pytest.fixture
+def mock_firefox_env(tmp_path):
+    """Create a mock Firefox profiles directory with cookies.sqlite.
+
+    Returns (profiles_dir, profile_dir) for patching.
+    """
+
+    def _make(
+        *,
+        profiles_ini=None,        # type: Optional[str]
+        profiles=None,             # type: Optional[Dict[str, List[Tuple[str, str, str]]]]
+        default_profile="abc123.default-release",  # type: str
+    ):
+        profiles_dir = tmp_path / "Firefox"
+        profiles_dir.mkdir(parents=True, exist_ok=True)
+
+        # Default: one profile with X cookies
+        if profiles is None:
+            profiles = {
+                default_profile: [
+                    (".x.com", "auth_token", "tok_abc123"),
+                    (".x.com", "ct0", "ct0_xyz789"),
+                    (".example.com", "session", "sess_other"),
+                ],
+            }
+
+        # Create profile directories with cookies databases
+        for profile_name, cookies in profiles.items():
+            profile_dir = profiles_dir / profile_name
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            db_path = profile_dir / "cookies.sqlite"
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                "CREATE TABLE moz_cookies ("
+                "  id INTEGER PRIMARY KEY,"
+                "  name TEXT NOT NULL,"
+                "  value TEXT NOT NULL,"
+                "  host TEXT NOT NULL,"
+                "  path TEXT DEFAULT '/',"
+                "  expiry INTEGER DEFAULT 0,"
+                "  isSecure INTEGER DEFAULT 1,"
+                "  isHttpOnly INTEGER DEFAULT 1,"
+                "  sameSite INTEGER DEFAULT 0,"
+                "  schemeMap INTEGER DEFAULT 0"
+                ")"
+            )
+            for host, name, value in cookies:
+                conn.execute(
+                    "INSERT INTO moz_cookies (name, value, host) VALUES (?, ?, ?)",
+                    (name, value, host),
+                )
+            conn.commit()
+            conn.close()
+
+        # Write profiles.ini
+        if profiles_ini is None:
+            profiles_ini = textwrap.dedent(f"""\
+                [General]
+                StartWithLastProfile=1
+
+                [Profile0]
+                Name=default-release
+                IsRelative=1
+                Path={default_profile}
+                Default=1
+            """)
+
+        (profiles_dir / "profiles.ini").write_text(profiles_ini)
+
+        return profiles_dir
+
+    return _make
+
+
+class TestExtractFirefoxCookies:
+    """Tests for extract_firefox_cookies."""
+
+    def test_valid_cookies_extracted(self, mock_firefox_env):
+        """Cookies for the target domain are returned correctly."""
+        profiles_dir = mock_firefox_env()
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "tok_abc123"
+        assert result["ct0"] == "ct0_xyz789"
+        assert "session" not in result  # different domain cookie not included
+
+    def test_multiple_profiles_selects_default(self, mock_firefox_env):
+        """When multiple profiles exist, the one with Default=1 is used."""
+        profiles_dir = mock_firefox_env(
+            profiles={
+                "aaa111.other": [
+                    (".x.com", "auth_token", "wrong_token"),
+                ],
+                "bbb222.default-release": [
+                    (".x.com", "auth_token", "correct_token"),
+                    (".x.com", "ct0", "correct_ct0"),
+                ],
+            },
+            profiles_ini=textwrap.dedent("""\
+                [General]
+                StartWithLastProfile=1
+
+                [Profile0]
+                Name=other
+                IsRelative=1
+                Path=aaa111.other
+
+                [Profile1]
+                Name=default-release
+                IsRelative=1
+                Path=bbb222.default-release
+                Default=1
+            """),
+        )
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "correct_token"
+        assert result["ct0"] == "correct_ct0"
+
+    def test_firefox_not_installed(self):
+        """Returns None when Firefox profiles directory doesn't exist."""
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=None,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token"])
+
+        assert result is None
+
+    def test_cookies_sqlite_empty(self, mock_firefox_env):
+        """Returns None when cookies.sqlite has no rows."""
+        profiles_dir = mock_firefox_env(
+            profiles={"abc123.default-release": []},  # no cookies
+        )
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is None
+
+    def test_domain_has_no_cookies(self, mock_firefox_env):
+        """Returns None when cookies exist but not for the target domain."""
+        profiles_dir = mock_firefox_env(
+            profiles={
+                "abc123.default-release": [
+                    (".example.com", "session", "sess_123"),
+                ],
+            },
+        )
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is None
+
+    def test_malformed_profiles_ini_falls_back(self, mock_firefox_env):
+        """Falls back to first profile on disk when profiles.ini is garbage."""
+        profiles_dir = mock_firefox_env(
+            profiles={
+                "zzz999.fallback": [
+                    (".x.com", "auth_token", "fallback_token"),
+                ],
+            },
+            profiles_ini="this is not valid ini content\n[[[broken",
+        )
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token"])
+
+        assert result is not None
+        assert result["auth_token"] == "fallback_token"
+
+
+class TestExtractCookiesAuto:
+    """Tests for extract_cookies with browser='auto'."""
+
+    def test_auto_macos_tries_chrome_then_firefox(self, mock_firefox_env):
+        """On macOS, auto tries Chrome first, falls back to Firefox if Chrome fails."""
+        profiles_dir = mock_firefox_env()
+
+        with (
+            patch("scripts.lib.cookie_extract.platform.system", return_value="Darwin"),
+            patch(
+                "scripts.lib.cookie_extract.extract_chrome_cookies",
+                return_value=None,
+            ),
+            patch(
+                "scripts.lib.cookie_extract.extract_safari_cookies",
+                return_value=None,
+            ),
+            patch(
+                "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+                return_value=profiles_dir,
+            ),
+        ):
+            result = extract_cookies("auto", ".x.com", ["auth_token", "ct0"])
+
+        # Chrome and Safari return None, Firefox succeeds
+        assert result is not None
+        assert result["auth_token"] == "tok_abc123"
+        assert result["ct0"] == "ct0_xyz789"
+
+    def test_auto_linux_tries_firefox_only(self, mock_firefox_env):
+        """On Linux, auto only tries Firefox."""
+        profiles_dir = mock_firefox_env()
+
+        with (
+            patch("scripts.lib.cookie_extract.platform.system", return_value="Linux"),
+            patch(
+                "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+                return_value=profiles_dir,
+            ),
+        ):
+            result = extract_cookies("auto", ".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "tok_abc123"
+
+    def test_explicit_firefox(self, mock_firefox_env):
+        """Explicit browser='firefox' goes directly to Firefox."""
+        profiles_dir = mock_firefox_env()
+
+        with patch(
+            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_cookies("firefox", ".x.com", ["auth_token"])
+
+        assert result is not None
+        assert result["auth_token"] == "tok_abc123"
+
+    def test_unknown_browser_returns_none(self):
+        """Unknown browser name returns None."""
+        result = extract_cookies("netscape", ".x.com", ["auth_token"])
+        assert result is None
+
+    def test_chrome_delegates_to_chrome_module(self):
+        """Chrome extraction delegates to chrome_cookies module."""
+        with patch(
+            "scripts.lib.cookie_extract.extract_chrome_cookies",
+            return_value={"auth_token": "chrome_tok"},
+        ):
+            result = extract_cookies("chrome", ".x.com", ["auth_token"])
+        assert result == {"auth_token": "chrome_tok"}
+
+    def test_safari_delegates_to_safari_module(self):
+        """Safari extraction delegates to safari_cookies module."""
+        with patch(
+            "scripts.lib.cookie_extract.extract_safari_cookies",
+            return_value={"auth_token": "safari_tok"},
+        ):
+            result = extract_cookies("safari", ".x.com", ["auth_token"])
+        assert result == {"auth_token": "safari_tok"}

--- a/tests/test_safari_cookies.py
+++ b/tests/test_safari_cookies.py
@@ -1,0 +1,219 @@
+"""Tests for Safari binary cookie extraction."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Import the internal parser directly for testability (avoids platform check)
+from scripts.lib.safari_cookies import (
+    _parse_binary_cookies,
+    extract_safari_cookies_macos,
+)
+
+
+def _build_cookie_record(url: str, name: str, value: str, path: str = "/") -> bytes:
+    """Build a single binary cookie record."""
+    # Fixed header: size(4) + flags(4) + padding(8) + url_off(4) + name_off(4) + path_off(4) + value_off(4) + comment(8) + expiry(8) + creation(8)
+    # Total fixed = 4 + 4 + 8 + 4 + 4 + 4 + 4 + 8 + 8 + 8 = 56 bytes
+    # String data starts at offset 56
+
+    url_b = url.encode("utf-8") + b"\x00"
+    name_b = name.encode("utf-8") + b"\x00"
+    path_b = path.encode("utf-8") + b"\x00"
+    value_b = value.encode("utf-8") + b"\x00"
+
+    str_offset_base = 56
+    url_offset = str_offset_base
+    name_offset = url_offset + len(url_b)
+    path_offset = name_offset + len(name_b)
+    value_offset = path_offset + len(path_b)
+
+    total_size = value_offset + len(value_b)
+
+    record = struct.pack("<I", total_size)  # size
+    record += struct.pack("<I", 0)  # flags
+    record += b"\x00" * 8  # padding/unknown
+    record += struct.pack("<I", url_offset)  # url offset
+    record += struct.pack("<I", name_offset)  # name offset
+    record += struct.pack("<I", path_offset)  # path offset
+    record += struct.pack("<I", value_offset)  # value offset
+    record += b"\x00" * 8  # comment (unused)
+    record += struct.pack("<d", 700000000.0)  # expiry (Mac epoch)
+    record += struct.pack("<d", 690000000.0)  # creation (Mac epoch)
+    record += url_b + name_b + path_b + value_b
+
+    return record
+
+
+def _build_page(cookie_records: list[bytes]) -> bytes:
+    """Build a binary cookies page from a list of cookie records."""
+    num_cookies = len(cookie_records)
+
+    # Page header: 4-byte marker + 4-byte cookie count + offset array
+    header_size = 4 + 4 + num_cookies * 4
+    # Also add 4 bytes for end-of-page marker
+    offsets_start = header_size
+
+    # Calculate offsets for each cookie record
+    offsets = []
+    current_offset = offsets_start
+    for rec in cookie_records:
+        offsets.append(current_offset)
+        current_offset += len(rec)
+
+    page = b"\x00\x00\x01\x00"  # page header marker
+    page += struct.pack("<I", num_cookies)
+    for off in offsets:
+        page += struct.pack("<I", off)
+    for rec in cookie_records:
+        page += rec
+
+    return page
+
+
+def _build_binary_cookies_file(pages: list[bytes]) -> bytes:
+    """Build a complete Cookies.binarycookies file from pages."""
+    num_pages = len(pages)
+
+    data = b"cook"  # magic
+    data += struct.pack(">I", num_pages)  # page count (big-endian)
+
+    # Page sizes (big-endian)
+    for page in pages:
+        data += struct.pack(">I", len(page))
+
+    # Page data
+    for page in pages:
+        data += page
+
+    return data
+
+
+@pytest.fixture
+def x_cookies_file() -> bytes:
+    """Build a minimal valid binary cookies file with .x.com cookies."""
+    rec1 = _build_cookie_record(".x.com", "auth_token", "test_auth_abc123")
+    rec2 = _build_cookie_record(".x.com", "ct0", "test_ct0_xyz789")
+    rec3 = _build_cookie_record(".google.com", "NID", "google_nid_value")
+    page = _build_page([rec1, rec2, rec3])
+    return _build_binary_cookies_file([page])
+
+
+class TestParseValidCookies:
+    def test_extracts_matching_cookies(self, x_cookies_file: bytes):
+        result = _parse_binary_cookies(x_cookies_file, "x.com", ["auth_token", "ct0"])
+        assert result is not None
+        assert result["auth_token"] == "test_auth_abc123"
+        assert result["ct0"] == "test_ct0_xyz789"
+
+    def test_ignores_other_domains(self, x_cookies_file: bytes):
+        result = _parse_binary_cookies(x_cookies_file, "google.com", ["auth_token"])
+        assert result is None
+
+    def test_partial_match_returns_found_only(self, x_cookies_file: bytes):
+        result = _parse_binary_cookies(
+            x_cookies_file, "x.com", ["auth_token", "nonexistent"]
+        )
+        assert result is not None
+        assert result["auth_token"] == "test_auth_abc123"
+        assert "nonexistent" not in result
+
+    def test_no_matching_cookie_names(self, x_cookies_file: bytes):
+        result = _parse_binary_cookies(x_cookies_file, "x.com", ["bogus"])
+        assert result is None
+
+    def test_domain_substring_match_with_leading_dot(self, x_cookies_file: bytes):
+        """Domain '.x.com' in cookie should match search for 'x.com'."""
+        result = _parse_binary_cookies(x_cookies_file, "x.com", ["auth_token"])
+        assert result is not None
+        assert result["auth_token"] == "test_auth_abc123"
+
+
+class TestMultiplePages:
+    def test_cookies_across_pages(self):
+        rec1 = _build_cookie_record(".x.com", "auth_token", "page1_auth")
+        rec2 = _build_cookie_record(".x.com", "ct0", "page2_ct0")
+        page1 = _build_page([rec1])
+        page2 = _build_page([rec2])
+        data = _build_binary_cookies_file([page1, page2])
+
+        result = _parse_binary_cookies(data, "x.com", ["auth_token", "ct0"])
+        assert result is not None
+        assert result["auth_token"] == "page1_auth"
+        assert result["ct0"] == "page2_ct0"
+
+
+class TestErrorPaths:
+    def test_file_not_found(self, tmp_path: Path):
+        with patch(
+            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            mock_sys.stderr = sys.stderr
+            result = extract_safari_cookies_macos("x.com", ["auth_token"])
+        assert result is None
+
+    def test_permission_denied(self, tmp_path: Path, capsys):
+        cookie_dir = tmp_path / "Library" / "Cookies"
+        cookie_dir.mkdir(parents=True)
+        cookie_file = cookie_dir / "Cookies.binarycookies"
+        cookie_file.write_bytes(b"cook")
+        cookie_file.chmod(0o000)
+
+        try:
+            with patch(
+                "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
+            ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+                mock_sys.platform = "darwin"
+                mock_sys.stderr = sys.stderr
+                result = extract_safari_cookies_macos("x.com", ["auth_token"])
+            assert result is None
+            captured = capsys.readouterr()
+            assert "Full Disk Access" in captured.err
+        finally:
+            cookie_file.chmod(0o644)
+
+    def test_truncated_magic_only(self):
+        result = _parse_binary_cookies(b"cook", "x.com", ["auth_token"])
+        assert result is None
+
+    def test_empty_file(self):
+        result = _parse_binary_cookies(b"", "x.com", ["auth_token"])
+        assert result is None
+
+    def test_wrong_magic(self):
+        result = _parse_binary_cookies(b"notcook!", "x.com", ["auth_token"])
+        assert result is None
+
+    def test_truncated_page_sizes(self):
+        # Header says 5 pages but data is too short
+        data = b"cook" + struct.pack(">I", 5) + b"\x00" * 4
+        result = _parse_binary_cookies(data, "x.com", ["auth_token"])
+        assert result is None
+
+    def test_truncated_page_data(self):
+        # Valid header with 1 page of size 1000, but no actual page data
+        data = b"cook" + struct.pack(">I", 1) + struct.pack(">I", 1000)
+        result = _parse_binary_cookies(data, "x.com", ["auth_token"])
+        assert result is None
+
+    def test_non_darwin_returns_none(self):
+        with patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            result = extract_safari_cookies_macos("x.com", ["auth_token"])
+        assert result is None
+
+    def test_garbage_data_no_crash(self):
+        """Random bytes after valid magic should not crash."""
+        import os
+
+        data = b"cook" + os.urandom(200)
+        # Should not raise — may return None or a dict
+        result = _parse_binary_cookies(data, "x.com", ["auth_token"])
+        # Just verify no exception; result is either None or dict
+        assert result is None or isinstance(result, dict)


### PR DESCRIPTION
## Summary

- Add browser cookie extraction modules (Chrome, Firefox, Safari) from upstream v2.9.6
- Chrome: macOS Keychain + system openssl for AES-128-CBC decryption (v10), including Chrome 130+ SHA-256 prefix handling
- Safari: binary cookie file parser (stdlib only)
- Firefox: profiles.ini parsing + sqlite cookie DB query

## Test plan

- [x] `uv run pytest tests/test_cookie_extract.py tests/test_chrome_cookies.py tests/test_safari_cookies.py -x -q` -- 49 tests pass
- [x] Full test suite passes (5 pre-existing failures in test_codex_auth, test_models, test_openai_reddit unrelated to this change)
- [x] Import check: `python3 -c "from scripts.lib import cookie_extract, chrome_cookies, safari_cookies; print('OK')"`