### PR TITLE
fix: honor explicit optional source requests

### DIFF
--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -126,9 +126,7 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.append("perplexity")
     if requested_sources and "xiaohongshu" in requested_sources and env.is_xiaohongshu_available(config):
         available.append("xiaohongshu")
-    if env.is_threads_available(config) or (
-        requested_sources and "threads" in requested_sources and config.get("SCRAPECREATORS_API_KEY")
-    ):
+    if env.is_threads_available(config):
         available.append("threads")
     if requested_sources and "pinterest" in requested_sources and env.is_pinterest_available(config):
         available.append("pinterest")

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -124,7 +124,9 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.append("perplexity")
     if requested_sources and "xiaohongshu" in requested_sources and env.is_xiaohongshu_available(config):
         available.append("xiaohongshu")
-    if env.is_threads_available(config):
+    if env.is_threads_available(config) or (
+        requested_sources and "threads" in requested_sources and config.get("SCRAPECREATORS_API_KEY")
+    ):
         available.append("threads")
     if requested_sources and "pinterest" in requested_sources and env.is_pinterest_available(config):
         available.append("pinterest")

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -120,7 +120,9 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.append("grounding")
     # Perplexity Sonar: opt-in additive source via INCLUDE_SOURCES=perplexity
     include_sources = (config.get("INCLUDE_SOURCES") or "").lower().split(",")
-    if config.get("OPENROUTER_API_KEY") and "perplexity" in include_sources:
+    if config.get("OPENROUTER_API_KEY") and (
+        "perplexity" in include_sources or (requested_sources and "perplexity" in requested_sources)
+    ):
         available.append("perplexity")
     if requested_sources and "xiaohongshu" in requested_sources and env.is_xiaohongshu_available(config):
         available.append("xiaohongshu")

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -79,6 +79,8 @@ MOCK_AVAILABLE_SOURCES = [
     "xiaohongshu",
     "github",
     "perplexity",
+    "threads",
+    "pinterest",
     "xquik",
     "digg",
 ]

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -84,6 +84,13 @@ class CliV3Tests(unittest.TestCase):
         )
         self.assertIn("threads", available)
 
+    def test_explicit_perplexity_search_uses_openrouter_key_without_include_sources(self):
+        available = cli.pipeline.available_sources(
+            {"OPENROUTER_API_KEY": "test-key", "INCLUDE_SOURCES": ""},
+            requested_sources=["perplexity"],
+        )
+        self.assertIn("perplexity", available)
+
     def test_parse_search_flag_rejects_invalid_or_empty_inputs(self):
         with self.assertRaises(SystemExit):
             cli.parse_search_flag("unknown")

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -77,6 +77,13 @@ class CliV3Tests(unittest.TestCase):
             cli.parse_search_flag("threads, pinterest"),
         )
 
+    def test_explicit_threads_search_uses_scrapecreators_key_without_include_sources(self):
+        available = cli.pipeline.available_sources(
+            {"SCRAPECREATORS_API_KEY": "test-key", "INCLUDE_SOURCES": ""},
+            requested_sources=["threads"],
+        )
+        self.assertIn("threads", available)
+
     def test_parse_search_flag_rejects_invalid_or_empty_inputs(self):
         with self.assertRaises(SystemExit):
             cli.parse_search_flag("unknown")

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -71,6 +71,12 @@ class CliV3Tests(unittest.TestCase):
             cli.parse_search_flag("web, reddit, hn, web"),
         )
 
+    def test_parse_search_flag_accepts_optional_social_sources(self):
+        self.assertEqual(
+            ["threads", "pinterest"],
+            cli.parse_search_flag("threads, pinterest"),
+        )
+
     def test_parse_search_flag_rejects_invalid_or_empty_inputs(self):
         with self.assertRaises(SystemExit):
             cli.parse_search_flag("unknown")


### PR DESCRIPTION
## Summary

Allows explicitly requested optional sources to pass validation and availability checks when their credentials are configured.

## Changes

- Add `threads` and `pinterest` to the accepted `--search` source list.
- Allow explicit `requested_sources=["threads"]` when `SCRAPECREATORS_API_KEY` is configured, even without `INCLUDE_SOURCES=threads`.
- Allow explicit `requested_sources=["perplexity"]` when `OPENROUTER_API_KEY` is configured, even without `INCLUDE_SOURCES=perplexity`.
- Add parser and availability coverage for these optional sources.

## Testing

- [x] Ran `uv run pytest tests/test_cli_v3.py tests/test_plugin_contract.py tests/test_version_consistency.py`
- [ ] Ran `bash skills/last30days/scripts/sync.sh` (not run; source change prepared for PR review)

## Related Issues

None