### PR TITLE
fix(tests): isolate env in resolve_google_judge_api_key test

### DIFF
--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -99,7 +100,10 @@ class EvaluatorV3Tests(unittest.TestCase):
     def test_resolve_google_judge_api_key_prefers_google_key(self):
         with mock.patch.dict("os.environ", {"GOOGLE_API_KEY": "google", "GEMINI_API_KEY": "gemini"}, clear=False):
             self.assertEqual("google", evaluator.resolve_google_judge_api_key({}))
-        self.assertEqual("fallback", evaluator.resolve_google_judge_api_key({"GOOGLE_GENAI_API_KEY": "fallback"}))
+        with mock.patch.dict("os.environ", {k: "" for k in ("GOOGLE_API_KEY", "GEMINI_API_KEY", "GOOGLE_GENAI_API_KEY")}, clear=False):
+            for k in ("GOOGLE_API_KEY", "GEMINI_API_KEY", "GOOGLE_GENAI_API_KEY"):
+                os.environ.pop(k, None)
+            self.assertEqual("fallback", evaluator.resolve_google_judge_api_key({"GOOGLE_GENAI_API_KEY": "fallback"}))
 
     def test_extract_gemini_text_raises_when_missing(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary

Fixes a test isolation bug in `test_evaluator_v3.py` where `test_resolve_google_judge_api_key_prefers_google_key` fails for developers who have `GOOGLE_API_KEY` or `GEMINI_API_KEY` set in their environment.

## Changes

The second assertion ran outside the `mock.patch.dict` context, so `resolve_google_judge_api_key()` picked up real env vars instead of using the config dict fallback. Wrapped it in its own mock scope that clears the three relevant keys.

Added `import os` (needed for `os.environ.pop`).

## Testing

```
$ pytest tests/test_evaluator_v3.py::EvaluatorV3Tests::test_resolve_google_judge_api_key_prefers_google_key -v
1 passed in 0.02s
```

Passes both with and without `GOOGLE_API_KEY` set in the environment.

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)