### PR TITLE
fix: persist raw items when rankings are absent

### DIFF
--- a/skills/last30days/scripts/store.py
+++ b/skills/last30days/scripts/store.py
@@ -687,11 +687,16 @@ def findings_from_report(
         findings.append(finding)
         seen_urls.add(candidate.url)
     
-    # Phase 2: Add HN/PM items not already captured in ranked candidates
-    for source_name in ["hackernews", "polymarket"]:
-        if source_name not in report.items_by_source:
-            continue
-        for item in report.items_by_source[source_name]:
+    # Phase 2: Add raw items not already captured in ranked candidates.
+    # When rankings are present, keep the historical HN/PM supplement behavior.
+    # When rankings are absent, preserve watchlist/mock runs from every source.
+    raw_source_names = (
+        report.items_by_source.keys()
+        if not report.ranked_candidates
+        else ("hackernews", "polymarket")
+    )
+    for source_name in raw_source_names:
+        for item in report.items_by_source.get(source_name, []):
             if item.url in seen_urls:
                 continue  # Already captured with rich data
             findings.append({


### PR DESCRIPTION
Watchlist persistence now keeps raw `items_by_source` findings when a report has no ranked candidates. Ranked reports keep the existing high-quality candidate path plus the HN/Polymarket supplement, while mock/headless reports no longer drop Reddit, X, or other raw-source findings.

Tests: `uv run pytest tests/test_store.py tests/test_watchlist_commands.py tests/test_plugin_contract.py tests/test_version_consistency.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
