### PR TITLE
docs: fix stale script paths

### DIFF
--- a/docs/search-quality-eval.md
+++ b/docs/search-quality-eval.md
@@ -1,6 +1,6 @@
 # Search Quality Eval
 
-`scripts/evaluate_search_quality.py` is an optional local evaluation step for retrieval quality. It is not part of the user-facing runtime and does not need to run in CI by default.
+`skills/last30days/scripts/evaluate_search_quality.py` is an optional local evaluation step for retrieval quality. It is not part of the user-facing runtime and does not need to run in CI by default.
 
 What it does:
 
@@ -18,13 +18,13 @@ What it does:
 Recommended usage:
 
 ```bash
-uv run python scripts/evaluate_search_quality.py
+uv run python skills/last30days/scripts/evaluate_search_quality.py
 ```
 
 Useful flags:
 
 ```bash
-uv run python scripts/evaluate_search_quality.py \
+uv run python skills/last30days/scripts/evaluate_search_quality.py \
   --baseline-rev origin/main \
   --candidate-rev HEAD \
   --no-default-topics \


### PR DESCRIPTION
## Summary

Fixes stale contributor-doc references to scripts that now live under `skills/last30days/scripts/`.

## Changes

- Update search quality eval documentation command paths.
- ~~Update the PR template sync command path.~~ (Dropped during rebase — the stale line in `.github/PULL_REQUEST_TEMPLATE.md` was already removed upstream before this PR could land, so the diff covers only `docs/search-quality-eval.md`.)

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: docs-only change)

## Related Issues

None