### PR TITLE
docs: fix bug report repro command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
       label: Steps to Reproduce
       description: How can we reproduce this?
       placeholder: |
-        1. Run `python3 scripts/last30days.py "topic" --emit compact`
+        1. Run `python3 skills/last30days/scripts/last30days.py "topic" --emit=compact`
         2. ...
     validations:
       required: true


### PR DESCRIPTION
## Summary

Updates the bug report template repro placeholder to use the current last30days CLI path under `skills/last30days/scripts/`.

## Changes

- Replace the stale root `scripts/last30days.py` path in the bug report template.
- Use the common `--emit=compact` flag spelling.

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: docs-only change)

## Related Issues

None