### PR TITLE
test: expect current footer quality nudge

### DIFF
--- a/tests/test_footer_nudge_suppression.py
+++ b/tests/test_footer_nudge_suppression.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-"""Tests for the BRAVE/SERPER web-promo suppression when hosting-model-driven."""
+"""Tests for footer nudges when hosting-model-driven."""
 
 from __future__ import annotations
 
@@ -35,12 +35,14 @@ class FooterNudgeSuppressionTests(unittest.TestCase):
             env.pop(key, None)
         return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
-    def test_bare_run_emits_web_promo(self):
+    def test_bare_run_emits_quality_nudge(self):
         result = self._run(topic="OpenAI")
         combined = result.stdout + result.stderr
-        # Mock mode still shows the promo when nothing indicates a hosting
-        # model is driving. Check both streams since the UI may emit to stderr.
-        self.assertIn("BRAVE_API_KEY", combined)
+        # Mock mode still shows user-facing quality guidance when nothing
+        # indicates a hosting model is driving. Check both streams since the UI
+        # may emit to stderr.
+        self.assertIn("Research quality:", combined)
+        self.assertIn("XAI_API_KEY", combined)
 
     def test_competitors_plan_suppresses_web_promo(self):
         result = self._run(


### PR DESCRIPTION
The footer nudge suppression test now matches the current bare-run behavior: mock runs already have Web active, so the user-facing guidance is the core-source quality nudge rather than a BRAVE/SERPER web-key prompt. The plan and competitors-plan checks still guard that hosting-model-driven runs suppress the old web promo path.

Tests: `uv run pytest tests/test_footer_nudge_suppression.py tests/test_cli_v3.py tests/test_plugin_contract.py tests/test_version_consistency.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
