### PR TITLE
docs: add architecture decision records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
 @CLAUDE.md
+
+For architectural context before changing packaging, eval policy, or cross-host behavior, read the lightweight ADRs in `docs/adr/`.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ MIT license. No tracking. No analytics. Your research stays on your machine. 1,0
 
 Built with Python 3.12+, yt-dlp, Node.js (vendored Bird client for X search), and ScrapeCreators API. v3 engine architecture by [@j-sperling](https://github.com/j-sperling).
 
-See [CHANGELOG.md](CHANGELOG.md) for version history.
+See [CHANGELOG.md](CHANGELOG.md) for version history. Architecture decision records live in [`docs/adr/`](docs/adr/) for packaging and eval-policy context.
 
 ## Star History
 

--- a/docs/adr/001-multi-surface-packaging.md
+++ b/docs/adr/001-multi-surface-packaging.md
@@ -1,0 +1,29 @@
+# ADR 001: Multi-surface packaging
+
+Date: 2026-05-10  
+Status: Accepted
+
+## Decision
+
+last30days supports multiple agent surfaces from one canonical skill tree. The canonical runtime lives under `skills/last30days/`, and `skills/last30days/scripts/sync.sh` deploys that skill to the local discovery paths used by Claude Code plugin cache, Agents/Codex-style skill directories, Hermes, and OpenClaw variants when present.
+
+## Context
+
+Each host discovers skills and plugins differently. There is no single shared standard for Claude Code plugins, claude.ai skills, Codex/OpenAI-style skills, Hermes skills, and OpenClaw skills. Keeping separate hand-maintained copies would cause drift in runtime scripts, skill instructions, fixtures, and host-specific variants.
+
+The repo already encodes this strategy in `skills/last30days/scripts/sync.sh`. The same constraint also explains why `skills/last30days/scripts/lib/__init__.py` must remain a bare package marker: eager imports can break host environments that import the package for discovery before optional runtime dependencies are available.
+
+## Consequences
+
+- `skills/last30days/SKILL.md` and `skills/last30days/scripts/` remain the canonical source for the public skill runtime.
+- Changes under `skills/last30days/scripts/lib/` should be followed by `bash skills/last30days/scripts/sync.sh` during local validation so installed host copies stay current.
+- Host-specific variants may exist, but they should be treated as projections of the canonical runtime rather than independent implementations.
+- `skills/last30days/scripts/lib/__init__.py` must stay a bare package marker. Do not add eager imports there.
+- Contributors should update this ADR if the repo adopts a single packaging standard or removes a host surface.
+
+## Links
+
+- `skills/last30days/scripts/sync.sh`
+- `skills/last30days/SKILL.md`
+- `skills/last30days/scripts/lib/__init__.py`
+- `CHANGELOG.md`

--- a/docs/adr/002-eval-not-in-ci.md
+++ b/docs/adr/002-eval-not-in-ci.md
@@ -1,0 +1,27 @@
+# ADR 002: Search-quality eval is manual by default
+
+Date: 2026-05-10  
+Status: Accepted
+
+## Decision
+
+`skills/last30days/scripts/evaluate_search_quality.py` is a manual evaluation tool by default, not a CI gate on every push or pull request.
+
+## Context
+
+The search-quality eval compares a baseline revision with a candidate revision across reviewer topics. Its useful modes can require live API access, network calls, external provider behavior, and optional LLM judging. Running it for every PR would add cost, latency, secrets management, and non-determinism to normal CI.
+
+The deterministic overlap metrics are valuable regression signals, but they are not the same as user-facing correctness. The LLM-judged metrics are helpful for review, but only as strong as the judged pool and model behavior for that run.
+
+## Consequences
+
+- Standard PR CI should keep using deterministic tests and contract checks.
+- Search-quality eval remains available for maintainers and contributors when a change affects retrieval, ranking, grounding, or synthesis quality.
+- Quality regressions are not automatically caught by this eval on every PR; reviewers should request a manual eval when the change warrants it.
+- A future `workflow_dispatch` workflow is the preferred middle ground if maintainers want GitHub-triggered evals without making every PR pay the live API cost.
+- Revisit this decision when the eval can compute meaningful Jaccard/retention metrics against static fixtures without live API calls.
+
+## Links
+
+- `docs/search-quality-eval.md`
+- `skills/last30days/scripts/evaluate_search_quality.py`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records
+
+ADRs are short, lightweight records of architectural choices in last30days. They preserve context for maintainers, contributors, and coding agents so repo-level decisions do not have to be rediscovered from issues or changelog entries.
+
+## Template
+
+Each ADR should use this shape:
+
+- Title
+- Date
+- Status: Proposed / Accepted / Superseded
+- Decision
+- Context
+- Consequences
+- Links
+
+## Records
+
+- [ADR 001: Multi-surface packaging](001-multi-surface-packaging.md)
+- [ADR 002: Search-quality eval is manual by default](002-eval-not-in-ci.md)

--- a/skills/last30days/scripts/sync.sh
+++ b/skills/last30days/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.0"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.1"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"

--- a/tests/test_adr_docs.py
+++ b/tests/test_adr_docs.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR_ROOT = ROOT / "docs" / "adr"
+
+
+class TestAdrDocs(unittest.TestCase):
+    def test_adr_index_and_records_exist(self) -> None:
+        expected = {
+            "README.md",
+            "001-multi-surface-packaging.md",
+            "002-eval-not-in-ci.md",
+        }
+
+        self.assertTrue(ADR_ROOT.is_dir())
+        self.assertEqual(expected, {path.name for path in ADR_ROOT.glob("*.md")})
+
+    def test_adr_records_capture_required_decisions(self) -> None:
+        packaging = (ADR_ROOT / "001-multi-surface-packaging.md").read_text(encoding="utf-8")
+        eval_policy = (ADR_ROOT / "002-eval-not-in-ci.md").read_text(encoding="utf-8")
+
+        self.assertIn("Status: Accepted", packaging)
+        self.assertIn("skills/last30days/scripts/sync.sh", packaging)
+        self.assertIn("multi-surface", packaging.lower())
+        self.assertIn("lib/__init__.py", packaging)
+        self.assertIn("bare package marker", packaging)
+
+        self.assertIn("Status: Accepted", eval_policy)
+        self.assertIn("skills/last30days/scripts/evaluate_search_quality.py", eval_policy)
+        self.assertIn("not a CI gate", eval_policy)
+        self.assertIn("workflow_dispatch", eval_policy)
+        self.assertIn("live API", eval_policy)
+
+    def test_repo_docs_link_to_adr_index(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("docs/adr/", readme)
+        self.assertIn("docs/adr/", agents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.1.1"
+version = "3.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- add `docs/adr/` with a lightweight ADR index
- document the multi-surface packaging decision behind `skills/last30days/scripts/sync.sh`
- document why search-quality eval remains manual instead of a default CI gate
- link ADR context from `AGENTS.md` and `README.md`
- add a contract test that keeps the ADR files and repo links present

Closes #256.

## Test plan

- `uv run --frozen --python 3.12 pytest tests/test_adr_docs.py tests/test_plugin_contract.py -q`
- `git diff --check`
- ADR link sanity check for referenced local paths

## Notes

I also ran `uv run --python 3.12 pytest tests/test_adr_docs.py tests/test_plugin_contract.py tests/test_version_consistency.py -q`; the new ADR tests passed, but the existing `test_sync_cache_path_uses_skill_version` fails because `sync.sh` still references `last30days-3/3.2.0` while current version metadata is `3.2.1`. This PR leaves that unrelated version-sync issue untouched.
