### PR TITLE
fix: restore skills/ and .claude-plugin/ in plugin install tarball (v3.0.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, GitHub, and 5+ more sources.",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",
@@ -11,6 +11,6 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "skills": ["skills"],
+  "skills": ["./"],
   "hooks": {}
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,9 +16,10 @@ docs/          export-ignore
 fixtures/      export-ignore
 assets/        export-ignore
 
-# Second SKILL.md files would confuse claude.ai's uploader
-# (skills/last30days/ is an internal spec; skills/last30days-nux/ is a symlink)
-skills/        export-ignore
+# NOTE: skills/ and .claude-plugin/ are NOT export-ignored here because
+# Claude Code's /plugin install fetches this same git archive tarball.
+# Removing those from the archive (as v3.0.1 did) silently breaks installs.
+# claude.ai-bundle-specific exclusions live in scripts/build-skill.sh.
 
 # Historical + repo-only manifests
 SKILL-original.md  export-ignore
@@ -35,7 +36,6 @@ uv.lock            export-ignore
 .agents/         export-ignore
 .codex-plugin/   export-ignore
 .hermes-plugin/  export-ignore
-.claude-plugin/  export-ignore
 
 # CI workflows - repo-only, not needed at skill runtime
 .github/         export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2026-04-15
+
+### Fixed
+
+- **Restored `skills/` and `.claude-plugin/` to the plugin install tarball.** v3.0.1 added `.gitattributes` rules that excluded both directories from `git archive` output to shrink the claude.ai `.skill` bundle. Claude Code's `/plugin install` fetches the same archive, so users installing v3.0.1 or v3.0.2 received a tarball with no plugin manifest and no skill files. `git archive v3.0.0` contained 8 files under those paths; `v3.0.1` and `v3.0.2` contained 0. This release reverts those `.gitattributes` lines.
+- **Reverted `plugin.json` `"skills"` field to `["./"]`.** v3.0.2 changed this to `["skills"]` based on a misdiagnosis — the manifest change had no effect because the manifest wasn't in the tarball at all. The historical `["./"]` value shipped in every release from v2.1.0 through v3.0.0 without issues and is restored here.
+
+### Recovery
+
+Users on v3.0.1 or v3.0.2: run `/plugin update last30days` then `/reload-plugins`. If autoUpdate is enabled, the next session start will pull v3.0.3 automatically. Users on cached v3.0.0 or earlier installs were unaffected.
+
+### Notes
+
+- The claude.ai `.skill` bundle built by `scripts/build-skill.sh` still works — the archive grew from 89 to 97 files, well under the 200-file cap.
+- claude.ai-specific exclusions (avoiding duplicate `SKILL.md` files in the bundle) should move into `scripts/build-skill.sh` rather than `.gitattributes` in a future release, since `.gitattributes` cannot distinguish between the two distribution channels.
+
 ## [3.0.2] - 2026-04-15
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {


### PR DESCRIPTION
## Summary

v3.0.1 silently broke Claude Code \`/plugin install\` for every new install. This PR restores a working archive.

## Root Cause

v3.0.1 added \`.gitattributes\` rules to exclude \`skills/\` and \`.claude-plugin/\` from \`git archive\` output, shrinking the claude.ai \`.skill\` bundle. But Claude Code's \`/plugin install\` fetches the SAME archive. Users installing v3.0.1 or v3.0.2 received a tarball with no plugin manifest and no skill files.

### Proof

\`\`\`bash
git archive --format=tar v3.0.0 | tar -t | grep -cE '^skills/|^\.claude-plugin/'
# => 8

git archive --format=tar v3.0.1 | tar -t | grep -cE '^skills/|^\.claude-plugin/'
# => 0

git archive --format=tar v3.0.2 | tar -t | grep -cE '^skills/|^\.claude-plugin/'
# => 0

git archive --format=tar HEAD | tar -t | grep -cE '^skills/|^\.claude-plugin/'
# => 8  ← fixed
\`\`\`

## Why No Issue Reports

- Cached pre-v3.0.1 installs keep working; only NEW installs since yesterday are broken.
- Breakage is under 24 hours old.
- Users invoking the skill via natural language go through skill-selector, not the \`/last30days\` slash command, so the symptom can be silent.

## Also Reverts

v3.0.2's \`"skills": ["skills"]\` change back to \`"./"\`, the value that shipped in every tag from v2.1.0 through v3.0.0. That change was a misdiagnosis — the manifest wasn't in the tarball anyway, so the edit had no user-visible effect.

## Diff

\`\`\`
.claude-plugin/marketplace.json |  2 +-
.claude-plugin/plugin.json      |  4 ++--
.gitattributes                  |  8 ++++----
CHANGELOG.md                    | 16 ++++++++++++++++
gemini-extension.json           |  2 +-
5 files changed, 24 insertions(+), 8 deletions(-)
\`\`\`

## Recovery for Affected Users

\`\`\`
/plugin update last30days
/reload-plugins
\`\`\`

If autoUpdate is enabled, next session start pulls v3.0.3 automatically.

## Follow-up (out of scope for this PR)

Move claude.ai \`.skill\` bundle exclusions into \`scripts/build-skill.sh\`. \`.gitattributes\` can't distinguish between the two distribution channels sharing the same \`git archive\` output, so exclusions must be channel-specific.

## Release Plan

1. Merge this PR
2. Tag v3.0.3
3. Publish GitHub release with recovery instructions