### PR TITLE
fix(bluesky): use api.bsky.app instead of public.api.bsky.app for search

### DIFF
--- a/skills/last30days/scripts/lib/bluesky.py
+++ b/skills/last30days/scripts/lib/bluesky.py
@@ -1,7 +1,12 @@
 """Bluesky search via AT Protocol (requires app password).
 
-Uses bsky.social for auth and public.api.bsky.app for post search.
+Uses bsky.social for auth and api.bsky.app for post search.
 Requires BSKY_HANDLE and BSKY_APP_PASSWORD env vars.
+
+Note on search host: api.bsky.app is the main AppView (what the official web
+client uses). public.api.bsky.app is a public CDN mirror that has stricter
+access policies — confirmed to block residential IPs that api.bsky.app accepts
+with the same bearer token. Use the main AppView to avoid spurious 403s.
 """
 
 import math
@@ -14,7 +19,7 @@ from typing import Any, Dict, List, Optional
 from . import http, log
 
 BSKY_SESSION_URL = "https://bsky.social/xrpc/com.atproto.server.createSession"
-BSKY_SEARCH_URL = "https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts"
+BSKY_SEARCH_URL = "https://api.bsky.app/xrpc/app.bsky.feed.searchPosts"
 
 DEPTH_CONFIG = {
     "quick": 15,


### PR DESCRIPTION
## Problem

The Bluesky source can fail silently with HTTP 403 on `searchPosts` from certain client IPs, even when the user has valid `BSKY_HANDLE` + `BSKY_APP_PASSWORD` and the session token is created successfully against `bsky.social`. The engine surfaces this as a generic `Bluesky search failed: HTTP 403: Forbidden` and the source returns 0 items.

## Root cause

`public.api.bsky.app` is a CDN mirror of the AppView with stricter access policies than the main `api.bsky.app` host (the one the official Bluesky web client uses). Some residential IPs are blocked from the mirror but accepted by the main host with the same bearer token.

The 403 response body is an HTML page (~2.3KB) with title "403 Forbidden" but no "cloudflare" string, so the engine's existing Cloudflare-detection regex at `bluesky.py:81` misses it and emits the generic error.

## Repro

Same machine, same app-password session token, same query string:

| Host | Result |
|---|---|
| `bsky.social/xrpc/app.bsky.feed.searchPosts` (PDS) | HTTP 200, posts returned |
| `api.bsky.app/xrpc/app.bsky.feed.searchPosts` (main AppView) | HTTP 200, posts returned |
| `public.api.bsky.app/xrpc/app.bsky.feed.searchPosts` (this mirror) | HTTP 403 |

```python
# Auth identical for all three:
headers = {"Authorization": f"Bearer {token}"}
```

Verified in a real Topics pipeline run after the patch: ad-hoc topic "Claude Code" went from 0 items (public.api) to 12 items (api.bsky.app) — auth + plumbing identical, host change only.

## Fix

One-line: `BSKY_SEARCH_URL = "https://api.bsky.app/xrpc/app.bsky.feed.searchPosts"`. Also updated the module docstring to point to the main AppView and added a note explaining the public-mirror divergence so future readers don't revert.

## Why this is safe

- `api.bsky.app` is what the official Bluesky web app uses for `searchPosts`, so it's the canonical authenticated path.
- Same bearer token authenticates against both hosts — no auth shape change.
- Response JSON shape is identical (`{ posts: [...] }` from the `app.bsky.feed.searchPosts` lexicon).
- Backwards compatible — anyone whose IP works on `public.api.bsky.app` will also work on `api.bsky.app`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>