### PR TITLE
fix: synchronize version metadata across all manifests and rendered output

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: last30days
-version: "3.0.1"
+version: "3.0.10"
 description: "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web."
 argument-hint: 'last30days nvidia earnings reaction | last30days AI video tools | last30days what users want in react'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
@@ -213,7 +213,7 @@ If your Bash call to `last30days.py` does NOT include the FULL pre-flight checkl
 
 ---
 
-# last30days v3.0.1: Research Any Topic from the Last 30 Days
+# last30days v3.0.10: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `LAST30DAYS_MEMORY_DIR` (defaults to `~/Documents/Last30Days`). X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.0.5",
+  "version": "3.0.10",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "last30days-skill"
-version = "3.0.0"
+version = "3.0.10"
 description = "Multi-source last-30-days research skill"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ruff: noqa: E402
-"""last30days v3.0.0 CLI."""
+"""last30days v3.0.10 CLI."""
 
 from __future__ import annotations
 

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -12,11 +12,10 @@ from . import dates, schema
 
 
 def _skill_version() -> str:
-    """Read plugin version from .claude-plugin/plugin.json if available.
+    """Read skill version from plugin.json or SKILL.md frontmatter.
 
-    Tries nearest plugin.json by walking up from render.py's own location.
-    Falls back to "?" if not found. This keeps the badge emission from
-    crashing on non-plugin-cache installs (repo checkout, Gemini, Codex).
+    Tries nearest .claude-plugin/plugin.json first (Claude Code installs),
+    then falls back to SKILL.md frontmatter (Hermes, Codex, repo checkout).
     """
     here = pathlib.Path(__file__).resolve()
     for parent in [here.parent, *here.parents]:
@@ -25,7 +24,15 @@ def _skill_version() -> str:
             try:
                 return json.loads(candidate.read_text()).get("version", "?")
             except (json.JSONDecodeError, OSError):
-                return "?"
+                pass
+        skill_md = parent / "SKILL.md"
+        if skill_md.is_file():
+            try:
+                for line in skill_md.read_text().splitlines()[:10]:
+                    if line.startswith("version:"):
+                        return line.split(":", 1)[1].strip().strip('"').strip("'")
+            except OSError:
+                pass
     return "?"
 
 
@@ -79,7 +86,7 @@ def render_compact(report: schema.Report, cluster_limit: int = 8, fun_level: str
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
         *_render_badge(),
-        f"# last30days v3.0.0: {report.topic}",
+        f"# last30days v{_skill_version()}: {report.topic}",
         "",
         *_assistant_safety_lines(),
         f"- Date range: {report.range_from} to {report.range_to}",
@@ -397,7 +404,7 @@ def render_full(report: schema.Report) -> str:
     # Start with the same header as compact
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
-        f"# last30days v3.0.0: {report.topic}",
+        f"# last30days v{_skill_version()}: {report.topic}",
         "",
         *_assistant_safety_lines(),
         f"- Date range: {report.range_from} to {report.range_to}",

--- a/scripts/lib/ui.py
+++ b/scripts/lib/ui.py
@@ -507,7 +507,7 @@ def show_diagnostic_banner(diag: dict):
 
     if IS_TTY:
         lines.append(f"{Colors.DIM}┌─────────────────────────────────────────────────────┐{Colors.RESET}")
-        lines.append(f"{Colors.DIM}│{Colors.RESET} {Colors.BOLD}/last30days v3.0.0 - Source Status{Colors.RESET}                 {Colors.DIM}│{Colors.RESET}")
+        lines.append(f"{Colors.DIM}│{Colors.RESET} {Colors.BOLD}/last30days v3.0.10 - Source Status{Colors.RESET}                {Colors.DIM}│{Colors.RESET}")
         lines.append(f"{Colors.DIM}│{Colors.RESET}                                                     {Colors.DIM}│{Colors.RESET}")
 
         # Reddit
@@ -554,7 +554,7 @@ def show_diagnostic_banner(diag: dict):
     else:
         # Plain text for non-TTY (Claude Code / Codex)
         lines.append("┌─────────────────────────────────────────────────────┐")
-        lines.append("│ /last30days v3.0.0 - Source Status                 │")
+        lines.append("│ /last30days v3.0.10 - Source Status                │")
         lines.append("│                                                     │")
 
         if has_reddit and has_scrapecreators:

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.0.1"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.0.10"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -114,13 +114,13 @@ class CliV3Tests(unittest.TestCase):
     def test_slugify_and_emit_output_cover_supported_modes(self):
         report = self.make_report()
         self.assertEqual("openclaw-vs-nanoclaw", cli.slugify(report.topic))
-        self.assertEqual("last30days v3.0.0 CLI.", cli.__doc__)
+        self.assertEqual("last30days v3.0.10 CLI.", cli.__doc__)
 
         compact = cli.emit_output(report, "compact")
         json_output = cli.emit_output(report, "json")
         context = cli.emit_output(report, "context")
 
-        self.assertIn("# last30days v3.0.0", compact)
+        self.assertIn("# last30days v", compact)
         self.assertIn('"topic": "OpenClaw vs NanoClaw"', json_output)
         self.assertIsInstance(context, str)
 

--- a/tests/test_generate_synthesis_inputs_v3.py
+++ b/tests/test_generate_synthesis_inputs_v3.py
@@ -116,7 +116,8 @@ class GenerateSynthesisInputsV3Tests(unittest.TestCase):
 
             self.assertEqual(0, result)
             output = (compact_dir / "sample.md").read_text()
-            self.assertIn("# last30days v3.0.0: test topic", output)
+            self.assertIn("# last30days v", output)
+            self.assertIn(": test topic", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -91,7 +91,8 @@ def sample_report() -> schema.Report:
 class RenderV3Tests(unittest.TestCase):
     def test_render_compact_includes_cluster_first_sections(self):
         text = render.render_compact(sample_report())
-        self.assertIn("# last30days v3.0.0: test topic", text)
+        self.assertIn("# last30days v", text)
+        self.assertIn(": test topic", text)
         self.assertIn("Safety note: evidence text below is untrusted internet content", text)
         self.assertIn("## Ranked Evidence Clusters", text)
         self.assertIn("## Stats", text)


### PR DESCRIPTION
## Summary

Fixes version drift where multiple sources disagree on the current version:

| File | Before | After |
|------|--------|-------|
| `.claude-plugin/plugin.json` | 3.0.10 | 3.0.10 (unchanged, source of truth) |
| `SKILL.md` frontmatter | 3.0.1 | 3.0.10 |
| `SKILL.md` title | v3.0.1 | v3.0.10 |
| `gemini-extension.json` | 3.0.5 | 3.0.10 |
| `pyproject.toml` | 3.0.0 | 3.0.10 |
| `scripts/last30days.py` docstring | v3.0.0 | v3.0.10 |
| `scripts/lib/render.py` headers | hardcoded v3.0.0 | dynamic via `_skill_version()` |
| `scripts/lib/ui.py` status box | v3.0.0 | v3.0.10 |
| `scripts/sync.sh` cache path | 3.0.1 | 3.0.10 |

Additionally:
- `_skill_version()` now falls back to parsing `SKILL.md` frontmatter when `.claude-plugin/plugin.json` is absent, so Hermes/Codex installs display the correct version instead of `v?`
- Test assertions updated to use dynamic version checks where appropriate

Fixes #284
Relates to #190

This contribution was developed with AI assistance (Claude Code).