### PR TITLE
Fix path-quoting in SessionStart check-config hook (handles spaces in…

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
Quoting `${CLAUDE_PLUGIN_ROOT}` in `hooks/hooks.json` so the SessionStart hook works when the plugin path contains spaces (e.g. `~/Library/Application Support/...` on macOS).

If `CLAUDE_PLUGIN_ROOT` ever expands to a path containing whitespace, the unquoted `${CLAUDE_PLUGIN_ROOT}` in `hooks/hooks.json` word-splits and bash receives the path as multiple arguments, failing with "No such file or directory" on the first split.

Quoting the expansion makes the invocation correct regardless of the characters in the resolved path.

## Summary

One-line fix to `hooks/hooks.json`. Wraps the `${CLAUDE_PLUGIN_ROOT}` expansion in the SessionStart hook command in double quotes so paths containing spaces are passed to bash as a single argument.

## Changes

- `hooks/hooks.json`: wrap `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh` in double quotes inside the SessionStart hook command string.

```diff
- "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh",
+ "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh\"",
```

No changes to `check-config.sh` itself — its internal quoting was already correct.

## Testing

Verified manually with four cases:

| Case | Result |
|---|---|
| Unquoted + path with spaces | `bash: /tmp/with: No such file or directory` (the bug) |
| Quoted + path with spaces | Path passed as single argument (correct) |
| Unquoted + path without spaces | Works |
| Quoted + path without spaces | Works |

Hook fires cleanly on SessionStart in real `last30days` runs after the fix.

## Related Issues

None filed upstream — surfaced during local use across three consecutive `last30days` sessions.
