### PR TITLE
fix(youtube): use ?query= not ?keyword= for ScrapeCreators search endpoint

### DIFF
--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -886,7 +886,7 @@ def _sc_youtube_search(keyword: str, token: str) -> List[Dict[str, Any]]:
     if not _requests:
         try:
             from urllib.parse import urlencode
-            params = urlencode({"keyword": keyword})
+            params = urlencode({"query": keyword})
             url = f"{SCRAPECREATORS_YT_BASE}/search?{params}"
             headers = http.scrapecreators_headers(token)
             headers["User-Agent"] = http.USER_AGENT
@@ -899,7 +899,7 @@ def _sc_youtube_search(keyword: str, token: str) -> List[Dict[str, Any]]:
     try:
         resp = _requests.get(
             f"{SCRAPECREATORS_YT_BASE}/search",
-            params={"keyword": keyword},
+            params={"query": keyword},
             headers=http.scrapecreators_headers(token),
             timeout=30,
         )

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -407,5 +407,49 @@ class TestSearchAndTranscribe(unittest.TestCase):
         ft_mock.assert_not_called()
 
 
+class TestScrapeCreatorsYouTubeSearchParam(unittest.TestCase):
+    """The ScrapeCreators YouTube search endpoint requires ?query=, not ?keyword=."""
+
+    def test_sc_youtube_search_sends_query_param_requests_branch(self):
+        """The requests-branch call must send params={'query': ...}, not 'keyword'."""
+        captured = {}
+
+        class _FakeResp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"videos": []}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            captured["params"] = params
+            return _FakeResp()
+
+        fake_requests = mock.MagicMock()
+        fake_requests.get = fake_get
+
+        with mock.patch.object(youtube_yt, "_requests", fake_requests):
+            youtube_yt._sc_youtube_search("agent memory", token="dummy")
+
+        self.assertIn("query", captured["params"])
+        self.assertNotIn("keyword", captured["params"])
+        self.assertEqual(captured["params"]["query"], "agent memory")
+
+    def test_sc_youtube_search_sends_query_param_urllib_branch(self):
+        """The urllib fallback branch must also send query= (not keyword=) in the URL."""
+        captured = {}
+
+        def fake_http_get(url, headers=None, timeout=None, retries=None):
+            captured["url"] = url
+            return {"videos": []}
+
+        with mock.patch.object(youtube_yt, "_requests", None), \
+             mock.patch.object(youtube_yt.http, "get", side_effect=fake_http_get):
+            youtube_yt._sc_youtube_search("agent memory", token="dummy")
+
+        self.assertIn("query=", captured["url"])
+        self.assertNotIn("keyword=", captured["url"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The ScrapeCreators YouTube `/search` endpoint requires `?query=`, but `_sc_youtube_search()` in `scripts/lib/youtube_yt.py` sends `?keyword=`. Every call returns HTTP 400 deterministically:

```
{"error":"missing_parameter","message":"You must provide a query"}
```

The same typo is present in both the urllib fallback branch (line 889) and the `requests` happy path (line 902).

## Changes

- `skills/last30days/scripts/lib/youtube_yt.py` — flip both `{"keyword": keyword}` dict-key occurrences to `{"query": keyword}`. The internal function variable name `keyword` stays the same; only the outbound API parameter is renamed.
- `tests/test_youtube_yt.py` — add two regression tests (one per branch) asserting the outbound parameter key is `query`, not `keyword`.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short tests/test_youtube_yt.py tests/test_youtube_relevance.py` — 51/51 pass (49 existing + 2 new).
- [x] Manually verified the SC YouTube endpoint behavior: `?keyword=...` returns HTTP 400; `?query=...` returns the expected video list.

## Related Issues

None filed upstream yet — this PR is the fix. Surfaced during a community-signal pass where `/last30days` returned zero YouTube results deterministically across multiple research queries; a direct probe with `?query=` against the same endpoint returned rich data.