### PR TITLE
fix: restore /last30days slash command on Claude Code v2.1.105+

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, GitHub, and 5+ more sources.",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",
@@ -11,6 +11,6 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "skills": ["./"],
+  "skills": ["skills"],
   "hooks": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-04-15
+
+### Fixed
+
+- **`/last30days` slash command now registers on Claude Code v2.1.105+.** `.claude-plugin/plugin.json` declared `"skills": ["./"]`, which newer Claude Code rejects with `Path escapes plugin directory: ./ (skills)`. The skill silently failed to register, so `/last30days <query>` returned "Unknown command" even though `/plugin list` showed the plugin as installed. Fix: `"skills": ["skills"]` so the loader scans the real skill subdirectory.
+- **Version drift between manifests.** `.claude-plugin/marketplace.json` was pinned to `3.0.0` while `.claude-plugin/plugin.json` advertised `3.0.1`. The `/plugin` resolver used the marketplace version and could install stale cached metadata alongside the correct build. Both manifests now agree on `3.0.2`.
+
+### Recovery
+
+If `/last30days` stopped working for you, run `/plugin update last30days` then `/reload-plugins`. If `/doctor` still reports errors, uninstall and reinstall the plugin from the marketplace.
+
 ## [3.0.1] - 2026-04-14
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {


### PR DESCRIPTION
## Summary

Two regressions silently broke \`/last30days\` for every user on current Claude Code. This ships both fixes together as 3.0.2 so users can \`/plugin update\` to recover.

## Bugs Fixed

**1. Path-escape error — \`plugin.json\` declared \`\"skills\": [\"./\"]\`**

Claude Code v2.1.105+ rejects \`./\` as a skill directory with:
\`\`\`
Path escapes plugin directory: ./ (skills)
\`\`\`

The skill loader refused to register the command. Users saw \`Unknown command: /last30days\` even though \`/plugin list\` showed the plugin as installed.

Fix: \`\"skills\": [\"skills\"]\` so the loader scans \`skills/last30days-nux/\` (the canonical plugin skill). Root \`SKILL.md\` stays intact for \`build-skill.sh\` / \`.skill\` distribution to claude.ai.

Prior art: commit \`93fbed2\` ("Drop \"skills\": [\"./\"] to fix v2.1.105 load regression") made this exact change once and got reverted. This re-lands it in a tagged release so it sticks.

**2. Version drift — marketplace.json pinned 3.0.0, plugin.json advertised 3.0.1**

The \`/plugin\` resolver uses marketplace.json's version. On a fresh install it resolved \`3.0.0\` against stale cached metadata (a SHA that isn't even in public repo history), creating a phantom user-scope install at an old commit alongside the correct project-scope install. Two plugins declaring the same \`name: last30days\` → skill resolver collision → slash command silently fails to register.

Fix: both manifests now say \`3.0.2\`. \`gemini-extension.json\` bumped for consistency.

## Diff

\`\`\`
.claude-plugin/marketplace.json |  2 +-
.claude-plugin/plugin.json      |  4 ++--
CHANGELOG.md                    | 11 +++++++++++
gemini-extension.json           |  2 +-
4 files changed, 15 insertions(+), 4 deletions(-)
\`\`\`

## Who This Affects

Anyone who installed \`mvanhorn/last30days-skill\` on Claude Code v2.1.105+. The plugin \*looks\* installed but \`/last30days <query>\` returns \`Unknown command\`, and \`/doctor\` reports the path-escape error.

## Recovery Instructions (also in CHANGELOG)

If \`/last30days\` stopped working:
1. \`/plugin update last30days\`
2. \`/reload-plugins\`
3. If \`/doctor\` still reports errors: uninstall and reinstall from marketplace.

## Testing

Local dogfood on this machine after merge + tag:
- Purged stale \`last30days-3@last30days-skill\` phantom from settings.json + installed_plugins.json
- Cleaned user-scope cache dirs
- Will reinstall from v3.0.2 tag in a fresh Claude Code session after tagging
- Evidence: \`/last30days\` in autocomplete + \`/doctor\` clean will be added as follow-up comment

## Release Plan

1. Merge this PR
2. Tag \`v3.0.2\` on main
3. Publish GitHub release (CI auto-attaches \`.skill\` artifact per commit \`21b8e5c\`)
4. Verify locally, comment screenshot evidence on this PR