### PR TITLE
docs(v3): prep CHANGELOG and release notes for v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - 2026-04
+## [3.0.0] - 2026-04-11
 
 ### Highlights
 
@@ -34,10 +34,18 @@ Intelligent search, fun judge, cross-source cluster merging, single-pass compari
 - Polymarket display shows % odds only; dollar volumes removed
 - 852 tests passing
 
+### Fixed
+
+- Marketplace validation: duplicate `name: last30days` collision in `skills/last30days/SKILL.md` caused strict validators to reject the plugin. Resolved by renaming the internal v3 architecture spec to `last30days-v3-spec` with `user-invocable: false`. Fixed in #214 (reported by @Cody-Coyote in #204).
+- Stale README link to the deleted `skills/last30days-v3/` path from the v3 directory rename. Fixed in #214.
+- OpenAI Codex CLI discoverability: added `.agents/skills/last30days/SKILL.md` as a real file (Codex's loader skips symlinked files) plus `.codex-plugin/plugin.json` as the namespace marker. The skill now registers as `last30days:last30days` when Codex runs in a checkout of the repo. Fixed in #219 (inspired by @Jah-yee in #153 and @dannyshmueli on X).
+
 ### Contributors
 
 - @j-sperling -- v3 engine architecture, Python pre-research brain
 - @hnshah -- Watchlist features
+- @Cody-Coyote -- Marketplace validation bug report (#204)
+- @Jah-yee -- Codex CLI integration inspiration (#153)
 
 ## [2.9.4] - 2026-03-06
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,75 +1,114 @@
 The AI world reinvents itself every month. This skill keeps you current.
 
-`/last30days` researches your topic across **Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web** from the last 30 days, finds what the community is actually upvoting, sharing, betting on, and saying on camera, and writes you a grounded narrative with real citations.
+`/last30days` researches your topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources from the last 30 days, finds what the community is actually upvoting, sharing, betting on, and saying on camera, and writes you a grounded narrative with real citations.
+
+## v3 is the intelligent search release
+
+v3 is a ground-up engine rewrite by [@j-sperling](https://github.com/j-sperling). The old engine searched keywords. The new engine understands your topic first, then searches the right people and communities.
+
+Type "OpenClaw" and v3 resolves @steipete, r/openclaw, r/ClaudeCode, and the right YouTube channels and TikTok hashtags before a single API call fires. Type "Peter Steinberger" and it resolves his X handle and GitHub profile, switches to person mode, and shows what he shipped this month at 85% merge rate across 22 PRs. None of that was on Google.
+
+## Headline features
+
+### Intelligent pre-research
+
+The killer feature. A new Python pre-research brain resolves X handles, GitHub repos, subreddits, TikTok hashtags, and YouTube channels before searching. Bidirectional: person to company, product to founder, name to GitHub profile. The right subreddits, the right handles, the right hashtags, all resolved before a single API call.
+
+### Best Takes
+
+A second LLM judge scores every result for humor, wit, and virality alongside relevance. Every brief now ends with a Best Takes section surfacing the cleverest one-liners and most viral quotes. The Reddit and X people are funny, and the old engine buried their best stuff.
+
+### Cross-source cluster merging
+
+When the same story hits Reddit, X, and YouTube, v3 merges them into one cluster instead of three duplicates. Entity-based overlap detection catches matches even when the titles use different words.
+
+### Single-pass comparisons
+
+"X vs Y" used to run three serial passes (12+ minutes). v3 runs one pass with entity-aware subqueries for both sides at once. Same depth, 3 minutes.
+
+### GitHub person-mode and project-mode
+
+When the topic is a person, the engine switches from keyword search to author-scoped queries. PR velocity, top repos by stars, release notes for what shipped this month, woven into the narrative alongside X posts and Reddit threads.
+
+When the topic is a project, it pulls live star counts, READMEs, releases, and top issues from the GitHub API. No stale blog posts.
+
+### ELI5 mode
+
+Say "eli5 on" after any research run. The synthesis rewrites in plain language. No jargon. Same data, same sources, same citations, just clearer. Say "eli5 off" to go back.
+
+### 13+ sources
+
+v3 adds Threads, Pinterest, Perplexity, Bluesky, and Parallel AI grounding to the existing Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and Web lineup. Perplexity Deep Research (`--deep-research`) gives you 50+ citation reports for serious investigation.
+
+### Per-author cap and entity disambiguation
+
+Max 3 items per author prevents single-voice dominance. Synthesis trusts resolved handles over fuzzy keyword matches.
+
+## Install
+
+Claude Code:
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+OpenClaw:
+
+```
+clawhub install last30days-official
+```
+
+OpenAI Codex CLI: run `codex` from a checkout of this repo and v3's skill at `.agents/skills/last30days/SKILL.md` will be discovered automatically. Or copy `SKILL.md` to `~/.agents/skills/last30days/SKILL.md` for a global install.
+
+Zero config. Reddit, Hacker News, Polymarket, and GitHub work immediately. Run it once and the setup wizard unlocks X, YouTube, TikTok, and more in 30 seconds.
 
 ## v3 Community
 
-v3 was shaped by community contributors whose PRs and issues inspired core features. Their code wasn't merged directly (v3 was a ground-up rewrite), but their ideas drove what shipped. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
+v3 was shaped by community contributors whose PRs and issues inspired core features. Their code wasn't merged directly (v3 was a ground-up rewrite), but their ideas drove what shipped.
 
-Thanks to @uppinote20, @zerone0x, @thinkun, @thomasmktong, @fanispoulinakisai-boop, @pejmanjohn, @zl190, and @hnshah.
+Thanks to @uppinote20, @zerone0x, @thinkun, @thomasmktong, @fanispoulinakisai-boop, @pejmanjohn, @zl190, and @hnshah. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
 
-## What's New in v2.9.1
+Contributors who shaped the release itself:
 
-**Auto-save to ~/Documents/Last30Days/.** Every run now saves the complete research briefing - synthesis, stats, and follow-up suggestions - as a topic-named `.md` file to your Documents folder. Build a personal research library without lifting a finger. Inspired by [@devin_explores](https://x.com/devin_explores) who was already doing this manually.
-
-## Three Headline Features in v2.9
-
-**1. ScrapeCreators Reddit as default.** One `SCRAPECREATORS_API_KEY` now covers Reddit, TikTok, and Instagram - three sources, one key. No more `OPENAI_API_KEY` required for Reddit search. Faster, more reliable, and simpler to configure.
-
-**2. Smart subreddit discovery.** Relevance-weighted scoring replaces pure frequency count. Each candidate subreddit is scored by `frequency x recency x topic-word match`, and a `UTILITY_SUBS` blocklist filters noise subs like r/tipofmytongue. Search "Claude Code skills" and get r/ClaudeAI, r/ClaudeCode, r/openclaw - not generic programming subs.
-
-**3. Top comments elevated.** The best comment on each Reddit thread now carries a 10% weight in engagement scoring and displays prominently with upvote counts. Reddit's value is in the comments - now the skill surfaces them.
-
-Plus: **Instagram Reels** (v2.8), **Polymarket prediction markets** (v2.5), **YouTube transcripts** (v2.1), **bundled X search** - no external CLI needed.
-
-## Beta Test Results (v2.9)
-
-| Topic | Time | Threads | Discovered Subreddits |
-|-------|------|---------|----------------------|
-| Claude Code skills | 77.1s | 99 | r/ClaudeAI, r/ClaudeCode, r/openclaw |
-| Kanye West | 71.7s | 84 | r/hiphopheads, r/NFCWestMemeWar, r/Kanye |
-| Anthropic odds | 68.0s | 65 | r/Anthropic, r/ClaudeAI, r/OpenAI |
-| Best rap songs lately | 68.9s | 114 | r/BestofRedditorUpdates, r/rap, r/TeenageRapFans |
-| Nano Banana Pro | 66.6s | 99 | r/GeminiAI, r/nanobanana2pro, r/macbookpro |
+- @Jah-yee (#153) surfaced the need for a real Codex CLI integration, which shipped in #219
+- @Cody-Coyote (#204) reported the marketplace validation bug that needed fixing before v3 could ship cleanly
+- @dannyshmueli pushed for v3 and Codex family support publicly on X
 
 ## What's New
 
 ### Added
-- ScrapeCreators Reddit backend with keyword search and subreddit discovery
-- Smart subreddit discovery with relevance-weighted scoring
-- Utility subreddit blocklist (`UTILITY_SUBS`)
-- Top comment scoring (10% engagement weight) and prominent rendering
-- Comment excerpts increased to 400 chars, insights raised to 10
+
+- Intelligent pre-research brain resolving X handles, subreddits, TikTok hashtags, and YouTube channels before searching
+- Fun judge and Best Takes section scoring humor, wit, and virality
+- Cross-source cluster merging with entity-based overlap detection
+- Single-pass comparisons for "X vs Y" queries
+- GitHub as a first-class source with person-mode and project-mode
+- Perplexity Sonar Pro via OpenRouter (`INCLUDE_SOURCES=perplexity`)
+- Perplexity Deep Research (`--deep-research` flag)
+- Parallel AI grounding backend (`--web-backend parallel`)
+- OpenRouter as a reasoning provider (auto-detected after Gemini / OpenAI / xAI)
+- Per-author cap (max 3 items per author)
+- Entity disambiguation trusting resolved handles over keyword matches
+- OpenAI Codex CLI integration via `.agents/skills/last30days/SKILL.md` and `.codex-plugin/plugin.json`
+- ELI5 mode
 
 ### Changed
-- `primaryEnv` → `SCRAPECREATORS_API_KEY` (one key for Reddit, TikTok, Instagram)
-- Reddit engagement scoring: `0.55/0.40/0.05` → `0.50/0.35/0.05/0.10`
-- SKILL.md synthesis instructions emphasize quoting top comments
+
+- YouTube transcript candidate pool widened 3x to reach talk and review content with captions
+- Reddit comment enrichment sorted by total engagement (upvotes + comments), not just upvotes
+- Polymarket display shows % odds only, dollar volumes removed
+- 852 tests passing
 
 ### Fixed
-- Utility sub noise in subreddit discovery
-- Reddit no longer requires `OPENAI_API_KEY`
 
-## New Contributors
-
-- @JosephOIbrahim -- Windows Unicode fix ([#17](https://github.com/mvanhorn/last30days-skill/pull/17))
-- @levineam -- Model fallback for unverified orgs ([#16](https://github.com/mvanhorn/last30days-skill/pull/16))
-- @jonthebeef -- `--days=N` configurable lookback ([#18](https://github.com/mvanhorn/last30days-skill/pull/18))
+- Marketplace validation: duplicate `name: last30days` collision in `skills/last30days/SKILL.md` that caused strict validators to reject the plugin. Resolved by renaming the internal v3 architecture spec to `last30days-v3-spec` in #214
+- Stale README link to the deleted `skills/last30days-v3/` path from the v3 directory rename. Fixed in #214
+- Codex CLI discovery: added the real `.agents/skills/last30days/SKILL.md` (regular file, not a symlink, since Codex's loader skips symlinked files) and `.codex-plugin/plugin.json` namespace marker in #219
 
 ## Credits
 
-- [@steipete](https://github.com/steipete) -- Bird CLI (vendored X search) and yt-dlp/summarize inspiration for YouTube transcripts
-- [@galligan](https://github.com/galligan) -- Marketplace plugin inspiration
-- [@hutchins](https://x.com/hutchins) -- Pushed for YouTube feature
+- [@steipete](https://github.com/steipete) for Bird CLI (vendored X search) and yt-dlp/summarize inspiration for YouTube transcripts
+- [@galligan](https://github.com/galligan) for marketplace plugin inspiration
+- [@hutchins](https://x.com/hutchins) for pushing the YouTube feature
 
-## Install
-
-```bash
-# Claude Code
-git clone https://github.com/mvanhorn/last30days-skill.git ~/.claude/skills/last30days
-
-# Codex CLI
-git clone https://github.com/mvanhorn/last30days-skill.git ~/.agents/skills/last30days
-```
-
-30 days of research. 30 seconds of work. Eight sources. Zero stale prompts.
+30 days of research. 30 seconds of work. Thirteen sources. Zero stale prompts.


### PR DESCRIPTION
## Summary

Prep the v3.0.0 release. No code changes. Two files updated:

- `CHANGELOG.md`: adds a Fixed section to `[3.0.0]` covering the two post-merge prep fixes (#214 marketplace validation, #219 Codex CLI integration), bumps the date from `2026-04` to `2026-04-11`, and adds @Cody-Coyote and @Jah-yee to the contributors list
- `release-notes.md`: full rewrite from its stale v2.9.1 focus into the v3 story. Leads with @j-sperling as the engine architect, covers intelligent pre-research, fun judge / Best Takes, cross-source cluster merging, single-pass comparisons, GitHub person-mode and project-mode, 13+ sources, ELI5 mode. Updates install instructions from `git clone` to the real paths (`/plugin marketplace add`, `clawhub install`, and the Codex skill path)

## Why now

Screenshot from the GitHub repo page still shows `v2.9.0: ScrapeCreators Re...` as Latest even though v3 has been in `main` for several days. This PR is the prep for cutting the `v3.0.0` tag and publishing the GitHub release. The release notes will be passed to `gh release create --notes-file release-notes.md` in the follow-up step.

## Testing

Docs-only change. No behavior touched. Verified:

- `CHANGELOG.md` still parses as valid Keep-a-Changelog format
- `release-notes.md` renders cleanly as GitHub Flavored Markdown
- Every feature mentioned in release-notes.md is already on `main` (intelligent pre-research, fun judge, cluster merging, single-pass comparisons, GitHub person-mode, ELI5, 13+ sources)
- Every contributor handle resolves to a real GitHub user
- Install commands match what the README actually documents for v3

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Docs change only, no runtime impact.

## Follow-up (not in this PR)

- Cut the `v3.0.0` tag and create the GitHub release via `gh release create v3.0.0 --latest --notes-file release-notes.md`
- `scripts/sync.sh` still references `variants/open/` (deleted in v3) and stale `3.0.0-alpha` cache paths. Dev-only script, not a release blocker, tracked separately
- ClawhHub publish of the OpenClaw variant is a separate workflow in the private repo