### PR TITLE
docs: point skill metadata at public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 **An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**
 
+This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days-v3/SKILL.md](skills/last30days-v3/SKILL.md), which is the source of truth for the latest command and setup behavior.
+
 Claude Code:
 ```
 /plugin marketplace add mvanhorn/last30days-skill
@@ -86,7 +88,7 @@ The synthesis ranks by what real people actually engaged with. Social relevancy,
 
 **To learn something fast.** `/last30days Nano Banana Pro prompting` - JSON-structured prompts are replacing tag soup. @pictsbyai's nested format prevents "concept bleeding." Edit-first workflow beats regeneration. Then it writes you a production prompt using exactly what the community said works.
 
-## What's New in v3
+## What v3 Changed
 
 ### Intelligent search: the killer feature
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,8 +4,8 @@ version: "3.0.0"
 description: "Multi-query social search with intelligent planning. Agent plans queries when possible, falls back to Gemini/OpenAI when not. Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web."
 argument-hint: 'last30days-3 AI video tools, last30days-3 best noise cancelling headphones'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
-homepage: https://github.com/mvanhorn/last30days-skill-private
-repository: https://github.com/mvanhorn/last30days-skill-private
+homepage: https://github.com/mvanhorn/last30days-skill
+repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn
 license: MIT
 user-invocable: true


### PR DESCRIPTION
This PR updates the skill frontmatter to reference the public repository URL instead of the old private placeholder. That keeps install/metadata links aligned with the repo users can actually access.