### PR TITLE
fix: correct invalid OPENROUTER_DEFAULT model ID

### DIFF
--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -19,7 +19,7 @@ OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
 XAI_RESPONSES_URL = "https://api.x.ai/v1/responses"
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
-OPENROUTER_DEFAULT = "google/gemini-flash-2.0"
+OPENROUTER_DEFAULT = "google/gemini-3.1-flash-lite-preview"
 
 
 class ReasoningClient:

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -19,6 +19,10 @@ OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
 XAI_RESPONSES_URL = "https://api.x.ai/v1/responses"
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+# OpenRouter routes the Gemini Flash Lite tier as the -preview slug; that is the
+# stable form on that routing layer even though native Gemini's GEMINI_FLASH_LITE
+# constant is suffix-free. If GEMINI_FLASH_LITE moves to a non-preview stable ID,
+# double-check that OpenRouter's slug still maps to the same upstream model.
 OPENROUTER_DEFAULT = "google/gemini-3.1-flash-lite-preview"
 
 


### PR DESCRIPTION
## Summary

`OPENROUTER_DEFAULT` in `scripts/lib/providers.py` is set to `google/gemini-flash-2.0`, which is not a valid OpenRouter model ID (the segments are reversed). This causes **every** rerank and FunJudge call to fail with HTTP 400 when `LAST30DAYS_REASONING_PROVIDER=openrouter` unless the user has explicitly pinned `LAST30DAYS_RERANK_MODEL` themselves.

## Symptom

```
[Rerank] LLM reranking failed, using local fallback: HTTPError: HTTP 400: Bad Request
[FunJudge] LLM scoring failed: HTTPError: HTTP 400: Bad Request
```

OpenRouter's response body confirms:
```json
{"error":{"message":"google/gemini-flash-2.0 is not a valid model ID","code":400}}
```

Every ranked-evidence cluster ends up tagged `Why: fallback-local-score`.

## Root Cause

`scripts/lib/providers.py:22`:
```python
OPENROUTER_DEFAULT = "google/gemini-flash-2.0"   # segments reversed
```

The valid OpenRouter format is `google/gemini-{VERSION}-flash[-VARIANT]`, e.g. `google/gemini-2.0-flash-001`. `google/gemini-flash-2.0` is not listed.

`LAST30DAYS_PLANNER_MODEL` masks this for the planner because most users pin it, but `LAST30DAYS_RERANK_MODEL` is rarely pinned, so rerank/FunJudge always hit the bad default.

## Fix

Switch to `google/gemini-3.1-flash-lite-preview`.

Rationale for this specific replacement: `providers.py:12` already declares
```python
GEMINI_FLASH_LITE = "gemini-3.1-flash-lite-preview"
```
as the default for the native Gemini provider (`_MODEL_DEFAULTS["gemini"]`). Aligning the OpenRouter default to the same model keeps both code paths consistent and prevents future divergence whenever this constant is updated.

Alternative considered: minimal-change `google/gemini-2.0-flash-001` (the closest valid ID to the original typo). Happy to switch if you prefer the more conservative fix.

## Validation

After the fix, ran `last30days "Claude Opus 4.7" --quick`:

| Metric | Before | After |
|---|---|---|
| `[Rerank] LLM reranking failed` log lines | 1 per run | 0 |
| `[FunJudge] LLM scoring failed` log lines | 1 per run | 0 |
| `Why: fallback-local-score` markers in output | all clusters | 0 |
| LLM-generated `Why:` reasoning lines | 0 | 11 |

Sample of restored LLM-rerank reasoning:
> "Directly addresses benchmark performance comparisons against competitors..."
> "Provides specific technical specifications regarding image resolution capabilities..."

## Diff

```diff
- OPENROUTER_DEFAULT = "google/gemini-flash-2.0"
+ OPENROUTER_DEFAULT = "google/gemini-3.1-flash-lite-preview"
```

One line, restores broken default and aligns OpenRouter with the existing native-Gemini default.
