### PR TITLE
chore: align plugin manifests, add Codex AGENTS.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,7 @@
   "plugins": [
     {
       "name": "last30days",
-      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, HN, Polymarket, GitHub, and 5+ more sources.",
-      "version": "3.1.1",
+      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+      "version": "3.1.1",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,5 @@
   "homepage": "https://github.com/mvanhorn/last30days-skill",
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
-  "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"],
-  "hooks": {}
+  "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "last30days",
   "version": "3.1.1",
-  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and more sources.",
+  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",
     "email": "mvanhorn@gmail.com",
@@ -26,7 +26,7 @@
   "interface": {
     "displayName": "Last 30 Days",
     "shortDescription": "Research recent discussion across social and web sources",
-    "longDescription": "Use Last 30 Days to research what people are saying, upvoting, sharing, and betting on across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and web sources.",
+    "longDescription": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
     "developerName": "Matt Van Horn",
     "category": "Research",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@CLAUDE.md


### PR DESCRIPTION
Plugin manifests now read consistently across Claude Code and Codex installs: the same description copy on every surface, and Codex picks up repo-level context the same way Claude already does.

- `.claude-plugin/plugin.json`: drop the empty `"hooks": {}` block. Auto-discovery from `hooks/hooks.json` already wires the `SessionStart` hook (verified by the "Ready — N sources active" status line).
- `.claude-plugin/marketplace.json` and `.codex-plugin/plugin.json`: sync `description` and `longDescription` so the Claude and Codex catalog entries read the same copy. The marketplace plugin entry's `version` is intentionally retained — `tests/test_plugin_contract.py::test_versions_match_across_manifests` enforces that every version-bearing surface agrees.
- `AGENTS.md`: new 1-line shim (`@CLAUDE.md`) so the Codex CLI loads the same repo instructions Claude reads from `CLAUDE.md`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)