### PR TITLE
Fix Codex skill routing when WebSearch is available

### DIFF
--- a/.agents/skills/last30days/SKILL.md
+++ b/.agents/skills/last30days/SKILL.md
@@ -91,8 +91,8 @@ To detect first run: check if `~/.config/last30days/.env` exists. If it does NOT
 
 **When first run is detected, detect your platform first:**
 
-**If you do NOT have WebSearch capability (OpenClaw, Codex, raw CLI):** Run the OpenClaw setup flow below.
-**If you DO have WebSearch (Claude Code):** Run the standard setup flow below.
+**If you do NOT have WebSearch capability in this session (for example, OpenClaw or a raw CLI session):** Run the OpenClaw setup flow below.
+**If you DO have WebSearch capability in this session (for example, Claude Code or Codex with search enabled):** Run the standard setup flow below.
 
 ---
 
@@ -762,10 +762,10 @@ fi
 - `--github-repo={RESOLVED_GITHUB_REPOS}` (from Step 0.5c, product/project topics only)
 - Omit any flag where the value was not resolved (empty).
 
-**If you skipped Steps 0.55 and 0.75 (no WebSearch -- OpenClaw, Codex, etc.), add:**
+**If you skipped Steps 0.55 and 0.75 because WebSearch is unavailable in this session, add:**
 - `--auto-resolve` (the engine will use Brave/Exa/Serper to discover subreddits and context before planning)
 
-**If you skipped Steps 0.55 and 0.75 (no WebSearch), run the command as-is.** The Python engine will plan internally.
+**If you ran Steps 0.55 and 0.75 with WebSearch, do NOT add `--auto-resolve`.** The Python engine will use your `--plan` and resolved targeting flags.
 
 Use a **timeout of 300000** (5 minutes) on the Bash call. The script typically takes 1-3 minutes.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,8 +91,8 @@ To detect first run: check if `~/.config/last30days/.env` exists. If it does NOT
 
 **When first run is detected, detect your platform first:**
 
-**If you do NOT have WebSearch capability (OpenClaw, Codex, raw CLI):** Run the OpenClaw setup flow below.
-**If you DO have WebSearch (Claude Code):** Run the standard setup flow below.
+**If you do NOT have WebSearch capability in this session (for example, OpenClaw or a raw CLI session):** Run the OpenClaw setup flow below.
+**If you DO have WebSearch capability in this session (for example, Claude Code or Codex with search enabled):** Run the standard setup flow below.
 
 ---
 
@@ -762,10 +762,10 @@ fi
 - `--github-repo={RESOLVED_GITHUB_REPOS}` (from Step 0.5c, product/project topics only)
 - Omit any flag where the value was not resolved (empty).
 
-**If you skipped Steps 0.55 and 0.75 (no WebSearch -- OpenClaw, Codex, etc.), add:**
+**If you skipped Steps 0.55 and 0.75 because WebSearch is unavailable in this session, add:**
 - `--auto-resolve` (the engine will use Brave/Exa/Serper to discover subreddits and context before planning)
 
-**If you skipped Steps 0.55 and 0.75 (no WebSearch), run the command as-is.** The Python engine will plan internally.
+**If you ran Steps 0.55 and 0.75 with WebSearch, do NOT add `--auto-resolve`.** The Python engine will use your `--plan` and resolved targeting flags.
 
 Use a **timeout of 300000** (5 minutes) on the Bash call. The script typically takes 1-3 minutes.
 

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -288,8 +288,8 @@ def main() -> int:
                 sys.stderr.write(f"[Planner] Invalid --plan JSON: {exc}\n")
 
         # Auto-resolve: use web search to discover subreddits/handles before planning.
-        # This is the engine-side equivalent of SKILL.md Steps 0.55/0.75 for platforms
-        # without WebSearch (OpenClaw, Codex, raw CLI).
+        # This is the engine-side equivalent of SKILL.md Steps 0.55/0.75 for sessions
+        # where the agent cannot do external WebSearch planning.
         if args.auto_resolve and not external_plan:
             from lib import resolve
             resolution = resolve.auto_resolve(topic, config)

--- a/tests/test_skill_routing.py
+++ b/tests/test_skill_routing.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATHS = (
+    ROOT / "SKILL.md",
+    ROOT / ".agents" / "skills" / "last30days" / "SKILL.md",
+)
+
+SETUP_NON_WEBSEARCH_LINE = (
+    "**If you do NOT have WebSearch capability in this session "
+    "(for example, OpenClaw or a raw CLI session):** Run the OpenClaw setup flow below."
+)
+SETUP_WEBSEARCH_LINE = (
+    "**If you DO have WebSearch capability in this session "
+    "(for example, Claude Code or Codex with search enabled):** Run the standard setup flow below."
+)
+AUTO_RESOLVE_LINE = (
+    "**If you skipped Steps 0.55 and 0.75 because WebSearch is unavailable in this session, add:**"
+)
+PLAN_LINE = (
+    "**If you ran Steps 0.55 and 0.75 with WebSearch, do NOT add `--auto-resolve`.** "
+    "The Python engine will use your `--plan` and resolved targeting flags."
+)
+
+
+class TestSkillRouting(unittest.TestCase):
+    def test_shipped_skill_docs_route_by_capability_not_product_name(self) -> None:
+        for path in SKILL_PATHS:
+            text = path.read_text(encoding="utf-8")
+            self.assertIn(SETUP_NON_WEBSEARCH_LINE, text, str(path))
+            self.assertIn(SETUP_WEBSEARCH_LINE, text, str(path))
+            self.assertIn(AUTO_RESOLVE_LINE, text, str(path))
+            self.assertIn(PLAN_LINE, text, str(path))
+            self.assertNotIn("OpenClaw, Codex, raw CLI", text, str(path))
+            self.assertNotIn("no WebSearch -- OpenClaw, Codex, etc.", text, str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

The skill currently tells agents:

- Codex is part of the "no WebSearch" path in Step 0
- sessions that skip WebSearch planning should add `--auto-resolve`

That is stale for modern Codex runs. Codex can run with native web search enabled, so routing by product name is wrong. In that case the skill should take the WebSearch-capable path and keep using agent planning via `--plan`.

## Why it matters

This is not just a wording cleanup. `SKILL.md` is executable behavior for the agent.

Before this change, the skill could steer Codex toward the weaker fallback path that was meant for non-WebSearch environments. That means:

- worse first-run routing
- weaker pre-research and entity resolution
- more reliance on engine-side `--auto-resolve`
- less clear guidance for Codex users and maintainers

After this change, the skill routes by actual capability:

- if WebSearch is available in the current session, use the standard/WebSearch path
- if WebSearch is not available, use the OpenClaw / non-WebSearch fallback path and add `--auto-resolve`

## Changes

- update both shipped skill files to branch on actual `WebSearch` capability instead of hard-coding Codex into the non-WebSearch path
- clarify that WebSearch-capable runs should keep using `--plan` and should not add `--auto-resolve`
- add a regression test covering both shipped skill copies
- align the internal `--auto-resolve` comment in `scripts/last30days.py`

## Verification

```bash
python3 -m pytest -q tests/test_skill_routing.py tests/test_version_consistency.py
```

## Before / After

Before, a Codex probe had to work around the shipped wording:

```text
I think WebSearch is available in this session. The environment exposes the `web` search tool, so functionally this is a WebSearch-capable runtime even though the skill text lists “Codex” as a non-WebSearch example. I’d branch on actual capability, not that example label.
```

After this change, the routing is explicit:

```text
Follow the standard setup flow. In a Codex session with web search enabled, you do have `WebSearch` capability, so the Step 0 router sends you to the `DO have WebSearch capability` branch rather than the OpenClaw fallback path.
```
