### PR TITLE
fix(windows): stabilize bundled Bird X search

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -33,6 +33,11 @@ def ensure_supported_python(version_info: tuple[int, int, int] | object | None =
 
 ensure_supported_python()
 
+if os.name == "nt":
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
+
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 
@@ -103,7 +108,7 @@ def save_output(report: schema.Report, emit: str, save_dir: str, suffix: str = "
         content = emit_output(report, emit)
     else:
         content = render.render_full(report)
-    out_path.write_text(content)
+    out_path.write_text(content, encoding="utf-8")
     return out_path
 
 

--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -177,6 +177,8 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             preexec_fn=preexec,
             env=_subprocess_env(),
         )
@@ -336,6 +338,8 @@ def search_handles(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 preexec_fn=preexec,
                 env=_subprocess_env(),
             )

--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -579,6 +579,8 @@ def get_x_source_status(config: dict[str, Any]) -> dict[str, Any]:
     """
     from . import bird_x
 
+    if config.get('AUTH_TOKEN') and config.get('CT0'):
+        bird_x.set_credentials(config.get('AUTH_TOKEN'), config.get('CT0'))
     bird_status = bird_x.get_bird_status()
     xai_available = bool(config.get('XAI_API_KEY'))
 

--- a/scripts/lib/vendor/bird-search/bird-search.mjs
+++ b/scripts/lib/vendor/bird-search/bird-search.mjs
@@ -18,117 +18,130 @@ const SearchClient = withSearch(TwitterClientBase);
 
 const args = process.argv.slice(2);
 
-// --check: verify that credentials can be resolved
-if (args.includes('--check')) {
+function writeStdout(text) {
+  if (text) process.stdout.write(text);
+}
+
+function writeStderr(text) {
+  if (text) process.stderr.write(text);
+}
+
+async function main() {
+  // --check: verify that credentials can be resolved
+  if (args.includes('--check')) {
+    try {
+      const { cookies, warnings } = await resolveCredentials({});
+      if (cookies.authToken && cookies.ct0) {
+        writeStdout(JSON.stringify({ authenticated: true, source: cookies.source }));
+        return 0;
+      }
+      writeStdout(JSON.stringify({ authenticated: false, warnings }));
+      return 1;
+    } catch (err) {
+      writeStdout(JSON.stringify({ authenticated: false, error: err.message }));
+      return 1;
+    }
+  }
+
+  // --whoami: check auth and output source
+  if (args.includes('--whoami')) {
+    try {
+      const { cookies } = await resolveCredentials({});
+      if (cookies.authToken && cookies.ct0) {
+        writeStdout(cookies.source || 'authenticated');
+        return 0;
+      }
+      writeStderr('Not authenticated\n');
+      return 1;
+    } catch (err) {
+      writeStderr(`Auth check failed: ${err.message}\n`);
+      return 1;
+    }
+  }
+
+  // Parse search args
+  let query = null;
+  let count = 20;
+  let jsonOutput = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--count' && args[i + 1]) {
+      count = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === '-n' && args[i + 1]) {
+      count = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === '--json') {
+      jsonOutput = true;
+    } else if (!args[i].startsWith('-')) {
+      query = args[i];
+    }
+  }
+
+  if (!query) {
+    writeStderr('Usage: node bird-search.mjs <query> [--count N] [--json]\n');
+    return 1;
+  }
+
   try {
+    // Resolve credentials (env vars, then browser cookies)
     const { cookies, warnings } = await resolveCredentials({});
-    if (cookies.authToken && cookies.ct0) {
-      process.stdout.write(JSON.stringify({ authenticated: true, source: cookies.source }));
-      process.exit(0);
-    } else {
-      process.stdout.write(JSON.stringify({ authenticated: false, warnings }));
-      process.exit(1);
+
+    if (!cookies.authToken || !cookies.ct0) {
+      const msg = warnings.length > 0 ? warnings.join('; ') : 'No Twitter credentials found';
+      if (jsonOutput) {
+        writeStdout(JSON.stringify({ error: msg, items: [] }));
+      } else {
+        writeStderr(`Error: ${msg}\n`);
+      }
+      return 1;
     }
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ authenticated: false, error: err.message }));
-    process.exit(1);
-  }
-}
 
-// --whoami: check auth and output source
-if (args.includes('--whoami')) {
-  try {
-    const { cookies } = await resolveCredentials({});
-    if (cookies.authToken && cookies.ct0) {
-      process.stdout.write(cookies.source || 'authenticated');
-      process.exit(0);
-    } else {
-      process.stderr.write('Not authenticated\n');
-      process.exit(1);
+    const client = new SearchClient({
+      cookies: {
+        authToken: cookies.authToken,
+        ct0: cookies.ct0,
+        cookieHeader: cookies.cookieHeader,
+      },
+      timeoutMs: 30000,
+    });
+
+    const result = await client.search(query, count);
+
+    if (!result.success) {
+      if (jsonOutput) {
+        writeStdout(JSON.stringify({ error: result.error, items: [] }));
+      } else {
+        writeStderr(`Search failed: ${result.error}\n`);
+      }
+      return 1;
     }
+
+    const tweets = result.tweets || [];
+    if (jsonOutput) {
+      writeStdout(JSON.stringify(tweets));
+    } else {
+      for (const tweet of tweets) {
+        const author = tweet.author?.username || 'unknown';
+        writeStdout(`@${author}: ${tweet.text?.slice(0, 200)}\n\n`);
+      }
+    }
+
+    return 0;
   } catch (err) {
-    process.stderr.write(`Auth check failed: ${err.message}\n`);
-    process.exit(1);
+    if (jsonOutput) {
+      writeStdout(JSON.stringify({ error: err.message, items: [] }));
+    } else {
+      writeStderr(`Error: ${err.message}\n`);
+    }
+    return 1;
   }
-}
-
-// Parse search args
-let query = null;
-let count = 20;
-let jsonOutput = false;
-
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--count' && args[i + 1]) {
-    count = parseInt(args[i + 1], 10);
-    i++;
-  } else if (args[i] === '-n' && args[i + 1]) {
-    count = parseInt(args[i + 1], 10);
-    i++;
-  } else if (args[i] === '--json') {
-    jsonOutput = true;
-  } else if (!args[i].startsWith('-')) {
-    query = args[i];
-  }
-}
-
-if (!query) {
-  process.stderr.write('Usage: node bird-search.mjs <query> [--count N] [--json]\n');
-  process.exit(1);
 }
 
 try {
-  // Resolve credentials (env vars, then browser cookies)
-  const { cookies, warnings } = await resolveCredentials({});
-
-  if (!cookies.authToken || !cookies.ct0) {
-    const msg = warnings.length > 0 ? warnings.join('; ') : 'No Twitter credentials found';
-    if (jsonOutput) {
-      process.stdout.write(JSON.stringify({ error: msg, items: [] }));
-    } else {
-      process.stderr.write(`Error: ${msg}\n`);
-    }
-    process.exit(1);
-  }
-
-  // Create search client
-  const client = new SearchClient({
-    cookies: {
-      authToken: cookies.authToken,
-      ct0: cookies.ct0,
-      cookieHeader: cookies.cookieHeader,
-    },
-    timeoutMs: 30000,
-  });
-
-  // Run search
-  const result = await client.search(query, count);
-
-  if (!result.success) {
-    if (jsonOutput) {
-      process.stdout.write(JSON.stringify({ error: result.error, items: [] }));
-    } else {
-      process.stderr.write(`Search failed: ${result.error}\n`);
-    }
-    process.exit(1);
-  }
-
-  // Output results
-  const tweets = result.tweets || [];
-  if (jsonOutput) {
-    process.stdout.write(JSON.stringify(tweets));
-  } else {
-    for (const tweet of tweets) {
-      const author = tweet.author?.username || 'unknown';
-      process.stdout.write(`@${author}: ${tweet.text?.slice(0, 200)}\n\n`);
-    }
-  }
-
-  process.exit(0);
+  const code = await main();
+  process.exitCode = Number.isInteger(code) ? code : 1;
 } catch (err) {
-  if (jsonOutput) {
-    process.stdout.write(JSON.stringify({ error: err.message, items: [] }));
-  } else {
-    process.stderr.write(`Error: ${err.message}\n`);
-  }
-  process.exit(1);
+  writeStderr(`Fatal error: ${err?.message || err}\n`);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary
- avoid abrupt `process.exit(...)` shutdowns in the bundled Bird wrapper on Windows
- force UTF-8 decoding for Bird subprocess output to avoid Windows console/codepage crashes
- make X diagnose respect AUTH_TOKEN/CT0 values loaded from config
- write saved markdown output as UTF-8 and reconfigure Windows stdout/stderr to UTF-8

## Why
On Windows, free X search could authenticate but still fail during the bundled Bird runtime with a libuv assertion (`UV_HANDLE_CLOSING` in `src\\win\\async.c`).

This patch keeps the Bird wrapper alive long enough to flush handles cleanly, fixes Windows text decoding, and makes `/last30days --diagnose` report Bird auth correctly when cookies come from config.

## Testing
Tested on Windows with local AUTH_TOKEN/CT0 configured:
- `python scripts/last30days.py --diagnose`
- direct Bird smoke test via `bird_x.search_x('OpenClaw', '2026-04-04', '2026-04-11', 'quick')` -> returned 12 X items
- end-to-end run:
  - `python scripts/last30days.py OpenClaw --auto-resolve --emit=compact --save-dir=... --save-suffix=smoke --store`

## Related
- closes #81
- refs #91
- refs #110