### PR TITLE
fix(xurl): treat PermissionError from PATH lookup as unavailable

### DIFF
--- a/skills/last30days/scripts/lib/xurl_x.py
+++ b/skills/last30days/scripts/lib/xurl_x.py
@@ -46,9 +46,10 @@ def is_available() -> bool:
             timeout=10,
         )
         return result.returncode == 0 and '"username"' in result.stdout
-    except FileNotFoundError:
-        return False
-    except subprocess.TimeoutExpired:
+    except (OSError, subprocess.TimeoutExpired):
+        # OSError covers FileNotFoundError (no xurl on PATH) and
+        # PermissionError (a non-executable match on PATH, e.g. WSL's
+        # /mnt/c/.../WindowsApps shim returning EACCES on exec).
         return False
 
 

--- a/tests/test_xurl_x.py
+++ b/tests/test_xurl_x.py
@@ -44,6 +44,13 @@ class TestIsAvailable(unittest.TestCase):
         with mock.patch("subprocess.run", side_effect=FileNotFoundError):
             self.assertFalse(xurl_x.is_available())
 
+    def test_returns_false_on_permission_error(self):
+        # WSL hits this when a Windows-mounted PATH entry points at an
+        # exec-blocked shim (e.g. WindowsApps), which raises PermissionError
+        # before any other PATH candidate is tried.
+        with mock.patch("subprocess.run", side_effect=PermissionError(13, "Permission denied", "xurl")):
+            self.assertFalse(xurl_x.is_available())
+
     def test_returns_false_on_timeout(self):
         import subprocess
         with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired("xurl", 10)):


### PR DESCRIPTION
## Summary
- `xurl_x.is_available()` only caught `FileNotFoundError` from the `xurl whoami` probe. On WSL, a `/mnt/c/.../WindowsApps` entry on `$PATH` returns `EACCES` during exec, and Python raises `PermissionError`. That escaped `is_available()` and crashed `pipeline.diagnose()` before any source ran, so the engine could not start on that host even with Bird or xAI configured.
- Catch `OSError` instead. It covers `FileNotFoundError`, `PermissionError`, and any other spawn-time OS error, and lets the lookup fall through to the next backend.

## Test plan
- [x] `pytest tests/test_xurl_x.py` (added a `PermissionError` regression test)
- [x] `python3.12 skills/last30days/scripts/last30days.py --diagnose --search=x,youtube` runs to completion on a WSL host where a Windows-mounted `$PATH` entry previously crashed it