### PR TITLE
fix: write briefing files as utf-8

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,8 +4,8 @@ version: "3.0.0"
 description: "Multi-query social search with intelligent planning. Agent plans queries when possible, falls back to Gemini/OpenAI when not. Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web."
 argument-hint: 'last30days-3 AI video tools, last30days-3 best noise cancelling headphones'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
-homepage: https://github.com/mvanhorn/last30days-skill-private
-repository: https://github.com/mvanhorn/last30days-skill-private
+homepage: https://github.com/mvanhorn/last30days-skill
+repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn
 license: MIT
 user-invocable: true

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -216,7 +216,7 @@ def show_briefing(date: str = None) -> dict:
     if not path.exists():
         return {"status": "not_found", "message": f"No briefing found for {date}."}
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -225,7 +225,7 @@ def _save_briefing(data: dict, suffix: str = ""):
     BRIEFS_DIR.mkdir(parents=True, exist_ok=True)
     date = datetime.now().strftime("%Y-%m-%d")
     path = BRIEFS_DIR / f"{date}{suffix}.json"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, default=str)
 
 

--- a/tests/test_briefing_v3.py
+++ b/tests/test_briefing_v3.py
@@ -2,6 +2,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
@@ -28,6 +29,27 @@ class BriefingV3Tests(unittest.TestCase):
                 self.assertGreaterEqual(result["topics"][0]["hours_ago"], 0.0)
             finally:
                 store._db_override = old_db_override
+                briefing.BRIEFS_DIR = old_briefs_dir
+
+    def test_save_briefing_uses_utf8_encoding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_briefs_dir = briefing.BRIEFS_DIR
+            try:
+                briefing.BRIEFS_DIR = Path(tmpdir) / "briefs"
+                payload = {"status": "ok", "message": "emoji 💬 and accents café"}
+                with mock.patch("briefing.open", create=True) as mock_open:
+                    handle = mock.Mock()
+                    handle.__enter__ = mock.Mock(return_value=handle)
+                    handle.__exit__ = mock.Mock(return_value=False)
+                    mock_open.return_value = handle
+
+                    briefing._save_briefing(payload)
+
+                mock_open.assert_called_once()
+                _, kwargs = mock_open.call_args
+                self.assertEqual("w", kwargs["mode"] if "mode" in kwargs else mock_open.call_args.args[1])
+                self.assertEqual("utf-8", kwargs["encoding"])
+            finally:
                 briefing.BRIEFS_DIR = old_briefs_dir
 
 


### PR DESCRIPTION
This fixes the briefing archive writer to always read/write JSON as UTF-8, avoiding locale-encoded failures on Windows and other non-UTF-8 environments. It also adds a regression test that asserts the save path opens files with encoding='utf-8'.\n\nThe current codebase no longer has the old render.py write path from issue #167, so this patch applies the same encoding fix to the active briefing writer path instead.