### PR TITLE
fix(cli): Write saved output using UTF-8 encoding

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -103,7 +103,7 @@ def save_output(report: schema.Report, emit: str, save_dir: str, suffix: str = "
         content = emit_output(report, emit)
     else:
         content = render.render_full(report)
-    out_path.write_text(content)
+    out_path.write_text(content, encoding="utf-8")
     return out_path
 
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -128,6 +128,14 @@ class CliV3Tests(unittest.TestCase):
             payload = json.loads(path.read_text())
             self.assertEqual("OpenClaw vs NanoClaw", payload["topic"])
 
+    def test_save_output_writes_utf8_encoded_markdown(self):
+        report = self.make_report()
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch("pathlib.Path.write_text", autospec=True, return_value=1) as write_text:
+                cli.save_output(report, "md", tmp)
+        _, kwargs = write_text.call_args
+        self.assertEqual("utf-8", kwargs.get("encoding"))
+
     def test_persist_report_updates_run_status_on_success_and_failure(self):
         report = self.make_report()
 


### PR DESCRIPTION
Summary:\n- save generated output using explicit UTF-8 encoding to avoid Windows locale write errors\n- add regression test for save_output UTF-8 write behavior\n\nValidation:\n- python3 -m pytest tests/test_cli_v3.py -q\n\nFixes #167