### PR TITLE
fix(grounding): align Parallel AI search with current API schema

### DIFF
--- a/skills/last30days/scripts/lib/grounding.py
+++ b/skills/last30days/scripts/lib/grounding.py
@@ -140,7 +140,10 @@ def parallel_search(
     data = http.request(
         "POST", "https://api.parallel.ai/v1/search",
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        json_data={"query": query, "max_results": count},
+        json_data={
+            "search_queries": [query],
+            "advanced_settings": {"max_results": count},
+        },
         timeout=15,
     )
     items = []
@@ -150,7 +153,7 @@ def parallel_search(
         url = r.get("url", "")
         if not url:
             continue
-        raw_date = r.get("published_date") or ""
+        raw_date = r.get("publish_date") or ""
         pub_date = _normalize_date(raw_date[:10]) if raw_date else None
         if not _in_date_range(pub_date, date_range):
             continue
@@ -159,7 +162,7 @@ def parallel_search(
             "title": r.get("title", ""),
             "url": url,
             "source_domain": _domain(url),
-            "snippet": r.get("snippet", ""),
+            "snippet": (r.get("excerpts") or [""])[0],
             "date": pub_date,
             "relevance": 0.8,
             "why_relevant": "Parallel AI web search",

--- a/skills/last30days/scripts/lib/grounding.py
+++ b/skills/last30days/scripts/lib/grounding.py
@@ -162,7 +162,7 @@ def parallel_search(
             "title": r.get("title", ""),
             "url": url,
             "source_domain": _domain(url),
-            "snippet": (r.get("excerpts") or [""])[0],
+            "snippet": ((r.get("excerpts") or [""])[0] or "")[:500],
             "date": pub_date,
             "relevance": 0.8,
             "why_relevant": "Parallel AI web search",


### PR DESCRIPTION
## Summary

Update the Parallel AI web search integration in `lib/grounding.py` to the current API schema. The previous request/response field names had drifted and were returning HTTP 422 error.

There were major upgrades to the Parallel Search and Extract API on 2026-04-22. Refer to 

https://docs.parallel.ai/resources/changelog#april-22-2026
https://parallel.ai/blog/parallel-search-extract-ga
https://docs.parallel.ai/search/search-quickstart

## Changes

- `skills/last30days/scripts/lib/grounding.py`:
    - Request body: send `search_queries: [query]` and move `max_results` under `advanced_settings` (was top-level `query` / `max_results`).
    - Response parsing: read `publish_date` (was `published_date`) and pull the first entry of `excerpts[]` for the snippet (was `snippet`).

## Testing

Smoke-tested end-to-end:

`python3 skills/last30days/scripts/last30days.py "test query" --emit=compact` and confirmed Parallel AI results come back populated with snippet and date.

```text
[Planner] Plan: intent=concept, freshness=evergreen_ok, cluster_mode=none, subqueries=1, source=deterministic
[Planner]   sq1 label=primary search="openai gpt release" sources=[grounding]
[DEBUG] POST https://api.parallel.ai/v1/search
[DEBUG] Response: 200 (10151 bytes)
[DEBUG] POST https://api.parallel.ai/v1/search
[DEBUG] Response: 200 (12659 bytes)
```

  ## Related Issues

None