### PR TITLE
feat: show top 3 Reddit comments instead of 1

### DIFF
--- a/scripts/lib/reddit_enrich.py
+++ b/scripts/lib/reddit_enrich.py
@@ -251,7 +251,7 @@ def enrich_reddit_item(
             "score": c.get("score", 0),
             "date": dates.timestamp_to_date(c.get("created_utc")),
             "author": c.get("author", ""),
-            "excerpt": c.get("body", "")[:200],
+            "excerpt": c.get("body", "")[:400],
             "url": comment_url,
         })
 

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -180,13 +180,15 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
             lines.append(f"  {item.url}")
             lines.append(f"  *{item.why_relevant}*")
 
-            # Top comment (elevated — Reddit's value IS the comments)
-            if item.top_comments and item.top_comments[0].score >= 10:
-                tc = item.top_comments[0]
-                excerpt = tc.excerpt[:200]
-                if len(tc.excerpt) > 200:
-                    excerpt = excerpt.rstrip() + "..."
-                lines.append(f'  \U0001f4ac Top comment ({tc.score} upvotes): "{excerpt}"')
+            # Top comments (elevated — Reddit's value IS the comments)
+            if item.top_comments:
+                for tc in item.top_comments[:3]:
+                    if tc.score < 10:
+                        break
+                    excerpt = tc.excerpt[:200]
+                    if len(tc.excerpt) > 200:
+                        excerpt = excerpt.rstrip() + "..."
+                    lines.append(f'  \U0001f4ac Top comment ({tc.score} upvotes): "{excerpt}"')
 
             # Comment insights
             if item.comment_insights:
@@ -766,14 +768,16 @@ def render_full_report(report: schema.Report) -> str:
                 eng = item.engagement
                 lines.append(f"- **Engagement:** {eng.score or '?'} points, {eng.num_comments or '?'} comments")
 
-            if item.top_comments and item.top_comments[0].score >= 10:
-                tc = item.top_comments[0]
-                excerpt = tc.excerpt[:200]
-                if len(tc.excerpt) > 200:
-                    excerpt = excerpt.rstrip() + "..."
-                lines.append("")
-                lines.append(f'**\U0001f4ac Top Comment** ({tc.score} upvotes, u/{tc.author}):')
-                lines.append(f'> {excerpt}')
+            if item.top_comments:
+                for tc in item.top_comments[:3]:
+                    if tc.score < 10:
+                        break
+                    excerpt = tc.excerpt[:200]
+                    if len(tc.excerpt) > 200:
+                        excerpt = excerpt.rstrip() + "..."
+                    lines.append("")
+                    lines.append(f'**\U0001f4ac Top Comment** ({tc.score} upvotes, u/{tc.author}):')
+                    lines.append(f'> {excerpt}')
 
             if item.comment_insights:
                 lines.append("")


### PR DESCRIPTION
## Summary
- The free enrichment path (`enrich_reddit_item`) already fetches up to 10 top comments via Reddit's public `.json` endpoint, but only the single highest-scored comment was rendered
- This PR surfaces the top 3 comments (score >= 10) in both rendering paths, providing richer community signal without any additional API calls
- Comment excerpt length extended from 200 to 400 characters for more context

## Before
```
💬 Top comment (988 upvotes): "Wow did their AI not catch that lol..."
```

## After
```
💬 Top comment (988 upvotes): "Wow did their AI not catch that lol
Or maybe an Anthropic employee started vibe coding too hard"
💬 Top comment (944 upvotes): ">3. Undercover Mode - Automatically activated..."
💬 Top comment (696 upvotes): "All hail Claude code because it is now 'Open Source'?"
```

## Changes
| File | Change |
|------|--------|
| `render.py:184-189` | Iterate `top_comments[:3]` instead of `[0]` |
| `render.py:769-776` | Same change in detailed rendering path |
| `reddit_enrich.py:254` | Excerpt truncation `[:200]` → `[:400]` |

## Test plan
- [ ] Run research with a popular topic (high-upvote threads)
- [ ] Verify top 3 comments display with score threshold
- [ ] Verify comments with score < 10 are correctly skipped
- [ ] Verify no change for ScrapeCreators path (uses same rendering)