### PR TITLE
fix: replace hardcoded developer paths in test-v1-vs-v2.sh

### DIFF
--- a/scripts/test-v1-vs-v2.sh
+++ b/scripts/test-v1-vs-v2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # using `claude --print` to capture real end-to-end output.
 
 SKILL_DIR="$HOME/.claude/skills/last30days"
-REPO_DIR="/Users/mvanhorn/last30days-skill"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Safety: always restore V2 SKILL.md on exit/crash
 cleanup() {
@@ -101,7 +101,7 @@ run_version() {
 
     # Run claude --print with the skill invocation
     # No timeout — claude --print exits on its own; kill manually if stuck
-    if /Users/mvanhorn/.local/bin/claude --print \
+    if "${CLAUDE:-claude}" --print \
       "/last30days $query" \
       > "$outfile" 2>"$errfile"; then
       local end_time


### PR DESCRIPTION
## Summary

- `REPO_DIR` now derives from the script's location (`$(cd "$(dirname "$0")/.." && pwd)`) with env var override
- Claude binary found via `PATH` (with `CLAUDE` env var override) instead of `/Users/mvanhorn/.local/bin/claude`

Before: script only worked on the maintainer's machine.
After: works on any checkout. Override with `REPO_DIR=/path CLAUDE=/path/to/claude bash scripts/test-v1-vs-v2.sh`.

Fixes #98

This contribution was developed with AI assistance (Claude Code).