### PR TITLE
chore(release): v3.1.0 — consolidate 3.0.10-3.0.14 + OpenClaw republish prep

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.0.14",
+  "version": "3.1.0",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-22
+
+Consolidates the 3.0.10 to 3.0.14 dev cycle (commenter handles, `--competitors`, per-entity Step 0.55, vs-mode N passes, comparison title attribution) and republishes the OpenClaw bundle, which had been frozen on ClawHub at `3.0.0-open` since April 8.
+
+### Added
+
+- **OpenClaw republish.** `clawhub install last30days-official` now resolves to `3.1.0-open`, matching current main. Closes [#307](https://github.com/mvanhorn/last30days-skill/issues/307), [#195](https://github.com/mvanhorn/last30days-skill/issues/195), [#236](https://github.com/mvanhorn/last30days-skill/issues/236). The ClawHub bundle had shipped a broken `env.py get_config()` and stale SKILL.md path references since April; both are fixed at source on main and the republish carries the fixes to installers.
+
+### Fixed
+
+- **Claude Code plugin manifest path-escape.** The `.claude-plugin/plugin.json` `skills` key was removed in commit `93fbed2` but never shipped in a tagged release. Installing via `/plugin install last30days-skill` could hit `/doctor`'s `Path escapes plugin directory: ./ (skills)` error. This release ships the fix. Closes [#306](https://github.com/mvanhorn/last30days-skill/issues/306).
+- **Broken README link.** The README's "source of truth" link pointed at `skills/last30days/SKILL.md`, a path that does not exist. Fixed to point at root `SKILL.md`.
+
+### Dev cycle journal (3.0.10 - 3.0.14, not separately tagged)
+
+Individual changelog entries for 3.0.10 through 3.0.14 below document the incremental work consolidated into this release.
+
 ## [3.0.14] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**
 
-This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), which is the source of truth for the latest command and setup behavior.
+This README tracks the current v3 pipeline. The runtime skill spec lives in [SKILL.md](SKILL.md), which is the source of truth for the latest command and setup behavior.
 
 Claude Code:
 ```


### PR DESCRIPTION
## Summary

- Bump `plugin.json` version from 3.0.14 to 3.1.0
- Add CHANGELOG `[3.1.0] - 2026-04-22` entry consolidating the 3.0.10-3.0.14 dev cycle and noting the OpenClaw republish
- Fix broken README link: `skills/last30days/SKILL.md` (does not exist) -> root `SKILL.md`

## Why 3.1.0 instead of 3.0.14

User direction: ship prepared 3.0.10-3.0.14 work plus the OpenClaw republish as a single 3.1.0 release. The v3.0.10-v3.0.14 tags were never cut; CHANGELOG entries for those versions remain below the 3.1.0 entry as a dev-cycle journal.

## What this release carries

- **From 3.0.10-3.0.14:** commenter handles on evidence lines (#292), `--competitors` flag (#308), per-entity Step 0.55 + canonical SKILL.md (#311), vs-mode N passes + auto-discovery (#312), comparison title attribution (3.0.14).
- **New in 3.1.0:**
  - Closes #306 — the `plugin.json` path-escape fix from commit `93fbed2` finally ships in a tagged release.
  - Will close #307 / #195 / #236 once the ClawHub `3.1.0-open` publish lands on top of this tag.

## Follow-up after merge

1. Tag `v3.1.0` on main to trigger `.github/workflows/release.yml`.
2. Publish to ClawHub: `clawhub publish . --slug last30days-official --version 3.1.0-open`.
3. Acknowledge reporters on #307, #195, #236, #306.

## Test plan

- [x] Verified diff is scoped to plugin.json + CHANGELOG + README — no code changes
- [x] README link now resolves to existing `SKILL.md` file
- [ ] After merge + tag: `release.yml` produces `dist/last30days.skill` attached to v3.1.0 GitHub release
- [ ] After tag: fresh `/plugin marketplace update && /plugin install last30days-skill` on a test Claude Code profile reports no `/doctor` path-escape error