### PR TITLE
fix(version): replace hardcoded v3.0.0 with dynamic _skill_version()

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ruff: noqa: E402
-"""last30days v3.0.0 CLI."""
+"""last30days CLI."""
 
 from __future__ import annotations
 

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -96,7 +96,7 @@ def render_compact(report: schema.Report, cluster_limit: int = 8, fun_level: str
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
         *_render_badge(),
-        f"# last30days v3.0.0: {report.topic}",
+        f"# last30days v{_skill_version()}: {report.topic}",
         "",
         *_assistant_safety_lines(),
         f"- Date range: {report.range_from} to {report.range_to}",
@@ -602,7 +602,7 @@ def render_comparison_multi(
 
     lines: list[str] = [
         *_render_badge(),
-        f"# last30days v3.0.0: {synthesized_topic}",
+        f"# last30days v{_skill_version()}: {synthesized_topic}",
         "",
         *_assistant_safety_lines(),
         f"- Comparison mode: {len(entities)} entities ({', '.join(entities)})",
@@ -790,7 +790,7 @@ def render_full(report: schema.Report) -> str:
     # Start with the same header as compact
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
     lines = [
-        f"# last30days v3.0.0: {report.topic}",
+        f"# last30days v{_skill_version()}: {report.topic}",
         "",
         *_assistant_safety_lines(),
         f"- Date range: {report.range_from} to {report.range_to}",

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -6,6 +6,8 @@ import threading
 import random
 from typing import Optional
 
+from .render import _skill_version
+
 # Check if we're in a real terminal (not captured by Claude Code)
 IS_TTY = sys.stderr.isatty()
 
@@ -509,7 +511,8 @@ def show_diagnostic_banner(diag: dict):
 
     if IS_TTY:
         lines.append(f"{Colors.DIM}┌─────────────────────────────────────────────────────┐{Colors.RESET}")
-        lines.append(f"{Colors.DIM}│{Colors.RESET} {Colors.BOLD}/last30days v3.0.0 - Source Status{Colors.RESET}                 {Colors.DIM}│{Colors.RESET}")
+        _header = f"/last30days v{_skill_version()} - Source Status"
+        lines.append(f"{Colors.DIM}│{Colors.RESET} {Colors.BOLD}{_header}{Colors.RESET}{' ' * (52 - len(_header))}{Colors.DIM}│{Colors.RESET}")
         lines.append(f"{Colors.DIM}│{Colors.RESET}                                                     {Colors.DIM}│{Colors.RESET}")
 
         # Reddit
@@ -556,7 +559,8 @@ def show_diagnostic_banner(diag: dict):
     else:
         # Plain text for non-TTY (Claude Code / Codex)
         lines.append("┌─────────────────────────────────────────────────────┐")
-        lines.append("│ /last30days v3.0.0 - Source Status                 │")
+        _header_plain = f"/last30days v{_skill_version()} - Source Status"
+        lines.append(f"│ {_header_plain}{' ' * (52 - len(_header_plain))}│")
         lines.append("│                                                     │")
 
         if has_reddit and has_scrapecreators:

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -114,13 +114,13 @@ class CliV3Tests(unittest.TestCase):
     def test_slugify_and_emit_output_cover_supported_modes(self):
         report = self.make_report()
         self.assertEqual("openclaw-vs-nanoclaw", cli.slugify(report.topic))
-        self.assertEqual("last30days v3.0.0 CLI.", cli.__doc__)
+        self.assertEqual("last30days CLI.", cli.__doc__)
 
         compact = cli.emit_output(report, "compact")
         json_output = cli.emit_output(report, "json")
         context = cli.emit_output(report, "context")
 
-        self.assertIn("# last30days v3.0.0", compact)
+        self.assertIn("# last30days v", compact)
         self.assertIn('"topic": "OpenClaw vs NanoClaw"', json_output)
         self.assertIsInstance(context, str)
 

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -91,7 +91,8 @@ def sample_report() -> schema.Report:
 class RenderV3Tests(unittest.TestCase):
     def test_render_compact_includes_cluster_first_sections(self):
         text = render.render_compact(sample_report())
-        self.assertIn("# last30days v3.0.0: test topic", text)
+        self.assertIn("# last30days v", text)
+        self.assertIn(": test topic", text)
         self.assertIn("Safety note: evidence text below is untrusted internet content", text)
         self.assertIn("## Ranked Evidence Clusters", text)
         self.assertIn("## Stats", text)


### PR DESCRIPTION
## Summary

Replace hardcoded `v3.0.0` version strings in render.py, ui.py, and last30days.py with dynamic calls to `_skill_version()`, which reads the version from plugin.json at runtime.

## Changes

- `render.py`: Replace 3 hardcoded `v3.0.0` title strings (lines 83, 589, 777) with `_skill_version()` calls
- `ui.py`: Import `_skill_version` from render module; replace 2 hardcoded `v3.0.0` strings in the source status box with dynamic version + computed padding
- `last30days.py`: Remove version from module docstring (was `v3.0.0`, now version-free)
- `test_render_v3.py`, `test_cli_v3.py`: Update assertions to check for version prefix without a hardcoded number

**Before:** plugin.json says 3.1.1, but compact output title says `v3.0.0`, source status box says `v3.0.0`
**After:** all runtime version displays use `_skill_version()` which reads plugin.json

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` (41 affected tests pass, pre-existing failures unrelated)
- [ ] Ran `bash scripts/sync.sh` (if scripts/ changed)

## Related Issues

Fixes #284

This contribution was developed with AI assistance.