### PR TITLE
fix: drop plugin.json skills key to clear path-escape on Claude Code v2.1.109 (v3.0.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, GitHub, and 5+ more sources.",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",
@@ -11,6 +11,5 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "skills": ["./"],
   "hooks": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2026-04-15
+
+### Fixed
+
+- **Cleared `/doctor` path-escape error on Claude Code v2.1.109+.** `.claude-plugin/plugin.json` previously declared `"skills": ["./"]`. That value shipped unchanged from v2.1.0 through v3.0.3 and worked on older Claude Code, but current versions reject `./` with `Path escapes plugin directory: ./ (skills)`. The `"skills"` key is now omitted entirely, matching the pattern used by every other plugin in the Claude Code marketplace ecosystem. Claude Code auto-discovers `skills/*/SKILL.md` when the key is absent.
+
+### Recovery
+
+If `/doctor` reports a path-escape error for last30days, run `/plugin update last30days` then `/reload-plugins`. If errors persist, uninstall and reinstall the plugin.
+
 ## [3.0.3] - 2026-04-15
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {


### PR DESCRIPTION
## Why

After v3.0.3 restored the plugin archive contents, \`/doctor\` on Claude Code v2.1.109 still reports:

\`\`\`
last30days@last30days-skill [last30days]: Path escapes plugin directory: ./ (skills)
\`\`\`

The value \`"skills": ["./"]\` has been in plugin.json unchanged since v2.1.0. Older Claude Code accepted it. Current v2.1.x rejects \`./\` outright.

## Fix

Remove the \`"skills"\` key entirely. Every other plugin in the Claude Code marketplace ecosystem omits it — compound-engineering, coding-tutor, codex, esper, and 15+ Anthropic official plugins all rely on the loader's default \`skills/*/SKILL.md\` auto-discovery. Last30days was the only outlier.

## Diff

\`\`\`
.claude-plugin/marketplace.json |  2 +-
.claude-plugin/plugin.json      |  3 +--
CHANGELOG.md                    | 10 ++++++++++
gemini-extension.json           |  2 +-
4 files changed, 13 insertions(+), 4 deletions(-)
\`\`\`

## Recovery

\`\`\`
/plugin update last30days
/reload-plugins
/doctor
\`\`\`

Expect zero errors. \`/last30days\` should appear in autocomplete (bare or namespaced depending on Claude Code version).

## Release Plan

1. Merge
2. Tag v3.0.4
3. Publish release