### PR TITLE
fix(reddit): re-raise HTTP 402 so fallback chain triggers

### DIFF
--- a/scripts/lib/reddit.py
+++ b/scripts/lib/reddit.py
@@ -282,6 +282,11 @@ def _global_search(
         resp.raise_for_status()
         data = resp.json()
         return data.get("posts", data.get("data", []))
+    except _requests.exceptions.HTTPError as e:
+        _log(f"Global search error: {e}")
+        if e.response is not None and e.response.status_code == 402:
+            raise  # Payment required — API key exhausted, trigger fallback
+        return []
     except Exception as e:
         _log(f"Global search error: {e}")
         return []
@@ -337,6 +342,11 @@ def _subreddit_search(
         resp.raise_for_status()
         data = resp.json()
         return data.get("posts", data.get("data", []))
+    except _requests.exceptions.HTTPError as e:
+        _log(f"Subreddit search error for r/{subreddit}: {e}")
+        if e.response is not None and e.response.status_code == 402:
+            raise  # Payment required — trigger fallback
+        return []
     except Exception as e:
         _log(f"Subreddit search error for r/{subreddit}: {e}")
         return []
@@ -378,6 +388,11 @@ def fetch_post_comments(
         resp.raise_for_status()
         data = resp.json()
         return data.get("comments", data.get("data", []))
+    except _requests.exceptions.HTTPError as e:
+        _log(f"Comment fetch error: {e}")
+        if e.response is not None and e.response.status_code == 402:
+            raise  # Payment required — trigger fallback
+        return []
     except Exception as e:
         _log(f"Comment fetch error: {e}")
         return []


### PR DESCRIPTION
## Summary
- When ScrapeCreators returns HTTP 402 (payment required / credits exhausted), the broad `except Exception` handlers in `_global_search`, `_subreddit_search`, and `fetch_post_comments` were swallowing the error and returning empty results
- This prevented `_search_reddit_thread()` in `last30days.py` from falling through to the OpenAI or public Reddit JSON fallback paths
- Now 402 errors are re-raised so the existing fallback logic triggers correctly

## Context
A user with exhausted ScrapeCreators credits gets silently zero Reddit results instead of falling through to the free alternatives. The fallback chain in `last30days.py` (lines 216-229) is designed to catch exceptions and try OpenAI → public Reddit, but it never fires because the 402 is caught too early.

## Test plan
- [ ] Verify with an exhausted/invalid ScrapeCreators key that Reddit search falls through to OpenAI or public JSON fallback
- [ ] Verify that transient errors (429, 500) still return empty gracefully without triggering fallback
- [ ] Verify normal 200 path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)