### PR TITLE
fix(instagram): migrate search endpoint from v1 to v2

### DIFF
--- a/scripts/lib/instagram.py
+++ b/scripts/lib/instagram.py
@@ -217,7 +217,7 @@ def search_instagram(
 
     try:
         resp = _requests.get(
-            f"{SCRAPECREATORS_BASE}/v1/instagram/reels/search",
+            f"{SCRAPECREATORS_BASE}/v2/instagram/reels/search",
             params={"query": core_topic},
             headers=_sc_headers(token),
             timeout=30,


### PR DESCRIPTION
## Summary

ScrapeCreators migrated the Instagram Reels search endpoint. `/v1/instagram/reels/search` now returns a plain-text `404 Not Found` (gateway-level path miss), while `/v2/instagram/reels/search` is live and accepts the same parameters. This breaks the Instagram source in last30days with no warning — it just silently returns zero reels.

This PR changes the single endpoint reference in `scripts/lib/instagram.py:220` from `/v1/` to `/v2/`.

## Verification

Probed both endpoints with an invalid API key to compare gateway behavior:

```
/v1/instagram/reels/search   →  404  "Not Found"        (plain text, path gone)
/v2/instagram/reels/search   →  402  "out of credits"   (JSON, path exists, metering hit)
```

The plain-text vs JSON body distinction indicates `/v1/` is a routing miss at the edge, not a deprecated-with-stub. Auth failures return 401/403, so this is definitively a path migration, not an auth issue.

Live test with a valid `SCRAPECREATORS_API_KEY`:
```
python3 scripts/last30days.py "claude code" --quick --search=instagram
→ 9 Instagram reels returned, 3 with captions
```

The response shape is compatible — the existing parser at `instagram.py:232` already fans out across `reels`/`items`/`data` keys, so no parser changes needed.

## Test plan

- [x] Unauthenticated probe of both endpoints (path verification)
- [x] Live `last30days` run against v2 endpoint with real API key — returned reels successfully
- [ ] Maintainer confirms no other references to the old endpoint exist (grep shows only the one call site)