### PR TITLE
Fix Windows crash: guard os.killpg with hasattr check

### DIFF
--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -169,9 +169,12 @@ def search_youtube(
         try:
             stdout, stderr = proc.communicate(timeout=120)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
+            if hasattr(os, 'killpg'):
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+            else:
                 proc.kill()
             proc.wait(timeout=5)
             _log("YouTube search timed out (120s)")
@@ -392,9 +395,12 @@ def _fetch_transcript_ytdlp(video_id: str, temp_dir: str) -> Optional[str]:
         try:
             proc.communicate(timeout=30)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
+            if hasattr(os, 'killpg'):
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+            else:
                 proc.kill()
             proc.wait(timeout=5)
             return None


### PR DESCRIPTION
## Summary

Fixes #156 — YouTube search no longer crashes on Windows.

### Problem

`os.killpg()` is UNIX-only and raises `AttributeError` on Windows. Both the search and transcript fetch code paths call it unconditionally when a subprocess times out:

```python
# Line 173 and 396 — crashes on Windows
os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
```

Note: `preexec_fn=os.setsid` is already correctly guarded with `hasattr(os, 'setsid')`, but the downstream `os.killpg` calls were not.

### Fix

Guard both `os.killpg` calls with `hasattr(os, 'killpg')`, falling back to `proc.kill()` on Windows:

```python
if hasattr(os, 'killpg'):
    try:
        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
    except (ProcessLookupError, PermissionError, OSError):
        proc.kill()
else:
    proc.kill()
```

### Testing

- Tested on Windows 11, Python 3.12 — YouTube search now works correctly
- No functional change on UNIX systems (same code path as before)
