### PR TITLE
docs: mark root tasks as historical

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,8 @@
 # last30days Implementation Tasks
 
+> Historical checklist from the original implementation. Current runtime code
+> lives under `skills/last30days/scripts/`.
+
 ## Setup & Configuration
 - [x] Create directory structure
 - [x] Write SPEC.md


### PR DESCRIPTION
## Summary

Adds a note to `TASKS.md` that it is a historical checklist and points readers to the current runtime code location.

## Changes

- Mark `TASKS.md` as historical.
- Point to `skills/last30days/scripts/` for current runtime code.

## Testing

- [x] Ran `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not needed: docs-only change)

## Related Issues

None