### PR TITLE
feat: add Cursor IDE plugin support

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "last30days",
+  "version": "3.0.5",
+  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+  "author": {
+    "name": "Matt Van Horn",
+    "email": "mvanhorn@gmail.com",
+    "url": "https://github.com/mvanhorn"
+  },
+  "homepage": "https://github.com/mvanhorn/last30days-skill",
+  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "license": "MIT",
+  "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"]
+}

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Say "eli5 on" after any research run. The synthesis rewrites in plain language. 
 | **Claude Code** | `/plugin marketplace add mvanhorn/last30days-skill` |
 | **OpenClaw** | `clawhub install last30days-official` |
 | **Gemini CLI** | Clone then `gemini extensions install ./last30days-skill` (see below) |
+| **Cursor** | Clone then `ln -s` to `~/.cursor/skills/last30days/` (see below) |
 
 ### claude.ai (web)
 
@@ -177,6 +178,19 @@ Gemini CLI v0.9.0 has an upstream installer bug that can fail with `Configuratio
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill
 gemini extensions install ./last30days-skill
+```
+
+### Cursor
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill
+ln -s "$(pwd)/last30days-skill" ~/.cursor/skills/last30days
+```
+
+Or with `sync.sh` (also deploys to Claude Code, Codex, and other targets):
+
+```bash
+bash scripts/sync.sh
 ```
 
 ### Manual (developer)

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -15,6 +15,7 @@ COMMON_TARGETS=(
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"
+  "$HOME/.cursor/skills/last30days"
 )
 OPENCLAW_TARGET="$HOME/.openclaw/skills/last30days"
 


### PR DESCRIPTION
Added this because I use last30days in all my agents and Cursor is one of them. Sometimes Cursor models are a bit silly about discovering skills without an explicit path entry so having native install instructions helps. The plugin.json is mostly a namespace marker for now since last30days isn't in the Cursor marketplace yet but it matches what other plugins ship and keeps things consistent.

P.S. My twitter is @coldcooks lol you tagged an alt account I didn't even know I had in a prior PR :)

## Summary
- Add `.cursor-plugin/plugin.json` — Cursor IDE namespace + metadata
- Add `~/.cursor/skills/last30days` to `scripts/sync.sh` deploy targets
- Add Cursor install instructions to README

## How it works
Cursor discovers skills at `~/.cursor/skills/<name>/SKILL.md`. Adding the Cursor target to `COMMON_TARGETS` in sync.sh deploys the canonical root SKILL.md (plus scripts, lib, fixtures) to that path — same mechanism as the existing Codex and .agents targets.

No duplicate SKILL.md in the repo — follows the rule from v3.0.9 (e8105df).

## Validation
- [x] `bash scripts/sync.sh` — Cursor target syncs, 46 modules copied, import check OK
- [x] `.cursor-plugin/plugin.json` valid JSON, metadata matches `.claude-plugin/plugin.json`
- [x] Zero changes to existing Claude Code, Codex, Hermes, Gemini, or OpenClaw targets