### PR TITLE
feat: add Firecrawl MCP deep fetch as Step 2b

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.9.6"
 description: "Deep research engine covering the last 30 days across 10+ sources - Reddit, X/Twitter, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web. AI synthesizes findings into grounded, cited reports."
 argument-hint: 'last30 AI video tools, last30 best project management tools'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
 homepage: https://github.com/mvanhorn/last30days-skill
 repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn

--- a/SKILL.md
+++ b/SKILL.md
@@ -892,6 +892,7 @@ Want another prompt? Just tell me what you're creating next.
 - Runs `yt-dlp` locally for YouTube search and transcript extraction (no API key, public data)
 - Sends search queries to ScrapeCreators API (`api.scrapecreators.com`) for TikTok and Instagram search, transcript/caption extraction (same SCRAPECREATORS_API_KEY as Reddit, PAYG after 100 free API calls)
 - Optionally sends search queries to Brave Search API, Parallel AI API, or OpenRouter API for web search
+- Fetches full article content via Firecrawl MCP (`api.firecrawl.dev`) for top web results — no API key required, no user data sent
 - Fetches public Reddit thread data from `reddit.com` for engagement metrics
 - Stores research findings in local SQLite database (watchlist mode only)
 - Saves research briefings as .md files to ~/Documents/Last30Days/

--- a/SKILL.md
+++ b/SKILL.md
@@ -425,7 +425,7 @@ For ALL query types:
 
 ## STEP 2b: DEEP FETCH TOP WEB RESULTS
 
-After Step 2 (Exa MCP + WebSearch) completes, fetch full article content for the top web URLs using Firecrawl MCP.
+After Step 2 (WebSearch) completes, fetch full article content for the top web URLs using Firecrawl MCP.
 
 **Skip this step entirely if `--no-native-web` was passed.**
 
@@ -435,10 +435,10 @@ After Step 2 (Exa MCP + WebSearch) completes, fetch full article content for the
 - `--deep`: fetch top **8** URLs
 
 **URL selection:**
-1. Collect all URLs returned by Step 2 (Exa MCP results first, then WebSearch results)
-2. Rank by Exa relevance score descending; if no Exa scores available, use return order
-3. Remove any URLs from excluded domains: `reddit.com`, `x.com`, `twitter.com` (already covered by the script)
-4. Take the top N URLs per depth profile above
+1. Collect all URLs returned by Step 2 in the order they were returned
+2. Remove any URLs from excluded domains: `reddit.com`, `x.com`, `twitter.com` (already covered by the script)
+3. Take the top N URLs per depth profile above
+4. If no eligible URLs remain after domain exclusion, skip the fetch phase and proceed to synthesis
 
 **Fetch execution:**
 - Call `mcp__firecrawl__firecrawl_scrape` for each selected URL
@@ -448,7 +448,7 @@ After Step 2 (Exa MCP + WebSearch) completes, fetch full article content for the
 
 **In synthesis:**
 - Firecrawl-enriched articles count as web sources — no separate output section
-- Weight full-content articles higher than snippet-only results (more signal, richer content)
+- Treat Firecrawl-enriched articles as higher quality than snippet-only WebSearch results (they have full content, not just a teaser) — rank them above snippet-only sources but still below Reddit/X/YouTube which have engagement signals
 - Source domain names from enriched articles appear on the `🌐 Web:` stats line as normal
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.9.6"
 description: "Deep research engine covering the last 30 days across 10+ sources - Reddit, X/Twitter, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web. AI synthesizes findings into grounded, cited reports."
 argument-hint: 'last30 AI video tools, last30 best project management tools'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape
 homepage: https://github.com/mvanhorn/last30days-skill
 repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn

--- a/SKILL.md
+++ b/SKILL.md
@@ -423,6 +423,36 @@ For ALL query types:
 
 ---
 
+## STEP 2b: DEEP FETCH TOP WEB RESULTS
+
+After Step 2 (Exa MCP + WebSearch) completes, fetch full article content for the top web URLs using Firecrawl MCP.
+
+**Skip this step entirely if `--no-native-web` was passed.**
+
+**Fetch count by depth:**
+- `--quick`: fetch top **3** URLs
+- default: fetch top **5** URLs
+- `--deep`: fetch top **8** URLs
+
+**URL selection:**
+1. Collect all URLs returned by Step 2 (Exa MCP results first, then WebSearch results)
+2. Rank by Exa relevance score descending; if no Exa scores available, use return order
+3. Remove any URLs from excluded domains: `reddit.com`, `x.com`, `twitter.com` (already covered by the script)
+4. Take the top N URLs per depth profile above
+
+**Fetch execution:**
+- Call `mcp__firecrawl__firecrawl_scrape` for each selected URL
+- Run fetches in parallel where possible
+- Truncate each fetched markdown response to **1500 characters** before passing to synthesis
+- If Firecrawl returns an error or times out for any URL: skip that URL silently, do not block synthesis
+
+**In synthesis:**
+- Firecrawl-enriched articles count as web sources — no separate output section
+- Weight full-content articles higher than snippet-only results (more signal, richer content)
+- Source domain names from enriched articles appear on the `🌐 Web:` stats line as normal
+
+---
+
 ## Judge Agent: Synthesize All Sources
 
 **After all searches complete, internally synthesize (don't display stats yet):**

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.9.6"
 description: "Deep research engine covering the last 30 days across 10+ sources - Reddit, X/Twitter, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web. AI synthesizes findings into grounded, cited reports."
 argument-hint: 'last30 AI video tools, last30 best project management tools'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__firecrawl__firecrawl_scrape
 homepage: https://github.com/mvanhorn/last30days-skill
 repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn
@@ -423,7 +423,7 @@ For ALL query types:
 
 ---
 
-## STEP 2b: DEEP FETCH TOP WEB RESULTS
+## STEP 2.6: DEEP FETCH TOP WEB RESULTS
 
 After Step 2 (WebSearch) completes, fetch full article content for the top web URLs using Firecrawl MCP.
 

--- a/docs/superpowers/plans/2026-04-05-firecrawl-deep-fetch.md
+++ b/docs/superpowers/plans/2026-04-05-firecrawl-deep-fetch.md
@@ -1,0 +1,226 @@
+# Firecrawl Deep Fetch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Firecrawl MCP as a Step 2b deep-fetch layer in SKILL.md, scraping full article content for the top N web URLs after Step 2 search completes.
+
+**Architecture:** Agent-layer only — all changes are in SKILL.md instruction text. Firecrawl MCP tools (`mcp__firecrawl__firecrawl_scrape`) are called by the skill at runtime, not inside the Python subprocess. Follows the same pattern as the Exa MCP integration added in the same session.
+
+**Tech Stack:** SKILL.md markdown instructions, Firecrawl MCP (no API key required), `bash scripts/sync.sh` for deployment.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `SKILL.md` | Add 2 tools to `allowed-tools`; insert Step 2b section; update Security & Permissions bullet |
+| `variants/open/SKILL.md` | Add same 2 tools to `allowed-tools` only |
+
+---
+
+### Task 1: Add Firecrawl tools to `allowed-tools` in both SKILL.md files
+
+**Files:**
+- Modify: `SKILL.md` line 6
+- Modify: `variants/open/SKILL.md` line 6
+
+- [ ] **Step 1: Edit main SKILL.md `allowed-tools` line**
+
+Find line 6 in `SKILL.md`:
+```
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa
+```
+Replace with:
+```
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+```
+
+- [ ] **Step 2: Edit `variants/open/SKILL.md` `allowed-tools` line**
+
+Find line 6 in `variants/open/SKILL.md`:
+```
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa
+```
+Replace with:
+```
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+```
+
+- [ ] **Step 3: Verify both files**
+
+Run:
+```bash
+grep "allowed-tools" SKILL.md variants/open/SKILL.md
+```
+Expected output (both lines must contain `mcp__firecrawl__firecrawl_scrape`):
+```
+SKILL.md:allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+variants/open/SKILL.md:allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SKILL.md variants/open/SKILL.md
+git commit -m "feat: add Firecrawl MCP tools to allowed-tools"
+```
+
+---
+
+### Task 2: Insert Step 2b section in main SKILL.md
+
+**Files:**
+- Modify: `SKILL.md` — insert after line 424 (the `---` separator after Step 2's options block, before `## Judge Agent`)
+
+- [ ] **Step 1: Insert Step 2b section**
+
+Find this exact text in `SKILL.md` (lines 424–426):
+```
+---
+
+## Judge Agent: Synthesize All Sources
+```
+
+Replace with:
+```
+---
+
+## STEP 2b: DEEP FETCH TOP WEB RESULTS
+
+After Step 2 (Exa MCP + WebSearch) completes, fetch full article content for the top web URLs using Firecrawl MCP.
+
+**Skip this step entirely if `--no-native-web` was passed.**
+
+**Fetch count by depth:**
+- `--quick`: fetch top **3** URLs
+- default: fetch top **5** URLs
+- `--deep`: fetch top **8** URLs
+
+**URL selection:**
+1. Collect all URLs returned by Step 2 (Exa MCP results first, then WebSearch results)
+2. Rank by Exa relevance score descending; if no Exa scores available, use return order
+3. Remove any URLs from excluded domains: `reddit.com`, `x.com`, `twitter.com` (already covered by the script)
+4. Take the top N URLs per depth profile above
+
+**Fetch execution:**
+- Call `mcp__firecrawl__firecrawl_scrape` for each selected URL
+- Run fetches in parallel where possible
+- Truncate each fetched markdown response to **1500 characters** before passing to synthesis
+- If Firecrawl returns an error or times out for any URL: skip that URL silently, do not block synthesis
+
+**In synthesis:**
+- Firecrawl-enriched articles count as web sources — no separate output section
+- Weight full-content articles higher than snippet-only results (more signal, richer content)
+- Source domain names from enriched articles appear on the `🌐 Web:` stats line as normal
+
+---
+
+## Judge Agent: Synthesize All Sources
+```
+
+- [ ] **Step 2: Verify the section was inserted correctly**
+
+Run:
+```bash
+grep -n "STEP 2b\|Step 2b\|firecrawl_scrape\|Judge Agent" SKILL.md
+```
+Expected output must show Step 2b appearing before Judge Agent:
+```
+381:## STEP 2: DO WEBSEARCH AFTER SCRIPT COMPLETES
+NNN:## STEP 2b: DEEP FETCH TOP WEB RESULTS
+NNN:- Call `mcp__firecrawl__firecrawl_scrape` for each selected URL
+NNN:## Judge Agent: Synthesize All Sources
+```
+(line numbers will vary — what matters is the order)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add SKILL.md
+git commit -m "feat: add Step 2b Firecrawl deep fetch to SKILL.md"
+```
+
+---
+
+### Task 3: Update Security & Permissions section and deploy
+
+**Files:**
+- Modify: `SKILL.md` lines 864 (Security & Permissions bullet)
+
+- [ ] **Step 1: Update the web search bullet in Security & Permissions**
+
+Find this exact line in `SKILL.md`:
+```
+- Optionally sends search queries to Brave Search API, Parallel AI API, or OpenRouter API for web search
+```
+
+Replace with:
+```
+- Optionally sends search queries to Brave Search API, Parallel AI API, or OpenRouter API for web search
+- Fetches full article content via Firecrawl MCP (`api.firecrawl.dev`) for top web results — no API key required, no user data sent
+```
+
+- [ ] **Step 2: Verify the Security section**
+
+Run:
+```bash
+grep -n "Firecrawl\|firecrawl" SKILL.md
+```
+Expected: at least 3 matches — `allowed-tools` line, Step 2b section, and Security & Permissions bullet.
+
+- [ ] **Step 3: Deploy via sync.sh**
+
+Run from the project root:
+```bash
+bash scripts/sync.sh
+```
+Expected output (last lines):
+```
+--- Syncing to /Users/developer/.claude/skills/last30days ---
+  Copied 41 modules
+  Import check: OK
+
+--- Syncing to /Users/developer/.agents/skills/last30days ---
+  Copied 41 modules
+  Import check: OK
+
+--- Syncing to /Users/developer/.codex/skills/last30days ---
+  Copied 41 modules
+  Import check: OK
+
+Sync complete.
+```
+
+- [ ] **Step 4: Verify deployed SKILL.md contains Firecrawl**
+
+Run:
+```bash
+grep "firecrawl" ~/.claude/skills/last30days/SKILL.md
+```
+Expected: at least 2 matches (allowed-tools line + Step 2b content).
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add SKILL.md
+git commit -m "feat: add Firecrawl to Security & Permissions; deploy"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **allowed-tools** — Task 1 adds both tools to both files
+- [x] **Step 2b placement** — Task 2 inserts after Step 2, before Judge Agent
+- [x] **Depth-adaptive counts** — 3/5/8 for quick/default/deep specified in Step 2b text
+- [x] **URL selection logic** — Exa relevance ranking, excluded domains, take top N
+- [x] **1500 char truncation** — explicitly stated in fetch execution
+- [x] **Failure handling** — skip silently, don't block synthesis
+- [x] **--no-native-web flag** — skip condition stated at top of Step 2b
+- [x] **Synthesis weighting** — full-content weighted higher than snippet-only
+- [x] **Stats line** — unchanged format, source names appear on 🌐 Web: line
+- [x] **Security & Permissions** — Task 3 adds Firecrawl bullet
+- [x] **Diagnostics (--diagnose)** — spec called for a `--diagnose` line; this is rendered by `scripts/lib/quality_nudge.py` and `env.py` in the Python subprocess, not SKILL.md. Since Firecrawl is MCP-only (agent-layer), it cannot be detected by the Python subprocess. Omitting from `--diagnose` is correct — the spec note was aspirational but architecturally unsound. No task needed.
+- [x] **Deploy** — Task 3 runs sync.sh and verifies deployed copy
+- [x] **No placeholders** — all steps contain exact text/commands

--- a/docs/superpowers/specs/2026-04-05-firecrawl-deep-fetch-design.md
+++ b/docs/superpowers/specs/2026-04-05-firecrawl-deep-fetch-design.md
@@ -1,0 +1,123 @@
+# Firecrawl Deep Fetch — Design Spec
+
+**Date:** 2026-04-05  
+**Status:** Approved  
+**Scope:** SKILL.md + variants/open/SKILL.md only (agent-layer change, no Python subprocess changes)
+
+---
+
+## Problem
+
+Web search results from Exa MCP and WebSearch return snippets only (200–500 chars). Reddit threads get full comment enrichment; YouTube gets full transcripts. Web articles are the only source with no depth — synthesis sees teasers, not content.
+
+---
+
+## Solution
+
+Add **Step 2b: Deep Fetch** to SKILL.md. After Step 2 finds URLs, Firecrawl MCP scrapes the full markdown content of the top N results before synthesis. No API key required.
+
+---
+
+## Architecture
+
+### Layer
+
+Agent-layer only (SKILL.md instructions). Firecrawl MCP tools are called by the skill, not inside the Python subprocess. Consistent with the Exa MCP pattern established in the same session.
+
+### Tools added to `allowed-tools`
+
+```
+mcp__firecrawl__firecrawl_scrape
+mcp__firecrawl__firecrawl_crawl
+```
+
+Both `SKILL.md` and `variants/open/SKILL.md` updated.
+
+---
+
+## Depth-Adaptive Fetch Count
+
+| Mode | URLs fetched |
+|------|-------------|
+| `--quick` | 3 |
+| default | 5 |
+| `--deep` | 8 |
+
+Mirrors the existing depth profile pattern (quick/default/deep timeouts and volumes).
+
+---
+
+## Step 2b: Placement and Flow
+
+**Placement:** After Step 2 (Exa MCP + WebSearch), before Judge Agent synthesis.
+
+**URL selection:**
+1. Collect all URLs from Step 2 results
+2. Rank by Exa relevance score descending; fall back to return order if Exa MCP wasn't used
+3. Skip excluded domains: `reddit.com`, `x.com`, `twitter.com` (covered by script)
+4. Take top N per depth profile
+
+**Fetch execution:**
+- Call `mcp__firecrawl__firecrawl_scrape` for each selected URL
+- Run in parallel where possible
+- Truncate fetched markdown to **1500 characters** per article before passing to synthesis
+- On failure or timeout for any URL: skip silently, do not block synthesis
+
+---
+
+## Synthesis Integration
+
+- Firecrawl-enriched articles count as web sources — no separate section
+- Full-content articles weighted higher than snippet-only in synthesis (more signal)
+- Source names appear on the existing `🌐 Web:` stats line — format unchanged
+
+---
+
+## Flags
+
+| Flag | Behaviour |
+|------|-----------|
+| `--no-native-web` | Skip Step 2b entirely (consistent: flag means no agent-layer web fetching) |
+| `--quick` | Fetch 3 URLs |
+| `--deep` | Fetch 8 URLs |
+
+---
+
+## Diagnostics
+
+`--diagnose` output adds:
+```
+Firecrawl: active (MCP, no key required)
+```
+Always active — no key dependency.
+
+---
+
+## What Does NOT Change
+
+- `scripts/lib/` — no Python changes
+- `exa_search.py` HTTP path — unchanged
+- Stats block format — unchanged
+- Excluded domains list — unchanged
+- `scripts/sync.sh` deploy process — unchanged
+
+---
+
+## Files to Modify
+
+1. `SKILL.md`
+   - Add `mcp__firecrawl__firecrawl_scrape`, `mcp__firecrawl__firecrawl_crawl` to `allowed-tools`
+   - Add Step 2b section after Step 2
+   - Update `--diagnose` description in the transparency section
+
+2. `variants/open/SKILL.md`
+   - Add same two tools to `allowed-tools`
+
+---
+
+## Out of Scope
+
+- `firecrawl_search` as a search source (Role B) — explicitly excluded
+- `firecrawl_crawl` for recursive site crawling — tool allowed but not used in Step 2b
+- Python subprocess integration — architecturally impossible (MCP tools are agent-layer only)
+- Firecrawl API key support — not needed, MCP works without one

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.1-open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
 argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape
 ---
 
 # last30days (open variant): Research + Watchlist + Briefings

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.1-open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
 argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape, mcp__firecrawl__firecrawl_crawl
 ---
 
 # last30days (open variant): Research + Watchlist + Briefings

--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -3,7 +3,7 @@ name: last30days
 version: "2.1-open"
 description: "Research topics, manage watchlists, get briefings, query history. Also triggered by 'last30'. Sources: Reddit, X, YouTube, web."
 argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
-allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__exa__web_search_exa, mcp__exa__crawling_exa, mcp__firecrawl__firecrawl_scrape
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch, mcp__firecrawl__firecrawl_scrape
 ---
 
 # last30days (open variant): Research + Watchlist + Briefings


### PR DESCRIPTION
## Summary
- Add Firecrawl MCP to allowed-tools (scrape only)
- Add Step 2.6: deep fetch top web results with Firecrawl after WebSearch
- Security & Permissions: document Firecrawl credential handling
- Drop unused Exa tools (web_search_exa, crawling_exa) - only firecrawl_scrape is used in Step 2.6
- Exa integration deferred to future PR

## Test plan
- [ ] Run  with Firecrawl MCP configured
- [ ] Verify Step 2.6 fetches and truncates articles correctly
- [ ] Verify upstream v3.0.0 features still work