### PR TITLE
feat: add Tavily as parallel web search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ BSKY_APP_PASSWORD=xxxx-xxxx-xxxx
 
 ```bash
 # Add to ~/.config/last30days/.env
+TAVILY_API_KEY=...      # Tavily Search (top priority — LLM-optimized, 1K free/month at tavily.com)
 PARALLEL_API_KEY=...    # Parallel AI (preferred — LLM-optimized results)
 BRAVE_API_KEY=...       # Brave Search (free tier: 2,000 queries/month)
 OPENROUTER_API_KEY=...  # OpenRouter/Perplexity Sonar Pro
@@ -134,6 +135,7 @@ OPENROUTER_API_KEY=...  # OpenRouter/Perplexity Sonar Pro
 | YouTube | yt-dlp (`brew install yt-dlp`) | N/A | **No API key exists.** Install yt-dlp for search; transcripts work without it. |
 | Hacker News | Always free | N/A | **No.** Always works, no config needed. |
 | Polymarket | Always free | N/A | **No.** Always works, no config needed. |
+| Web search | N/A | Tavily (`TAVILY_API_KEY`) | **Optional.** Top-priority web backend. 1,000 free credits/month at tavily.com. |
 | Web search | N/A | Exa (`EXA_API_KEY`) | **Optional.** 1,000 free searches/month at exa.ai. |
 | Bluesky | Free app password | N/A | **Optional.** Free app password at bsky.app. |
 | TikTok | N/A | ScrapeCreators | **Optional.** Included with ScrapeCreators key. |
@@ -1232,6 +1234,7 @@ Thanks to the contributors who helped shape V2:
 | `youtube.com` (via yt-dlp) | Search query | None (public search) |
 | `hn.algolia.com` | Search query | None (public API) |
 | `gamma-api.polymarket.com` | Search query | None (public API) |
+| `api.tavily.com` | Search query (optional) | TAVILY_API_KEY |
 | `api.search.brave.com` | Search query (optional) | BRAVE_API_KEY |
 | `api.parallel.ai` | Search query (optional) | PARALLEL_API_KEY |
 | `openrouter.ai` | Search query (optional) | OPENROUTER_API_KEY |

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,7 @@ metadata:
         - XAI_API_KEY
         - OPENROUTER_API_KEY
         - PARALLEL_API_KEY
+        - TAVILY_API_KEY
         - BRAVE_API_KEY
         - APIFY_API_TOKEN
         - AUTH_TOKEN

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -617,7 +617,7 @@ def _search_web(
         Tuple of (web_items, web_error)
         web_items are raw dicts ready for websearch.normalize_websearch_items()
     """
-    from lib import brave_search, parallel_search, openrouter_search, exa_search
+    from lib import brave_search, parallel_search, openrouter_search, exa_search, tavily_search
 
     backend = env.get_web_search_source(config)
     if not backend:
@@ -627,7 +627,11 @@ def _search_web(
     raw_results = []
 
     try:
-        if backend == "exa":
+        if backend == "tavily":
+            raw_results = tavily_search.search_web(
+                topic, from_date, to_date, config["TAVILY_API_KEY"], depth=depth,
+            )
+        elif backend == "exa":
             raw_results = exa_search.search_web(
                 topic, from_date, to_date, config["EXA_API_KEY"], depth=depth,
             )
@@ -1605,6 +1609,7 @@ def main():
             "truthsocial": has_truthsocial,
             "polymarket": True,
             "web_search_backend": web_source,
+            "tavily": bool(config.get("TAVILY_API_KEY")),
             "exa": bool(config.get("EXA_API_KEY")),
             "parallel_ai": bool(config.get("PARALLEL_API_KEY")),
             "brave": bool(config.get("BRAVE_API_KEY")),

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -358,6 +358,7 @@ def get_config() -> Dict[str, Any]:
         ('OPENROUTER_API_KEY', None),
         ('PARALLEL_API_KEY', None),
         ('BRAVE_API_KEY', None),
+        ('TAVILY_API_KEY', None),
         ('EXA_API_KEY', None),
         ('XIAOHONGSHU_API_BASE', None),
         ('GEMINI_MODEL', None),
@@ -466,16 +467,18 @@ def get_available_sources(config: Dict[str, Any]) -> str:
 
 def has_web_search_keys(config: Dict[str, Any]) -> bool:
     """Check if any web search API keys are configured."""
-    return bool(config.get('EXA_API_KEY') or config.get('OPENROUTER_API_KEY') or config.get('PARALLEL_API_KEY') or config.get('BRAVE_API_KEY'))
+    return bool(config.get('EXA_API_KEY') or config.get('TAVILY_API_KEY') or config.get('OPENROUTER_API_KEY') or config.get('PARALLEL_API_KEY') or config.get('BRAVE_API_KEY'))
 
 
 def get_web_search_source(config: Dict[str, Any]) -> Optional[str]:
     """Determine the best available web search backend.
 
-    Priority: Exa (free) > Parallel AI > Brave > OpenRouter/Sonar Pro
+    Priority: Tavily > Exa (free) > Parallel AI > Brave > OpenRouter/Sonar Pro
 
-    Returns: 'exa', 'parallel', 'brave', 'openrouter', or None
+    Returns: 'tavily', 'exa', 'parallel', 'brave', 'openrouter', or None
     """
+    if config.get('TAVILY_API_KEY'):
+        return 'tavily'
     if config.get('EXA_API_KEY'):
         return 'exa'
     if config.get('PARALLEL_API_KEY'):

--- a/scripts/lib/tavily_search.py
+++ b/scripts/lib/tavily_search.py
@@ -1,0 +1,139 @@
+"""Tavily web search for last30days skill.
+
+Uses the Tavily Search API as a web search backend.
+Tavily is optimized for LLM consumption and returns relevance-scored results.
+
+API docs: https://docs.tavily.com/
+"""
+
+import sys
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from tavily import TavilyClient
+
+# Domains to exclude (handled by Reddit/X search)
+EXCLUDED_DOMAINS = {
+    "reddit.com", "www.reddit.com", "old.reddit.com",
+    "twitter.com", "www.twitter.com", "x.com", "www.x.com",
+}
+
+# Map date range (days) to Tavily time_range parameter
+# Tavily supports: "day", "week", "month", "year", or None (all time)
+_TIME_RANGE_MAP = [
+    (1, "day"),
+    (7, "week"),
+    (31, "month"),
+    (365, "year"),
+]
+
+
+def _compute_time_range(from_date: str, to_date: str) -> Optional[str]:
+    """Convert from_date/to_date to Tavily time_range parameter."""
+    try:
+        d1 = datetime.strptime(from_date, "%Y-%m-%d")
+        d2 = datetime.strptime(to_date, "%Y-%m-%d")
+        days = max(1, (d2 - d1).days)
+    except (ValueError, TypeError):
+        return "month"
+
+    for threshold, code in _TIME_RANGE_MAP:
+        if days <= threshold:
+            return code
+    return "year"
+
+
+def search_web(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    api_key: str,
+    depth: str = "default",
+) -> List[Dict[str, Any]]:
+    """Search the web via Tavily Search API.
+
+    Args:
+        topic: Search topic
+        from_date: Start date (YYYY-MM-DD)
+        to_date: End date (YYYY-MM-DD)
+        api_key: Tavily API key
+        depth: 'quick', 'default', or 'deep'
+
+    Returns:
+        List of result dicts with keys: id, title, url, source_domain,
+        snippet, date, date_confidence, relevance, why_relevant
+    """
+    max_results = {"quick": 8, "default": 15, "deep": 25}.get(depth, 15)
+    search_depth = {"quick": "basic", "default": "basic", "deep": "advanced"}.get(depth, "basic")
+    time_range = _compute_time_range(from_date, to_date)
+
+    sys.stderr.write(f"[Web] Searching Tavily for: {topic}\n")
+    sys.stderr.flush()
+
+    client = TavilyClient(api_key=api_key)
+
+    response = client.search(
+        query=topic,
+        max_results=max_results,
+        search_depth=search_depth,
+        topic="news",
+        time_range=time_range,
+        exclude_domains=list(EXCLUDED_DOMAINS),
+    )
+
+    return _normalize_results(response)
+
+
+def _normalize_results(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert Tavily response to the shared websearch item schema."""
+    items = []
+    results = response.get("results", [])
+
+    for i, result in enumerate(results):
+        if not isinstance(result, dict):
+            continue
+
+        url = result.get("url", "")
+        if not url:
+            continue
+
+        # Skip excluded domains (belt-and-suspenders; also filtered via API param)
+        try:
+            domain = urlparse(url).netloc.lower()
+            if domain in EXCLUDED_DOMAINS:
+                continue
+            if domain.startswith("www."):
+                domain = domain[4:]
+        except (ValueError, TypeError):
+            domain = ""
+
+        title = str(result.get("title", "")).strip()
+        snippet = str(result.get("content", "")).strip()
+
+        if not title and not snippet:
+            continue
+
+        # Tavily provides a relevance score (0-1)
+        score = result.get("score", 0.5)
+
+        # Tavily does not return per-result dates
+        date = result.get("published_date")
+        date_confidence = "med" if date else "low"
+
+        items.append({
+            "id": f"W{i+1}",
+            "title": title[:200],
+            "url": url,
+            "source_domain": domain,
+            "snippet": snippet[:500],
+            "date": date,
+            "date_confidence": date_confidence,
+            "relevance": round(score, 3),
+            "why_relevant": "",
+        })
+
+    sys.stderr.write(f"[Web] Tavily: {len(items)} results\n")
+    sys.stderr.flush()
+
+    return items

--- a/scripts/lib/tavily_search.py
+++ b/scripts/lib/tavily_search.py
@@ -11,8 +11,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-from tavily import TavilyClient
-
 # Domains to exclude (handled by Reddit/X search)
 EXCLUDED_DOMAINS = {
     "reddit.com", "www.reddit.com", "old.reddit.com",
@@ -71,18 +69,36 @@ def search_web(
     sys.stderr.write(f"[Web] Searching Tavily for: {topic}\n")
     sys.stderr.flush()
 
-    client = TavilyClient(api_key=api_key)
+    try:
+        from tavily import TavilyClient
+    except ImportError:
+        sys.stderr.write("[Web] Tavily: tavily-python package not installed\n")
+        sys.stderr.flush()
+        return []
 
-    response = client.search(
-        query=topic,
-        max_results=max_results,
-        search_depth=search_depth,
-        topic="news",
-        time_range=time_range,
-        exclude_domains=list(EXCLUDED_DOMAINS),
-    )
+    try:
+        client = TavilyClient(api_key=api_key)
 
-    return _normalize_results(response)
+        response = client.search(
+            query=topic,
+            max_results=max_results,
+            search_depth=search_depth,
+            topic="news",
+            time_range=time_range,
+            exclude_domains=list(EXCLUDED_DOMAINS),
+        )
+
+        return _normalize_results(response)
+    except Exception as e:
+        err_str = str(e).lower()
+        if "401" in err_str or "unauthorized" in err_str or "invalid api key" in err_str:
+            sys.stderr.write("[Web] Tavily: invalid API key (401)\n")
+        elif "429" in err_str or "rate limit" in err_str:
+            sys.stderr.write("[Web] Tavily: rate limited (429)\n")
+        else:
+            sys.stderr.write(f"[Web] Tavily: {e}\n")
+        sys.stderr.flush()
+        return []
 
 
 def _normalize_results(response: Dict[str, Any]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Added Tavily as a new web search backend option, running alongside existing providers (Exa, Parallel AI, Brave, OpenRouter)
- Tavily is inserted at the top of the priority chain in `get_web_search_source()` when `TAVILY_API_KEY` is configured
- Uses `tavily-python` SDK with `topic="news"` and automatic `time_range` derivation from date parameters

## Files changed

- **`scripts/lib/tavily_search.py`** (new) — Implements `search_web()` matching the shared result schema (`id`, `title`, `url`, `source_domain`, `snippet`, `date`, `date_confidence`, `relevance`, `why_relevant`). Filters `EXCLUDED_DOMAINS`, maps depth to Tavily `search_depth`, and converts date ranges to Tavily `time_range`.
- **`scripts/lib/env.py`** — Added `TAVILY_API_KEY` to config keys list, `has_web_search_keys()`, and `get_web_search_source()` priority chain (top position).
- **`scripts/last30days.py`** — Added `tavily_search` import and `elif backend == 'tavily'` dispatch in web search function. Added `tavily` key to `--diagnose` output.

## Dependency changes

- Added `tavily-python` (pip package)

## Environment variable changes

- Added `TAVILY_API_KEY` — set in `~/.config/last30days/.env` or `.claude/last30days.env` to enable Tavily

## Notes for reviewers

- All existing providers remain fully functional; Tavily is additive only
- Tavily takes top priority when its API key is present; adjust ordering in `get_web_search_source()` if needed
- The `topic="news"` parameter biases toward recent/news content, matching the tool's last-30-days focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily web search integration is correct, complete, and consistent with the existing codebase. All four issues from the prior review have been addressed: error handling, lazy import, SKILL.md optionalEnv, and README documentation. The implementation follows the same patterns as exa_search.py, integrates cleanly into the backend dispatch in last30days.py, and is purely additive — users without TAVILY_API_KEY are unaffected.
