### PR TITLE
feat: extend multi-key rotation to all rotatable API keys

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -285,6 +285,34 @@ def get_config() -> dict[str, Any]:
             config[key] = value
             config[f"_{key}_SOURCE"] = "browser"
 
+    import random
+    rotatable = (
+        'SCRAPECREATORS_API_KEY',
+        'BRAVE_API_KEY',
+        'XAI_API_KEY',
+        'OPENROUTER_API_KEY',
+        'EXA_API_KEY',
+        'OPENAI_API_KEY',
+        'SERPER_API_KEY',
+        'BSKY_APP_PASSWORD',
+    )
+    for _k in rotatable:
+        _raw = config.get(_k) or ''
+        if ',' in _raw:
+            _vals = [v.strip() for v in _raw.split(',') if v.strip()]
+            if _vals:
+                config[_k] = random.choice(_vals)
+
+    _auth_raw = config.get('AUTH_TOKEN') or ''
+    _ct0_raw = config.get('CT0') or ''
+    if ',' in _auth_raw and ',' in _ct0_raw:
+        _auth_vals = [v.strip() for v in _auth_raw.split(',') if v.strip()]
+        _ct0_vals = [v.strip() for v in _ct0_raw.split(',') if v.strip()]
+        if _auth_vals and _ct0_vals and len(_auth_vals) == len(_ct0_vals):
+            _idx = random.randrange(len(_auth_vals))
+            config['AUTH_TOKEN'] = _auth_vals[_idx]
+            config['CT0'] = _ct0_vals[_idx]
+
     return config
 
 


### PR DESCRIPTION
## Summary
- Generalizes the comma-separated key rotation pattern from #268 to cover **every rotatable credential** in `get_config()`, not just `SCRAPECREATORS_API_KEY`.
- **8 single-value keys** now support comma-list rotation (random pick per run): `SCRAPECREATORS_API_KEY`, `BRAVE_API_KEY`, `XAI_API_KEY`, `OPENROUTER_API_KEY`, `EXA_API_KEY`, `OPENAI_API_KEY`, `SERPER_API_KEY`, `BSKY_APP_PASSWORD`.
- **`AUTH_TOKEN` + `CT0`** rotate as a coherent pair — X cookies must come from the same account, so when both are comma-lists of equal length, the same random index is used for both.
- 28-line patch in `scripts/lib/env.py`. Zero breaking changes — single-key configs are unchanged.

## How it works
After config loading completes:

1. For each key in the rotatable tuple: if its value contains a comma, split on commas, strip whitespace, drop empties, and pick one via `random.choice`. Replace the original config value so all downstream code sees a single valid key.

2. For the X cookie pair: only engages when **both** `AUTH_TOKEN` and `CT0` contain commas. Verifies both lists have equal length, then `random.randrange(n)` picks one index used for both. This prevents accidentally pairing an `auth_token` from account A with a `ct0` from account B.

The selected values replace the originals, so all downstream code paths (xurl, browser-cookie hand-off, Bluesky session creation, etc.) see a single valid credential.

## Why this is useful
ScrapeCreators isn't the only credential where users hit free-tier quotas:
- Brave: 2,000 queries/month per key
- Exa: 1,000/month per key
- xAI / OpenRouter / OpenAI: paid keys with per-key spend caps
- BlueSky app passwords: rate-limited per-account
- X cookies: per-account graphql limits

Same single-line config UX as #268 (comma-separate values), now applied uniformly.

## Backwards compatibility
- Single-value (no comma) → guard `if ',' in raw:` fails → the loop body never executes for that key. Identical behavior to before.
- Empty value → `or ''` short-circuits → guard fails → no-op.
- X pair: requires **both** values to contain commas AND equal-length lists. Any other state (one comma'd, one not, or unequal lengths) silently no-ops, leaving both values untouched.

## Test plan
- [x] `SCRAPECREATORS_API_KEY=key1,key2,key3` — distribution across multiple runs is roughly even
- [x] `BRAVE_API_KEY=key1,key2` — same distribution check
- [x] `AUTH_TOKEN=a1,a2` + `CT0=c1,c2` — verify (a1,c1) and (a2,c2) pairs only; never (a1,c2) or (a2,c1)
- [ ] `AUTH_TOKEN=a1,a2` + `CT0=c1` (mismatched lengths) — verify both pass through unchanged
- [ ] `AUTH_TOKEN=single` + `CT0=single` — verify no-op, identical to current behavior
- [ ] Single-key config for any of the 8 rotatable keys — verify byte-identical output to pre-patch behavior
- [ ] Empty config values — no crash