### PR TITLE
feat: add Cursor IDE plugin support

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "last30days",
+  "version": "3.0.5",
+  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+  "author": {
+    "name": "Matt Van Horn",
+    "email": "mvanhorn@gmail.com",
+    "url": "https://github.com/mvanhorn"
+  },
+  "homepage": "https://github.com/mvanhorn/last30days-skill",
+  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "license": "MIT",
+  "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"]
+}

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Say "eli5 on" after any research run. The synthesis rewrites in plain language. 
 | **Claude Code** | `/plugin marketplace add mvanhorn/last30days-skill` |
 | **OpenClaw** | `clawhub install last30days-official` |
 | **Gemini CLI** | Clone then `gemini extensions install ./last30days-skill` (see below) |
+| **Cursor** | Clone then `ln -s` to `~/.cursor/skills/last30days/` (see below) |
 
 ### claude.ai (web)
 
@@ -177,6 +178,19 @@ Gemini CLI v0.9.0 has an upstream installer bug that can fail with `Configuratio
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill
 gemini extensions install ./last30days-skill
+```
+
+### Cursor
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill
+ln -s "$(pwd)/last30days-skill" ~/.cursor/skills/last30days
+```
+
+Or with `sync.sh` (also deploys to Claude Code, Codex, and other targets):
+
+```bash
+bash scripts/sync.sh
 ```
 
 ### Manual (developer)

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -15,6 +15,7 @@ COMMON_TARGETS=(
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"
+  "$HOME/.cursor/skills/last30days"
 )
 OPENCLAW_TARGET="$HOME/.openclaw/skills/last30days"
 


### PR DESCRIPTION
## Summary
- Add `.cursor-plugin/plugin.json` — Cursor IDE discovery + marketplace metadata
- Add `~/.cursor/skills/last30days` to `scripts/sync.sh` deploy targets
- Add Cursor install docs to README

## What Cursor reads
Cursor discovers skills at `~/.cursor/skills/<name>/SKILL.md`. The `.cursor-plugin/plugin.json` provides metadata (name, version, keywords) for marketplace search and plugin display. No duplicate SKILL.md needed — Cursor reads the canonical root SKILL.md via the sync target.

Follows the single-canonical-SKILL.md rule from v3.0.9 (commit e8105df) — no plugin-specific SKILL.md copies.

## Changes
| File | Action |
|------|--------|
| `.cursor-plugin/plugin.json` | **Created** — full metadata matching `.claude-plugin/plugin.json` (minus Claude-specific `hooks: {}`) |
| `scripts/sync.sh` | **+1 line** in `COMMON_TARGETS` array |
| `README.md` | **+1 table row** + **Cursor install section** (clone + symlink, or sync.sh) |

## Test plan
- [x] `python3 -c "import json; json.load(open('.cursor-plugin/plugin.json'))"` — valid JSON
- [x] `bash scripts/sync.sh` succeeds with new Cursor target
- [x] Import check passes for `~/.cursor/skills/last30days/`
- [x] Cursor discovers `/last30days` skill after sync
- [x] Existing Claude Code, Codex, Hermes, Gemini, OpenClaw installs unaffected