### PR TITLE
fix(youtube): YouTube comments enrichment broken - SC param + response shape

### DIFF
--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -732,10 +732,11 @@ def _fetch_video_comments(
     Returns:
         List of comment dicts with author, text, likes, date.
     """
+    video_url = f"https://www.youtube.com/watch?v={video_id}"
     if not _requests:
         try:
             from urllib.parse import urlencode
-            params = urlencode({"id": video_id})
+            params = urlencode({"url": video_url})
             url = f"{SCRAPECREATORS_YT_BASE}/video/comments?{params}"
             headers = http.scrapecreators_headers(token)
             headers["User-Agent"] = http.USER_AGENT
@@ -747,7 +748,7 @@ def _fetch_video_comments(
         try:
             resp = _requests.get(
                 f"{SCRAPECREATORS_YT_BASE}/video/comments",
-                params={"id": video_id},
+                params={"url": video_url},
                 headers=http.scrapecreators_headers(token),
                 timeout=30,
             )
@@ -763,11 +764,32 @@ def _fetch_video_comments(
         text = c.get("text") or c.get("body") or c.get("content", "")
         if not text:
             continue
+
+        # SC returns author as {"name": "@handle", ...}; legacy mocks may pass a string.
+        author = c.get("author") or c.get("author_name", "")
+        if isinstance(author, dict):
+            author = author.get("name") or author.get("handle") or ""
+
+        # SC nests likes under engagement.likes; legacy shapes used top-level keys.
+        engagement = c.get("engagement") or {}
+        likes = c.get("likes")
+        if likes is None:
+            likes = engagement.get("likes", 0) if isinstance(engagement, dict) else 0
+        if not likes:
+            likes = c.get("vote_count", 0)
+
+        date = (
+            c.get("date")
+            or c.get("published_at")
+            or c.get("publishedTime")
+            or c.get("publishedTimeText", "")
+        )
+
         comments.append({
-            "author": c.get("author") or c.get("author_name", ""),
+            "author": author,
             "text": text[:400],
-            "likes": c.get("likes") or c.get("vote_count", 0),
-            "date": c.get("date") or c.get("published_at", ""),
+            "likes": likes,
+            "date": date,
         })
 
     return comments
@@ -931,10 +953,11 @@ def _sc_fetch_transcript(video_id: str, token: str) -> Optional[str]:
     Returns:
         Plaintext transcript string, or None if unavailable.
     """
+    video_url = f"https://www.youtube.com/watch?v={video_id}"
     if not _requests:
         try:
             from urllib.parse import urlencode
-            params = urlencode({"id": video_id})
+            params = urlencode({"url": video_url})
             url = f"{SCRAPECREATORS_YT_BASE}/video/transcript?{params}"
             headers = http.scrapecreators_headers(token)
             headers["User-Agent"] = http.USER_AGENT
@@ -946,7 +969,7 @@ def _sc_fetch_transcript(video_id: str, token: str) -> Optional[str]:
         try:
             resp = _requests.get(
                 f"{SCRAPECREATORS_YT_BASE}/video/transcript",
-                params={"id": video_id},
+                params={"url": video_url},
                 headers=http.scrapecreators_headers(token),
                 timeout=30,
             )


### PR DESCRIPTION
## Summary
- YouTube comment enrichment was returning 400 on every call because `_fetch_video_comments` passed `id=<video_id>` to `/v1/youtube/video/comments`, but the endpoint requires `url=https://www.youtube.com/watch?v=<video_id>`
- `_sc_fetch_transcript` had the identical contract bug (latent — yt-dlp is preferred over the SC fallback, but would 400 on hosts without yt-dlp)
- After the param fix, a second bug surfaced: SC returns `author` as a dict (`{"name": "@handle", ...}`) and nests like counts under `engagement.likes`. The parser was reading `author` as a string and missing the nested likes, so every enriched comment would have landed with an object-shaped author and 0 likes

## Root cause
Introduced in PR #260 (`feat: surface YouTube + TikTok top comments alongside Reddit`). The TikTok sibling `_fetch_post_comments` in the same PR correctly uses `url=`; only the YouTube call was coded with `id=`. The response parser was written for an older SC shape that no longer matches what the comments endpoint returns.

## Repro (before this PR)
From a `/last30days Disney World` run on 2026-04-15:

```
[YouTube] Comment fetch error for T0CpOYZZZW4: 400 Client Error: Bad Request
[YouTube] Comment fetch error for dvBGOWeyuiY: 400 Client Error: Bad Request
[YouTube] Comment fetch error for 9yjZpBq1XBE: 400 Client Error: Bad Request
[YouTube] Enriched 0/3 videos with comments
```

## Verification (after this PR)
Live call against `api.scrapecreators.com` using a production key:

```
Got 3 comments
  - @JennyNicholson: Hey guys! As you can see, I'm still uploading content here... (49000 likes, 2025-04-15)
  - @allison8654: the rewatchability of this video is insane... (1200 likes, 2026-04-02)
  - @johnmoore2580: two dollars a minute is a little hard to conceptualize... (2600 likes, 2026-01-15)
```

## Changes
- `_fetch_video_comments`: send `url=<watch_url>` on both urllib and requests branches
- `_sc_fetch_transcript`: same switch, keeps the SC transcript fallback usable on yt-dlp-less hosts
- Response parser: extract `author.name` when author is a dict, read `engagement.likes` when top-level `likes` is absent, prefer `publishedTime` / `publishedTimeText` for date. Legacy string-author and top-level-likes shapes still work, so existing mocks/tests are unchanged.

## Testing
- All tests in `tests/test_youtube_yt.py`, `tests/test_youtube_relevance.py`, `tests/test_normalize_v3.py`, `tests/test_signals_v3.py`, `tests/test_render_v3.py` pass (118 tests green)
- Unrelated failures in `test_store.py` / `test_watchlist_commands.py` / `test_setup_openclaw.py` / `test_resolve.py` exist on `main` and are pre-existing (verified by stashing this change and running them)
- Live end-to-end probe against the real SC endpoint confirms the fix

## Scope
- Touches `scripts/lib/youtube_yt.py` only
- No signature changes, no caller changes, no config changes
- TikTok comments (`_fetch_post_comments`) were already correct; not touched
- YouTube search endpoint uses `keyword=`; unrelated, not touched

## Post-Deploy Monitoring & Validation
- **What to watch**
  - Logs: `Enriched N/M videos with comments` in `/last30days` runs where `SCRAPECREATORS_API_KEY` is set and `youtube_comments` is in `INCLUDE_SOURCES`. Healthy runs should now show N > 0 (was uniformly 0).
  - Absence of `Comment fetch error for <video_id>: 400 Client Error` lines.
- **Expected healthy behavior**
  - YouTube items in the output carry `top_comments` with real @handles and non-zero like counts
  - Synthesis starts quoting YouTube commenters (per SKILL.md judge instructions)
- **Failure signal / rollback trigger**
  - If 400s return, ScrapeCreators changed the contract again. Rollback is a single-file revert to `a2850e3`.
- **Validation window & owner**
  - First user-triggered run with a topic that returns YouTube videos, post-merge. Owner: @mvanhorn.

## Plan
[docs/plans/2026-04-15-002-fix-youtube-comments-scrapecreators-param-plan.md](docs/plans/2026-04-15-002-fix-youtube-comments-scrapecreators-param-plan.md) (gitignored, local)

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)