### PR TITLE
chore: sync gemini extension version

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.0.5",
+  "version": "3.2.4",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -36,6 +36,7 @@ class TestPluginContract(unittest.TestCase):
 
         self.assertEqual(version, _skill_version())
         self.assertEqual(version, _json(ROOT / ".claude-plugin" / "plugin.json")["version"])
+        self.assertEqual(version, _json(ROOT / "gemini-extension.json")["version"])
 
         marketplace = _json(ROOT / ".claude-plugin" / "marketplace.json")
         plugins = marketplace.get("plugins") or []


### PR DESCRIPTION
## Summary

Updates `gemini-extension.json` so its version matches the current project and plugin manifests, and adds it to the existing version contract test.

## Changes

- Change Gemini extension metadata from `3.0.5` to `3.2.4`. (Retargeted during rebase — PR was originally opened against `3.1.1` but main moved to `3.2.4` before merge. The contract test below is the durable fix; it'll catch future drift regardless of literal value.)
- Assert the Gemini extension version matches the project version in `tests/test_plugin_contract.py`.

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: metadata/test-only change)

## Related Issues

None