### PR TITLE
Add YOUTUBE_PROXY config for yt-dlp (YouTube blocked regions)

### DIFF
--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -375,6 +375,7 @@ def get_config() -> Dict[str, Any]:
         ('FROM_BROWSER', None),
         ('SETUP_COMPLETE', None),
         ('INCLUDE_SOURCES', None),
+        ('YOUTUBE_PROXY', None),
     ]
 
     for key, default in keys:

--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -86,6 +86,14 @@ def extract_transcript_highlights(transcript: str, topic: str, limit: int = 5) -
     return [sent for _, sent in candidates[:limit]]
 
 
+def _get_proxy_args() -> list:
+    """Return yt-dlp proxy args if YOUTUBE_PROXY is configured."""
+    proxy = os.environ.get("YOUTUBE_PROXY")
+    if proxy:
+        return ["--proxy", proxy]
+    return []
+
+
 def _log(msg: str):
     """Log to stderr."""
     sys.stderr.write(f"[YouTube] {msg}\n")
@@ -154,7 +162,7 @@ def search_youtube(
         "--dump-json",
         "--no-warnings",
         "--no-download",
-    ]
+    ] + _get_proxy_args()
 
     preexec = os.setsid if hasattr(os, 'setsid') else None
 
@@ -377,7 +385,7 @@ def _fetch_transcript_ytdlp(video_id: str, temp_dir: str) -> Optional[str]:
         "--no-warnings",
         "-o", f"{temp_dir}/%(id)s",
         f"https://www.youtube.com/watch?v={video_id}",
-    ]
+    ] + _get_proxy_args()
 
     preexec = os.setsid if hasattr(os, 'setsid') else None
 


### PR DESCRIPTION
## Summary

Closes #158 — adds `YOUTUBE_PROXY` env var for routing yt-dlp through a proxy.

### Problem

In regions where YouTube is blocked (e.g. Russia since August 2024), yt-dlp hangs or times out (120s wasted per run). There was no way to configure a proxy.

### Solution

**`YOUTUBE_PROXY` env var** — read via `os.environ.get()` and passed as `--proxy` to both yt-dlp commands:

```bash
# In ~/.config/last30days/.env or environment
YOUTUBE_PROXY=socks5://127.0.0.1:1080
```

Supports any proxy format yt-dlp accepts: `socks5://`, `http://`, `https://`.

### Changes

**`scripts/lib/env.py`:**
- Added `YOUTUBE_PROXY` to the config key list so it's loaded from `.env` files

**`scripts/lib/youtube_yt.py`:**
- Added `_get_proxy_args()` helper that returns `["--proxy", url]` when set
- Applied to both `search_youtube()` and `fetch_transcript()` commands

### Testing

Tested on Windows 11, Python 3.12 with a local SOCKS5 proxy:
- YouTube search returns results successfully through the proxy
- Without `YOUTUBE_PROXY` set, behavior is unchanged (no proxy used)
