### PR TITLE
docs: fix runtime skill spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**
 
-This README tracks the current v3 pipeline. The runtime skill spec lives in [SKILL.md](SKILL.md), which is the source of truth for the latest command and setup behavior.
+This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), which is the source of truth for the latest command and setup behavior.
 
 **Claude Code (recommended — auto-updates via marketplace):**
 ```


### PR DESCRIPTION
## Summary

Fixes the README link to the runtime skill spec so it points at the actual file under `skills/last30days/`.

## Changes

- Replace the broken root `SKILL.md` link with `skills/last30days/SKILL.md`.

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: docs-only change)

## Related Issues

None