### PR TITLE
feat(emit): --emit=research-prompt for cross-tool deep-research handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **Research-prompt emit mode.** `--emit=research-prompt` renders a six-section markdown handoff for deep-research tools without the badge, engine footer, or trailing sources block.
+
 ## [3.1.1] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The synthesis ranks by what real people actually engaged with. Social relevancy,
 
 ## What v3 Changed
 
+New in v3: `--emit=research-prompt` turns a last30days run into a six-section markdown handoff for deep-research tools. Run `/last30days "AI agent frameworks" --emit=research-prompt | pbcopy`, paste it into Perplexity, ChatGPT Deep Research, Gemini, or Anthropic Advanced Research, and the tool starts with the community claims, citations, engagement, resolved entities, and explicit gaps already loaded.
+
 ### Intelligent search: the killer feature
 
 The v3 engine doesn't just search for your topic. It figures out *where* to search before the search begins. Type "OpenClaw" and the engine resolves @steipete (Peter Steinberger, the creator), r/openclaw, r/ClaudeCode, and the right YouTube channels and TikTok hashtags - all via a new Python pre-research brain built by [@j-sperling](https://github.com/j-sperling). The old engine searched keywords. The new engine understands your topic first, then searches the right people and communities.

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -856,6 +856,8 @@ Store your plan as `QUERY_PLAN_JSON` - you'll pass it to the script in the next 
 
 **Degraded path (missing any of the above on a WebSearch platform) is a known regression shape. It produces bland 4-bullet summaries instead of rich synthesis. Do not take it.**
 
+**Handoff exception (`--emit=research-prompt`):** when the user explicitly asks for a deep-research handoff prompt to paste into Perplexity / ChatGPT Deep Research / Gemini Deep Research / Anthropic Advanced Research, run the engine with `--emit=research-prompt` instead of `--emit=compact`. That mode produces a fixed 6-section handoff artifact (Topic, Community pre-research summary, Resolved entities, Top community claims, Gaps the social engine cannot fill, Investigation directives) emitted by the engine wholesale. Pass through verbatim - do NOT synthesize, do NOT apply LAWs 1-8 (the engine deliberately omits the badge, the engine footer, and any trailing `Sources:` block because this is a downstream artifact, not a /last30days-as-itself output). Step 0.55 / 0.75 pre-research still applies so the handoff has good entity resolution; only the output contract differs.
+
 ---
 
 **Step 1: Run the research script WITH your query plan (FOREGROUND)**

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -97,15 +97,19 @@ def save_output(report: schema.Report, emit: str, save_dir: str, suffix: str = "
     path.mkdir(parents=True, exist_ok=True)
     slug = slugify(report.topic)
     extension = "json" if emit == "json" else "md"
-    suffix_part = f"-{suffix}" if suffix else ""
+    output_suffix = suffix
+    if emit == "research-prompt":
+        output_suffix = f"{suffix}-research-prompt" if suffix else "research-prompt"
+    suffix_part = f"-{output_suffix}" if output_suffix else ""
     out_path = path / f"{slug}-raw{suffix_part}.{extension}"
     if out_path.exists():
         out_path = path / f"{slug}-raw{suffix_part}-{datetime.now().strftime('%Y-%m-%d')}.{extension}"
-    # Always save the FULL dump to disk (all items, all sources, transcripts).
-    # Claude sees compact clusters via --emit=compact on stdout.
-    # The saved file is the complete debug artifact.
+    # Legacy markdown modes save the FULL dump to disk (all items, all sources,
+    # transcripts). The research-prompt mode saves the handoff artifact itself.
     if emit == "json":
         content = emit_output(report, emit)
+    elif emit == "research-prompt":
+        content = render.render_research_prompt(report)
     else:
         content = render.render_full(report)
     out_path.write_text(content, encoding="utf-8")
@@ -119,6 +123,8 @@ def emit_output(report: schema.Report, emit: str, fun_level: str = "medium", sav
         return render.render_compact(report, fun_level=fun_level, save_path=save_path)
     if emit == "context":
         return render.render_context(report)
+    if emit == "research-prompt":
+        return render.render_research_prompt(report)
     raise SystemExit(f"Unsupported emit mode: {emit}")
 
 
@@ -144,6 +150,8 @@ def emit_comparison_output(
         )
     if emit == "context":
         return render.render_comparison_multi_context(entity_reports)
+    if emit == "research-prompt":
+        return render.render_research_prompt_comparison(entity_reports)
     raise SystemExit(f"Unsupported emit mode: {emit}")
 
 
@@ -157,7 +165,10 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
     path = _Path(save_dir).expanduser().resolve()
     slug = slugify(topic)
     extension = "json" if emit == "json" else "md"
-    suffix_part = f"-{suffix}" if suffix else ""
+    output_suffix = suffix
+    if emit == "research-prompt":
+        output_suffix = f"{suffix}-research-prompt" if suffix else "research-prompt"
+    suffix_part = f"-{output_suffix}" if output_suffix else ""
     raw = path / f"{slug}-raw{suffix_part}.{extension}"
     try:
         home = _Path.home().resolve()
@@ -193,7 +204,12 @@ def persist_report(report: schema.Report) -> dict[str, int]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Research a topic across live social, market, and grounded web sources.")
     parser.add_argument("topic", nargs="*", help="Research topic")
-    parser.add_argument("--emit", default="compact", choices=["compact", "json", "context", "md"])
+    parser.add_argument(
+        "--emit",
+        default="compact",
+        choices=["compact", "json", "context", "md", "research-prompt"],
+        help="Output mode: compact, json, context, md, or research-prompt",
+    )
     parser.add_argument("--search", help="Comma-separated source list")
     parser.add_argument("--quick", action="store_true", help="Lower-latency retrieval profile")
     parser.add_argument("--deep", action="store_true", help="Higher-recall retrieval profile")

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -780,6 +780,387 @@ def render_context(report: schema.Report, cluster_limit: int = 6) -> str:
     return "\n".join(lines).strip() + "\n"
 
 
+def render_research_prompt(report: schema.Report, cluster_limit: int = 8) -> str:
+    """Render a markdown handoff prompt for external deep-research tools."""
+    topic = report.query_plan.raw_topic or report.topic
+    return _render_research_prompt_body([(report.topic, report)], topic, cluster_limit=cluster_limit)
+
+
+def render_research_prompt_comparison(
+    entity_reports: list[tuple[str, schema.Report]],
+    cluster_limit: int = 8,
+) -> str:
+    """Render a research handoff prompt for vs-mode and competitor runs."""
+    if not entity_reports:
+        raise ValueError("render_research_prompt_comparison requires at least one report")
+    topic = " vs ".join(label for label, _report in entity_reports)
+    return _render_research_prompt_body(entity_reports, topic, cluster_limit=cluster_limit)
+
+
+def _render_research_prompt_body(
+    entity_reports: list[tuple[str, schema.Report]],
+    topic: str,
+    *,
+    cluster_limit: int,
+) -> str:
+    clean_topic = _research_clean(topic)
+    lines: list[str] = [
+        f"**Topic:** {clean_topic}",
+        "",
+        "**Community pre-research summary**",
+        *_research_summary_lines(entity_reports, clean_topic),
+        "",
+        "**Resolved entities**",
+        *_research_resolved_entity_lines(entity_reports),
+        "",
+        "**Top community claims (cited, with engagement)**",
+        *_research_claim_lines(entity_reports, limit=cluster_limit),
+        "",
+        "**Gaps the social engine cannot fill**",
+        *_research_gap_lines(entity_reports),
+        "",
+        "**Investigation directives**",
+        *_research_directive_lines(entity_reports, clean_topic),
+    ]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _research_summary_lines(
+    entity_reports: list[tuple[str, schema.Report]],
+    topic: str,
+) -> list[str]:
+    clusters = [
+        (label, cluster)
+        for label, report in entity_reports
+        for cluster in report.clusters
+    ]
+    total_items = sum(
+        len(items)
+        for _label, report in entity_reports
+        for items in report.items_by_source.values()
+    )
+    source_counts: Counter[str] = Counter()
+    for _label, report in entity_reports:
+        for source, items in report.items_by_source.items():
+            if items:
+                source_counts[source] += len(items)
+
+    if not clusters:
+        return [
+            f"The 30-day community signal for {topic} is thin: no ranked clusters survived the engine's relevance pass. Treat the run as an absence-of-evidence map and use deep research to establish the primary source baseline.",
+            f"The engine found {total_items} usable item{'s' if total_items != 1 else ''} across {len(source_counts)} active source{'s' if len(source_counts) != 1 else ''}.",
+        ]
+
+    top_clusters = sorted(clusters, key=lambda item: item[1].score, reverse=True)[:3]
+    cluster_phrase = _join_phrase(
+        _research_clean(f"{label}: {cluster.title}" if len(entity_reports) > 1 else cluster.title)
+        for label, cluster in top_clusters
+    )
+    top_sources = _join_phrase(
+        _source_label(source)
+        for source, _count in source_counts.most_common(4)
+    )
+    lines = [
+        f"The 30-day community signal for {topic} clusters around {cluster_phrase}.",
+    ]
+    if top_sources:
+        lines.append(
+            f"The strongest coverage comes from {top_sources}, with {total_items} usable item{'s' if total_items != 1 else ''} feeding {len(clusters)} ranked cluster{'s' if len(clusters) != 1 else ''}."
+        )
+    if len(clusters) < 3 or total_items < 3:
+        lines.append("Coverage is still thin, so treat these claims as hypotheses for corroboration rather than settled facts.")
+    else:
+        lines.append("Use these community claims as hypotheses to verify, contradict, or quantify with primary-source research.")
+    return lines
+
+
+def _research_resolved_entity_lines(
+    entity_reports: list[tuple[str, schema.Report]],
+) -> list[str]:
+    rows = [
+        _research_resolved_entity_line(label, report)
+        for label, report in entity_reports
+    ]
+    return rows or ["- No explicit handles, repositories, or subreddits were resolved in this run."]
+
+
+def _research_resolved_entity_line(label: str, report: schema.Report) -> str:
+    resolved = report.artifacts.get("resolved")
+    if isinstance(resolved, dict):
+        entity = _research_clean(str(resolved.get("entity") or label or report.topic))
+        parts: list[str] = []
+        x_handle = str(resolved.get("x_handle") or "").strip().lstrip("@")
+        if x_handle:
+            parts.append(f"X @{_research_clean(x_handle)}")
+        subs = [
+            _research_clean(str(sub).strip().lstrip("r/"))
+            for sub in (resolved.get("subreddits") or [])
+            if str(sub).strip()
+        ]
+        if subs:
+            parts.append("Subs " + ", ".join(f"r/{sub}" for sub in subs[:5]))
+        github_user = str(resolved.get("github_user") or "").strip().lstrip("@")
+        github_repos = [
+            _research_clean(str(repo).strip())
+            for repo in (resolved.get("github_repos") or [])
+            if str(repo).strip()
+        ]
+        if github_user or github_repos:
+            github_part = f"GitHub @{_research_clean(github_user)}" if github_user else "GitHub"
+            if github_repos:
+                github_part += f" ({', '.join(github_repos[:3])})"
+            parts.append(github_part)
+        context = _research_clean(str(resolved.get("context") or ""))
+        if context:
+            parts.append(f"Context: {_truncate(context, 140)}")
+        if parts:
+            return f"- **{entity}**: " + " | ".join(parts)
+
+    observed = _research_observed_entities(report)
+    entity = _research_clean(label or report.topic)
+    if observed:
+        return f"- **{entity}**: " + " | ".join(observed)
+    return f"- **{entity}**: No explicit handles, repositories, or subreddits were resolved in this run."
+
+
+def _research_observed_entities(report: schema.Report) -> list[str]:
+    handles: list[str] = []
+    repos: list[str] = []
+    subs: list[str] = []
+    for source, items in report.items_by_source.items():
+        for item in items:
+            if source in {"x", "bluesky", "truthsocial", "tiktok", "instagram", "threads"} and item.author:
+                handle = f"@{item.author.lstrip('@')}"
+                if handle not in handles:
+                    handles.append(handle)
+            if source == "reddit" and item.container:
+                sub = f"r/{item.container.lstrip('r/')}"
+                if sub not in subs:
+                    subs.append(sub)
+            repo = _github_repo_from_url(item.url)
+            if repo and repo not in repos:
+                repos.append(repo)
+
+    out: list[str] = []
+    if handles:
+        out.append("Observed handles " + ", ".join(_research_clean(h) for h in handles[:5]))
+    if repos:
+        out.append("Observed repos " + ", ".join(_research_clean(r) for r in repos[:5]))
+    if subs:
+        out.append("Observed subs " + ", ".join(_research_clean(s) for s in subs[:5]))
+    return out
+
+
+def _github_repo_from_url(url: str) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    host = parsed.netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host != "github.com":
+        return None
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def _research_claim_lines(
+    entity_reports: list[tuple[str, schema.Report]],
+    *,
+    limit: int,
+) -> list[str]:
+    claims: list[tuple[str, schema.Report, schema.Cluster]] = [
+        (label, report, cluster)
+        for label, report in entity_reports
+        for cluster in report.clusters
+    ]
+    if not claims:
+        return ["- No ranked community claims were strong enough to render."]
+
+    claims = sorted(claims, key=lambda item: item[2].score, reverse=True)
+    out: list[str] = []
+    for index, (label, report, cluster) in enumerate(claims[:limit], start=1):
+        candidate = _research_representative_candidate(report, cluster)
+        title = _research_clean(cluster.title)
+        if len(entity_reports) > 1:
+            title = f"{_research_clean(label)}: {title}"
+        linked_title = _research_link(title, candidate.url if candidate else "")
+        attribution = _research_candidate_attribution(candidate) if candidate else _research_cluster_attribution(cluster)
+        engagement = _research_candidate_engagement(candidate)
+        out.append(
+            f"{index}. {linked_title} - {attribution}; engagement: {engagement}; cluster score {cluster.score:.0f}."
+        )
+    return out
+
+
+def _research_representative_candidate(
+    report: schema.Report,
+    cluster: schema.Cluster,
+) -> schema.Candidate | None:
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in report.ranked_candidates}
+    for candidate_id in cluster.representative_ids:
+        candidate = candidate_by_id.get(candidate_id)
+        if candidate:
+            return candidate
+    for candidate_id in cluster.candidate_ids:
+        candidate = candidate_by_id.get(candidate_id)
+        if candidate:
+            return candidate
+    return None
+
+
+def _research_candidate_attribution(candidate: schema.Candidate | None) -> str:
+    if not candidate:
+        return "platform attribution unavailable"
+    primary = schema.candidate_primary_item(candidate)
+    source_label = _source_label(candidate.source)
+    actor = _format_actor(primary)
+    if actor:
+        return _research_clean(f"{source_label} via {actor}")
+    sources = ", ".join(_source_label(source) for source in schema.candidate_sources(candidate))
+    return _research_clean(sources or source_label)
+
+
+def _research_cluster_attribution(cluster: schema.Cluster) -> str:
+    if not cluster.sources:
+        return "platform attribution unavailable"
+    return _research_clean(", ".join(_source_label(source) for source in cluster.sources))
+
+
+def _research_candidate_engagement(candidate: schema.Candidate | None) -> str:
+    if not candidate:
+        return "not captured"
+    primary = schema.candidate_primary_item(candidate)
+    engagement = _format_engagement(primary)
+    if engagement:
+        return _research_clean(engagement.strip("[]"))
+    if candidate.engagement not in (None, "", 0):
+        return _research_clean(str(candidate.engagement))
+    return "not captured"
+
+
+def _research_gap_lines(entity_reports: list[tuple[str, schema.Report]]) -> list[str]:
+    source_counts: Counter[str] = Counter()
+    clusters: list[schema.Cluster] = []
+    topic_text = " ".join(
+        [label for label, _report in entity_reports]
+        + [report.topic for _label, report in entity_reports]
+    )
+    for _label, report in entity_reports:
+        clusters.extend(report.clusters)
+        for source, items in report.items_by_source.items():
+            source_counts[source] += len(items)
+
+    gaps: list[str] = []
+    if source_counts["grounding"] == 0:
+        gaps.append("Authoritative web sources / official documentation")
+    if source_counts["hackernews"] == 0:
+        gaps.append("Developer-community technical analysis")
+    if source_counts["polymarket"] == 0 and _research_topic_looks_predictive(topic_text):
+        gaps.append("Quantitative outcome odds / forecasts")
+
+    single_source_titles = [
+        _research_clean(cluster.title)
+        for cluster in clusters
+        if len(cluster.sources) <= 1 or cluster.uncertainty == "single-source"
+    ][:4]
+    if single_source_titles:
+        gaps.append("Independent corroboration of: " + "; ".join(single_source_titles))
+
+    if not gaps:
+        gaps.append("Primary-source verification for the highest-engagement community claims")
+    return [f"- {gap}" for gap in gaps]
+
+
+def _research_topic_looks_predictive(topic: str) -> bool:
+    lowered = topic.lower()
+    markers = [
+        "will ",
+        "forecast",
+        "predict",
+        "odds",
+        "election",
+        "price",
+        "market",
+        "release date",
+        "launch",
+        "by ",
+    ]
+    return any(marker in lowered for marker in markers)
+
+
+def _research_directive_lines(
+    entity_reports: list[tuple[str, schema.Report]],
+    topic: str,
+) -> list[str]:
+    claims: list[str] = []
+    for label, report in entity_reports:
+        for cluster in report.clusters:
+            claim = _research_clean(cluster.title)
+            if len(entity_reports) > 1:
+                claim = f"{_research_clean(label)}: {claim}"
+            claims.append(claim)
+
+    directives: list[str] = []
+    if claims:
+        directives.append(
+            f"1. Verify or contradict the community claim that {claims[0]} using primary sources, official documentation, or reputable reporting."
+        )
+        if len(claims) > 1:
+            directives.append(
+                f"2. Find independent evidence for {claims[1]}; separate first-hand data from repeated social summaries."
+            )
+        else:
+            directives.append(
+                f"2. Find independent evidence for the strongest {topic} claim; separate first-hand data from repeated social summaries."
+            )
+    else:
+        directives.extend([
+            f"1. Establish the authoritative baseline for {topic} from official sources, primary documents, and reputable long-form analysis.",
+            f"2. Identify whether the lack of recent community clusters reflects low activity, poor query coverage, or a genuinely quiet topic.",
+        ])
+
+    if len(entity_reports) > 1:
+        directives.append(
+            f"{len(directives) + 1}. Build a side-by-side comparison of the entities on architecture, adoption, risks, pricing, and best-fit use cases."
+        )
+    gaps = [line[2:] for line in _research_gap_lines(entity_reports)]
+    if gaps:
+        directives.append(
+            f"{len(directives) + 1}. Fill this explicit gap from the social run: {gaps[0]}."
+        )
+    directives.append(
+        f"{len(directives) + 1}. Return a concise brief that labels each conclusion as confirmed, contradicted, or still uncertain relative to the community signal."
+    )
+    return directives[:5]
+
+
+def _research_link(text: str, url: str) -> str:
+    clean_text = _research_clean(text).replace("[", "(").replace("]", ")")
+    clean_url = _research_clean(url).replace(")", "%29").strip()
+    if not clean_url:
+        return clean_text
+    return f"[{clean_text}]({clean_url})"
+
+
+def _join_phrase(values) -> str:
+    items = [str(value).strip() for value in values if str(value).strip()]
+    if not items:
+        return "no dominant theme"
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return f"{', '.join(items[:-1])}, and {items[-1]}"
+
+
+def _research_clean(text: str) -> str:
+    cleaned = str(text).replace(chr(8212), " - ").replace(chr(8211), " - ")
+    return " ".join(cleaned.split())
+
+
 def _render_candidate(candidate: schema.Candidate, prefix: str) -> list[str]:
     primary = schema.candidate_primary_item(candidate)
     detail_parts = [

--- a/tests/test_research_prompt_render.py
+++ b/tests/test_research_prompt_render.py
@@ -1,0 +1,258 @@
+# ruff: noqa: E402
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
+
+import last30days as cli
+from lib import render, schema
+
+
+def _runtime() -> schema.ProviderRuntime:
+    return schema.ProviderRuntime(
+        reasoning_provider="gemini",
+        planner_model="gemini-3.1-flash-lite-preview",
+        rerank_model="gemini-3.1-flash-lite-preview",
+    )
+
+
+def _plan(topic: str, sources: list[str]) -> schema.QueryPlan:
+    return schema.QueryPlan(
+        intent="comparison",
+        freshness_mode="balanced_recent",
+        cluster_mode="debate",
+        raw_topic=topic,
+        subqueries=[
+            schema.SubQuery(
+                label="primary",
+                search_query=topic,
+                ranking_query=topic,
+                sources=sources,
+            )
+        ],
+        source_weights={source: 1.0 for source in sources},
+    )
+
+
+def _source_item(
+    item_id: str,
+    source: str,
+    title: str,
+    url: str,
+    *,
+    author: str | None = None,
+    container: str | None = None,
+    engagement: dict[str, int] | None = None,
+) -> schema.SourceItem:
+    return schema.SourceItem(
+        item_id=item_id,
+        source=source,
+        title=title,
+        body=f"Body for {title}",
+        url=url,
+        author=author,
+        container=container,
+        published_at="2026-04-20",
+        date_confidence="high",
+        engagement=engagement or {},
+        snippet=f"Snippet for {title}",
+    )
+
+
+def _candidate(
+    candidate_id: str,
+    item: schema.SourceItem,
+    *,
+    sources: list[str] | None = None,
+    source_items: list[schema.SourceItem] | None = None,
+    score: float = 90,
+) -> schema.Candidate:
+    return schema.Candidate(
+        candidate_id=candidate_id,
+        item_id=item.item_id,
+        source=item.source,
+        title=item.title,
+        url=item.url,
+        snippet=item.snippet,
+        subquery_labels=["primary"],
+        native_ranks={f"primary:{item.source}": 1},
+        local_relevance=0.9,
+        freshness=7,
+        engagement=sum(item.engagement.values()) if item.engagement else None,
+        source_quality=1.0,
+        rrf_score=0.03,
+        sources=sources or [item.source],
+        source_items=source_items or [item],
+        final_score=score,
+    )
+
+
+def rich_report() -> schema.Report:
+    reddit = _source_item(
+        "r1",
+        "reddit",
+        "LangGraph wins production workflows",
+        "https://reddit.com/r/LangChain/comments/abc",
+        container="LangChain",
+        engagement={"score": 344, "num_comments": 119},
+    )
+    web = _source_item(
+        "w1",
+        "grounding",
+        "LangGraph documentation",
+        "https://docs.langchain.com/langgraph",
+        container="docs.langchain.com",
+    )
+    x_post = _source_item(
+        "x1",
+        "x",
+        "CrewAI stays fastest for prototypes",
+        "https://x.com/joaomdmoura/status/1",
+        author="joaomdmoura",
+        engagement={"likes": 1200, "reposts": 90},
+    )
+    hn = _source_item(
+        "hn1",
+        "hackernews",
+        "HN wants explicit state machines",
+        "https://news.ycombinator.com/item?id=1",
+        container="news.ycombinator.com",
+        engagement={"points": 88, "comments": 42},
+    )
+    candidates = [
+        _candidate("c1", reddit, sources=["reddit", "grounding"], source_items=[reddit, web], score=92),
+        _candidate("c2", x_post, score=85),
+        _candidate("c3", hn, score=75),
+    ]
+    clusters = [
+        schema.Cluster("cl1", "LangGraph wins production workflows", ["c1"], ["c1"], ["reddit", "grounding"], 92),
+        schema.Cluster("cl2", "CrewAI stays fastest for prototypes", ["c2"], ["c2"], ["x"], 85, "single-source"),
+        schema.Cluster("cl3", "HN wants explicit state machines", ["c3"], ["c3"], ["hackernews"], 75),
+    ]
+    return schema.Report(
+        topic="Agent frameworks",
+        range_from="2026-03-30",
+        range_to="2026-04-29",
+        generated_at="2026-04-29T00:00:00+00:00",
+        provider_runtime=_runtime(),
+        query_plan=_plan("Agent frameworks", ["grounding", "reddit", "x", "hackernews"]),
+        clusters=clusters,
+        ranked_candidates=candidates,
+        items_by_source={
+            "grounding": [web],
+            "reddit": [reddit],
+            "x": [x_post],
+            "hackernews": [hn],
+        },
+        errors_by_source={},
+        artifacts={
+            "resolved": {
+                "entity": "Agent frameworks",
+                "x_handle": "LangChainAI",
+                "subreddits": ["LangChain", "LocalLLaMA"],
+                "github_user": "langchain-ai",
+                "github_repos": ["langchain-ai/langgraph", "crewAIInc/crewAI"],
+                "context": "LangGraph and CrewAI are the main community-named frameworks.",
+            }
+        },
+    )
+
+
+def thin_report() -> schema.Report:
+    return schema.Report(
+        topic="Obscure Widget",
+        range_from="2026-03-30",
+        range_to="2026-04-29",
+        generated_at="2026-04-29T00:00:00+00:00",
+        provider_runtime=_runtime(),
+        query_plan=_plan("Obscure Widget", ["grounding", "reddit"]),
+        clusters=[],
+        ranked_candidates=[],
+        items_by_source={"grounding": [], "reddit": []},
+        errors_by_source={},
+    )
+
+
+class ResearchPromptRenderTests(unittest.TestCase):
+    def test_rich_report_snapshot(self):
+        rendered = render.render_research_prompt(rich_report())
+        expected = """**Topic:** Agent frameworks
+
+**Community pre-research summary**
+The 30-day community signal for Agent frameworks clusters around LangGraph wins production workflows, CrewAI stays fastest for prototypes, and HN wants explicit state machines.
+The strongest coverage comes from Web, Reddit, X, and Hacker News, with 4 usable items feeding 3 ranked clusters.
+Use these community claims as hypotheses to verify, contradict, or quantify with primary-source research.
+
+**Resolved entities**
+- **Agent frameworks**: X @LangChainAI | Subs r/LangChain, r/LocalLLaMA | GitHub @langchain-ai (langchain-ai/langgraph, crewAIInc/crewAI) | Context: LangGraph and CrewAI are the main community-named frameworks.
+
+**Top community claims (cited, with engagement)**
+1. [LangGraph wins production workflows](https://reddit.com/r/LangChain/comments/abc) - Reddit via r/LangChain; engagement: 344pts, 119cmt; cluster score 92.
+2. [CrewAI stays fastest for prototypes](https://x.com/joaomdmoura/status/1) - X via @joaomdmoura; engagement: 1,200likes, 90rt; cluster score 85.
+3. [HN wants explicit state machines](https://news.ycombinator.com/item?id=1) - Hacker News via news.ycombinator.com; engagement: 88pts, 42cmt; cluster score 75.
+
+**Gaps the social engine cannot fill**
+- Independent corroboration of: CrewAI stays fastest for prototypes; HN wants explicit state machines
+
+**Investigation directives**
+1. Verify or contradict the community claim that LangGraph wins production workflows using primary sources, official documentation, or reputable reporting.
+2. Find independent evidence for CrewAI stays fastest for prototypes; separate first-hand data from repeated social summaries.
+3. Fill this explicit gap from the social run: Independent corroboration of: CrewAI stays fastest for prototypes; HN wants explicit state machines.
+4. Return a concise brief that labels each conclusion as confirmed, contradicted, or still uncertain relative to the community signal.
+"""
+        self.assertEqual(expected, rendered)
+
+    def test_handoff_omits_last30days_output_envelope(self):
+        rendered = render.render_research_prompt(rich_report())
+        self.assertFalse(rendered.startswith("🌐 last30days"))
+        self.assertNotIn("✅ All agents reported back!", rendered)
+        self.assertNotIn("\nSources:", rendered)
+
+    def test_all_six_section_headers_present(self):
+        rendered = render.render_research_prompt(rich_report())
+        for header in [
+            "**Topic:**",
+            "**Community pre-research summary**",
+            "**Resolved entities**",
+            "**Top community claims (cited, with engagement)**",
+            "**Gaps the social engine cannot fill**",
+            "**Investigation directives**",
+        ]:
+            self.assertIn(header, rendered)
+
+    def test_thin_cluster_topic_surfaces_gap_directives(self):
+        rendered = render.render_research_prompt(thin_report())
+        self.assertIn("no ranked clusters survived", rendered)
+        self.assertIn("- Authoritative web sources / official documentation", rendered)
+        self.assertIn("- Developer-community technical analysis", rendered)
+        self.assertIn("No ranked community claims were strong enough to render.", rendered)
+
+    def test_vs_mode_research_prompt(self):
+        rendered = render.render_research_prompt_comparison([
+            ("LangGraph", rich_report()),
+            ("CrewAI", thin_report()),
+        ])
+        self.assertIn("**Topic:** LangGraph vs CrewAI", rendered)
+        self.assertIn("LangGraph: LangGraph wins production workflows", rendered)
+        self.assertIn("CrewAI", rendered)
+        self.assertNotIn("✅ All agents reported back!", rendered)
+
+    def test_cli_routes_and_save_suffix(self):
+        report = rich_report()
+        self.assertEqual(
+            render.render_research_prompt(report),
+            cli.emit_output(report, "research-prompt"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = cli.save_output(report, "research-prompt", tmp)
+            self.assertEqual("agent-frameworks-raw-research-prompt.md", path.name)
+            self.assertEqual(render.render_research_prompt(report), path.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `--emit=research-prompt` as a fifth emit mode. After the engine runs, renders a structured prompt designed to paste into Perplexity, ChatGPT Deep Research, Gemini Deep Research, or any external deep-research tool. Six labeled sections: Topic, Community pre-research summary, Resolved entities, Top community claims (cited with engagement), Gaps the social engine cannot fill, Investigation directives.

Same data as `--emit=md`. New audience: deep-research tools that read web/docs but cannot reach Reddit comments, X posts, TikTok captions, HN karma, or Polymarket odds.

## Why this matters

last30days reads platforms deep-research tools structurally cannot. Deep-research tools read long-form web/document context that last30days deliberately treats as one signal among many. The two are complementary; the bridge has been missing.

[mayrsascha/deep-research-skill](https://github.com/mayrsascha/deep-research-skill) prototyped this pattern for codebase-context handoff: "Your agent knows your codebase. Deep research tools know everything else." last30days has the inverse asymmetric advantage - it knows the community signal that deep-research tools cannot reach. This PR ships the bridge in that direction.

The README's own use cases support this: "before I build anything to know what problems people are actually hitting" - a builder runs last30days, gets the community signal, then needs deep technical research with that context loaded. `--emit=research-prompt` makes the second half of that workflow one shell pipe away.

## Demo

`python3 scripts/last30days.py "AI agent frameworks" --mock --emit=research-prompt` (using fixture data):

```markdown
**Topic:** AI agent frameworks

**Community pre-research summary**
The 30-day community signal for AI agent frameworks clusters around three claims spanning Reddit, X, and Web, with 3 usable items feeding 3 ranked clusters. Use these community claims as hypotheses to verify, contradict, or quantify with primary-source research.

**Resolved entities**
- **AI agent frameworks**: Observed handles @example | Observed subs r/example

**Top community claims (cited, with engagement)**
1. [People on X are discussing ai agent frameworks right now.](https://x.com/example/status/1) - X via @example; engagement: 200likes, 35rt, 18re; cluster score 50.
2. [ai agent frameworks discussion thread](https://reddit.com/r/example/comments/1) - Reddit via r/example; engagement: 120pts, 48cmt; cluster score 47.
3. [ai agent frameworks article](https://example.com/article) - Web via example.com; engagement: not captured; cluster score 45.

**Gaps the social engine cannot fill**
- Developer-community technical analysis
- Independent corroboration of: People on X are discussing ai agent frameworks right now.; ...

**Investigation directives**
1. Verify or contradict the community claim that People on X are discussing ai agent frameworks right now. using primary sources, official documentation, or reputable reporting.
2. Find independent evidence for ai agent frameworks discussion thread; separate first-hand data from repeated social summaries.
3. Fill this explicit gap from the social run: Developer-community technical analysis.
4. Return a concise brief that labels each conclusion as confirmed, contradicted, or still uncertain relative to the community signal.
```

User pipes to clipboard, pastes into ChatGPT Deep Research / Perplexity / Gemini, gets the deep technical analysis with community context already loaded.

## Approach

- New `--emit=research-prompt` argparse choice (no removed choices, no changed defaults).
- New `render_research_prompt(report)` and `render_research_prompt_comparison(entity_reports)` in `lib/render.py`. Reuses `Report` data; deliberately omits the badge, the engine footer, and any trailing `Sources:` block - this is a handoff artifact, not a /last30days-as-itself output.
- Six fixed sections; the `Gaps the social engine cannot fill` block detects from absent/thin source coverage (no HN -> "Developer-community technical analysis"; no web grounding -> "Authoritative web sources / official documentation"; single-source clusters -> "Independent corroboration of: ...").
- LAW 3 (no em-dashes, use ` - `) and LAW 8 (inline markdown links for citations) still applied throughout.
- Saves to `--save-dir` with `-research-prompt.md` suffix so files don't collide with default `--emit=md` runs.

## Changes

- `skills/last30days/scripts/last30days.py`: argparse choice, stdout routing in `emit_output` and `emit_comparison_output`, save-suffix in `save_output` and `compute_save_path_display`.
- `skills/last30days/scripts/lib/render.py`: +381 lines for `render_research_prompt` (single topic) and `render_research_prompt_comparison` (vs-mode). Helper functions for the 6 sections, gap detection, and cluster-claim formatting.
- `tests/test_research_prompt_render.py`: snapshot test on rich and thin fixture reports + edge cases (envelope omission, all 6 headers present, vs-mode handoff, save-suffix path).
- `README.md`: 1-paragraph callout under "What's New in v3" with a CLI example.
- `CHANGELOG.md`: one-line entry.

## Tests

```
$ python3 -m pytest tests/test_research_prompt_render.py -q
......                                                                   [100%]
6 passed
```

Full suite passes except for one pre-existing unrelated flake in `tests/test_setup_openclaw.py::TestPollDeviceAuth::test_timeout_returns_none` (a `time.time()` mock StopIteration that also fails on `main` without these changes; verified by stashing and re-running).

## Open questions for review

1. Section names are designed to be category-agnostic ("Top community claims", "Gaps the social engine cannot fill"). Open to renaming if you have a preferred shape.
2. Currently emits to stdout AND saves to `--save-dir` like other modes. Sensible default, or should this be stdout-only since the typical use is pipe-to-clipboard?
3. The vs-mode handoff format collapses entity-by-entity claims into one combined list. Want a per-entity section breakdown instead?

## Non-changes

- No change to `compact`/`json`/`context`/`md` modes.
- No change to `lib/render.py` voice contract or LAWs 1-8 in SKILL.md.
- No new pip dependencies.

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
