### PR TITLE
fix: align v3 skill version metadata and sync target

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,7 +59,7 @@ metadata:
       - clawhub
 ---
 
-# last30days v2.9.5: Research Any Topic from the Last 30 Days
+# last30days v3.0.0: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `~/Documents/Last30Days/`. X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.0.0-alpha"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.0.0"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,30 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _skill_version() -> str:
+    text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*"([^"]+)"\s*$', text, re.MULTILINE)
+    if not match:
+        raise AssertionError("SKILL.md version frontmatter not found")
+    return match.group(1)
+
+
+class TestVersionConsistency(unittest.TestCase):
+    def test_root_skill_header_matches_frontmatter_version(self) -> None:
+        text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+        version = _skill_version()
+        self.assertIn(f"# last30days v{version}:", text)
+
+    def test_sync_cache_path_uses_skill_version(self) -> None:
+        sync_text = (ROOT / "scripts" / "sync.sh").read_text(encoding="utf-8")
+        version = _skill_version()
+        self.assertIn(f'last30days-3/{version}"', sync_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update root SKILL.md title header from v2.9.5 to v3.0.0 to match frontmatter
- update scripts/sync.sh Claude cache target from 3.0.0-alpha to 3.0.0
- add tests/test_version_consistency.py to guard header/frontmatter/sync version consistency

## Validation
- python3 -m unittest tests/test_version_consistency.py -v
- bash -n scripts/sync.sh