### PR TITLE
fix: handle None value for INCLUDE_SOURCES config

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1737,7 +1737,7 @@ def main():
     search_run_xiaohongshu = has_xiaohongshu
 
     # INCLUDE_SOURCES override: force specific sources on regardless of tier
-    _include_sources = {s.strip().lower() for s in config.get('INCLUDE_SOURCES', '').split(',') if s.strip()}
+    _include_sources = {s.strip().lower() for s in (config.get('INCLUDE_SOURCES') or '').split(',') if s.strip()}
     if _include_sources:
         if 'tiktok' in _include_sources and has_tiktok:
             if not search_run_tiktok:


### PR DESCRIPTION
## Summary
- `config.get('INCLUDE_SOURCES', '')` returns `None` instead of `''` when the key exists with a `None` value in the config dict, causing `AttributeError: 'NoneType' object has no attribute 'split'` on line 1740
- Replaced with `(config.get('INCLUDE_SOURCES') or '')` to safely handle both `None` and missing key cases

## Reproduction
1. Install the skill without setting `INCLUDE_SOURCES` in `.env`
2. Run any research query
3. Script crashes with `AttributeError` at line 1740

## Root cause
Python's `dict.get(key, default)` only returns the default when the key is **absent**. If the key exists with value `None`, it returns `None` — not the default `''`.

The config loader populates missing keys with `None`, so `INCLUDE_SOURCES` exists in the dict but has no value.

## Test plan
- [ ] Run research without `INCLUDE_SOURCES` in `.env`
- [ ] Run research with `INCLUDE_SOURCES=tiktok,instagram`
- [ ] Run research with `INCLUDE_SOURCES=` (empty value)