### PR TITLE
fix: skip POSIX secret warning on Windows

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -70,6 +70,10 @@ class OpenAIAuth:
 
 def _check_file_permissions(path: Path) -> None:
     """Warn to stderr if a secrets file has overly permissive permissions."""
+    if os.name == "nt":
+        # Windows reports synthesized POSIX mode bits that do not reflect NTFS ACLs.
+        return
+
     try:
         mode = path.stat().st_mode
         # Check if group or other can read (bits 0o044)

--- a/tests/test_env_v3.py
+++ b/tests/test_env_v3.py
@@ -41,6 +41,14 @@ class EnvV3Tests(unittest.TestCase):
             with mock.patch.dict(os.environ, {}, clear=False):
                 self.assertIsNone(bird_x.is_bird_authenticated())
 
+    def test_file_permission_check_skips_windows_posix_mode_bits(self):
+        path = mock.Mock(spec=Path)
+        with mock.patch.object(env.os, "name", "nt"), mock.patch.object(env.sys.stderr, "write") as write:
+            env._check_file_permissions(path)
+
+        path.stat.assert_not_called()
+        write.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Windows no longer gets a repeated `.env` permission warning from synthesized POSIX mode bits. `_check_file_permissions` now leaves Windows ACL validation alone instead of suggesting `chmod 600`, and the regression test verifies the Windows path does not stat or warn.

Fixes mvanhorn/last30days-skill#325.

Tests: `uv run pytest tests/test_env_v3.py tests/test_plugin_contract.py tests/test_version_consistency.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
