### PR TITLE
feat: add CI workflow to run pytest on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - run: uv sync --group dev
+
+      - run: uv run python -m pytest -q --tb=short


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs pytest on every push to `main` and on all pull requests
- Uses `uv sync --group dev` for dependency installation (matching `pyproject.toml` dev group)
- Runs on Python 3.12 (matching `requires-python = ">=3.12"`)
- Intentionally minimal — no lint or coverage gates (those are #253 and #254)

The test suite has 1,000+ tests that currently have no CI signal. Every PR merges without pass/fail feedback.

Fixes #249

This contribution was developed with AI assistance (Claude Code).