### PR TITLE
fix(sync): skip OpenClaw variant branch when variants/open is absent

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -24,7 +24,7 @@ sync_target() {
 
   echo ""
   echo "--- Syncing to $target ---"
-  mkdir -p "$target/scripts/lib" "$target/variants/open/references"
+  mkdir -p "$target/scripts/lib"
 
   cp "$skill_md" "$target/SKILL.md"
 
@@ -35,7 +35,13 @@ sync_target() {
     "$SRC/scripts/store.py" \
     "$target/scripts/"
   rsync -a "$SRC/scripts/lib/"*.py "$target/scripts/lib/"
-  rsync -a "$SRC/variants/open/" "$target/variants/open/"
+
+  # The OpenClaw variant lives in the private repo only. Skip cleanly when
+  # running this script from the public repo where variants/open does not exist.
+  if [ -d "$SRC/variants/open" ]; then
+    mkdir -p "$target/variants/open/references"
+    rsync -a "$SRC/variants/open/" "$target/variants/open/"
+  fi
 
   if [ -d "$SRC/scripts/lib/vendor" ]; then
     rsync -a "$SRC/scripts/lib/vendor" "$target/scripts/lib/"
@@ -63,7 +69,16 @@ for t in "${COMMON_TARGETS[@]}"; do
   sync_target "$t" "$SRC/SKILL.md"
 done
 
-sync_target "$OPENCLAW_TARGET" "$SRC/variants/open/SKILL.md"
+# OpenClaw sync only runs when the private-repo OpenClaw variant is present
+# in the source tree. The public repo does not ship variants/open (the variant
+# is sanitized via strip_for_openclaw.py and published separately from
+# last30days-skill-private).
+if [ -d "$SRC/variants/open" ]; then
+  sync_target "$OPENCLAW_TARGET" "$SRC/variants/open/SKILL.md"
+else
+  echo ""
+  echo "Skipping OpenClaw target (no variants/open in this repo)"
+fi
 
 echo ""
 echo "Sync complete."


### PR DESCRIPTION
## Summary

Makes the `variants/open/` sync in `scripts/sync.sh` conditional on the directory actually existing. The script is shared between the public and private repos of last30days-skill, but the OpenClaw variant only lives in the private repo (it's sanitized via `strip_for_openclaw.py` and published separately to ClawhHub). When the script ran from a public-repo checkout, the unconditional `rsync` and `sync_target` calls errored out immediately on missing `variants/open/` paths.

## Changes

- `sync_target()` now only creates `variants/open/references` and rsyncs `variants/open/` when `$SRC/variants/open` exists
- The trailing `sync_target "$OPENCLAW_TARGET" ...` call is now gated by the same check, with an explanatory skip message when the directory is absent

## Relationship to PR #211

PR #211 (@fanispoulinakisai-boop) tried to fix this by adding `variants/open/` back to the public repo. That was the wrong direction - the variant was intentionally removed from public in v3 (commit 0a9ff16) for ClawhHub scanner compliance, and the content in #211 was v2-era (wrong API keys, old mode router). The real fix is making the script tolerate the absence.

Closed #211 with a detailed explanation. @fanispoulinakisai-boop is already credited in `CONTRIBUTORS.md` v3 Inspiration section for #100 (Reddit timeout resilience work).

## Testing

- `bash -n scripts/sync.sh` passes (syntax check)
- No behavior change when running from the private repo (which has `variants/open/`)
- No error when running from the public repo (tested by reading the branches - `if [ -d "$SRC/variants/open" ]` is false, both branches skip cleanly)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Dev-only script, runs locally.