### PR TITLE
test: skip docs/ in memory-dir-paths sweep

### DIFF
--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -37,7 +37,7 @@ class TestVersionConsistency(unittest.TestCase):
 
     def test_no_stray_hardcoded_memory_dir_paths(self) -> None:
         allowed_suffixes = {".md", ".py", ".sh", ".txt", ".yml", ".yaml", ".json"}
-        skip_dirs = {".git", "assets", "fixtures"}
+        skip_dirs = {".git", "assets", "fixtures", "docs"}
         offenders = []
 
         for path in ROOT.rglob("*"):


### PR DESCRIPTION
## Summary

Follow-up to #290. The `test_no_stray_hardcoded_memory_dir_paths` regression test walks the filesystem via `Path.rglob`, so gitignored `docs/plans/*.md` files (internal ce:plan output) trip the assertion on any dev machine that has run planning in this repo. Fresh clones and CI never see them, but local `python3 -m unittest discover tests` runs fail with ~51 offenders.

Adding `docs` to `skip_dirs` keeps the guard narrow to first-class source files while letting internal planning docs reference old paths verbatim.

## Validation

- `python3.14 -m unittest tests.test_version_consistency` -> all 4 pass
- `python3.14 -m unittest discover tests` -> back to baseline (2 pre-existing failures unrelated to this PR or #290)