### PR TITLE
fix(bluesky): add token expiry handling to session cache

### DIFF
--- a/scripts/lib/bluesky.py
+++ b/scripts/lib/bluesky.py
@@ -7,6 +7,7 @@ Requires BSKY_HANDLE and BSKY_APP_PASSWORD env vars.
 import math
 import re
 import sys
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -23,7 +24,9 @@ DEPTH_CONFIG = {
 
 # Module-level token cache (valid for the lifetime of a single research run)
 _cached_token: Optional[str] = None
+_token_created_at: float = 0.0
 _session_error: Optional[str] = None
+_TOKEN_MAX_AGE_SECONDS = 5400  # 90 minutes (conservative, tokens last ~2 hours)
 
 
 def _log(msg: str):
@@ -40,9 +43,13 @@ def _create_session(handle: str, app_password: str) -> Optional[str]:
     Returns:
         Access JWT string, or None on failure. Sets _session_error on failure.
     """
-    global _cached_token, _session_error
-    if _cached_token:
+    global _cached_token, _token_created_at, _session_error
+    if _cached_token and (time.monotonic() - _token_created_at < _TOKEN_MAX_AGE_SECONDS):
         return _cached_token
+    if _cached_token:
+        _log("Session token expired, re-authenticating")
+        _cached_token = None
+        _token_created_at = 0.0
 
     try:
         response = http.request(
@@ -54,6 +61,7 @@ def _create_session(handle: str, app_password: str) -> Optional[str]:
         token = response.get("accessJwt")
         if token:
             _cached_token = token
+            _token_created_at = time.monotonic()
             _session_error = None
             _log("Session created successfully")
             return token
@@ -76,8 +84,9 @@ def _create_session(handle: str, app_password: str) -> Optional[str]:
 
 
 def _reset_session_cache() -> None:
-    global _cached_token, _session_error
+    global _cached_token, _token_created_at, _session_error
     _cached_token = None
+    _token_created_at = 0.0
     _session_error = None
 
 


### PR DESCRIPTION
## Summary

Adds a 90-minute expiry check to the module-level `_cached_token` in `scripts/lib/bluesky.py`. AT Protocol access tokens expire after ~2 hours, but the cached token was returned indefinitely without checking age. Long-running sessions (watchlist cron) would get silent 401 errors.

## Changes

- Added `_token_created_at` timestamp using `time.monotonic()`
- Added `_TOKEN_MAX_AGE_SECONDS = 5400` (90 min, conservative buffer below ~2hr token lifetime)
- `_create_session()` now checks token age before returning cached value and logs when re-authenticating
- `_reset_session_cache()` also resets the timestamp
- Existing 401 retry in `search_bluesky` already calls `_reset_session_cache()`, so that path works with this change

Fixes #92

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)