### PR TITLE
fix(cli): restore --days alias compatibility

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -165,7 +165,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tiktok-hashtags", help="Comma-separated TikTok hashtags without # (e.g., tella,screenrecording)")
     parser.add_argument("--tiktok-creators", help="Comma-separated TikTok creator handles (e.g., TellaHQ,taborplace)")
     parser.add_argument("--ig-creators", help="Comma-separated Instagram creator handles (e.g., tella.tv,laborstories)")
-    parser.add_argument("--lookback-days", type=int, default=30, help="Number of days to look back for research (default: 30, watchlist uses 90)")
+    parser.add_argument(
+        "--days",
+        "--lookback-days",
+        dest="lookback_days",
+        type=int,
+        default=30,
+        help="Number of days to look back for research (default: 30, watchlist uses 90)",
+    )
     parser.add_argument("--auto-resolve", action="store_true",
                         help="Use web search to discover subreddits/handles before planning (for platforms without WebSearch)")
     parser.add_argument("--github-user", help="GitHub username for person-mode search (e.g., steipete)")

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -77,6 +77,13 @@ class CliV3Tests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             cli.parse_search_flag(" , ")
 
+    def test_build_parser_accepts_days_alias_and_preserves_topic_tokens(self):
+        parser = cli.build_parser()
+        args, extra = parser.parse_known_args(["--days", "7", "biosecurity", "ai", "agents"])
+        self.assertEqual(7, args.lookback_days)
+        self.assertEqual(["biosecurity", "ai", "agents"], args.topic)
+        self.assertEqual([], extra)
+
     def test_ensure_supported_python_rejects_old_interpreter_with_actionable_error(self):
         stderr = io.StringIO()
         with redirect_stderr(stderr):


### PR DESCRIPTION
## Summary
- restore `--days` as a backward-compatible alias for `--lookback-days`
- preserve existing `lookback_days` destination
- add a CLI test covering the alias and topic token preservation

## Why
Using the older `--days` flag currently causes argparse to treat the numeric value as topic input, which leads to nonsense runs like researching `30` instead of the requested topic.

## Repro
```bash
python3 scripts/last30days.py --quick --days 30 --emit compact "biosecurity AI agents"
```
Before this change, the run mis-parses and researches `30`.

## Validation
```bash
python3 -m unittest tests.test_cli_v3.CliV3Tests.test_build_parser_accepts_days_alias_and_preserves_topic_tokens
python3 scripts/last30days.py --quick --days 30 --emit compact "biosecurity AI agents"
```