### PR TITLE
fix(openclaw): move SCRAPECREATORS_API_KEY to optionalEnv so the skill loads without it

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -13,9 +13,9 @@ metadata:
   openclaw:
     emoji: "📰"
     requires:
-      env:
-        - SCRAPECREATORS_API_KEY
+      env: []
       optionalEnv:
+        - SCRAPECREATORS_API_KEY
         - OPENAI_API_KEY
         - XAI_API_KEY
         - OPENROUTER_API_KEY


### PR DESCRIPTION
## What this fixes

Closes #385.

On OpenClaw the skill is filtered out of the menu entirely because `metadata.openclaw.requires.env` hard-requires `SCRAPECREATORS_API_KEY`. That gate is wrong for two concrete reasons.

1. The skill is documented as zero-config for five sources. The README and the skill description both state Reddit, Hacker News, Polymarket, GitHub, and web search work with no API keys. A hard `requires.env` gate contradicts that and hides the skill from users who could run it today with zero setup.
2. The key is never read from the gateway process environment. `scripts/lib/env.py` sources `SCRAPECREATORS_API_KEY` from the standard config path at load time (`env.py` line 216) and treats it as optional (`env.py` line 252, default `None`). The process-env gate is redundant on every host and actively blocking on OpenClaw.

Net effect today. A user installs the skill, places the key correctly in the documented config location, and the skill still never appears in the OpenClaw menu.

## The change

`SCRAPECREATORS_API_KEY` moves from `requires.env` to `optionalEnv` in `skills/last30days/SKILL.md`. One frontmatter block, two lines. `env` becomes an empty list because `SCRAPECREATORS_API_KEY` was its only entry.

```yaml
    requires:
-     env:
-       - SCRAPECREATORS_API_KEY
+     env: []
      optionalEnv:
+       - SCRAPECREATORS_API_KEY
        - OPENAI_API_KEY
```

`primaryEnv: SCRAPECREATORS_API_KEY` is intentionally left as is. It designates the key for setup and display, not menu gating, so it is out of scope for this fix.

## Why this is safe to merge

This changes a menu-visibility gate only. No runtime code path is touched. Behavior with the key set is identical. Behavior without it goes from "skill hidden" to "skill visible and runs its five zero-config sources", which is exactly what the skill description already promises. There is no host where requiring the key in process env did useful work, because the runtime resolves it from the config file regardless.

Suggested labels: `bug`
