### PR TITLE
docs: mark root spec as historical

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,8 @@
 # last30days Skill Specification
 
+> Historical implementation spec. The maintained runtime contract lives in
+> `skills/last30days/SKILL.md`.
+
 ## Overview
 
 `last30days` is a Claude Code skill that researches a given topic across Reddit and X (Twitter) using the OpenAI Responses API and xAI Responses API respectively. It enforces a strict 30-day recency window, popularity-aware ranking, and produces actionable outputs including best practices, a prompt pack, and a reusable context snippet. OpenAI auth can come from `OPENAI_API_KEY` or Codex login credentials.


### PR DESCRIPTION
## Summary

Adds a note to `SPEC.md` that it is historical and points readers to the maintained runtime contract.

## Changes

- Mark `SPEC.md` as historical.
- Point to `skills/last30days/SKILL.md` for current runtime behavior.

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: docs-only change)

## Related Issues

None