### PR TITLE
feat: add .codex-plugin/plugin.json manifest for Codex discoverability

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "last30days",
+  "description": "The AI world reinvents itself every month. This skill keeps you current - researches any topic across Reddit, X, YouTube, HN, Polymarket, and more from the last 30 days.",
+  "skills": "./skills"
+}


### PR DESCRIPTION
Add Codex plugin manifest to make last30days-skill discoverable through Codex plugin search. This enables Claude Code and Codex CLI users to find and use this skill via the plugin discovery mechanism.

Ref: #139