### PR TITLE
refactor(normalize): extract _join_comment_excerpts helper

### DIFF
--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -110,6 +110,19 @@ def _first_present(d: dict[str, Any], keys: tuple[str, ...], default: Any) -> An
     return default
 
 
+def _join_comment_excerpts(
+    top_comments: list[Any],
+    key: str,
+    limit: int = 3,
+) -> str:
+    """Space-join the `key` field from the first `limit` dict-shaped comments."""
+    return " ".join(
+        str(comment.get(key) or "").strip()
+        for comment in top_comments[:limit]
+        if isinstance(comment, dict)
+    )
+
+
 def _domain_from_url(url: str) -> str | None:
     if not url:
         return None
@@ -169,11 +182,7 @@ def _normalize_reddit(
     to_date: str,
 ) -> schema.SourceItem:
     top_comments = item.get("top_comments") or []
-    comment_text = " ".join(
-        str(comment.get("excerpt") or "").strip()
-        for comment in top_comments[:3]
-        if isinstance(comment, dict)
-    )
+    comment_text = _join_comment_excerpts(top_comments, "excerpt")
     body = "\n".join(
         part
         for part in [
@@ -338,11 +347,7 @@ def _normalize_hackernews(
     to_date: str,
 ) -> schema.SourceItem:
     top_comments = item.get("top_comments") or []
-    comment_text = " ".join(
-        str(comment.get("text") or "").strip()
-        for comment in top_comments[:3]
-        if isinstance(comment, dict)
-    )
+    comment_text = _join_comment_excerpts(top_comments, "text")
     title = str(item.get("title") or "").strip()
     body = "\n".join(part for part in [title, str(item.get("text") or "").strip(), comment_text] if part)
     return _source_item(
@@ -441,11 +446,7 @@ def _normalize_github(
     title = str(item.get("title") or "").strip()
     snippet_text = str(item.get("snippet") or "").strip()
     top_comments = item.get("metadata", {}).get("top_comments") or []
-    comment_text = " ".join(
-        str(comment.get("excerpt") or "").strip()
-        for comment in top_comments[:3]
-        if isinstance(comment, dict)
-    )
+    comment_text = _join_comment_excerpts(top_comments, "excerpt")
     body = "\n".join(part for part in [title, snippet_text, comment_text] if part)
     metadata = item.get("metadata") or {}
     return _source_item(


### PR DESCRIPTION
## What

`_normalize_reddit`, `_normalize_hackernews`, and `_normalize_github` each inlined the same 5-line comprehension to stringify and space-join the first 3 top_comments' excerpt field. Extract one helper, call it from all three.

```python
def _join_comment_excerpts(top_comments, key, limit=3) -> str:
    return " ".join(
        str(comment.get(key) or "").strip()
        for comment in top_comments[:limit]
        if isinstance(comment, dict)
    )
```

The comment field name varies per source: Reddit and GitHub use `"excerpt"`, HN uses `"text"`. Passing it as a parameter keeps each caller's intent visible at the call site.

## Why

Small dedup. Any future change to comment-excerpt handling (truncation, separator choice) now happens in one place instead of three. Behavior unchanged.

## Verification

Full suite: **1088 pass, 15 pre-existing fail** (matches main baseline).

## Files

~~~
scripts/lib/normalize.py | 31 ++++++++++++++++---------------
1 file changed, 16 insertions(+), 15 deletions(-)
~~~
