### PR TITLE
fix: remove trailing slash from plugin paths to resolve path escape error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"
       },
-      "source": "./",
+      "source": ".",
       "category": "productivity",
       "homepage": "https://github.com/mvanhorn/last30days-skill"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,6 +11,6 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "skills": ["./"],
+  "skills": ["."],
   "hooks": {}
 }


### PR DESCRIPTION
## Problem

Installing the plugin via Claude Code marketplace fails with:

```
✘ Plugin errors
└ 1 plugin error(s) detected:
  └ last30days@last30days-skill [last30days]: Path escapes plugin directory: ./ (skills)
```

## Root Cause

Both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` use `"./"` (with trailing slash) as the path value. Claude Code's plugin path resolver treats the trailing slash in `"./"` as a path that escapes the plugin directory boundary.

## Fix

Removed the trailing slash from both path values:

| File | Before | After |
|------|--------|-------|
| `.claude-plugin/plugin.json` | `"skills": ["./"]` | `"skills": ["."]` |
| `.claude-plugin/marketplace.json` | `"source": "./"` | `"source": "."` |

`"."` correctly resolves to the plugin root directory where `SKILL.md` lives, without triggering the path escape check.


Simple fix for https://github.com/mvanhorn/last30days-skill/issues/239