### PR TITLE
fix(build): strip skills/ and .claude-plugin/ from .skill bundle (fixes v3.0.3 CI)

### DIFF
--- a/scripts/build-skill.sh
+++ b/scripts/build-skill.sh
@@ -19,12 +19,19 @@ mkdir -p dist
 OUT="dist/last30days.skill"
 git archive --format=zip --prefix=last30days/ --output="$OUT" HEAD
 
+# claude.ai's .skill bundle only needs the root SKILL.md + scripts/ runtime.
+# Claude Code needs skills/ and .claude-plugin/ in the git archive
+# (that's why they're NOT in .gitattributes export-ignore), but the .skill
+# bundle must strip them to keep a single canonical SKILL.md and stay under
+# the 200-file cap.
+zip -d "$OUT" "last30days/skills/*" "last30days/.claude-plugin/*" > /dev/null 2>&1 || true
+
 COUNT=$(unzip -l "$OUT" | tail -1 | awk '{print $2}')
 SIZE=$(du -h "$OUT" | cut -f1)
 
 if [ "$COUNT" -gt 200 ]; then
   echo "error: $COUNT files in zip, claude.ai's cap is 200" >&2
-  echo "       check .gitattributes export-ignore entries" >&2
+  echo "       check .gitattributes export-ignore entries and this script's zip -d excludes" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why

PR #262 restored \`skills/\` and \`.claude-plugin/\` to the git archive (users need them for \`/plugin install\`). But the release workflow's \`scripts/build-skill.sh\` uses the same archive to build the claude.ai \`.skill\` bundle and asserts exactly one SKILL.md + ≤200 files. Three SKILL.md files are now present (root + skills/last30days + skills/last30days-nux), so the assertion failed and the v3.0.3 release workflow errored out.

## Fix

After \`git archive\`, run \`zip -d\` to strip \`skills/\` and \`.claude-plugin/\` from the \`.skill\` bundle. The git archive itself is unchanged — Claude Code still gets the full tarball on \`/plugin install\`. Only the claude.ai bundle is trimmed.

## Local test

\`\`\`
$ bash scripts/build-skill.sh
built dist/last30days.skill (90 files, 268K)

$ unzip -l dist/last30days.skill | grep -c SKILL.md
1
\`\`\`

## Who needs this

This fixes the CI workflow for v3.0.3. No version bump needed — this is a build-only change that affects only the claude.ai \`.skill\` artifact attachment on GitHub releases. Users installing via \`/plugin install\` on v3.0.3 are already working per PR #262's fix.