### PR TITLE
fix: surface Codex API errors instead of silently returning empty results

### DIFF
--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -98,6 +98,13 @@ def _parse_codex_stream(raw: str) -> Dict[str, Any]:
     """Parse SSE stream from Codex responses into a response-like dict."""
     events = _parse_sse_stream_raw(raw)
 
+    # Fail fast if the stream is completely empty (indicates API error, not zero results)
+    if not events:
+        raw_preview = raw[:100] if raw else "(empty)"
+        raise http.HTTPError(
+            f"Codex API returned empty response (no SSE events parsed from: {raw_preview})"
+        )
+
     # Prefer explicit completed response payload if present
     for evt in reversed(events):
         if isinstance(evt, dict):
@@ -129,7 +136,8 @@ def _parse_codex_stream(raw: str) -> Dict[str, Any]:
             ]
         }
 
-    return {}
+    # No output text after parsing all events — this is a silent failure
+    raise http.HTTPError("Codex API returned valid SSE stream but no output text (malformed response)")
 
 # Depth configurations: (min, max) threads to request
 # Request MORE than needed since many get filtered by date

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from lib import env, openai_reddit
+from lib import env, openai_reddit, http
 
 
 def _make_jwt(payload: dict) -> str:
@@ -169,8 +169,15 @@ class TestParseCodexStream(unittest.TestCase):
         self.assertEqual(text, "hello")
 
     def test_empty_stream(self):
-        result = openai_reddit._parse_codex_stream("")
-        self.assertEqual(result, {})
+        """Empty SSE stream should raise HTTPError (indicates API failure, not zero results)."""
+        with self.assertRaises(http.HTTPError):
+            openai_reddit._parse_codex_stream("")
+
+    def test_malformed_stream_no_output(self):
+        """SSE stream with events but no output text should raise HTTPError."""
+        sse = 'data: {"type":"response.created"}\n\n'
+        with self.assertRaises(http.HTTPError):
+            openai_reddit._parse_codex_stream(sse)
 
 
 class TestBuildPayload(unittest.TestCase):


### PR DESCRIPTION
## Summary

When Codex API returns an empty or malformed SSE response, the parsing function was silently returning an empty dict, which resulted in zero Reddit search results being delivered to the user with **no error indication**.

This is a **silent failure** — the research output appears complete but is missing critical data, and the user has no way to know the API failed.

## What Changed

Added explicit error handling in `_parse_codex_stream()`:

1. **Raise HTTPError** if SSE stream is completely empty (no events parsed)
2. **Raise HTTPError** if stream has events but produces no output text

These exceptions propagate through existing error handlers that set `reddit_error`, which surfaces to the user via `progress.show_error()`.

## Root Cause

- Empty/malformed Codex responses were returning `{}` (empty dict)
- `parse_reddit_response({})` would print a warning and return `[]`
- The caller in `_search_reddit()` never set `reddit_error`
- Result: degraded output with no error indication

## Testing

✅ All 32 Codex auth + OpenAI Reddit tests pass  
✅ New tests validate error cases work correctly  
✅ Existing valid response parsing unaffected  
✅ No regressions in related modules  

### Test Coverage Added
- `test_empty_stream`: Empty SSE stream raises HTTPError
- `test_malformed_stream_no_output`: SSE with events but no output raises HTTPError

## How to Verify

Run the test suite:
```bash
python3 -m unittest tests.test_codex_auth.TestParseCodexStream -v
