### PR TITLE
fix: initialize OpenClaw poll timing once

### DIFF
--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -335,8 +335,9 @@ def poll_device_auth(
     """
     import sys
 
-    deadline = time.time() + timeout
-    last_reminder = time.time()
+    started_at = time.time()
+    deadline = started_at + timeout
+    last_reminder = started_at
     reminder_count = 0
     max_reminders = 4
     reminder_interval = 30  # seconds between reminders

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -213,10 +213,10 @@ class TestPollDeviceAuth:
     @patch("lib.setup_wizard.urlopen")
     def test_timeout_returns_none(self, mock_urlopen, mock_time):
         """Returns None when timeout is exceeded."""
-        # poll_device_auth calls time.time() for deadline init, last_reminder init,
-        # then once per while-loop iteration. Three values are enough for one check
-        # that exceeds the deadline.
-        mock_time.time = MagicMock(side_effect=[0, 0, 301])
+        # poll_device_auth captures started_at once, derives deadline + last_reminder
+        # from it, then checks time.time() in the while-loop. Two values: started_at,
+        # then a value past the deadline so the loop exits immediately.
+        mock_time.time = MagicMock(side_effect=[0, 301])
         mock_time.sleep = MagicMock()
 
         result = setup_wizard.poll_device_auth("dc-123", interval=5, timeout=300)


### PR DESCRIPTION
OpenClaw device-auth polling now initializes its deadline and reminder timer from the same timestamp. This keeps the polling clock model simpler and fixes the brittle timeout/expired-token test paths that expected one start time followed by loop checks.

Tests: `uv run pytest tests/test_setup_openclaw.py tests/test_plugin_contract.py tests/test_version_consistency.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
