### PR TITLE
Fix ScrapeCreators YouTube search param: keyword → query

### DIFF
--- a/scripts/lib/youtube_yt.py
+++ b/scripts/lib/youtube_yt.py
@@ -918,7 +918,7 @@ def _sc_youtube_search(keyword: str, token: str) -> List[Dict[str, Any]]:
     if not _requests:
         try:
             from urllib.parse import urlencode
-            params = urlencode({"keyword": keyword})
+            params = urlencode({"query": keyword})
             url = f"{SCRAPECREATORS_YT_BASE}/search?{params}"
             headers = http.scrapecreators_headers(token)
             headers["User-Agent"] = http.USER_AGENT
@@ -931,7 +931,7 @@ def _sc_youtube_search(keyword: str, token: str) -> List[Dict[str, Any]]:
     try:
         resp = _requests.get(
             f"{SCRAPECREATORS_YT_BASE}/search",
-            params={"keyword": keyword},
+            params={"query": keyword},
             headers=http.scrapecreators_headers(token),
             timeout=30,
         )


### PR DESCRIPTION
## Summary

`scripts/lib/youtube_yt.py` `_sc_youtube_search` sends the search term as `keyword`, but the ScrapeCreators `/v1/youtube/search` endpoint requires `query`. Every call returns HTTP 400, so the YouTube SC fallback silently degrades to zero results whenever yt-dlp is unavailable or fails.

## Bug

GET https://api.scrapecreators.com/v1/youtube/search?keyword=...
HTTP/1.1 400 Bad Request
{"error": "missing_parameter", "message": "You must provide a query"}

The `except Exception` block in `_sc_youtube_search` swallows this, so the only user-visible symptom is `SC YouTube search returned 0 results` in the logs.

## Root cause

Both code paths in `_sc_youtube_search` use the wrong query-string key:

- urllib branch: `urlencode({"keyword": keyword})`
- requests branch: `params={"keyword": keyword}`

The internal Python arg `keyword` is fine, only the outgoing API parameter name is wrong. The two adjacent SC endpoints in the same file (`/video/comments`, `/video/transcript`) build their requests correctly, so this is isolated to `/search`.

## Verification

```python
import requests
BASE = "https://api.scrapecreators.com/v1/youtube"
H = {"x-api-key": "<your SC key>"}

# Before:
requests.get(f"{BASE}/search", params={"keyword": "claude code"}, headers=H, timeout=30).status_code
# -> 400  {"error":"missing_parameter","message":"You must provide a query"}

# After:
r = requests.get(f"{BASE}/search", params={"query": "claude code"}, headers=H, timeout=30)
r.status_code, len(r.json().get("videos", []))
# -> 200, N
```