### PR TITLE
fix(hooks): replace unsafe eval with declare in check-config.sh

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -37,7 +37,9 @@ load_env_vars() {
       # command substitution in backtick-containing comments
       value="${value%%[[:space:]]#*}"
       if [[ -n "$key" && -n "$value" ]]; then
-        declare -g "ENV_${key}=${value}"
+        # printf -v writes via assignment semantics (global from inside a
+        # function), works on macOS's /bin/bash 3.2 — `declare -g` is 4.2+.
+        printf -v "ENV_${key}" '%s' "$value"
       fi
     done < "$file"
   fi

--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -33,8 +33,11 @@ load_env_vars() {
       [[ -z "$key" ]] && continue
       key=$(echo "$key" | xargs)
       value=$(echo "$value" | xargs | sed 's/^["'\''"]//;s/["'\''"]$//')
+      # Strip inline comments (# preceded by whitespace) to prevent
+      # command substitution in backtick-containing comments
+      value="${value%%[[:space:]]#*}"
       if [[ -n "$key" && -n "$value" ]]; then
-        eval "ENV_${key}=\"${value}\""
+        declare "ENV_${key}=${value}"
       fi
     done < "$file"
   fi

--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -37,7 +37,7 @@ load_env_vars() {
       # command substitution in backtick-containing comments
       value="${value%%[[:space:]]#*}"
       if [[ -n "$key" && -n "$value" ]]; then
-        declare "ENV_${key}=${value}"
+        declare -g "ENV_${key}=${value}"
       fi
     done < "$file"
   fi


### PR DESCRIPTION
## Summary

Replace `eval` with `declare` in `load_env_vars()` and strip inline comments before variable assignment. This prevents command substitution from backtick-containing comments in `.env` files.

## Changes

- `hooks/scripts/check-config.sh`: Strip inline comments (`# ...`) from values before assignment using `${value%%[[:space:]]#*}`
- Replace `eval "ENV_${key}=\"${value}\""` with `declare "ENV_${key}=${value}"` to prevent shell expansion

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` (pre-existing failures only, no regressions)
- [ ] Ran `bash scripts/sync.sh` (if scripts/ changed)

Tested with a `.env` containing:
```
FOO=bar      # this comment has `touch /tmp/pwned` in it
```
Before: `eval` executes `touch /tmp/pwned` via backtick expansion on every SessionStart.
After: `declare` assigns `bar` without command substitution, inline comment stripped.

## Related Issues

Fixes #361

This contribution was developed with AI assistance.