### PR TITLE
fix: use GNU stat first in check_perms (Linux false-warn)

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -12,7 +12,11 @@ check_perms() {
   local file="$1"
   if [[ ! -f "$file" ]]; then return; fi
   local perms
-  perms=$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file" 2>/dev/null || echo "")
+  # Try GNU stat first (Linux), fall back to BSD stat (macOS).
+  # On Linux, `stat -f` prints filesystem info (not permissions) and exits 0,
+  # so the previous BSD-first ordering left $perms as multi-line garbage on
+  # every Linux session start and printed a false WARNING.
+  perms=$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")
   if [[ -n "$perms" && "$perms" != "600" && "$perms" != "400" ]]; then
     echo "/last30days: WARNING — $file has permissions $perms (should be 600)."
     echo "  Fix: chmod 600 $file"


### PR DESCRIPTION
## Summary

`hooks/scripts/check-config.sh`'s `check_perms()` uses BSD `stat -f '%Lp'` first. On Linux, `stat -f` prints **filesystem** info (Block size, Inodes, etc.) and exits `0`, so the `||` fallback to GNU `stat -c '%a'` never triggers. The `$perms` variable ends up holding multi-line garbage, `[[ "$perms" != "600" ]]` is always true, and **every** SessionStart hook invocation prints a bogus warning plus a dump of the underlying filesystem.

Example of the broken output on Linux (Python 3.12, bash 5.x, `.env` actually `chmod 600`):

```
/last30days: WARNING — /root/.config/last30days/.env has permissions   File: "/root/.config/last30days/.env"
    ID: fd0100000000 Namelen: 255     Type: xfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 47169275   Free: 26904503   Available: 26904503
Inodes: Total: 94371312   Free: 93292919
600 (should be 600).
  Fix: chmod 600 /root/.config/last30days/.env
/last30days: Ready — 4 sources active.
```

Because SessionStart hook stdout is injected into every `claude` session's context, this also wastes tokens on every invocation and can confuse the model with irrelevant filesystem noise — particularly painful for people running `claude -p` in tight loops (IM bridges, routers, etc.).

## Fix

Reorder `check_perms()` to try GNU `stat -c '%a'` first and fall back to BSD `stat -f '%Lp'` for macOS. One-line change plus a comment explaining the gotcha.

```diff
-  perms=$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file" 2>/dev/null || echo "")
+  # Try GNU stat first (Linux), fall back to BSD stat (macOS).
+  perms=$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")
```

## Test plan

- [x] Before: Linux bash 5.x produces garbage `$perms` + false warning
- [x] After: Linux bash 5.x produces `perms=600` and skips the warning branch — only the legitimate Ready banner is emitted
- [ ] macOS verification welcome from a maintainer who has a Mac handy — GNU path should fail silently (no `-c`), BSD fallback takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)