### PR TITLE
docs(claude.md): add Orientation section + scope sync.sh rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@ Python scripts with multi-source search aggregation.
 - `skills/last30days/scripts/lib/` — search, enrichment, rendering modules
 - `skills/last30days/scripts/lib/vendor/bird-search/` — vendored X search client
 
+## Orientation
+- This is a Claude Code skill, not a CLI tool. `/last30days <topic>` is the product; `scripts/last30days.py` is implementation.
+- Feature design starts from the slash-command UX. A new engine flag with no SKILL.md integration is incomplete.
+- README and PR examples show `/last30days <topic>` first. Direct CLI is a fallback for scripting/cron; label it as such.
+- Slash commands don't pass shell mechanics through. `/last30days OpenClaw --emit=html | pbcopy` is invalid; either use the slash form (no flags or pipes) or the direct CLI form (full `python3 ...`).
+
 ## Commands
 ```bash
 python3 skills/last30days/scripts/last30days.py "test query" --emit=compact
@@ -17,7 +23,7 @@ bash skills/last30days/scripts/sync.sh
 
 ## Rules
 - `lib/__init__.py` must be bare package marker (comment only, NO eager imports)
-- After edits: run `bash skills/last30days/scripts/sync.sh` to deploy
+- `bash skills/last30days/scripts/sync.sh` — local-dev deploy only. Skip if the plugin is already installed via marketplace (creates duplicate skill entries).
 - Git remote: origin = public (`mvanhorn/last30days-skill`)
 
 ## Beta channel


### PR DESCRIPTION
## Summary

Adds a 4-bullet `Orientation` section to `CLAUDE.md` and tightens the `sync.sh` rule.

```
+## Orientation
+- This is a Claude Code skill, not a CLI tool. `/last30days <topic>` is the product; `scripts/last30days.py` is implementation.
+- Feature design starts from the slash-command UX. A new engine flag with no SKILL.md integration is incomplete.
+- README and PR examples show `/last30days <topic>` first. Direct CLI is a fallback for scripting/cron; label it as such.
+- Slash commands don't pass shell mechanics through. `/last30days OpenClaw --emit=html | pbcopy` is invalid; either use the slash form (no flags or pipes) or the direct CLI form (full `python3 ...`).
```

```
-- After edits: run `bash skills/last30days/scripts/sync.sh` to deploy
+- `bash skills/last30days/scripts/sync.sh` — local-dev deploy only. Skip if the plugin is already installed via marketplace (creates duplicate skill entries).
```

Net: +7 lines, -1 line in `CLAUDE.md`. `AGENTS.md` is `@CLAUDE.md` so it inherits the change automatically.

## Why

The current `CLAUDE.md` correctly identifies the project as "Claude Code skill" in its title, but the worked example in `Commands` shows direct python invocation as the canonical command. Agents reading this form a CLI-first mental model that leads to recurring concrete mistakes:

- Engine flags shipped without `SKILL.md` integration
- README examples that mix slash-command syntax with shell flags or shell redirection (e.g. `/last30days OpenClaw --emit=html | pbcopy` — invalid; the slash command grammar doesn't pass shell mechanics through)
- Direct CLI invocation framed as the canonical path in docs

The `Orientation` section names the trap explicitly with one concrete invalid-syntax example so the rule sticks. Style matches the existing `Rules` section (declarative bullets, no prose wrappers).

The `sync.sh` rule fix is independent: the previous wording (`After edits: run X to deploy`) was unconditional and assumed local-dev. Running `sync.sh` on top of a marketplace install creates duplicate skill entries (the marketplace version and the synced version both register), which is confusing to debug. The corrected rule scopes it to local-dev only and surfaces the failure mode inline.

## Tests

`CLAUDE.md` is documentation; no test changes. Existing test suite still passes (verified `tests/test_version_consistency.py`).

## Non-changes

- No code changes
- No `SKILL.md` changes
- No README changes
- `Commands` section unchanged (it's already correctly scoped to dev testing — the python form is the right shape for a developer testing the engine without the model in the loop)
