### PR TITLE
fix: resolve duplicate skill name causing marketplace validation failure (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**
 
-This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days-v3/SKILL.md](skills/last30days-v3/SKILL.md), which is the source of truth for the latest command and setup behavior.
+This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), which is the source of truth for the latest command and setup behavior.
 
 Claude Code:
 ```

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: last30days
+name: last30days-v3-spec
 version: "3.0.0"
-description: "Multi-query social search with intelligent planning. Agent plans queries when possible, falls back to Gemini/OpenAI when not. Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web."
+description: "Internal architecture spec for the v3 last30days runtime pipeline. Not user-invocable."
 argument-hint: "last30days codex vs claude code"
 allowed-tools: Bash, Read, Write, WebSearch
 homepage: https://github.com/mvanhorn/last30days-skill
 repository: https://github.com/mvanhorn/last30days-skill
 author: mvanhorn
 license: MIT
-user-invocable: true
+user-invocable: false
 ---
 
 # last30days v3.0.0
@@ -86,7 +86,6 @@ fi
 - `yt-dlp` enables YouTube.
 - Planning and reranking fall back gracefully: Gemini -> OpenAI -> xAI -> deterministic/local.
 - Web retrieval stays within Brave/Serper dated results. Undated web hits are dropped.
-- For OpenClaw-specific watchlist, briefing, and history workflows, use `variants/open/SKILL.md`.
 
 ## Output model
 


### PR DESCRIPTION
## Summary

Fix #204 by resolving a duplicate skill name in the plugin layout. Two SKILL.md files declared `name: last30days` with `user-invocable: true`, causing strict marketplace validators to reject the plugin with "Some plugins in this marketplace have validation errors."

## Root cause

In v2.9.6, `skills/last30days/SKILL.md` was a symlink to `../../SKILL.md`, so only one skill existed. Commit `0a9ff16` (v3.0.0) added a new real file at `skills/last30days-v3/SKILL.md`. Commit `9be0780` then renamed that directory to `skills/last30days/`, replacing the original symlink with a different real file. The collision has been live since v3.0.0 shipped. PR #203 fixed `marketplace.json` plugin name and version but did not touch the SKILL.md collision.

After the fix, three paths still lead to skill files but only one canonical name remains:
- `./SKILL.md` -> `name: last30days, user-invocable: true` (canonical)
- `./skills/last30days-nux/SKILL.md` -> symlink to `../../SKILL.md` (same inode)
- `./skills/last30days/SKILL.md` -> `name: last30days-v3-spec, user-invocable: false` (internal arch docs)

## Changes

- `skills/last30days/SKILL.md` frontmatter: `name` -> `last30days-v3-spec`, `user-invocable` -> `false`, description updated to clarify it is internal architecture documentation.
- `README.md`: fix stale link that pointed to the deleted `skills/last30days-v3/` path.
- `skills/last30days/SKILL.md`: remove stale reference to `variants/open/SKILL.md` (deleted in v3.0.0).

## Verification

Static check (run after merge in a clean workspace):
```
grep -l "^name: last30days$" SKILL.md skills/*/SKILL.md
grep -l "^user-invocable: true$" SKILL.md skills/*/SKILL.md
```

Both commands should match only `SKILL.md` and `skills/last30days-nux/SKILL.md` (which is a symlink to the same inode). `skills/last30days/SKILL.md` should not appear in either list.

Runtime check: install the plugin in a clean Claude Code session via `/plugin marketplace add mvanhorn/last30days-skill`. The marketplace sync should succeed without validation errors.

## Risk

Minimal. The renamed file is internal documentation that no command resolves to. Anyone who linked directly to `skills/last30days/SKILL.md` will still find the file at the same path, just with a different `name` field. The canonical user-invocable `last30days` skill is unchanged.

Thanks @Cody-Coyote for the report.

This contribution was developed with AI assistance (Codex).