### PR TITLE
feat: wire compare.sh and CLAUDE.md for /last30days-beta channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,4 +18,8 @@ bash scripts/sync.sh                                        # Deploy to ~/.claud
 ## Rules
 - `lib/__init__.py` must be bare package marker (comment only, NO eager imports)
 - After edits: run `bash scripts/sync.sh` to deploy
-- Git remotes: origin=private, upstream=public
+- Git remote: origin = public (`mvanhorn/last30days-skill`)
+
+## Beta channel
+
+Experimental changes get tested on `mvanhorn/last30days-skill-private`, which installs as a parallel `/last30days-beta` slash command. Beta-only changes never ship to public without a review PR here. Workflow guide lives at `BETA.md` in the private repo. Plan that established this setup: `docs/plans/2026-04-17-005-feat-beta-skill-from-private-repo-plan.md`.

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-# A/B/C test runner for last30days skill variants
+# A/B test runner: public release vs private beta
 # Usage: bash scripts/compare.sh "Kanye West"
 #
-# Runs all 3 skills sequentially (30s gap for rate limits),
-# saves raw results with unique suffixes, then prints file paths
-# for comparison.
+# Runs /last30days (public release) and /last30days-beta (private beta)
+# sequentially with a 30s gap, saves raw results with distinct suffixes,
+# prints file paths for comparison.
 
 set -e
 
-# Join all args as the topic (so "bash compare.sh Kevin Rose" works without quotes)
 if [ $# -eq 0 ]; then
   echo "Usage: bash scripts/compare.sh <topic>"
   echo "  Example: bash scripts/compare.sh Kevin Rose"
@@ -20,40 +19,42 @@ DIR="$HOME/Documents/Last30Days"
 DATE=$(date +%Y-%m-%d)
 
 echo "=============================================="
-echo " A/B/C Test: $TOPIC"
+echo " A/B Test: $TOPIC"
 echo " Date: $DATE"
 echo "=============================================="
 echo ""
 
-# Run 1: v2.9 production
-echo "[1/3] Running v2.9 (production /last30days)..."
+# Run 1: public release
+echo "[1/2] Running /last30days (public release)..."
 echo "  This takes 2-4 minutes..."
 claude -p --dangerously-skip-permissions "/last30days $TOPIC" > /dev/null 2>&1 || true
-V2_FILE="$DIR/${SLUG}-raw.md"
-[ -f "$V2_FILE" ] && echo "  ✓ Done → $V2_FILE" || echo "  ✗ FAILED — no output file"
+RELEASE_FILE="$DIR/${SLUG}-raw.md"
+[ -f "$RELEASE_FILE" ] && echo "  Done: $RELEASE_FILE" || echo "  FAILED: no output file"
 echo ""
 
 echo "  Waiting 30s for API rate limits..."
 sleep 30
 
-# Run 2: v3 Gemini
-echo "[2/3] Running v3 (/last30days-3)..."
+# Run 2: private beta
+echo "[2/2] Running /last30days-beta (private beta)..."
 echo "  This takes 2-4 minutes..."
-claude -p --dangerously-skip-permissions "/last30days-3:last30days-skill-private $TOPIC" > /dev/null 2>&1 || true
-V3GEM_FILE="$DIR/${SLUG}-raw-v3.md"
-[ -f "$V3GEM_FILE" ] && echo "  ✓ Done → $V3GEM_FILE" || echo "  ✗ FAILED — no output file"
-echo ""
-
+claude -p --dangerously-skip-permissions "/last30days-beta $TOPIC" > /dev/null 2>&1 || true
+BETA_FILE="$DIR/${SLUG}-raw-beta.md"
+[ -f "$BETA_FILE" ] && echo "  Done: $BETA_FILE" || echo "  FAILED: no output file"
 echo ""
 
 echo "=============================================="
 echo " Both complete. Raw files:"
 echo "=============================================="
 echo ""
-ls -la "$DIR/${SLUG}-raw"*.md 2>/dev/null || echo "  (no files found — check if skills saved correctly)"
+ls -la "$DIR/${SLUG}-raw"*.md 2>/dev/null || echo "  (no files found - check if skills saved correctly)"
 echo ""
 echo "To compare, run in Claude Code:"
 echo "  Read and compare these raw research files, produce a detailed report:"
-echo "  $DIR/${SLUG}-raw.md"
-echo "  $DIR/${SLUG}-raw-v3.md"
+echo "  $RELEASE_FILE"
+echo "  $BETA_FILE"
+echo ""
+echo "Beta output should start with a line like:"
+echo "  🧪 last30days-beta · branch <name> · synced $DATE"
+echo "If that line is missing, the beta badge regressed. See docs/plans/2026-04-17-005-*-plan.md."
 echo ""


### PR DESCRIPTION
## Summary

- `scripts/compare.sh` now A/B tests `/last30days` against `/last30days-beta` (instead of the stale `/last30days-3:last30days-skill-private` reference that no longer works).
- `CLAUDE.md` adds a "Beta channel" section pointing at `mvanhorn/last30days-skill-private`, so future agent sessions discover the two-skill layout on project load.
- No engine code changes. No runtime impact on `/last30days` itself.

## Testing

- `scripts/compare.sh "Test Topic"` now invokes the correct slash commands.
- `CLAUDE.md` section renders correctly and points to the right private repo.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: both files are project-facing docs/tooling with no production runtime impact. The slash command `/last30days` itself is unchanged by this PR.

## Context

Companion private-repo work (separate repo):
- `mvanhorn/last30days-skill-private` main now hosts the `last30days-beta` plugin
- PR #54 established the beta channel, PR #55 fixed the marketplace-name collision, PR #56 added `BETA.md` workflow docs
- Preserved pre-reset private main as branch `legacy/pre-2026-04-17-reset`

Plan (gitignored locally, included below for context):
`docs/plans/2026-04-17-005-feat-beta-skill-from-private-repo-plan.md`