### PR TITLE
last30days: finish runtime/report rename after /last30days plugin rename

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ruff: noqa: E402
-"""last30days-3 v3.0.0-alpha CLI."""
+"""last30days v3.0.0 CLI."""
 
 from __future__ import annotations
 

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -27,7 +27,7 @@ _FUN_LEVELS = {
 def render_compact(report: schema.Report, cluster_limit: int = 8, fun_level: str = "medium") -> str:
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
-        f"# last30days-3 v3.0.0-alpha: {report.topic}",
+        f"# last30days v3.0.0: {report.topic}",
         "",
         f"- Date range: {report.range_from} to {report.range_to}",
         f"- Sources: {len(non_empty)} active ({', '.join(_source_label(s) for s in non_empty)})" if non_empty else "- Sources: none",
@@ -81,7 +81,7 @@ def render_full(report: schema.Report) -> str:
     # Start with the same header as compact
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
-        f"# last30days-3 v3.0.0-alpha: {report.topic}",
+        f"# last30days v3.0.0: {report.topic}",
         "",
         f"- Date range: {report.range_from} to {report.range_to}",
         f"- Sources: {len(non_empty)} active ({', '.join(_source_label(s) for s in non_empty)})" if non_empty else "- Sources: none",

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -93,12 +93,13 @@ class CliV3Tests(unittest.TestCase):
     def test_slugify_and_emit_output_cover_supported_modes(self):
         report = self.make_report()
         self.assertEqual("openclaw-vs-nanoclaw", cli.slugify(report.topic))
+        self.assertEqual("last30days v3.0.0 CLI.", cli.__doc__)
 
         compact = cli.emit_output(report, "compact")
         json_output = cli.emit_output(report, "json")
         context = cli.emit_output(report, "context")
 
-        self.assertIn("# last30days-3 v3.0.0-alpha", compact)
+        self.assertIn("# last30days v3.0.0", compact)
         self.assertIn('"topic": "OpenClaw vs NanoClaw"', json_output)
         self.assertIsInstance(context, str)
 

--- a/tests/test_generate_synthesis_inputs_v3.py
+++ b/tests/test_generate_synthesis_inputs_v3.py
@@ -116,7 +116,7 @@ class GenerateSynthesisInputsV3Tests(unittest.TestCase):
 
             self.assertEqual(0, result)
             output = (compact_dir / "sample.md").read_text()
-            self.assertIn("# last30days-3 v3.0.0-alpha: test topic", output)
+            self.assertIn("# last30days v3.0.0: test topic", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -91,7 +91,7 @@ def sample_report() -> schema.Report:
 class RenderV3Tests(unittest.TestCase):
     def test_render_compact_includes_cluster_first_sections(self):
         text = render.render_compact(sample_report())
-        self.assertIn("# last30days-3 v3.0.0-alpha: test topic", text)
+        self.assertIn("# last30days v3.0.0: test topic", text)
         self.assertIn("## Ranked Evidence Clusters", text)
         self.assertIn("## Stats", text)
         self.assertIn("Total evidence: 2 items across 2 sources", text)


### PR DESCRIPTION
## Summary
- follow up on [565deb4](https://github.com/mvanhorn/last30days-skill/commit/565deb443e3ada3e7ab87d4f1103c81e0e564045), which renamed the plugin to `/last30days`
- update the remaining user-facing v3 runtime/report strings that still emitted `last30days-3 v3.0.0-alpha`
- refresh the focused tests to assert the current `/last30days` 3.0 identity

## Why
The April 8, 2026 rename updated the plugin metadata, but the CLI docstring and rendered report headers were still using the old `last30days-3` label. That left generated output with mixed naming even after the rename landed.

This follow-up keeps the runtime output consistent with the renamed plugin so users see the same `/last30days` identity in the command, the reports it generates, and the tests that cover that behavior.

## Verification
- `/Users/pejman/.oss-pr-manager/workspaces/mvanhorn__last30days-skill/.venv/bin/python -m pytest tests/test_cli_v3.py tests/test_render_v3.py -q`