### PR TITLE
chore: gitignore dev artifacts (.venv, .coverage, htmlcov, .memsearch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ variants/open/references/research.md
 __pycache__/
 *.pyc
 mise.toml
+.memsearch/
+.venv/
+.coverage
+htmlcov/


### PR DESCRIPTION
## Summary

Add four missing gitignore patterns for standard development artifacts.

| Pattern | Why |
|---|---|
| `.venv/` | Standard Python virtualenv directory |
| `.coverage` | SQLite database from pytest-cov (declared in pyproject.toml dev deps) |
| `htmlcov/` | HTML coverage reports from `coverage html` |
| `.memsearch/` | Per-user session memory directory |

## Context

pyproject.toml already configures `[tool.coverage.run]` and lists `pytest-cov` as a dev
dependency, but the output artifacts aren't gitignored. These patterns prevent
accidental commits of local-only files.

No code changes. No test impact.