### PR TITLE
fix(schema): Engagement.to_dict() returns {} instead of None

### DIFF
--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -53,7 +53,7 @@ class Engagement:
             d['volume'] = self.volume
         if self.liquidity is not None:
             d['liquidity'] = self.liquidity
-        return d if d else None
+        return d if d else {}
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fixes #88

`Engagement.to_dict()` returned `None` when all fields were `None`, causing potential `AttributeError` on `.get()` calls and unexpected `null` values in JSON serialization. Now returns an empty dict `{}` instead.

## Changes
- `scripts/lib/schema.py` line 56: `return d if d else None` → `return d if d else {}`

---
🤖 Generated with Claude Code