### PR TITLE
fix(bird_x): normalize list responses from Bird search

### DIFF
--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -213,7 +213,10 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
         if not output:
             return {"items": []}
 
-        return json.loads(output)
+        parsed = json.loads(output)
+        if isinstance(parsed, list):
+            return {"items": parsed}
+        return parsed
 
     except json.JSONDecodeError as e:
         return {"error": f"Invalid JSON response: {e}", "items": []}


### PR DESCRIPTION
## Summary

- `_run_bird_search()` declares a `Dict[str, Any]` return type, but when Bird's JSON response is a raw array (e.g., `[{...}, {...}]`), `json.loads` returns a `list`. All callers use `.get('items')` on the result, which raises `AttributeError: 'list' object has no attribute 'get'`.
- Wraps list responses in `{"items": parsed}` so callers always receive a dict with an `items` key, matching the declared return type.

## Test plan

- [x] Trigger a Bird search that returns a raw JSON array and verify no `AttributeError`
- [x] Trigger a Bird search that returns a JSON object and verify existing behavior unchanged
- [x] Confirm `_run_bird_search` return type matches `Dict[str, Any]` in both cases

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)