### PR TITLE
fix(sync): point sync.sh at this repo's plugin cache, not the private repo's

### DIFF
--- a/skills/last30days/scripts/sync.sh
+++ b/skills/last30days/scripts/sync.sh
@@ -7,12 +7,15 @@ SRC="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Source: $SRC"
 
 COMMON_TARGETS=(
-  # Claude Code plugin cache: marketplace installs overwrite on update,
-  # but local development needs the cache kept in sync with the repo.
-  # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
-  # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.1"
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
+  # Claude Code plugin cache for this (public) repo's marketplace install.
+  # Marketplace name = last30days-skill (.claude-plugin/marketplace.json).
+  # Plugin name      = last30days       (.claude-plugin/plugin.json).
+  # Path shape       = .../cache/{marketplace-name}/{plugin-name}/{version}.
+  # Marketplace pulls overwrite this on update; local sync keeps it fresh
+  # against the working tree so /last30days reflects local dev without
+  # waiting for a release. Do NOT add ~/.claude/skills/last30days - it
+  # creates a duplicate slash-command entry alongside the plugin version.
+  "$HOME/.claude/plugins/cache/last30days-skill/last30days/3.2.1"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"
 )

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -24,7 +24,10 @@ class TestVersionConsistency(unittest.TestCase):
     def test_sync_cache_path_uses_skill_version(self) -> None:
         sync_text = (SKILL_ROOT / "scripts" / "sync.sh").read_text(encoding="utf-8")
         version = _skill_version()
-        self.assertIn(f'last30days-3/{version}"', sync_text)
+        self.assertIn(
+            f'last30days-skill/last30days/{version}"',
+            sync_text,
+        )
 
     def test_memory_save_dir_uses_single_env_variable(self) -> None:
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

`sync.sh` was writing to `~/.claude/plugins/cache/last30days-skill-private/last30days-3/{version}` — the path used by the **separate** `mvanhorn/last30days-skill-private` repo. Running it from this (public) repo populated the **beta** channel's cache (`/last30days-beta`) instead of this repo's own `/last30days` cache.

This meant devs working on this repo couldn't test local changes via the public slash command without waiting for a marketplace release. It also silently overwrote whatever the private repo had deployed to the beta cache.

Path now derives from this repo's own manifests:
- marketplace name `last30days-skill` (from `.claude-plugin/marketplace.json`)
- plugin name `last30days` (from `.claude-plugin/plugin.json`)
- → `.../cache/last30days-skill/last30days/{version}` (matches what Claude Code's marketplace install actually creates)

Also drops the `last30days-3-nogem/3.0.0-nogem` second target — that's a no-gem variant in the private repo with no public-repo equivalent; no reason for the public repo's sync to populate it.

## Why now

This was a latent bug introduced when `sync.sh` was first added in the "Restructure as Codex plugin" commit (`72495c1`, ~3 weeks ago). The file appears to have been authored against (or copy-pasted from) the private repo's workflow and the path never got updated when it landed in the public repo. Noticed during a code-review pass on PR #400.

## Test plan

- [x] `bash skills/last30days/scripts/sync.sh` — now reports `Syncing to ~/.claude/plugins/cache/last30days-skill/last30days/3.2.1`, no longer writes to `-private`
- [x] `uv run pytest tests/test_version_consistency.py tests/test_plugin_contract.py` — 8 passed
- [x] `ls ~/.claude/plugins/cache/last30days-skill/last30days/3.2.1/skills/last30days/SKILL.md` resolves correctly after sync
- [x] `/last30days` (Claude Code slash command) now loads the locally-synced version on the developer's machine, no marketplace round-trip needed

## Notes for reviewer

- `test_sync_cache_path_uses_skill_version` was updated to assert `last30days-skill/last30days/{version}` instead of `last30days-3/{version}`. The old pattern only happened to pass because the wrong path also contained `last30days-3` as the plugin-name segment.
- Followup if there's appetite: the private repo's `sync.sh` (in its own repo) could probably consolidate to the same path-derivation logic so it doesn't drift again.