### PR TITLE
Codex/add openclaw variant files

### DIFF
--- a/variants/open/SKILL.md
+++ b/variants/open/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: last30days
+version: "3.0.0-open"
+description: "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, Perplexity, and more. AI agent scores by upvotes, likes, and real money. Also triggered by 'last30'."
+argument-hint: 'last30 AI video tools, last30 watch my competitor every week, last30 give me my briefing'
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+disable-model-invocation: true
+---
+
+# last30days (open variant): Research + Watchlist + Briefings
+
+Multi-mode research skill with persistent knowledge accumulation.
+
+## Command Routing
+
+Parse the user's first argument to determine the mode:
+
+| First word | Mode | Reference |
+|---|---|---|
+| `watch` | Watchlist management | `references/watchlist.md` |
+| `briefing` | Morning briefing | `references/briefing.md` |
+| `history` | Query accumulated knowledge | `references/history.md` |
+| *(anything else)* | One-shot research | `references/research.md` |
+
+## Setup: Find Skill Root
+
+```bash
+for dir in \
+  "." \
+  "${CLAUDE_PLUGIN_ROOT:-}" \
+  "${GEMINI_EXTENSION_DIR:-}" \
+  "$HOME/.gemini/extensions/last30days-skill" \
+  "$HOME/.gemini/extensions/last30days" \
+  "$HOME/.claude/skills/last30days" \
+  "$HOME/.agents/skills/last30days" \
+  "$HOME/.codex/skills/last30days"; do
+  [ -n "$dir" ] && [ -f "$dir/scripts/last30days.py" ] && SKILL_ROOT="$dir" && break
+done
+
+if [ -z "${SKILL_ROOT:-}" ]; then
+  echo "ERROR: Could not find scripts/last30days.py" >&2
+  exit 1
+fi
+```
+
+Use `$SKILL_ROOT` for all script and reference file paths.
+
+## Load Context
+
+At session start, read `${SKILL_ROOT}/variants/open/context.md` for user preferences and source quality notes. Update it after interactions.
+
+## Shared Configuration
+
+- **Database**: `~/.local/share/last30days/research.db` (SQLite, WAL mode)
+- **Briefings**: `~/.local/share/last30days/briefs/`
+- **API keys**: `~/.config/last30days/.env` or environment variables
+- **Key priority**: env vars > config file
+
+### API Keys
+
+| Key | Required | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | For Reddit | Reddit search via OpenAI responses API |
+| `XAI_API_KEY` | For X (fallback) | X search via xAI Grok API |
+| `OPENROUTER_API_KEY` | Optional | Perplexity Sonar Pro search + AI reasoning (planning/reranking). Add `INCLUDE_SOURCES=perplexity` to enable. Use `--deep-research` for exhaustive reports. |
+| `PARALLEL_API_KEY` | Optional | Web search via Parallel AI |
+| `BRAVE_API_KEY` | Optional | Web search via Brave Search |
+
+Bird CLI provides free X search if installed. YouTube search uses yt-dlp (free).
+
+Run `python3 "${SKILL_ROOT}/scripts/last30days.py" --diagnose` to check source availability.
+
+## Routing Logic
+
+After determining the mode, **read the corresponding reference file** using the Read tool:
+
+```
+Read: ${SKILL_ROOT}/variants/open/references/{mode}.md
+```
+
+Then follow the instructions in that reference file exactly.

--- a/variants/open/context.md
+++ b/variants/open/context.md
@@ -1,0 +1,16 @@
+# last30days Context
+
+Agent memory for improving research quality over time.
+
+## User Preferences
+<!-- Record preferences discovered during interactions -->
+<!-- e.g., "Prefers detailed technical analysis over general summaries" -->
+
+## Source Quality Notes
+<!-- Record which sources work best for which topics -->
+<!-- e.g., "r/LocalLLaMA is highest signal for AI hardware topics" -->
+<!-- e.g., "@kaboratech provides reliable AI tool reviews" -->
+
+## Interaction History
+<!-- Record topics researched and useful follow-up patterns -->
+<!-- e.g., "2026-02-14: Researched 'AI video tools', user wanted Runway vs Kling comparison" -->

--- a/variants/open/references/briefing.md
+++ b/variants/open/references/briefing.md
@@ -1,0 +1,82 @@
+# Morning Briefing
+
+Synthesize accumulated findings into a formatted briefing.
+
+## Commands
+
+| Command | Action |
+|---|---|
+| `briefing` | Generate today's briefing |
+| `briefing --weekly` | Weekly digest with trends |
+| `briefing --since YYYY-MM-DD` | Briefing since specific date |
+
+## Generate Briefing
+
+```bash
+python3 "${SKILL_ROOT}/scripts/briefing.py" generate [--weekly] [--since DATE]
+```
+
+The script returns JSON with per-topic findings, staleness info, and cost data.
+
+## Staleness Check
+
+Before synthesizing, check each topic's freshness:
+- **Fresh** (< 12h): show normally
+- **Aging** (12-36h): note when last run was
+- **Stale** (> 36h): warn user, suggest running `watch run-one "topic"`
+
+## Daily Briefing Format
+
+```
+Good morning! Here's your research briefing for [DATE].
+
+TL;DR: [One sentence about the top finding across all topics]
+
+---
+
+**[Topic 1]** (N new findings)
+Top signal: [Highest engagement finding with source]
+Also trending: [2nd finding], [3rd finding]
+
+**[Topic 2]** (N new findings)
+Top signal: [Highest engagement finding]
+Also trending: [2nd finding]
+
+---
+Cost: $X.XX / $Y.YY budget | N topics active | N findings today
+```
+
+## Weekly Digest Format
+
+```
+Weekly digest for week of [DATE]:
+
+**[Topic 1]**
+This week: N findings (up/down X% from last week)
+Trending up: [engagement increasing]
+Key voices: @handle1, r/sub1
+
+**[Topic 2]**
+This week: N findings
+Trending down: [engagement decreasing]
+```
+
+## Synthesis Rules
+
+- Lead with people, not publications
+- 3-5 topics max per briefing
+- 2-3 findings per topic
+- Include cost/budget footer
+- Note any failed or stale topics
+
+## No Data Handling
+
+If no topics or no findings:
+```
+No briefing data available.
+
+To get started:
+1. Add a topic: /last30days watch add "your topic"
+2. Run research: /last30days watch run-all
+3. Generate briefing: /last30days briefing
+```

--- a/variants/open/references/history.md
+++ b/variants/open/references/history.md
@@ -1,0 +1,102 @@
+# History & Knowledge Query
+
+Query the accumulated findings database.
+
+## Commands
+
+| Command | Action |
+|---|---|
+| `history "topic"` | Show findings for a topic |
+| `history "topic" --since=7d` | Findings from last N days |
+| `history --search "query"` | Full-text search across all findings |
+| `history --trending` | Topics with most recent activity |
+| `history --stats` | Watchlist health dashboard |
+
+## Topic History
+
+```bash
+python3 "${SKILL_ROOT}/scripts/store.py" query "TOPIC" [--since DAYS]
+```
+
+Display findings grouped by date (newest first):
+```
+**[Topic Name]** — N findings since [date]
+
+[DATE]
+- [Reddit] Title (score pts, N comments) — r/subreddit
+- [X] Tweet text... (N likes) — @handle
+- [YouTube] Video title (N views) — channel
+
+[EARLIER DATE]
+- ...
+```
+
+Mark updated findings (engagement changed since first seen).
+
+## Full-Text Search
+
+```bash
+python3 "${SKILL_ROOT}/scripts/store.py" search "QUERY"
+```
+
+Uses FTS5 with BM25 ranking. Show results across all topics:
+```
+Search: "QUERY" — N results
+
+1. [Reddit] Title — r/subreddit (topic: AI video)
+   ...snippet with **highlighted** matches...
+
+2. [X] Tweet text — @handle (topic: NVIDIA)
+   ...snippet...
+```
+
+## Trending Topics
+
+```bash
+python3 "${SKILL_ROOT}/scripts/store.py" trending
+```
+
+Show topics ranked by recent activity:
+```
+Trending topics (last 7 days):
+
+1. AI video tools — 12 new findings, engagement up 45%
+2. NVIDIA news — 8 new findings, engagement steady
+3. Claude Code — 3 new findings, engagement down 20%
+```
+
+## Stats Dashboard
+
+```bash
+python3 "${SKILL_ROOT}/scripts/store.py" stats
+```
+
+Display as a health dashboard:
+```
+Watchlist Health
+- Active topics: N
+- Total findings: N
+- Database size: N KB
+
+Research Runs (7 days)
+- Successful: N
+- Failed: N
+- Cost: $X.XX
+
+Source Breakdown
+- Reddit: N findings
+- X: N findings
+- YouTube: N findings
+- Web: N findings
+```
+
+## No Data Handling
+
+If no findings exist:
+```
+No research history yet.
+
+To start building knowledge:
+1. Run research: /last30days "your topic"
+2. Or add a watchlist topic: /last30days watch add "topic"
+```

--- a/variants/open/references/research.md
+++ b/variants/open/references/research.md
@@ -1,0 +1,220 @@
+# One-Shot Research Mode (v3)
+
+Research ANY topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web. Surface what people are actually discussing, recommending, betting on, and debating right now.
+
+---
+
+## 1. Parse User Intent
+
+Before doing anything, parse the user's input for:
+
+1. **TOPIC**: What they want to learn about
+2. **TARGET TOOL** (if specified): Where they'll use the prompts
+3. **QUERY TYPE**:
+   - **PROMPTING** - "X prompts", "prompting for X" -> copy-paste prompts
+   - **RECOMMENDATIONS** - "best X", "top X" -> list of specific things
+   - **NEWS** - "what's happening with X" -> current events
+   - **COMPARISON** - "X vs Y", "X versus Y", "compare X and Y" -> side-by-side comparison
+   - **GENERAL** - anything else -> broad understanding
+
+Common patterns:
+- `[topic] for [tool]` -> TOOL IS SPECIFIED
+- `[topic] prompts for [tool]` -> TOOL IS SPECIFIED
+- Just `[topic]` -> TOOL NOT SPECIFIED, that's OK
+- "best [topic]" or "top [topic]" -> QUERY_TYPE = RECOMMENDATIONS
+- "X vs Y" or "X versus Y" -> QUERY_TYPE = COMPARISON, TOPIC_A = X, TOPIC_B = Y
+
+**Do NOT ask about target tool before research.** Run research first, ask after.
+
+**Store these variables:**
+- `TOPIC = [extracted topic]`
+- `TARGET_TOOL = [extracted tool, or "unknown" if not specified]`
+- `QUERY_TYPE = [PROMPTING | RECOMMENDATIONS | NEWS | COMPARISON | GENERAL]`
+- `TOPIC_A = [first item]` (only if COMPARISON)
+- `TOPIC_B = [second item]` (only if COMPARISON)
+
+---
+
+## 2. Confirm Topic
+
+Display a branded one-liner before starting research. Build ACTIVE_SOURCES_LIST by checking what's configured in .env (Reddit, HN, Polymarket are always active; add X, YouTube, TikTok, Instagram, GitHub, Perplexity based on configured keys/tools).
+
+For GENERAL / NEWS / RECOMMENDATIONS / PROMPTING queries:
+```
+/last30days - searching {ACTIVE_SOURCES_LIST} for what people are saying about {TOPIC}.
+```
+
+For COMPARISON queries:
+```
+/last30days - comparing {TOPIC_A} vs {TOPIC_B} across {ACTIVE_SOURCES_LIST}.
+```
+
+Do NOT show a multi-line "Parsed intent" block with TOPIC=, TARGET_TOOL=, QUERY_TYPE= variables. Do NOT promise a specific time. Do NOT list sources that aren't configured.
+
+Then proceed immediately to research execution.
+
+---
+
+## 3. Handle / GitHub Resolution
+
+**OpenClaw does not have WebSearch.** Skip manual handle resolution (Steps 0.5, 0.55, 0.75 from the main skill). Instead, add `--auto-resolve` to the research command. The engine will use configured web search backends (Brave, Exa, Serper) to discover subreddits, X handles, and context before planning.
+
+If the user manually provides handles or community names, pass them through as CLI flags (see the flags list in Research Execution below). But do NOT attempt WebSearch-based resolution yourself.
+
+---
+
+## 4. Agent Mode (--agent flag)
+
+If `--agent` appears in ARGUMENTS (e.g., `/last30days plaud granola --agent`):
+
+1. **Skip** the intro display block
+2. **Skip** any `AskUserQuestion` calls - use `TARGET_TOOL = "unknown"` if not specified
+3. **Run** the research script exactly as normal
+4. **Skip** the follow-up invitation
+5. **Output** the complete research report and stop - do not wait for further input
+
+Agent mode saves raw research data to `~/Documents/Last30Days/` automatically via `--save-dir`.
+
+Agent mode report format:
+
+```
+## Research Report: {TOPIC}
+Generated: {date} | Sources: Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, Web
+
+### Key Findings
+[3-5 bullet points, highest-signal insights with citations]
+
+### What I learned
+{The full "What I learned" synthesis from normal output}
+
+### Stats
+{The standard stats block}
+```
+
+---
+
+## 5. Comparison Mode (QUERY_TYPE = COMPARISON)
+
+When the user asks "X vs Y", run ONE research pass with a comparison-optimized query that covers both entities AND their rivalry.
+
+**Single pass with entity-aware subqueries:**
+```bash
+python3 "${SKILL_ROOT}/scripts/last30days.py" "{TOPIC_A} vs {TOPIC_B}" --auto-resolve --emit=compact --save-dir=~/Documents/Last30Days --save-suffix=v3 --store 2>&1
+```
+
+If the user provided manual handles or subreddits, include those flags too.
+
+Then skip the normal Research Execution below - go directly to the comparison synthesis format (see Synthesis section).
+
+**Comparison output format:**
+
+```
+# {TOPIC_A} vs {TOPIC_B}: What the Community Says (Last 30 Days)
+
+## Quick Verdict
+[1-2 sentence data-driven summary: which one the community prefers and why, with source counts]
+
+## {TOPIC_A}
+Community Sentiment: [Positive/Mixed/Negative] ({N} mentions across {sources})
+
+Strengths (what people love)
+- [Point 1 with source attribution]
+- [Point 2]
+
+Weaknesses (common complaints)
+- [Point 1 with source attribution]
+- [Point 2]
+
+## {TOPIC_B}
+Community Sentiment: [Positive/Mixed/Negative] ({N} mentions across {sources})
+
+Strengths (what people love)
+- [Point 1 with source attribution]
+- [Point 2]
+
+Weaknesses (common complaints)
+- [Point 1 with source attribution]
+- [Point 2]
+
+## Head-to-Head
+[Synthesis from the combined search - what people say when directly comparing]
+
+| Dimension | {TOPIC_A} | {TOPIC_B} |
+|-----------|-----------|-----------|
+| [Key dimension 1] | [A's position] | [B's position] |
+| [Key dimension 2] | [A's position] | [B's position] |
+| [Key dimension 3] | [A's position] | [B's position] |
+
+## The Bottom Line
+Choose {TOPIC_A} if... Choose {TOPIC_B} if... (based on actual community data, not assumptions)
+```
+
+Then show combined stats and the standard invitation section.
+
+---
+
+## 6. Research Execution
+
+**Run the research script in the FOREGROUND with a 5-minute timeout.**
+
+```bash
+python3 "${SKILL_ROOT}/scripts/last30days.py" $ARGUMENTS --auto-resolve --emit=compact --save-dir=~/Documents/Last30Days --save-suffix=v3 --store 2>&1
+```
+
+Use a **timeout of 300000** (5 minutes). The `--store` flag persists findings for watchlist/briefing integration.
+
+**Always include `--auto-resolve`** since OpenClaw has no WebSearch. The engine will use configured web search backends (Brave, Exa, Serper) to discover subreddits, X handles, and current events context before planning.
+
+**Available flags** (pass through if the user provides them manually):
+- `--x-handle={handle}` - primary X/Twitter handle (without @)
+- `--x-related={handle1},{handle2}` - related X handles (comma-separated, without @)
+- `--subreddits={sub1},{sub2}` - target subreddits (comma-separated, no r/ prefix)
+- `--tiktok-hashtags={tag1},{tag2}` - TikTok hashtags to search
+- `--tiktok-creators={creator1},{creator2}` - TikTok creator handles
+- `--ig-creators={creator1},{creator2}` - Instagram creator handles
+- `--github-user={username}` - GitHub username for person-mode search
+- `--github-repo={owner/repo}` - GitHub repo for project-mode search (comma-separated for multiple)
+- `--deep-research` - Perplexity Deep Research mode (exhaustive 50+ citation reports, ~$0.90/query, requires OPENROUTER_API_KEY + `INCLUDE_SOURCES=perplexity`)
+- `--days=N` - look back N days instead of 30
+- `--quick` - faster, fewer sources (8-12 each)
+- `--deep` - comprehensive (50-70 Reddit, 40-60 X)
+
+**Read the ENTIRE output.** It contains data sections for: Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and Web. If you miss sections, you will produce incomplete stats.
+
+---
+
+## 7. WebSearch Supplemental
+
+**If your platform supports WebSearch**, use it after the script finishes to supplement with blogs, tutorials, and news.
+
+Choose search queries based on QUERY_TYPE:
+
+- **RECOMMENDATIONS**: `best {TOPIC} recommendations`, `{TOPIC} list examples`
+- **NEWS**: `{TOPIC} news 2026`, `{TOPIC} announcement update`
+- **PROMPTING**: `{TOPIC} prompts examples 2026`, `{TOPIC} techniques tips`
+- **GENERAL**: `{TOPIC} 2026`, `{TOPIC} discussion`
+
+Rules:
+- **USE THE USER'S EXACT TERMINOLOGY**
+- EXCLUDE reddit.com, x.com, twitter.com (covered by script)
+- Do NOT output a separate "Sources:" block
+
+**If your platform does NOT support WebSearch**, the `--auto-resolve` flag already provides web context via the engine's configured backends. Skip this step.
+
+---
+
+## 8. Synthesis / Judge Agent
+
+### v3 Cluster-First Output
+
+v3 returns results grouped by STORY/THEME (clusters), not by source. Each cluster represents one narrative thread found across multiple platforms.
+
+**How to read v3 output:**
+- `### 1. Cluster Title (score N, M items, sources: X, Reddit, TikTok)` - a story found across multiple platforms
+- `Uncertainty: single-source` - only one platform found this story (lower confidence)
+- `Uncertainty: thin-evidence` - all items scored below 55 (unconfirmed)
+- Items within a cluster show: source label, title, date, score, URL, and evidence snippet
+
+**Synthesis strategy for cluster-first output:**
+1. **Synthesize per-cluster first.** Each cluster = one story. Summarize what each story is about.
+2. **Multi-source clusters are highest confidence.** A cluster with items from Reddit + X + YouTube is much stronger than single-source.

--- a/variants/open/references/watchlist.md
+++ b/variants/open/references/watchlist.md
@@ -1,0 +1,107 @@
+# Watchlist Management
+
+Manage topics you want to track continuously. Findings accumulate in the SQLite database for briefings and history queries.
+
+## Commands
+
+| Command | Action |
+|---|---|
+| `watch add "topic"` | Add a topic (daily schedule) |
+| `watch add "topic" --weekly` | Add with weekly schedule |
+| `watch "topic"` | Shorthand for `watch add` |
+| `watch remove "topic"` | Remove a topic |
+| `watch list` | Show all topics with status |
+| `watch config delivery [channel]` | Set delivery channel |
+| `watch config budget AMOUNT` | Set daily cost budget |
+| `watch run-all` | Run research for all topics now |
+| `watch run-one "topic"` | Run research for one topic now |
+
+## Adding a Topic
+
+```bash
+python3 "${SKILL_ROOT}/scripts/watchlist.py" add "TOPIC_NAME" [--weekly] [--queries "q1,q2"]
+```
+
+The script auto-bootstraps the SQLite database on first add.
+
+**Default schedule**: Daily at 8am (`0 8 * * *`).
+**Weekly**: Mondays at 8am (`0 8 * * 1`).
+
+**After adding**, confirm to the user:
+```
+Added "TOPIC_NAME" to watchlist.
+Schedule: daily at 8am (or weekly on Mondays)
+
+To run research now: /last30days watch run-one "TOPIC_NAME"
+To set up automated runs: add a cron/launchd job for `python3 ${SKILL_ROOT}/scripts/watchlist.py run-all`
+```
+
+## Removing a Topic
+
+```bash
+python3 "${SKILL_ROOT}/scripts/watchlist.py" remove "TOPIC_NAME"
+```
+
+Show confirmation or "not found" message.
+
+## Listing Topics
+
+```bash
+python3 "${SKILL_ROOT}/scripts/watchlist.py" list
+```
+
+Display as a formatted table:
+```
+Topic         | Schedule     | Last Run     | Findings | Status
+--------------+--------------+--------------+----------+--------
+AI video      | daily 8am    | 2h ago       | 47       | ok
+NVIDIA news   | weekly Mon   | 3d ago       | 23       | ok
+
+Budget: $0.42 / $5.00 today
+```
+
+## Running Research
+
+```bash
+# All enabled topics (with budget guard)
+python3 "${SKILL_ROOT}/scripts/watchlist.py" run-all
+
+# Single topic
+python3 "${SKILL_ROOT}/scripts/watchlist.py" run-one "TOPIC_NAME"
+```
+
+Show results: new findings count, updated findings, duration, and any errors.
+
+## Configuration
+
+```bash
+# Set delivery channel (for future notification support)
+python3 "${SKILL_ROOT}/scripts/watchlist.py" config delivery telegram
+
+# Set daily budget limit
+python3 "${SKILL_ROOT}/scripts/watchlist.py" config budget 10.00
+```
+
+## Scheduling
+
+The watchlist doesn't auto-schedule. To automate, set up a system job:
+
+**macOS (launchd)**:
+```bash
+# Run daily at 8am
+crontab -e
+# Add: 0 8 * * * python3 /path/to/scripts/watchlist.py run-all
+```
+
+**Linux (cron)**:
+```bash
+crontab -e
+# Add: 0 8 * * * python3 /path/to/scripts/watchlist.py run-all
+```
+
+## Error Handling
+
+- Duplicate topic: update the existing schedule
+- Topic not found on remove: show "not found" message
+- Budget exceeded: skip remaining topics, show which were skipped
+- Research failure: record error, continue to next topic


### PR DESCRIPTION
Description
This adds the missing OpenClaw variant files under variants/open that the repo already references in README and scripts/sync.sh.

Why:

README tells OpenClaw users to install last30days-official
scripts/sync.sh already tries to sync variants/open into ~/.openclaw/skills/last30days
main is missing those files, so the OpenClaw sync path is incomplete
What’s included:

variants/open/SKILL.md
variants/open/context.md
variants/open/references/briefing.md
variants/open/references/history.md
variants/open/references/research.md
variants/open/references/watchlist.md
What I tested:

cloned the public repo
reproduced that scripts/sync.sh expected variants/open
added these files on a branch
re-ran scripts/sync.sh in a temp HOME and it completed successfully