### PR TITLE
feat: add eval_topics.json fixture for offline quality evaluation

### DIFF
--- a/fixtures/eval_topics.json
+++ b/fixtures/eval_topics.json
@@ -1,0 +1,42 @@
+[
+  {
+    "topic": "OpenClaw vs NanoClaw vs ZeroClaw",
+    "query_type": "comparison",
+    "rationale": "Multi-entity extraction, 3-way split across AI agent frameworks."
+  },
+  {
+    "topic": "how to set up a GLP-1 supplement routine",
+    "query_type": "how_to",
+    "rationale": "Trending health topic. Tests non-tech how_to."
+  },
+  {
+    "topic": "2026 March Madness",
+    "query_type": "breaking_news",
+    "rationale": "Live sporting event. Tests broad breaking news recall."
+  },
+  {
+    "topic": "best budget noise cancelling headphones 2026",
+    "query_type": "product",
+    "rationale": "Evergreen consumer query. Tests product review aggregation."
+  },
+  {
+    "topic": "thoughts on OpenAI Codex pricing",
+    "query_type": "opinion",
+    "rationale": "Active developer debate. Tests opinion mining."
+  },
+  {
+    "topic": "odds of US recession 2026",
+    "query_type": "prediction",
+    "rationale": "Major macro topic. Tests prediction market + news synthesis."
+  },
+  {
+    "topic": "what is retrieval augmented generation",
+    "query_type": "concept",
+    "rationale": "Widely discussed AI concept. Tests explanation quality."
+  },
+  {
+    "topic": "Google Wiz acquisition price and timeline",
+    "query_type": "factual",
+    "rationale": "Completed event ($32B). Tests factual precision."
+  }
+]


### PR DESCRIPTION
## Summary

Add `fixtures/eval_topics.json` containing 8 evaluation topics that span
all intent types. Both `scripts/evaluate_search_quality.py` and
`tests/e2e_comparison.py` already reference this file path with hardcoded
fallbacks -- this PR supplies the actual fixture.

## Topics

| Topic | Intent | Domain |
|---|---|---|
| OpenClaw vs NanoClaw vs ZeroClaw | comparison | AI/tech |
| how to set up a GLP-1 supplement routine | how_to | health |
| 2026 March Madness | breaking_news | sports |
| best budget noise cancelling headphones 2026 | product | consumer |
| thoughts on OpenAI Codex pricing | opinion | dev tools |
| odds of US recession 2026 | prediction | finance |
| what is retrieval augmented generation | concept | AI/tech |
| Google Wiz acquisition price and timeline | factual | business |

## Selection methodology

Topics were selected using Maximal Marginal Relevance (MMR) dispersion to
maximize domain diversity while covering each of the 8 supported intent types
exactly once.

## Existing references

- `scripts/evaluate_search_quality.py:26` -- `EVAL_TOPICS_FILE = REPO_ROOT / "fixtures" / "eval_topics.json"`
- `tests/e2e_comparison.py:25` -- `EVAL_TOPICS_FILE = REPO / "fixtures" / "eval_topics.json"`