### PR TITLE
feat: add Exa MCP as no-key web search backend

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.9.6"
 description: "Deep research engine covering the last 30 days across 10+ sources - Reddit, X/Twitter, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web. AI synthesizes findings into grounded, cited reports."
 argument-hint: 'last30 AI video tools, last30 best project management tools'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa
 homepage: https://github.com/mvanhorn/last30days-skill
 repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn
@@ -380,9 +380,16 @@ The script will automatically:
 
 ## STEP 2: DO WEBSEARCH AFTER SCRIPT COMPLETES
 
-After the script finishes, do WebSearch to supplement with blogs, tutorials, and news.
+After the script finishes, search the web to supplement with blogs, tutorials, and news.
 
-For **ALL modes**, do WebSearch to supplement (or provide all data in web-only mode).
+**Web search strategy — use BOTH tools for maximum coverage:**
+
+1. **`mcp__exa__web_search_exa`** — always available, no API key required. Semantic search, high quality. Run this first.
+2. **`WebSearch`** — Claude's built-in web search. Run this second for additional coverage.
+
+Run both in parallel where possible. Merge and deduplicate results before synthesis.
+
+For **ALL modes**, do web search to supplement (or provide all data in web-only mode).
 
 Choose search queries based on QUERY_TYPE:
 

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.1-open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
 argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa
 ---
 
 # last30days (open variant): Research + Watchlist + Briefings


### PR DESCRIPTION
## Summary

- Adds `mcp__exa__web_search_exa` and `mcp__exa__crawling_exa` to `allowed-tools` in both `SKILL.md` and `variants/open/SKILL.md`
- Updates Step 2 to use Exa MCP **first** (semantic search, no API key required) and `WebSearch` second, running both in parallel for maximum web coverage
- Users without `EXA_API_KEY` now get free semantic web search via the MCP tool on every research run

## Motivation

The existing `exa_search.py` module requires an `EXA_API_KEY` (Tier 2). The `mcp__exa__*` tools are available in the Claude Code skill environment and work without any key. This change unlocks better web search coverage for zero-config users.

The existing HTTP API path (`exa_search.py`) is unchanged — users with `EXA_API_KEY` still benefit from it inside the Python subprocess.

## Test plan

- [ ] Run `/last30days <topic>` without `EXA_API_KEY` set — confirm Exa MCP fires in Step 2
- [ ] Run with `EXA_API_KEY` set — confirm both the subprocess API path and MCP path run
- [ ] Verify `--diagnose` output still reflects key-based web source availability correctly