### PR TITLE
docs: add plugin update command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,15 @@ Say "eli5 on" after any research run. The synthesis rewrites in plain language. 
 ## Install
 
 ### Claude Code
+
+#### Install
 ```
 /plugin marketplace add mvanhorn/last30days-skill
+```
+
+#### Update
+```
+claude plugin update last30days@last30days-skill
 ```
 
 ### OpenClaw


### PR DESCRIPTION
## Problem

The README documents how to install the plugin but not how to update it. Users need to know the marketplace name (`last30days-skill`) for the update command.

## Change

Adds an "Update" subheading under Install > Claude Code with the `claude plugin update` command.