### PR TITLE
chore: add greptile.json (triggerOnUpdates + statusCheck)

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,4 @@
+{
+  "triggerOnUpdates": true,
+  "statusCheck": true
+}


### PR DESCRIPTION
## Summary

Adds a 4-line `greptile.json` to make Greptile's behavior on this repo explicit and machine-checkable.

```json
{
  "triggerOnUpdates": true,
  "statusCheck": true
}
```

## Why now

Per Greptile's docs, the default is `triggerOnUpdates: false` — only the initial PR open triggers a review. Empirically Greptile has been re-reviewing on force-push to this repo anyway (probably via web-UI config or a default I can't see), but documenting the intent makes the behavior reliable across plan changes and any future config-source shifts on Greptile's side.

`statusCheck: true` is the higher-value field: it registers Greptile as a GitHub status check (not just a PR comment). That gives maintainer-tooling a machine-readable heartbeat — `GET /repos/.../commits/SHA/check-runs`, filter by app name, observe `queued → in_progress → completed`. Without it the only signal is "did a new Greptile comment appear since I pushed," which is silently ambiguous when Greptile re-reviews and finds nothing to flag.

If `statusCheck` is OSS-plan-restricted Greptile silently ignores the key — no harm, the rolling-summary comment with `Confidence Score: N/5` remains the fallback signal.

## Where this matters

Triage tooling that monitors `ready-for-maintainer`-labeled PRs needs to distinguish:

- **CLEAN** (Greptile re-reviewed and the score is 5/5, no unresolved P-flag threads)
- **FLAGGED** (Greptile re-reviewed and found issues)
- **PENDING** (Greptile is still running)
- **STALE** (Greptile didn't re-review at all; needs `@greptileai review`)

Without `statusCheck` the PENDING/STALE distinction is "wait 5 min and hope." With it the distinction is a single API call.

## Test plan

- [x] `git diff --check` clean
- [x] JSON parse check: `python3 -c 'import json; json.load(open("greptile.json"))'`
- [ ] On merge: confirm Greptile posts a status check on the next PR push (verifies `statusCheck` is honored on this plan; if not, the field is silently ignored and we can decide whether to drop it)