### PR TITLE
Claim contributor entry — @thinkun

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,7 +23,7 @@ v3 has full GitHub search: issues, PRs, person-mode profiles, project-mode repos
 ### @thinkun
 [PR #116](https://github.com/mvanhorn/last30days-skill/pull/116) - Resilient Reddit, prevent enrichment timeout from discarding results
 v3 has parallel enrichment with per-item timeouts. No results are ever dropped.
-> _Add your bio, website, or anything you'd like here._
+> Thinker, technologist, AI expert, music-tinkerer. Founder of [Thinkun](https://thinkun.com). [@thinkun on GitHub](https://github.com/thinkun) · [@unthink on X](https://x.com/unthink)
 
 ### @thomasmktong
 [PR #124](https://github.com/mvanhorn/last30days-skill/pull/124) - Pure Python Reddit fallback


### PR DESCRIPTION
Per the convention in CONTRIBUTORS.md ("Submit a PR replacing the placeholder line below your name"), this updates my entry with bio + handles.

Thanks for the recognition and the kind words on #116. v3's parallel-enrichment approach landed in a great place, and I'm glad the underlying insight from that PR is reflected in your acknowledgement.