### PR TITLE
fix(sync): bump cache target to 3.2.1 to match SKILL.md

### DIFF
--- a/skills/last30days/scripts/sync.sh
+++ b/skills/last30days/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.0"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.1"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"


### PR DESCRIPTION
## Summary

- Bumps `last30days-3/3.2.0` to `last30days-3/3.2.1` in `skills/last30days/scripts/sync.sh` so the plugin cache target matches the SKILL.md frontmatter version that landed in #371.
- Fixes the pre-existing `plugin-contract` CI failure (`test_sync_cache_path_uses_skill_version`) that was blocking every PR (e.g. #393).

## Test plan

- [x] `uv run pytest tests/test_version_consistency.py` -> 4 passed