### PR TITLE
fix(env): restore multi-key rotation for SCRAPECREATORS_API_KEY

### DIFF
--- a/scripts/lib/env.py
+++ b/scripts/lib/env.py
@@ -278,6 +278,14 @@ def get_config() -> dict[str, Any]:
     else:
         config['_CONFIG_SOURCE'] = 'env_only'
 
+    # Resolve comma-separated SCRAPECREATORS_API_KEY — pick one randomly for load distribution
+    # Restored from PR #268 (accidentally removed in v3.0.6 release commit d14814a)
+    sc_key_raw = config.get('SCRAPECREATORS_API_KEY') or ''
+    if ',' in sc_key_raw:
+        import random
+        sc_keys = [k.strip() for k in sc_key_raw.split(',') if k.strip()]
+        config['SCRAPECREATORS_API_KEY'] = random.choice(sc_keys) if sc_keys else ''
+
     # Extract browser credentials if configured
     browser_creds = extract_browser_credentials(config)
     for key, value in browser_creds.items():


### PR DESCRIPTION
## Summary

- Restores the comma-separated `SCRAPECREATORS_API_KEY` rotation feature from PR #268 (by @zaydiscold)
- The original 7 lines were accidentally removed in commit d14814a (v3.0.6 release)
- The v3.0.9 changelog still advertises this feature, but the code no longer exists in `scripts/lib/env.py`

## What was lost

PR #268 added support for `SCRAPECREATORS_API_KEY=key1,key2` — on each run, one key is picked randomly, distributing load across multiple free-tier accounts. This was merged and shipped in v3.0.0-v3.0.5.

In the v3.0.6 release commit (d14814a, "promote plans 003-009 from private beta to public"), the 7-line block was removed from `get_config()` in `env.py`. The removal does not appear in the PR description or changelog — it was likely a merge casualty during the large consolidation.

## What this PR does

Re-applies the exact same code from #268:

```python
sc_key_raw = config.get('SCRAPECREATORS_API_KEY') or ''
if ',' in sc_key_raw:
    import random
    sc_keys = [k.strip() for k in sc_key_raw.split(',') if k.strip()]
    config['SCRAPECREATORS_API_KEY'] = random.choice(sc_keys) if sc_keys else ''
```

## Test plan

- [ ] Set `SCRAPECREATORS_API_KEY=key1,key2` in `~/.config/last30days/.env`
- [ ] Run multiple research queries — verify both keys appear in API calls (check stderr debug output)
- [ ] Set `SCRAPECREATORS_API_KEY=singlekey` — verify no regression for single-key users
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)