### PR TITLE
ci: add advisory security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,67 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Export locked dependency set
+        run: |
+          uv export \
+            --locked \
+            --all-groups \
+            --no-hashes \
+            --format requirements.txt \
+            --output-file /tmp/last30days-requirements.txt
+
+      # Advisory-first: visibility before enforcement. This repo handles API keys,
+      # cookies, browser tokens, and local env files, so dependency CVEs should be
+      # visible in CI logs even before the project has a clean blocking baseline.
+      # Set continue-on-error: false once a clean baseline run is confirmed.
+      - name: Run pip-audit against locked dependencies
+        continue-on-error: true
+        run: uvx --python 3.12 pip-audit -r /tmp/last30days-requirements.txt --progress-spinner=off
+
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history for diff-aware scanning
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Advisory-first: this reports verified secrets in pull requests and pushes to
+      # main, but does not block merges until maintainers confirm a clean baseline.
+      # The TruffleHog action automatically scans the PR range for pull_request
+      # events and the pushed commit range for push events.
+      # Set continue-on-error: false once a clean baseline run is confirmed.
+      # Contributor policy: never commit real secrets in fixtures, tests, docs, or
+      # examples; use obvious dummy values and env-based auth patterns instead.
+      - name: Run TruffleHog OSS secret scan
+        if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: trufflesecurity/trufflehog@v3.95.2
+        continue-on-error: true
+        with:
+          path: ./
+          version: v3.95.2
+          extra_args: --only-verified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ npx skills add . -g -y   # one-time: symlink this repo into every detected harne
 - One-time setup: `npx skills add . -g -y` creates symlinks from each detected harness's skill dir to this repo. Edits in the working tree propagate live to every harness — no re-deploy step needed.
 - Git remote: origin = public (`mvanhorn/last30days-skill`)
 
+## Security hygiene
+- Never commit real API keys, browser cookies, auth tokens, app passwords, access tokens, or `.env` contents.
+- Use the env-based auth patterns in `skills/last30days/scripts/lib/env.py`; tests and fixtures must use obvious dummy values only.
+- Keep examples safe by redacting secrets and avoiding copy/pasteable live credentials in docs, fixtures, and test data.
+- Do not weaken or disable the advisory security workflow (`.github/workflows/security.yml`) without explaining why in the PR description or review thread.
+
 ## Beta channel
 
 Experimental changes get tested on `mvanhorn/last30days-skill-private`, which installs as a parallel `/last30days-beta` slash command. Beta-only changes never ship to public without a review PR here. Workflow guide lives at `BETA.md` in the private repo. Plan that established this setup: `docs/plans/2026-04-17-005-feat-beta-skill-from-private-repo-plan.md`.

--- a/tests/test_security_workflow.py
+++ b/tests/test_security_workflow.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "security.yml"
+# AGENTS.md is the canonical agent-guidance file; CLAUDE.md is a one-line
+# pointer (`@AGENTS.md`) so anything Claude Code-shaped reads the same source.
+AGENTS = ROOT / "AGENTS.md"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_security_workflow_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_security_workflow_runs_dependency_audit_advisory_first() -> None:
+    text = _workflow_text()
+
+    assert "dependency-audit:" in text
+    assert "pip-audit" in text
+    assert "continue-on-error: true" in text
+    assert "Set continue-on-error: false once a clean baseline run is confirmed" in text
+
+
+def test_security_workflow_runs_secret_scan_for_pull_requests_and_main_pushes() -> None:
+    text = _workflow_text()
+
+    assert "secret-scan:" in text
+    assert "trufflesecurity/trufflehog" in text
+    assert "github.event_name == 'pull_request'" in text
+    assert "github.event_name == 'push'" in text
+    assert "--only-verified" in text
+
+
+def test_security_workflow_documents_advisory_policy() -> None:
+    text = _workflow_text()
+
+    assert "advisory-first" in text.lower()
+    assert "does not block merges" in text.lower()
+    assert "fixtures" in text.lower()
+    assert "env-based auth" in text.lower()
+
+
+def test_agent_guidance_mentions_secret_hygiene() -> None:
+    text = AGENTS.read_text(encoding="utf-8")
+
+    assert "Security hygiene" in text
+    assert "Never commit real API keys" in text
+    assert "skills/last30days/scripts/lib/env.py" in text
+    assert "fixtures" in text


### PR DESCRIPTION
## Summary

Adds an advisory-first security workflow for dependency auditing and secret scanning.

## Changes

- Add `.github/workflows/security.yml`
  - `pip-audit` runs against the locked `uv.lock` dependency export
  - TruffleHog OSS scans pull requests and pushes to `main`
  - Both checks are advisory-first with `continue-on-error: true`
  - Workflow comments document when to make checks blocking after a clean baseline
- Add `tests/test_security_workflow.py` so the workflow contract is covered by CI
- Include that test in the existing `Validate` workflow
- Add security hygiene guidance to `CLAUDE.md` (and therefore `AGENTS.md`, which delegates to it)
- Refresh `pytest` in `uv.lock` from `9.0.2` to `9.0.3`, clearing the current `pip-audit` finding (`CVE-2025-71176`)

## Validation

- `uv run --python 3.12 pytest tests/test_plugin_contract.py tests/test_version_consistency.py tests/test_security_workflow.py -q`
- `git diff --check`
- YAML parse check for `.github/workflows/security.yml` and `.github/workflows/validate.yml`
- `uv export --locked --all-groups --no-hashes --format requirements.txt --output-file /tmp/last30days-review-requirements.txt`
- `uvx --python 3.12 pip-audit -r /tmp/last30days-review-requirements.txt --progress-spinner=off`

Result: `No known vulnerabilities found`

## Notes

A full local `pytest -q` run still has unrelated existing failures in footer nudge, setup wizard polling, store, and watchlist tests. The focused workflow/contract tests pass.

Fixes #252
