### PR TITLE
fix: remove contradictory assertion in test_product_queries

### DIFF
--- a/tests/test_query_type.py
+++ b/tests/test_query_type.py
@@ -20,7 +20,6 @@ class TestDetectQueryType(unittest.TestCase):
         self.assertEqual(detect_query_type("cursor IDE pricing"), "product")
         self.assertEqual(detect_query_type("is Claude Pro worth the cost"), "product")
         self.assertEqual(detect_query_type("best free tier LLM API"), "product")
-        self.assertEqual(detect_query_type("nano banana pro prompting"), "product")
 
     def test_concept_queries(self):
         self.assertEqual(detect_query_type("what is WebTransport"), "concept")


### PR DESCRIPTION
## Summary

- `test_product_queries` contained a contradictory assertion: `"nano banana pro prompting"` was expected to return `"product"`, but the same query string is already tested in `test_howto_queries` (line 39) where it correctly expects `"how_to"`.
- The word `"prompting"` matches `_HOWTO_PATTERNS`, and `how_to` has higher priority than `product` in `detect_query_type`'s dispatch order, so `"how_to"` is the correct result.
- This caused `test_product_queries` to **fail** in the test suite.

## Root cause

The assertion on line 23 of `test_query_type.py` was a copy-paste error: the test input was re-used from `test_howto_queries` but the expected type was left as `"product"`.

## Fix

Removed the duplicate/incorrect assertion. The query is already correctly covered by `test_howto_queries`.

## Test plan

- [ ] Run `python -m pytest tests/test_query_type.py` — all 28 tests pass (was 27 passing, 1 failing before this fix)
- [ ] Run full test suite `python -m pytest tests/` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)