### PR TITLE
fix: prefer sandboxed Safari cookie path

### DIFF
--- a/skills/last30days/scripts/lib/safari_cookies.py
+++ b/skills/last30days/scripts/lib/safari_cookies.py
@@ -107,7 +107,18 @@ def extract_safari_cookies_macos(
     if sys.platform != "darwin":
         return None
 
-    cookie_path = Path.home() / "Library" / "Cookies" / "Cookies.binarycookies"
+    cookie_paths = [
+        Path.home()
+        / "Library"
+        / "Containers"
+        / "com.apple.Safari"
+        / "Data"
+        / "Library"
+        / "Cookies"
+        / "Cookies.binarycookies",
+        Path.home() / "Library" / "Cookies" / "Cookies.binarycookies",
+    ]
+    cookie_path = next((path for path in cookie_paths if path.exists()), cookie_paths[0])
 
     try:
         raw = cookie_path.read_bytes()

--- a/tests/test_safari_cookies.py
+++ b/tests/test_safari_cookies.py
@@ -193,6 +193,37 @@ class TestErrorPaths:
         assert result["auth_token"] == "test_auth_abc123"
         assert result["ct0"] == "test_ct0_xyz789"
 
+    def test_falls_back_to_legacy_safari_cookie_path(self, tmp_path: Path):
+        # Sandboxed path is intentionally NOT created — only the legacy path exists.
+        legacy_dir = tmp_path / "Library" / "Cookies"
+        legacy_dir.mkdir(parents=True)
+        legacy_data = _build_binary_cookies_file(
+            [_build_page([_build_cookie_record(".x.com", "auth_token", "legacy_auth")])]
+        )
+        (legacy_dir / "Cookies.binarycookies").write_bytes(legacy_data)
+
+        sandbox_path = (
+            tmp_path
+            / "Library"
+            / "Containers"
+            / "com.apple.Safari"
+            / "Data"
+            / "Library"
+            / "Cookies"
+            / "Cookies.binarycookies"
+        )
+        assert not sandbox_path.exists()
+
+        with patch(
+            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            mock_sys.stderr = sys.stderr
+            result = extract_safari_cookies_macos("x.com", ["auth_token"])
+
+        assert result is not None
+        assert result["auth_token"] == "legacy_auth"
+
     def test_permission_denied(self, tmp_path: Path, capsys):
         cookie_dir = (
             tmp_path

--- a/tests/test_safari_cookies.py
+++ b/tests/test_safari_cookies.py
@@ -160,25 +160,64 @@ class TestErrorPaths:
             result = extract_safari_cookies_macos("x.com", ["auth_token"])
         assert result is None
 
+    def test_prefers_sandboxed_safari_cookie_path(
+        self, tmp_path: Path, x_cookies_file: bytes
+    ):
+        sandbox_dir = (
+            tmp_path
+            / "Library"
+            / "Containers"
+            / "com.apple.Safari"
+            / "Data"
+            / "Library"
+            / "Cookies"
+        )
+        sandbox_dir.mkdir(parents=True)
+        (sandbox_dir / "Cookies.binarycookies").write_bytes(x_cookies_file)
+
+        legacy_dir = tmp_path / "Library" / "Cookies"
+        legacy_dir.mkdir(parents=True)
+        legacy_data = _build_binary_cookies_file(
+            [_build_page([_build_cookie_record(".x.com", "auth_token", "legacy")])]
+        )
+        (legacy_dir / "Cookies.binarycookies").write_bytes(legacy_data)
+
+        with patch(
+            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            mock_sys.stderr = sys.stderr
+            result = extract_safari_cookies_macos("x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "test_auth_abc123"
+        assert result["ct0"] == "test_ct0_xyz789"
+
     def test_permission_denied(self, tmp_path: Path, capsys):
-        cookie_dir = tmp_path / "Library" / "Cookies"
+        cookie_dir = (
+            tmp_path
+            / "Library"
+            / "Containers"
+            / "com.apple.Safari"
+            / "Data"
+            / "Library"
+            / "Cookies"
+        )
         cookie_dir.mkdir(parents=True)
         cookie_file = cookie_dir / "Cookies.binarycookies"
         cookie_file.write_bytes(b"cook")
-        cookie_file.chmod(0o000)
 
-        try:
-            with patch(
-                "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
-            ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
-                mock_sys.platform = "darwin"
-                mock_sys.stderr = sys.stderr
-                result = extract_safari_cookies_macos("x.com", ["auth_token"])
-            assert result is None
-            captured = capsys.readouterr()
-            assert "Full Disk Access" in captured.err
-        finally:
-            cookie_file.chmod(0o644)
+        with patch(
+            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("scripts.lib.safari_cookies.sys") as mock_sys, patch.object(
+            Path, "read_bytes", side_effect=PermissionError
+        ):
+            mock_sys.platform = "darwin"
+            mock_sys.stderr = sys.stderr
+            result = extract_safari_cookies_macos("x.com", ["auth_token"])
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Full Disk Access" in captured.err
 
     def test_truncated_magic_only(self):
         result = _parse_binary_cookies(b"cook", "x.com", ["auth_token"])


### PR DESCRIPTION
## Summary
- prefer Safari's modern sandboxed Cookies.binarycookies path before the legacy ~/Library/Cookies path
- keep the legacy path as fallback
- make the permission-denied regression deterministic across platforms

## Validation
- `uv run --no-sync pytest tests/test_safari_cookies.py tests/test_env_include_sources_default.py -q`
- `git diff --check`

Fixes #342