### PR TITLE
Bump SKILL.md version header from v2.9.5 to v3.0.0

### DIFF
--- a/.agents/skills/last30days/SKILL.md
+++ b/.agents/skills/last30days/SKILL.md
@@ -59,7 +59,7 @@ metadata:
       - clawhub
 ---
 
-# last30days v2.9.5: Research Any Topic from the Last 30 Days
+# last30days v3.0.0: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `~/Documents/Last30Days/`. X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,7 +59,7 @@ metadata:
       - clawhub
 ---
 
-# last30days v2.9.5: Research Any Topic from the Last 30 Days
+# last30days v3.0.0: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `~/Documents/Last30Days/`. X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 


### PR DESCRIPTION
## Summary
- SKILL.md and .agents/skills/last30days/SKILL.md still had `v2.9.5` in the `# last30days v2.9.5` header, while `pyproject.toml` and the rest of the codebase are on `v3.0.0`
- Updates both files to `v3.0.0` to match

## Test plan
- [ ] Verify the skill prompt displays `v3.0.0` in the header after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)