### PR TITLE
fix: expand sync.sh import verification to cover all library modules

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -57,7 +57,7 @@ sync_target() {
 
   if (
     cd "$target/scripts" &&
-    python3 -c "import briefing, store, watchlist; from lib import youtube_yt, bird_x, render, ui; print('  Import check: OK')"
+    python3 -c "import briefing, store, watchlist; from lib import youtube_yt, bird_x, render, ui, schema, env, normalize, dedupe, reddit, reddit_public, reddit_enrich, hackernews, polymarket, bluesky, truthsocial, tiktok, instagram, pinterest, threads, perplexity, github, xai_x, xiaohongshu_api, xquik, pipeline, planner, cluster, fusion, rerank, relevance, grounding, entity_extract, signals, snippet, query, dates, http, log, preflight, providers, quality_nudge, resolve, setup_wizard; print('  Import check: OK')"
   ); then
     true
   else
@@ -100,7 +100,7 @@ if [ -d "$HOME/.hermes/skills/research" ]; then
   
   if (
     cd "$HERMES_TARGET/scripts" &&
-    python3 -c "import briefing, store, watchlist; from lib import youtube_yt, bird_x, render, ui; print('  Import check: OK')"
+    python3 -c "import briefing, store, watchlist; from lib import youtube_yt, bird_x, render, ui, schema, env, normalize, dedupe, reddit, reddit_public, reddit_enrich, hackernews, polymarket, bluesky, truthsocial, tiktok, instagram, pinterest, threads, perplexity, github, xai_x, xiaohongshu_api, xquik, pipeline, planner, cluster, fusion, rerank, relevance, grounding, entity_extract, signals, snippet, query, dates, http, log, preflight, providers, quality_nudge, resolve, setup_wizard; print('  Import check: OK')"
   ); then
     true
   else


### PR DESCRIPTION
## Summary

- Expands the import check in `sync.sh` from 7 modules to all 46 library modules
- Skips browser-dependent modules (`chrome_cookies`, `cookie_extract`, `safari_cookies`) that require browser binaries
- Both sync targets (common + Hermes) are updated

**Before:** `sync.sh` only checked `briefing, store, watchlist, youtube_yt, bird_x, render, ui` — broken imports in 39 other modules would only surface at runtime.

**After:** all core modules are verified at sync time. Verified that the full import list passes locally.

Fixes #96

This contribution was developed with AI assistance (Claude Code).