### PR TITLE
chore: sync release manifest versions

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.2.4"
+version = "3.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- update `gemini-extension.json` to match the v3.3.0 project/SKILL version
- update the root package entry in `uv.lock` to the same version

## Why
The v3.3.0 release tag and `pyproject.toml` report `3.3.0`, but the Gemini extension manifest and lockfile still reported `3.2.4`. That breaks the plugin contract version check.

## Test plan
- `uv run pytest tests/test_plugin_contract.py tests/test_version_consistency.py tests/test_skill_version.py`

Result: `17 passed`

