### PR TITLE
fix(render): use forward slashes in save-path footer for Windows

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -197,7 +197,7 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
         relative = raw.relative_to(home)
         return f"~/{relative.as_posix()}"
     except ValueError:
-        return str(raw)
+        return raw.as_posix()
 
 
 def read_synthesis_file(path: str) -> str:

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -195,7 +195,7 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
     try:
         home = _Path.home().resolve()
         relative = raw.relative_to(home)
-        return f"~/{relative}"
+        return f"~/{relative.as_posix()}"
     except ValueError:
         return str(raw)
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -187,7 +187,7 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
     try:
         home = _Path.home().resolve()
         relative = raw.relative_to(home)
-        return f"~/{relative}"
+        return f"~/{relative.as_posix()}"
     except ValueError:
         return str(raw)
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E402
 import json
 import io
+import shutil
 import tempfile
 import subprocess
 import sys
@@ -150,7 +151,6 @@ class CliV3Tests(unittest.TestCase):
         # f"~/{relative.as_posix()}" which forces forward slashes regardless
         # of host OS. On POSIX hosts this asserts the contract for
         # cross-platform safety; on Windows hosts it would fail without the fix.
-        import shutil
         real_home = Path.home()
         tmp_under_home = Path(tempfile.mkdtemp(prefix="l30d_save_path_", dir=str(real_home)))
         try:

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -143,6 +143,31 @@ class CliV3Tests(unittest.TestCase):
         _, kwargs = write_text.call_args
         self.assertEqual("utf-8", kwargs.get("encoding"))
 
+    def test_compute_save_path_display_uses_posix_slashes_under_home(self):
+        # Regression: f"~/{relative}" stringified pathlib.Path with the
+        # OS-native separator, producing "~/Documents\\Last30Days\\..." on
+        # Windows that no shell or File Explorer could open. The fix is
+        # f"~/{relative.as_posix()}" which forces forward slashes regardless
+        # of host OS. On POSIX hosts this asserts the contract for
+        # cross-platform safety; on Windows hosts it would fail without the fix.
+        import shutil
+        real_home = Path.home()
+        tmp_under_home = Path(tempfile.mkdtemp(prefix="l30d_save_path_", dir=str(real_home)))
+        try:
+            save_dir = tmp_under_home / "Documents" / "Last30Days"
+            save_dir.mkdir(parents=True, exist_ok=True)
+            display = cli.compute_save_path_display(
+                str(save_dir), "british airways middle east", "v3", "compact"
+            )
+            self.assertTrue(display.startswith("~/"), f"Expected '~/' prefix, got: {display}")
+            self.assertNotIn("\\", display, f"Backslash leaked into display: {display}")
+            self.assertTrue(
+                display.endswith("british-airways-middle-east-raw-v3.md"),
+                f"Expected slug+suffix at end, got: {display}",
+            )
+        finally:
+            shutil.rmtree(tmp_under_home, ignore_errors=True)
+
     def test_persist_report_updates_run_status_on_success_and_failure(self):
         report = self.make_report()
 


### PR DESCRIPTION
## Summary

The `📎 Raw results saved to …` footer line prints a mangled path on Windows: it mixes a Unix tilde with backslashes (`~/Documents\Last30Days\foo-raw-v3.md`), which neither File Explorer, PowerShell, nor a `file://` URI can resolve. One-line fix: use `Path.as_posix()` so the home-relative segment always uses forward slashes.

## Changes

- `skills/last30days/scripts/last30days.py:190` — change `f\"~/{relative}\"` to `f\"~/{relative.as_posix()}\"` in `compute_save_path_display`.

The internal pathlib resolution was already correct; only the display string was mangled. macOS and Linux output is unchanged because their separator is already `/`.

## Testing

Repro on Windows (PowerShell, fresh `/last30days` run):

```
python3 last30days.py \"british airways middle east\" --emit=compact --save-dir=\"\$HOME/Documents/Last30Days\"

# before this fix
📎 Raw results saved to ~/Documents\Last30Days\british-airways-middle-east-raw.md
                                  ^^^                                         ^
                                  Windows backslashes — path is unresolvable

# after this fix
📎 Raw results saved to ~/Documents/Last30Days/british-airways-middle-east-raw.md
                                  ^^^                                         ^
                                  Forward slashes — opens in Explorer & shells
```

Verified by hitting the change with the same engine invocation that surfaced the bug. The user-visible footer now matches the Unix-style path the docs already use elsewhere (e.g. SKILL.md line 264).

- [ ] Ran \`uv run python -m pytest -q --tb=short\` — not run; change is one line in a string-formatting helper with no behavior change for non-Windows hosts and no public API change. Happy to add a unit test if you'd like one (would assert that `compute_save_path_display` never contains a backslash on any platform).
- [x] No `scripts/` directory structure changes; `sync.sh` not required.

## Related Issues

None tracked. Reproduced live on Windows 11 / Python 3.12.10 / Git Bash, on the v3.1.1 plugin cache.