### PR TITLE
fix: update argument-hint in root SKILL.md from last30days-3 to last30days

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: last30days
 version: "3.0.0"
 description: "Multi-query social search with intelligent planning. Agent plans queries when possible, falls back to Gemini/OpenAI when not. Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web."
-argument-hint: 'last30days-3 AI video tools, last30days-3 best noise cancelling headphones'
+argument-hint: 'last30days AI video tools, last30days best noise cancelling headphones'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
 homepage: https://github.com/mvanhorn/last30days-skill-private
 repository: https://github.com/mvanhorn/last30days-skill-private


### PR DESCRIPTION
## Problem

The root `SKILL.md` (symlinked as `skills/last30days-nux/SKILL.md`) still shows `last30days-3` in the `argument-hint` field. Users see stale invocation examples that reference the old plugin name.

## Change

One line — updates `argument-hint` from:
```
last30days-3 AI video tools, last30days-3 best noise cancelling headphones
```
to:
```
last30days AI video tools, last30days best noise cancelling headphones
```

Follow-up to #186 which fixed the same class of stale name in the `skills/last30days-v3` directory and `marketplace.json`.