### PR TITLE
fix: use removeprefix("r/") for subreddit names, not lstrip("r/")

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -303,7 +303,7 @@ def main() -> int:
     depth = "deep" if args.deep else "quick" if args.quick else "default"
     try:
         x_related = [h.strip() for h in args.x_related.split(",") if h.strip()] if args.x_related else None
-        subreddits = [s.strip().lstrip("r/") for s in args.subreddits.split(",") if s.strip()] if args.subreddits else None
+        subreddits = [s.strip().removeprefix("r/") for s in args.subreddits.split(",") if s.strip()] if args.subreddits else None
         tiktok_hashtags = [h.strip().lstrip("#") for h in args.tiktok_hashtags.split(",") if h.strip()] if args.tiktok_hashtags else None
         tiktok_creators = [c.strip().lstrip("@") for c in args.tiktok_creators.split(",") if c.strip()] if args.tiktok_creators else None
         ig_creators = [c.strip().lstrip("@") for c in args.ig_creators.split(",") if c.strip()] if args.ig_creators else None

--- a/scripts/lib/entity_extract.py
+++ b/scripts/lib/entity_extract.py
@@ -106,7 +106,7 @@ def _extract_subreddits(reddit_items: List[Dict[str, Any]]) -> List[str]:
 
     for item in reddit_items:
         # Primary subreddit
-        sub = item.get("subreddit", "").strip().lstrip("r/")
+        sub = item.get("subreddit", "").strip().removeprefix("r/")
         if sub:
             sub_counts[sub] += 1
 

--- a/scripts/lib/reddit_public.py
+++ b/scripts/lib/reddit_public.py
@@ -198,7 +198,7 @@ def search(
     encoded_query = _url_encode(query)
 
     if subreddit:
-        sub = subreddit.lstrip("r/").strip()
+        sub = subreddit.strip().removeprefix("r/")
         url = (
             f"https://www.reddit.com/r/{sub}/search.json"
             f"?q={encoded_query}&restrict_sr=on&sort=relevance&t=month&limit={limit}&raw_json=1"

--- a/tests/test_reddit_public.py
+++ b/tests/test_reddit_public.py
@@ -153,6 +153,18 @@ class TestSubredditScopedSearch:
         assert "/r/ClaudeAI/search.json" in req.full_url
         assert "/r/r/" not in req.full_url
 
+    @mock.patch("lib.reddit_public.urllib.request.urlopen")
+    def test_subreddit_name_starting_with_r_preserved(self, mock_urlopen):
+        """Subs starting with 'r' must not be chewed."""
+
+        mock_urlopen.return_value = _mock_urlopen_ok(SAMPLE_LISTING)
+
+        reddit_public.search("mobile robots", subreddit="robotics")
+
+        req = mock_urlopen.call_args[0][0]
+        assert "/r/robotics/search.json" in req.full_url
+        assert "/r/obotics" not in req.full_url
+
 
 class TestRetryOn429:
     """429 response triggers retries, eventually returns partial results."""


### PR DESCRIPTION
## Problem

`str.lstrip("r/")` treats its argument as a character set, not a literal prefix — it strips leading `r` and `/` repeatedly. For subs starting with `r` the result is wrong:

```python
>>> "robotics".lstrip("r/")
'obotics'
>>> "r/ruby".lstrip("r/")
'uby'
```

The result is that subs starting with "r" can't be searched by the agent. 

## Fix

Replace with `str.removeprefix("r/")` (Python 3.9+, project already requires 3.12) at three sites:

- `scripts/last30days.py:306` — CLI arg parsing
- `scripts/lib/reddit_public.py:201` — URL building
- `scripts/lib/entity_extract.py:109` — mention counting

## Test

One regression test in `tests/test_reddit_public.py` that fails on the bug and passes on the fix. Existing tests happened not to cover this case — they used names like `ClaudeAI` / `MachineLearning` whose first post-prefix character isn't in `{r, /}`.