### PR TITLE
Add YOUTUBE_PROXY config for yt-dlp (YouTube blocked regions)

### DIFF
--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -375,6 +375,7 @@ def get_config() -> Dict[str, Any]:
         ('FROM_BROWSER', None),
         ('SETUP_COMPLETE', None),
         ('INCLUDE_SOURCES', None),
+        ('YOUTUBE_PROXY', None),
     ]
 
     for key, default in keys:

--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -37,6 +37,17 @@ TRANSCRIPT_LIMITS = {
 # Max words to keep from each transcript
 TRANSCRIPT_MAX_WORDS = 5000
 
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def _get_proxy_args() -> list:
+    """Return yt-dlp --proxy args if YOUTUBE_PROXY is configured."""
+    proxy = os.environ.get("YOUTUBE_PROXY")
+    if proxy:
+        return ["--proxy", proxy]
+    return []
+
+
 from .relevance import token_overlap_relevance as _compute_relevance
 
 
@@ -156,6 +167,8 @@ def search_youtube(
         "--no-download",
     ]
 
+    cmd.extend(_get_proxy_args())
+
     preexec = os.setsid if hasattr(os, 'setsid') else None
 
     try:
@@ -169,9 +182,12 @@ def search_youtube(
         try:
             stdout, stderr = proc.communicate(timeout=120)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
+            if hasattr(os, 'killpg'):
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+            else:
                 proc.kill()
             proc.wait(timeout=5)
             _log("YouTube search timed out (120s)")
@@ -379,6 +395,8 @@ def _fetch_transcript_ytdlp(video_id: str, temp_dir: str) -> Optional[str]:
         f"https://www.youtube.com/watch?v={video_id}",
     ]
 
+    cmd.extend(_get_proxy_args())
+
     preexec = os.setsid if hasattr(os, 'setsid') else None
 
     try:
@@ -392,9 +410,12 @@ def _fetch_transcript_ytdlp(video_id: str, temp_dir: str) -> Optional[str]:
         try:
             proc.communicate(timeout=30)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
+            if hasattr(os, 'killpg'):
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+            else:
                 proc.kill()
             proc.wait(timeout=5)
             return None


### PR DESCRIPTION
## Summary

Closes #158 — adds `YOUTUBE_PROXY` env var for routing yt-dlp through a proxy.

Also includes the Windows `os.killpg` fix from PR #157 (since both touch the same code, it made sense to combine them).

### Problem

In regions where YouTube is blocked (e.g. Russia since August 2024), yt-dlp hangs or times out. There was no way to configure a proxy.

### Solution

**`YOUTUBE_PROXY` env var** — read via `os.environ.get()` and passed as `--proxy` to both yt-dlp commands:

```bash
# In ~/.config/last30days/.env or environment
YOUTUBE_PROXY=socks5://127.0.0.1:1080
```

Supports any proxy format yt-dlp accepts: `socks5://`, `http://`, `https://`.

### Changes

**`scripts/lib/youtube_yt.py`:**
- Added `_get_proxy_args()` helper that returns `["--proxy", url]` when set
- Applied to both `search_youtube()` and `fetch_transcript()` commands
- Also guards `os.killpg` with `hasattr()` for Windows compatibility (from PR #157)

**`scripts/lib/env.py`:**
- Added `YOUTUBE_PROXY` to the config key list so it's loaded from `.env` files

### Testing

Tested on Windows 11, Python 3.12 with a local SOCKS5 proxy (xray):
- YouTube search returns results successfully through the proxy
- Without `YOUTUBE_PROXY` set, behavior is unchanged (no proxy used)
