### PR TITLE
fix(env): default INCLUDE_SOURCES to empty string

### DIFF
--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -264,7 +264,7 @@ def get_config() -> dict[str, Any]:
         ('XQUIK_API_KEY', None),
         ('FROM_BROWSER', None),
         ('SETUP_COMPLETE', None),
-        ('INCLUDE_SOURCES', None),
+        ('INCLUDE_SOURCES', ''),
     ]
 
     for key, default in keys:

--- a/tests/test_env_include_sources_default.py
+++ b/tests/test_env_include_sources_default.py
@@ -1,16 +1,14 @@
-import os
-
-from scripts.lib.env import get_config
+from scripts.lib import env
 
 
 def test_include_sources_defaults_to_empty_string(monkeypatch, tmp_path):
     # Ensure the env var is not set
     monkeypatch.delenv("INCLUDE_SOURCES", raising=False)
 
-    # Avoid reading any real user config file
-    monkeypatch.setenv("LAST30DAYS_CONFIG_FILE", str(tmp_path / "does-not-exist.env"))
+    # Avoid reading any real user config file by patching the resolved module path directly
+    monkeypatch.setattr(env, "CONFIG_FILE", tmp_path / "does-not-exist.env")
 
-    cfg = get_config()
+    cfg = env.get_config()
 
     assert "INCLUDE_SOURCES" in cfg
     assert cfg["INCLUDE_SOURCES"] == ""

--- a/tests/test_env_include_sources_default.py
+++ b/tests/test_env_include_sources_default.py
@@ -1,0 +1,16 @@
+import os
+
+from scripts.lib.env import get_config
+
+
+def test_include_sources_defaults_to_empty_string(monkeypatch, tmp_path):
+    # Ensure the env var is not set
+    monkeypatch.delenv("INCLUDE_SOURCES", raising=False)
+
+    # Avoid reading any real user config file
+    monkeypatch.setenv("LAST30DAYS_CONFIG_FILE", str(tmp_path / "does-not-exist.env"))
+
+    cfg = get_config()
+
+    assert "INCLUDE_SOURCES" in cfg
+    assert cfg["INCLUDE_SOURCES"] == ""


### PR DESCRIPTION
## Summary

Fixes a fresh-install crash where `INCLUDE_SOURCES` can be `None`, causing `.split(',')` call sites to raise `AttributeError`.

## Motivation

Issue #166 reports a Windows crash on startup when `INCLUDE_SOURCES` is present in config as `None`.

## Implementation

- Change `scripts/lib/env.py` default for `INCLUDE_SOURCES` from `None` to an empty string.
- Add a unit test asserting `INCLUDE_SOURCES` defaults to `""` when unset.

## Test

- `pytest -q tests/test_env_include_sources_default.py`

## Notes

This is a defensive default that prevents future regressions in any call site that assumes `INCLUDE_SOURCES` is a string.
