### PR TITLE
Drop "skills": ["./"] to fix v2.1.105 load regression

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,6 +11,5 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "skills": ["./"],
   "hooks": {}
 }


### PR DESCRIPTION
## Summary

- Plugin fails to load on harness v2.1.105 with the error `Path escapes plugin directory: ./ (skills)`. Removing `"skills": ["./"]` from `.claude-plugin/plugin.json` lets `skills/` auto-discovery register the canonical user skill via the existing `skills/last30days-nux/` symlink.
- The `"./"` entry also creates a latent duplicate-name collision: it registers the root `SKILL.md` as `last30days`, and auto-discovery of the NUX symlink registers the same content under the same name. The duplicate was harmless while `"./"` parsed, but it was never necessary.

## Evidence

This is a harness-side regression, not a plugin defect:

- **v2.1.94 explicitly sanctioned `"./"`.** From its changelog: *"Plugin skills declared via `\"skills\": [\"./\"]` now use the skill's frontmatter `name` for the invocation name instead of the directory basename, giving a stable name across install methods."*
- **Binary diff confirms the check was added between v2.1.101 and v2.1.105.** `strings` on the v2.1.105 binary returns 3 hits for `Path escapes plugin directory`, with the minified handler `case"path-traversal":return\`Path escapes plugin directory: ${H.path} (${H.component})\``. The same string returns 0 hits on v2.1.92 and v2.1.101 binaries.
- **No changelog entry in v2.1.105** mentions skills path validation, plugin sandboxing, or marketplace validation tightening.

Until the harness restores `"./"` support, the plugin is broken for every user on v2.1.105+ with `FORCE_AUTOUPDATE_PLUGINS=1`. This PR is a minimal workaround.

## What stays the same

- Root `SKILL.md` is unchanged. `.agents/`, `.hermes-plugin/`, `.codex-plugin/`, and `gemini-extension.json` still point at it.
- The user-facing skill still registers with frontmatter `name: last30days`, `user-invocable: true`.
- The self-locating `SKILL_ROOT` discovery loop in root `SKILL.md` continues to resolve `scripts/last30days.py` via `${CLAUDE_PLUGIN_ROOT}`, which points at the plugin root regardless of whether the skill was registered via `./` or via the `skills/last30days-nux/` symlink.

## Test plan

- [ ] Install this branch on v2.1.105.
- [ ] `/reload-plugins` reports no plugin errors.
- [ ] Registered skill appears as `last30days:last30days-nux` (frontmatter `name: last30days` after plugin namespace).
- [ ] `/last30days <topic>` invocation still runs end to end.