### PR TITLE
chore: migrate to gemini-3.1-flash-lite GA model

### DIFF
--- a/skills/last30days/scripts/evaluate_search_quality.py
+++ b/skills/last30days/scripts/evaluate_search_quality.py
@@ -43,7 +43,7 @@ def _load_default_topics() -> list[tuple[str, str]]:
 
 DEFAULT_TOPICS = _load_default_topics()
 DEFAULT_SEARCH = ""
-DEFAULT_JUDGE_MODEL = "gemini-3.1-flash-lite-preview"
+DEFAULT_JUDGE_MODEL = "gemini-3.1-flash-lite"
 GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
 
 

--- a/skills/last30days/scripts/evaluate_search_quality.py
+++ b/skills/last30days/scripts/evaluate_search_quality.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from lib import env as envlib
 from lib import schema
+from lib.providers import GEMINI_FLASH_LITE
 
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
@@ -43,7 +44,7 @@ def _load_default_topics() -> list[tuple[str, str]]:
 
 DEFAULT_TOPICS = _load_default_topics()
 DEFAULT_SEARCH = ""
-DEFAULT_JUDGE_MODEL = "gemini-3.1-flash-lite"
+DEFAULT_JUDGE_MODEL = GEMINI_FLASH_LITE
 GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
 
 

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from . import env, http, schema
 
-GEMINI_FLASH_LITE = "gemini-3.1-flash-lite-preview"
+GEMINI_FLASH_LITE = "gemini-3.1-flash-lite"
 GEMINI_PRO = "gemini-3.1-pro-preview"
 OPENAI_DEFAULT = "gpt-5.4-nano"
 XAI_DEFAULT = "grok-4-1-fast"
@@ -232,8 +232,8 @@ def _resolve_model_pins(config: dict[str, Any], depth: str, provider_name: str) 
     rerank_model = config.get("LAST30DAYS_RERANK_MODEL") or default_rerank
 
     if provider_name == "gemini":
-        _require_gemini_31_preview(planner_model, role="planner")
-        _require_gemini_31_preview(rerank_model, role="rerank")
+        _require_gemini_31(planner_model, role="planner")
+        _require_gemini_31(rerank_model, role="rerank")
 
     return planner_model, rerank_model
 
@@ -344,11 +344,11 @@ def _resolve_x_backend(config: dict[str, Any]) -> str | None:
     return env.get_x_source(config)
 
 
-def _require_gemini_31_preview(model: str, *, role: str) -> None:
-    if model.startswith("gemini-3.1-") and model.endswith("-preview"):
+def _require_gemini_31(model: str, *, role: str) -> None:
+    if model.startswith("gemini-3.1-"):
         return
     raise RuntimeError(
-        f"{role} must use a Gemini 3.1 preview model. Got: {model}"
+        f"{role} must use a Gemini 3.1 model. Got: {model}"
     )
 
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -27,8 +27,8 @@ class CliV3Tests(unittest.TestCase):
             generated_at="2026-03-16T00:00:00+00:00",
             provider_runtime=schema.ProviderRuntime(
                 reasoning_provider="gemini",
-                planner_model="gemini-3.1-flash-lite-preview",
-                rerank_model="gemini-3.1-flash-lite-preview",
+                planner_model="gemini-3.1-flash-lite",
+                rerank_model="gemini-3.1-flash-lite",
             ),
             query_plan=schema.QueryPlan(
                 intent="comparison",

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -125,7 +125,7 @@ class EvaluatorV3Tests(unittest.TestCase):
                 topic="test topic",
                 query_type="general",
                 items=[{"key": "a"}],
-                judge_model="gemini-3.1-flash-lite-preview",
+                judge_model="gemini-3.1-flash-lite",
                 gemini_api_key="key",
             )
             self.assertEqual({"a": 3}, cached)
@@ -136,7 +136,7 @@ class EvaluatorV3Tests(unittest.TestCase):
                 topic="test topic",
                 query_type="general",
                 items=[],
-                judge_model="gemini-3.1-flash-lite-preview",
+                judge_model="gemini-3.1-flash-lite",
                 gemini_api_key=None,
             )
             self.assertEqual({}, skipped)

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -70,8 +70,8 @@ def sample_report() -> schema.Report:
         generated_at="2026-03-16T00:00:00+00:00",
         provider_runtime=schema.ProviderRuntime(
             reasoning_provider="gemini",
-            planner_model="gemini-3.1-flash-lite-preview",
-            rerank_model="gemini-3.1-flash-lite-preview",
+            planner_model="gemini-3.1-flash-lite",
+            rerank_model="gemini-3.1-flash-lite",
         ),
         query_plan=schema.QueryPlan(
             intent="breaking_news",
@@ -239,8 +239,8 @@ class RenderTopCommentsTests(unittest.TestCase):
             generated_at="2026-03-16T00:00:00+00:00",
             provider_runtime=schema.ProviderRuntime(
                 reasoning_provider="gemini",
-                planner_model="gemini-3.1-flash-lite-preview",
-                rerank_model="gemini-3.1-flash-lite-preview",
+                planner_model="gemini-3.1-flash-lite",
+                rerank_model="gemini-3.1-flash-lite",
             ),
             query_plan=schema.QueryPlan(
                 intent="breaking_news",
@@ -424,8 +424,8 @@ class RenderBestTakesCompactTests(unittest.TestCase):
             generated_at="2026-03-16T00:00:00+00:00",
             provider_runtime=schema.ProviderRuntime(
                 reasoning_provider="gemini",
-                planner_model="gemini-3.1-flash-lite-preview",
-                rerank_model="gemini-3.1-flash-lite-preview",
+                planner_model="gemini-3.1-flash-lite",
+                rerank_model="gemini-3.1-flash-lite",
             ),
             query_plan=schema.QueryPlan(
                 intent="breaking_news",

--- a/tests/test_rerank_v3.py
+++ b/tests/test_rerank_v3.py
@@ -172,10 +172,10 @@ class RerankV3Tests(unittest.TestCase):
             plan=make_plan(),
             candidates=[first, second],
             provider=provider,
-            model="gemini-3.1-flash-lite-preview",
+            model="gemini-3.1-flash-lite",
             shortlist_size=1,
         )
-        self.assertEqual("gemini-3.1-flash-lite-preview", provider.model)
+        self.assertEqual("gemini-3.1-flash-lite", provider.model)
         self.assertEqual(95.0, first.rerank_score)
         self.assertEqual("high fit", first.explanation)
         # Tail is scored via the fallback (may or may not carry the entity-miss

--- a/tests/test_schema_v3.py
+++ b/tests/test_schema_v3.py
@@ -16,8 +16,8 @@ class SchemaV3Tests(unittest.TestCase):
             generated_at="2026-03-16T00:00:00+00:00",
             provider_runtime=schema.ProviderRuntime(
                 reasoning_provider="gemini",
-                planner_model="gemini-3.1-flash-lite-preview",
-                rerank_model="gemini-3.1-flash-lite-preview",
+                planner_model="gemini-3.1-flash-lite",
+                rerank_model="gemini-3.1-flash-lite",
             ),
             query_plan=schema.QueryPlan(
                 intent="breaking_news",


### PR DESCRIPTION
## Summary

- Google is discontinuing `gemini-3.1-flash-lite-preview` on **May 25, 2026** as it moves to GA.
- Per Google's announcement, the underlying model architecture is identical; only the model identifier needs to change from `gemini-3.1-flash-lite-preview` to `gemini-3.1-flash-lite`.
- Relaxes `_require_gemini_31_preview` to accept any `gemini-3.1-*` identifier (renamed to `_require_gemini_31`), keeping the still-preview `gemini-3.1-pro-preview` valid alongside the new GA name.

## Changes

- `skills/last30days/scripts/lib/providers.py`: `GEMINI_FLASH_LITE` constant points at the GA model; guard renamed and loosened.
- `skills/last30days/scripts/evaluate_search_quality.py`: `DEFAULT_JUDGE_MODEL` updated.
- `tests/test_*_v3.py`: fixture model strings refreshed to the GA name so they stay in sync with the constants.

## Testing

- [x] Ran `uv run python -m pytest tests/test_providers_v3.py tests/test_cli_v3.py tests/test_pipeline_v3.py tests/test_regression.py tests/test_render_v3.py tests/test_schema_v3.py tests/test_evaluator_v3.py tests/test_rerank_v3.py tests/test_save_raw_per_entity.py -q --tb=short` — all 153 tests pass.
- Note: the full suite has ~14 unrelated pre-existing failures on `main` (test_store, test_watchlist_commands, test_version_consistency, test_footer_nudge_suppression, test_setup_openclaw) that I did not touch. Happy to spin a separate PR for any of those if you'd like.
- [ ] `bash scripts/sync.sh` — not run; scripts/ unchanged.

## Related Issues

None.