### PR TITLE
fix(openclaw): make ScrapeCreators key optional

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -13,9 +13,9 @@ metadata:
   openclaw:
     emoji: "📰"
     requires:
-      env:
-        - SCRAPECREATORS_API_KEY
+      env: []
       optionalEnv:
+        - SCRAPECREATORS_API_KEY
         - OPENAI_API_KEY
         - XAI_API_KEY
         - OPENROUTER_API_KEY

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -64,6 +64,19 @@ class TestRunOpenclawSetup:
         assert result["keys"]["brave"] is True
         assert result["keys"]["scrapecreators"] is False
 
+    def test_openclaw_metadata_keeps_scrapecreators_optional(self):
+        """OpenClaw metadata should not hard-require the ScrapeCreators key."""
+        skill_md = Path(__file__).parent.parent / "skills" / "last30days" / "SKILL.md"
+        text = skill_md.read_text()
+        assert "SCRAPECREATORS_API_KEY" in text
+        expected = (
+            "requires:\n"
+            "      env: []\n"
+            "      optionalEnv:\n"
+            "        - SCRAPECREATORS_API_KEY"
+        )
+        assert expected in text
+
     @patch("shutil.which")
     def test_x_method_xai(self, mock_which):
         """x_method is 'xai' when XAI_API_KEY is set."""


### PR DESCRIPTION
## Summary

- move `SCRAPECREATORS_API_KEY` from OpenClaw `requires.env` to `optionalEnv`
- keep ScrapeCreators as the primary/optional key so TikTok/Instagram remain discoverable when configured
- add a metadata regression test so the skill does not become hidden behind a process-env gate again

Fixes #385.

## Tests

- `python3 -m pytest tests/test_setup_openclaw.py::TestRunOpenclawSetup tests/test_plugin_contract.py -q`
- `git diff --check`

Note: full `tests/test_setup_openclaw.py` currently has unrelated existing failures in device-auth polling tests where mocked `time.time()` side effects are exhausted.
