### PR TITLE
fix: guard against None from config.get('INCLUDE_SOURCES')

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1737,7 +1737,7 @@ def main():
     search_run_xiaohongshu = has_xiaohongshu
 
     # INCLUDE_SOURCES override: force specific sources on regardless of tier
-    _include_sources = {s.strip().lower() for s in config.get('INCLUDE_SOURCES', '').split(',') if s.strip()}
+    _include_sources = {s.strip().lower() for s in (config.get('INCLUDE_SOURCES', '') or '').split(',') if s.strip()}
     if _include_sources:
         if 'tiktok' in _include_sources and has_tiktok:
             if not search_run_tiktok:


### PR DESCRIPTION
## Summary
- `config.get('INCLUDE_SOURCES', '')` returns `None` (not `''`) when the key exists with a `None` value in the config dict, causing `AttributeError: 'NoneType' object has no attribute 'split'` at line 1740
- This crashes the script on first run for **every new user who skips TikTok/Instagram** during the setup wizard, since `INCLUDE_SOURCES` is never written to `.env` in that path
- One-liner fix: `(config.get(...) or '')` ensures the fallback works regardless

## Repro
1. Fresh install, run setup wizard
2. Choose "Just Reddit comments for now" (skip TikTok/Instagram)
3. Run any research query → crash

## Test plan
- [ ] Fresh `.env` with no `INCLUDE_SOURCES` key → no crash
- [ ] `.env` with `INCLUDE_SOURCES=tiktok,instagram` → sources correctly forced on
- [ ] `.env` with `INCLUDE_SOURCES=` (empty value) → no crash