### PR TITLE
docs(v3): drop redundant What's New list and remove stale @steipete credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,6 @@ Three headline features: watchlists for always-on bots, YouTube transcripts as a
 
 ### Credits
 
-- @steipete -- Bird CLI (vendored X search) and yt-dlp/summarize inspiration for YouTube transcripts
 - @galligan -- Marketplace plugin inspiration
 - @hutchins -- Pushed for YouTube feature
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -74,40 +74,12 @@ Contributors who shaped the release itself:
 - @Cody-Coyote (#204) reported the marketplace validation bug that needed fixing before v3 could ship cleanly
 - @dannyshmueli pushed for v3 and Codex family support publicly on X
 
-## What's New
+Full Added / Changed / Fixed detail lives in [CHANGELOG.md](CHANGELOG.md) under `[3.0.0]`.
 
-### Added
+## Earlier contributors
 
-- Intelligent pre-research brain resolving X handles, subreddits, TikTok hashtags, and YouTube channels before searching
-- Fun judge and Best Takes section scoring humor, wit, and virality
-- Cross-source cluster merging with entity-based overlap detection
-- Single-pass comparisons for "X vs Y" queries
-- GitHub as a first-class source with person-mode and project-mode
-- Perplexity Sonar Pro via OpenRouter (`INCLUDE_SOURCES=perplexity`)
-- Perplexity Deep Research (`--deep-research` flag)
-- Parallel AI grounding backend (`--web-backend parallel`)
-- OpenRouter as a reasoning provider (auto-detected after Gemini / OpenAI / xAI)
-- Per-author cap (max 3 items per author)
-- Entity disambiguation trusting resolved handles over keyword matches
-- OpenAI Codex CLI integration via `.agents/skills/last30days/SKILL.md` and `.codex-plugin/plugin.json`
-- ELI5 mode
+From the v1 and v2 lineage:
 
-### Changed
-
-- YouTube transcript candidate pool widened 3x to reach talk and review content with captions
-- Reddit comment enrichment sorted by total engagement (upvotes + comments), not just upvotes
-- Polymarket display shows % odds only, dollar volumes removed
-- 852 tests passing
-
-### Fixed
-
-- Marketplace validation: duplicate `name: last30days` collision in `skills/last30days/SKILL.md` that caused strict validators to reject the plugin. Resolved by renaming the internal v3 architecture spec to `last30days-v3-spec` in #214
-- Stale README link to the deleted `skills/last30days-v3/` path from the v3 directory rename. Fixed in #214
-- Codex CLI discovery: added the real `.agents/skills/last30days/SKILL.md` (regular file, not a symlink, since Codex's loader skips symlinked files) and `.codex-plugin/plugin.json` namespace marker in #219
-
-## Credits
-
-- [@steipete](https://github.com/steipete) for Bird CLI (vendored X search) and yt-dlp/summarize inspiration for YouTube transcripts
 - [@galligan](https://github.com/galligan) for marketplace plugin inspiration
 - [@hutchins](https://x.com/hutchins) for pushing the YouTube feature
 


### PR DESCRIPTION
## Summary

Two cleanups to the v3 release docs after the v3.0.0 tag was cut:

1. **Drop the redundant "What's New" section from `release-notes.md`.** It repeated the same items as the Headline features section above it in bulleted Added / Changed / Fixed form, a holdover from the old v2.9 release notes pattern. CHANGELOG.md is the canonical Added / Changed / Fixed list; release notes is marketing copy and shouldn't duplicate it. Added a one-line pointer to CHANGELOG.md `[3.0.0]` for anyone looking for the detail.
2. **Remove `@steipete` credit** from both `release-notes.md` and `CHANGELOG.md [2.1.0]` Credits sections. He didn't actually contribute to this repo.

Also renamed the release-notes.md "Credits" heading to "Earlier contributors" and noted they are from the v1 and v2 lineage, so readers don't confuse @galligan and @hutchins with v3-era contributors.

## Follow-up

The v3.0.0 GitHub release body was generated from the pre-cleanup `release-notes.md`. After this PR merges, the release body on github.com/mvanhorn/last30days-skill/releases/tag/v3.0.0 should be updated via `gh release edit v3.0.0 --notes-file release-notes.md` so the live page reflects the cleanup.

## Testing

Docs-only change. Verified:

- `release-notes.md` still renders as valid GitHub Flavored Markdown
- No remaining `@steipete` references in `release-notes.md` or `CHANGELOG.md [2.1.0]` or `[3.0.0]` credits
- README.md demo-output examples that mention @steipete are untouched (those are illustrations of what the pre-research brain resolves when you search, not credits)
- The CHANGELOG line about "Bird's Twitter GraphQL client (MIT, originally by @steipete)" in the `[2.1.0] Added` section is also untouched. That's a license attribution for vendored code, not a claim that @steipete contributed to this repo. Flag if you want it removed too.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Docs change only, no runtime impact.