### PR TITLE
fix(bird_x): skip all-None engagement dicts

### DIFF
--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -460,7 +460,7 @@ def parse_bird_response(response: Dict[str, Any], query: str = "") -> List[Dict[
             "url": url,
             "author_handle": author_handle.lstrip("@"),
             "date": date,
-            "engagement": engagement,
+            "engagement": engagement if any(v is not None for v in engagement.values()) else None,
             "why_relevant": "",  # Bird doesn't provide relevance explanations
             "relevance": _compute_relevance(query, str(tweet.get("text", ""))) if query else 0.7,
         }

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -175,7 +175,7 @@ class TestVendoredBirdRuntime(unittest.TestCase):
             }
         ]
         items = parse_bird_response(tweets, "test query")
-        self.assertIsNone(items[0]["engagement"]["likes"])
+        self.assertIsNone(items[0]["engagement"])
 
     def test_fallback_to_second_key(self):
         tweets = [
@@ -202,6 +202,32 @@ class TestVendoredBirdRuntime(unittest.TestCase):
         ]
         items = parse_bird_response(tweets, "test query")
         self.assertEqual(0, items[0]["engagement"]["likes"])
+
+    def test_engagement_none_when_all_fields_missing(self):
+        """All-None engagement dict should become None, not propagate."""
+        tweets = [
+            {
+                "id": "1",
+                "text": "test",
+                "permanent_url": "https://x.com/u/status/1",
+            }
+        ]
+        items = parse_bird_response(tweets, "test query")
+        self.assertIsNone(items[0]["engagement"])
+
+    def test_engagement_preserved_when_any_field_present(self):
+        """Engagement dict kept when at least one metric exists."""
+        tweets = [
+            {
+                "id": "1",
+                "text": "test",
+                "permanent_url": "https://x.com/u/status/1",
+                "likeCount": 5,
+            }
+        ]
+        items = parse_bird_response(tweets, "test query")
+        self.assertIsNotNone(items[0]["engagement"])
+        self.assertEqual(5, items[0]["engagement"]["likes"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When a tweet has no engagement metrics at all (all fields missing from API
response), `_first_of()` returns `None` for each key, producing:
```python
{"likes": None, "reposts": None, "replies": None, "quotes": None}
```

This all-None dict propagates downstream to `signals.py` and `fusion.py`,
where engagement scoring treats it as "data exists but is zero" rather than
"no engagement data available."

## Fix

Single-line guard: return `None` instead of an all-None dict.

```python
# Before:
"engagement": engagement,

# After:
"engagement": engagement if any(v is not None for v in engagement.values()) else None,
```

## Test plan

- [x] `test_engagement_none_when_all_fields_missing` -- all-None dict becomes None
- [x] `test_engagement_preserved_when_any_field_present` -- dict kept when any metric exists
- [x] Updated `test_none_likes_when_missing` to assert `engagement` is None (not subscript into it)
- [x] Full test suite: 1024 passed, 15 pre-existing failures (store, watchlist, resolve, setup -- unrelated)