### PR TITLE
fix: handle None value for INCLUDE_SOURCES config

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1737,7 +1737,7 @@ def main():
     search_run_xiaohongshu = has_xiaohongshu
 
     # INCLUDE_SOURCES override: force specific sources on regardless of tier
-    _include_sources = {s.strip().lower() for s in config.get('INCLUDE_SOURCES', '').split(',') if s.strip()}
+    _include_sources = {s.strip().lower() for s in (config.get('INCLUDE_SOURCES') or '').split(',') if s.strip()}
     if _include_sources:
         if 'tiktok' in _include_sources and has_tiktok:
             if not search_run_tiktok:


### PR DESCRIPTION
## Problem

After 61904b3 (`feat: INCLUDE_SOURCES config`), `/last30days` crashes on every run when `INCLUDE_SOURCES` is unset:

```
Traceback (most recent call last):
  File "scripts/last30days.py", line 2137, in <module>
    main()
  File "scripts/last30days.py", line 1740, in main
    _include_sources = {s.strip().lower() for s in config.get('INCLUDE_SOURCES', '').split(',') if s.strip()}
AttributeError: 'NoneType' object has no attribute 'split'
```

## Root cause

`config.get('INCLUDE_SOURCES', '')` returns `None` (not the `''` default) when the key exists in the loaded env/config but is set to `None`. Calling `.split(',')` on `None` raises `AttributeError`.

## Fix

Coerce with `or ''` so a `None` value falls back to the empty string before `.split()`:

```python
_include_sources = {s.strip().lower() for s in (config.get('INCLUDE_SOURCES') or '').split(',') if s.strip()}
```

## Repro

```bash
python3 scripts/last30days.py --mock --emit compact "test topic"
# crashes before fix, runs cleanly after
```

## Test

Verified locally with mock run — banner displays, sources tier, no crash.