### PR TITLE
fix: bump gemini-extension and v3 skill version to 3.0.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "2.9.5",
+  "version": "3.0.0",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/skills/last30days-v3/SKILL.md
+++ b/skills/last30days-v3/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: last30days
-version: "3.0.0-alpha"
-description: "[V3 DEV] Research any topic from the last 30 days. Side-by-side test version of the v3 pipeline."
+version: "3.0.0"
+description: "Multi-query social search with intelligent planning. Agent plans queries when possible, falls back to Gemini/OpenAI when not. Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web."
 argument-hint: "last30days-v3 codex vs claude code"
 allowed-tools: Bash, Read, Write, WebSearch
 homepage: https://github.com/mvanhorn/last30days-skill


### PR DESCRIPTION
## Summary

Aligns stale version strings and metadata left over from the v2-to-v3 transition with the canonical `3.0.0` in `pyproject.toml`.

## Changes

- `gemini-extension.json`: version `"2.9.5"` -> `"3.0.0"`
- `skills/last30days-v3/SKILL.md`: version `"3.0.0-alpha"` -> `"3.0.0"`, description updated from `[V3 DEV]` placeholder to production text

Structural decisions from #190 (SKILL.md consolidation, SKILL-original.md cleanup, allowed-tools mismatch) are left for the maintainer.

Fixes part of #190.

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)