### PR TITLE
fix: correct plugin name and version in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,9 +8,9 @@
   },
   "plugins": [
     {
-      "name": "last30days-3",
+      "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, GitHub, and 5+ more sources.",
-      "version": "3.0.0-alpha",
+      "version": "3.0.0",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"


### PR DESCRIPTION
## Summary

`marketplace.json` had stale v3 rename artifacts from the `last30days-v3` to `last30days` transition:
- Plugin name was `last30days-3`, should be `last30days` (matching `plugin.json`)
- Version was `3.0.0-alpha`, should be `3.0.0` (matching the stable release in `plugin.json`)

Same category as #190.

## Changes

- `.claude-plugin/marketplace.json`: updated plugin name and version to match `plugin.json`

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)