### PR TITLE
fix: make hooks.json polyglot for Gemini CLI and Claude Code compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh\"",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/hooks/scripts/check-config.sh\"",
             "timeout": 5
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/hooks/scripts/check-config.sh\"",
-            "timeout": 5
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/hooks/scripts/check-config.sh\""
           }
         ]
       }


### PR DESCRIPTION
Gemini CLI reads the `timeout` field in `hooks.json` as milliseconds, causing a 5ms timeout that fails on execution. This PR removes the timeout so both CLIs can fall back to their generous defaults (600s for Claude, 60s for Gemini).

Additionally, Gemini CLI uses `${extensionPath}` instead of `${CLAUDE_PLUGIN_ROOT}`. This PR uses a short-circuit bash command to gracefully try both directories, ensuring a single `hooks.json` file is perfectly compatible with both environments without any build steps.