### PR TITLE
chore: bump sync.sh cache path to 3.2.1

### DIFF
--- a/skills/last30days/scripts/sync.sh
+++ b/skills/last30days/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.0"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.1"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"


### PR DESCRIPTION
## Summary

- `pyproject.toml` is at `3.2.1` but `scripts/sync.sh` still references `last30days-3/3.2.0` in the plugin cache target.
- `test_sync_cache_path_uses_skill_version` derives the expected path from the pyproject version and asserts it appears in `sync.sh`, so it currently fails on `main` and on every open PR.

## Changes

- `skills/last30days/scripts/sync.sh`: bump the cache-path version literal `3.2.0` → `3.2.1` so it matches `pyproject.toml`.

## Testing

- [x] `uv run python -m pytest tests/test_plugin_contract.py tests/test_version_consistency.py -q --tb=short` — 8/8 pass on this branch (the same slice fails on `main` without this patch).
- [ ] `bash scripts/sync.sh` — not run; the script only writes to user-home directories on a developer machine.

## Notes

A more durable fix would derive the version dynamically from `pyproject.toml` inside `sync.sh` (e.g. `version=$(grep '^version' pyproject.toml | cut -d'\"' -f2)`) so this drift can't recur, but that's a bigger change. Happy to follow up if you'd prefer.

## Related Issues

Unblocks the `plugin-contract` CI check on PR #378 (and any other open PRs).