### PR TITLE
fix(youtube): surface SSH errors + route transcript fetch through SSH (follow-up to #376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LAST30DAYS_YOUTUBE_SSH_HOST` transcript routing** — yt-dlp transcript fetch now runs on the remote SSH host via a `mktemp + cat` shell pipeline that captures the .vtt to stdout. Previously the transcript path skipped yt-dlp entirely when SSH routing was on and fell back to direct HTTP, which is also IP-walled on datacenter VPS (verified: 0/6 transcript success on Hetzner). Follow-up to [#376](https://github.com/mvanhorn/last30days-skill/pull/376) — search routing landed there, transcript path was deferred.
+
+### Fixed
+
+- **SSH routing failures no longer present as "0 results"** — `search_youtube` now surfaces non-zero SSH exit codes (connection refused, auth rejected, yt-dlp missing on remote) as an explicit `error` field instead of swallowing them as a legitimate empty search. Addresses Greptile's P1 finding on [#376](https://github.com/mvanhorn/last30days-skill/pull/376). The error-surfacing branch is gated on `LAST30DAYS_YOUTUBE_SSH_HOST` being set so users on the local-yt-dlp path see no behavior change.
+
 ## [3.3.0] - 2026-05-17
 
 A week-long shipping cycle: ~75 PRs merged plus 7 community fixes salvaged through PR triage. Big themes: install story modernized for the multi-harness world (Claude Code, Codex, Cursor, Gemini CLI, Copilot, Windsurf, and 50+ Agent Skills hosts), new emit and source modes, and a substantial reliability sweep across Reddit, X, Windows, YouTube, and the planner.

--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -511,6 +511,81 @@ def _fetch_transcript_direct(
     return vtt_text
 
 
+def _fetch_transcript_ytdlp_via_ssh(video_id: str, ssh_host: str) -> Optional[str]:
+    """Fetch transcript via yt-dlp running on a remote SSH host.
+
+    The local-yt-dlp path writes the .vtt file to a temp dir on the
+    invoking machine; wrapping that command in ``ssh <host> "yt-dlp ..."``
+    would write the file to the *remote* filesystem where the local code
+    can't read it back. Instead this helper runs a small shell pipeline on
+    the remote host that:
+
+      1. Creates a remote tempdir (mktemp -d)
+      2. Runs yt-dlp into that tempdir, with the player extractor log
+         redirected to /dev/null (otherwise its ``[youtube] Solving JS
+         challenges`` chatter pollutes stdout and corrupts the VTT)
+      3. cats the resulting .vtt file to stdout
+      4. Cleans up the tempdir
+
+    The local side captures stdout (the VTT text), verifies it starts with
+    ``WEBVTT``, and returns it. This is one ssh round-trip per video, with
+    deterministic remote cleanup.
+
+    Why not just use ``-o -`` to stream stdout?  ``--write-auto-subs``
+    writes the captions to a file regardless of the ``-o`` template;
+    with ``-o -`` yt-dlp either writes a literal ``-.en.vtt`` file or
+    produces no output. The remote-mktemp + cat trick is the only
+    approach that actually returns VTT bytes via stdout.
+
+    Why not ``scp`` the file back?  Adds connection setup latency for
+    every transcript fetch (search routes 6-40 videos through this) and
+    requires a writable local temp_dir contract that the wrapper would
+    have to honor. Single ssh + cat is simpler and faster.
+
+    Args:
+        video_id: YouTube video ID
+        ssh_host: Remote SSH alias (already validated by _ytdlp_ssh_host)
+
+    Returns:
+        Raw VTT text, or None if no captions available or SSH failed.
+    """
+    # Defense-in-depth: validate the host even though the caller already did.
+    if not _SSH_HOST_ALIAS_RE.match(ssh_host):
+        return None
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    quoted_url = shlex.quote(url)
+    remote_script = (
+        "set -e; "
+        "TMPD=$(mktemp -d); "
+        "yt-dlp --ignore-config --no-cookies-from-browser "
+        "--write-auto-subs --sub-lang en --sub-format vtt "
+        "--skip-download --no-warnings "
+        f'-o "$TMPD/%(id)s" {quoted_url} >/dev/null 2>&1 || true; '
+        'VTT=$(ls "$TMPD"/*.vtt 2>/dev/null | head -1); '
+        '[ -n "$VTT" ] && cat "$VTT"; '
+        'rm -rf "$TMPD"'
+    )
+    cmd = ["ssh", "-o", "BatchMode=yes", "--", ssh_host, remote_script]
+    try:
+        result = subproc.run_with_timeout(cmd, timeout=45)
+    except subproc.SubprocTimeout:
+        _log(f"SSH yt-dlp transcript timed out for {video_id} via {ssh_host!r}")
+        return None
+    except FileNotFoundError:
+        _log("ssh executable not found; cannot route transcript fetch")
+        return None
+    out = result.stdout or ""
+    if not out.strip().startswith("WEBVTT"):
+        if result.returncode != 0 and result.stderr:
+            first_line = result.stderr.strip().splitlines()[0]
+            _log(
+                f"SSH yt-dlp transcript via {ssh_host!r} failed for "
+                f"{video_id} (rc={result.returncode}): {first_line}"
+            )
+        return None
+    return out
+
+
 def _fetch_transcript_ytdlp(video_id: str, temp_dir: str) -> Optional[str]:
     """Fetch transcript using yt-dlp (original implementation).
 
@@ -579,22 +654,23 @@ def fetch_transcript(
         Plaintext transcript string, or None if no captions available.
     """
     raw_vtt = None
-    # When SSH-routing is on, the yt-dlp transcript path would write a VTT
-    # file on the remote host that we can't easily read back. Skip it and
-    # use the HTTP transcript fallback (different YouTube endpoint, less
-    # bot-walled, works fine from datacenter IPs).
     ssh_host = _ytdlp_ssh_host()
-    use_ytdlp = is_ytdlp_installed() and not ssh_host
-    if use_ytdlp:
+    if ssh_host and is_ytdlp_installed():
+        # Route yt-dlp through the residential-IP host (same pattern as
+        # search). The remote-mktemp + cat helper captures the VTT to
+        # stdout so the local temp_dir contract is preserved without
+        # actually writing anything locally.
+        raw_vtt = _fetch_transcript_ytdlp_via_ssh(video_id, ssh_host)
+        if not raw_vtt:
+            _log(f"SSH yt-dlp transcript failed for {video_id}, trying direct HTTP fallback")
+            raw_vtt = _fetch_transcript_direct(video_id, status=status)
+    elif is_ytdlp_installed():
         raw_vtt = _fetch_transcript_ytdlp(video_id, temp_dir)
         if not raw_vtt:
             _log(f"yt-dlp transcript failed for {video_id}, trying direct HTTP fallback")
             raw_vtt = _fetch_transcript_direct(video_id, status=status)
     else:
-        if ssh_host:
-            _log("SSH-routing active, using direct HTTP transcript fetch")
-        else:
-            _log("yt-dlp not installed, using direct HTTP transcript fetch")
+        _log("yt-dlp not installed, using direct HTTP transcript fetch")
         raw_vtt = _fetch_transcript_direct(video_id, status=status)
 
     if not raw_vtt:

--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -542,6 +542,13 @@ def _fetch_transcript_ytdlp_via_ssh(video_id: str, ssh_host: str) -> Optional[st
     requires a writable local temp_dir contract that the wrapper would
     have to honor. Single ssh + cat is simpler and faster.
 
+    The remote script uses ``find`` rather than ``ls "$TMPD"/*.vtt | head``
+    because when no .vtt exists the ``ls`` glob exits 1; under ``pipefail``
+    (which can leak into non-interactive SSH from ``/etc/bash.bashrc`` on
+    hardened hosts) the pipeline trips ``set -e`` before the cleanup line
+    runs, orphaning the remote tempdir. ``find`` exits 0 on no matches,
+    keeping cleanup deterministic.
+
     Args:
         video_id: YouTube video ID
         ssh_host: Remote SSH alias (already validated by _ytdlp_ssh_host)
@@ -561,7 +568,13 @@ def _fetch_transcript_ytdlp_via_ssh(video_id: str, ssh_host: str) -> Optional[st
         "--write-auto-subs --sub-lang en --sub-format vtt "
         "--skip-download --no-warnings "
         f'-o "$TMPD/%(id)s" {quoted_url} >/dev/null 2>&1 || true; '
-        'VTT=$(ls "$TMPD"/*.vtt 2>/dev/null | head -1); '
+        # Use `find` not `ls`: when no .vtt exists, `ls` exits 1 and a
+        # remote shell with `pipefail` set (common on hardened systems
+        # via /etc/bash.bashrc or login-shell config that leaks into
+        # non-interactive SSH) will trip `set -e` and skip the rm
+        # cleanup, leaking the tempdir. `find` exits 0 even with no
+        # matches, so the pipeline is pipefail-safe.
+        'VTT=$(find "$TMPD" -maxdepth 1 -name "*.vtt" 2>/dev/null | head -1); '
         '[ -n "$VTT" ] && cat "$VTT"; '
         'rm -rf "$TMPD"'
     )

--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -292,6 +292,7 @@ def search_youtube(
         "--no-download",
     ]
     cmd = _wrap_ytdlp_cmd(cmd)
+    ssh_host = _ytdlp_ssh_host()
 
     try:
         result = subproc.run_with_timeout(cmd, timeout=120)
@@ -302,6 +303,26 @@ def search_youtube(
         return {"items": [], "error": "yt-dlp not found"}
 
     stdout = result.stdout
+    # When SSH-routing is on, surface SSH/transport failures explicitly.
+    # run_with_timeout doesn't raise on non-zero exit — it returns a
+    # SubprocResult with returncode and stderr populated. Without this
+    # branch a failed SSH (auth rejected, host unreachable, yt-dlp not
+    # installed on remote) presents as stdout=="" and gets logged as
+    # "0 results", which is indistinguishable from a legitimate empty
+    # search. The first stderr line of ssh failures is short and
+    # diagnostic (e.g. "ssh: connect to host macmini port 22: Connection
+    # refused"), so we surface it both in the log and the error field.
+    if ssh_host and result.returncode != 0 and not stdout.strip():
+        stderr_first = (result.stderr or "").strip().splitlines()
+        first_line = stderr_first[0] if stderr_first else "(no stderr)"
+        _log(
+            f"YouTube search via SSH host {ssh_host!r} failed "
+            f"(rc={result.returncode}): {first_line}"
+        )
+        return {
+            "items": [],
+            "error": f"SSH routing to {ssh_host!r} failed: {first_line}",
+        }
     if not stdout.strip():
         _log("YouTube search returned 0 results")
         return {"items": []}

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -536,6 +536,87 @@ class TestYtdlpSSHRouting(unittest.TestCase):
         self.assertIn("--ignore-config", cmd[5])
         self.assertIn("--no-cookies-from-browser", cmd[5])
 
+    def test_search_ssh_failure_surfaces_error_not_empty_results(self):
+        """SSH connection failures surface as an error, not silent '0 results'.
+
+        Regression test for the silent-failure bug flagged by Greptile on
+        PR #376: run_with_timeout doesn't raise on a non-zero exit, so a
+        failed SSH (connection refused, auth rejected, yt-dlp missing on
+        remote) yields stdout="" with stderr populated. Before this fix
+        the empty stdout branch swallowed it as a legitimate "0 results"
+        and discarded stderr entirely.
+        """
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        fake_result = SubprocResult(
+            returncode=255,
+            stdout="",
+            stderr="ssh: connect to host macmini port 22: Connection refused\n",
+        )
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt.search_youtube("test", "2026-02-01", "2026-03-01")
+        self.assertEqual(out["items"], [])
+        self.assertIn("error", out, "SSH failure must populate the error field")
+        self.assertIn("macmini", out["error"])
+        self.assertIn("Connection refused", out["error"])
+
+    def test_search_ssh_yt_dlp_missing_on_remote_surfaces_error(self):
+        """yt-dlp missing on the remote host (rc=127) surfaces as an error."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        fake_result = SubprocResult(
+            returncode=127,
+            stdout="",
+            stderr="bash: line 1: yt-dlp: command not found\n",
+        )
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt.search_youtube("test", "2026-02-01", "2026-03-01")
+        self.assertEqual(out["items"], [])
+        self.assertIn("error", out)
+        self.assertIn("macmini", out["error"])
+        self.assertIn("command not found", out["error"])
+
+    def test_search_ssh_success_with_empty_results_does_not_synthesize_error(self):
+        """A successful SSH call (rc=0) with empty output is still '0 results', not an error.
+
+        Distinguishes genuine empty search results (yt-dlp ran fine, found
+        nothing) from SSH/transport failures. Only the latter should populate
+        the error field.
+        """
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        fake_result = SubprocResult(returncode=0, stdout="", stderr="")
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt.search_youtube("test", "2026-02-01", "2026-03-01")
+        self.assertEqual(out["items"], [])
+        self.assertNotIn(
+            "error", out,
+            "rc=0 with empty stdout should NOT synthesize an SSH error",
+        )
+
+    def test_search_local_nonzero_does_not_synthesize_ssh_error(self):
+        """Without SSH routing, a non-zero exit + empty stdout stays as '0 results'.
+
+        The error-surfacing branch is gated on ssh_host being set. Local
+        yt-dlp non-zero exits keep the original "0 results" behavior to avoid
+        a behavior change for users not on SSH routing.
+        """
+        # No env var set in setUp
+        from lib.subproc import SubprocResult
+        fake_result = SubprocResult(
+            returncode=1,
+            stdout="",
+            stderr="some local yt-dlp warning\n",
+        )
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt.search_youtube("test", "2026-02-01", "2026-03-01")
+        self.assertEqual(out["items"], [])
+        self.assertNotIn("error", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -663,6 +663,16 @@ class TestTranscriptSSHRouting(unittest.TestCase):
         self.assertIn(">/dev/null 2>&1", remote_script)
         self.assertIn("cat", remote_script)
         self.assertIn("rm -rf", remote_script)
+        # Use `find` not `ls` — `ls "$TMPD"/*.vtt` exits 1 on no match,
+        # and on a remote shell with `pipefail` set that trips `set -e`
+        # before cleanup runs, leaking the tempdir. `find` exits 0 on
+        # no match. Regression guard for greptile review on PR #422.
+        self.assertIn("find ", remote_script)
+        self.assertNotIn(
+            'ls "$TMPD"', remote_script,
+            "Don't use `ls`/glob to detect VTT — exits 1 on no match and "
+            "leaks the tempdir under pipefail. Use `find` instead.",
+        )
         # The video URL must be shell-quoted to survive the remote shell.
         self.assertIn("'https://www.youtube.com/watch?v=vid1'", remote_script)
 

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -618,5 +618,165 @@ class TestYtdlpSSHRouting(unittest.TestCase):
         self.assertNotIn("error", out)
 
 
+class TestTranscriptSSHRouting(unittest.TestCase):
+    """LAST30DAYS_YOUTUBE_SSH_HOST routes yt-dlp transcript fetches through SSH.
+
+    Search routing landed in #376; this class covers the transcript path
+    using the remote-mktemp + cat helper. Without these tests, the
+    fetch_transcript dispatch would silently regress to HTTP fallback on
+    every refactor (which is the bug this PR fixes — HTTP fallback fails
+    on datacenter VPS where the entire bot-wall problem started).
+    """
+
+    def setUp(self):
+        self._saved_env = os.environ.pop("LAST30DAYS_YOUTUBE_SSH_HOST", None)
+
+    def tearDown(self):
+        os.environ.pop("LAST30DAYS_YOUTUBE_SSH_HOST", None)
+        if self._saved_env is not None:
+            os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = self._saved_env
+
+    def test_ssh_helper_invokes_remote_mktemp_pipeline(self):
+        """The SSH helper sends mktemp + yt-dlp + cat + cleanup to the remote host."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        fake_vtt = "WEBVTT\nKind: captions\nLanguage: en\n\n00:00:00.000 --> 00:00:02.000\nhi\n"
+        fake_result = SubprocResult(returncode=0, stdout=fake_vtt, stderr="")
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result) as run_mock:
+            out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid1", "macmini")
+        self.assertEqual(out, fake_vtt)
+        cmd = run_mock.call_args.args[0]
+        # ssh -o BatchMode=yes -- <host> <remote-script>
+        self.assertEqual(cmd[0], "ssh")
+        self.assertEqual(cmd[1], "-o")
+        self.assertEqual(cmd[2], "BatchMode=yes")
+        self.assertEqual(cmd[3], "--")
+        self.assertEqual(cmd[4], "macmini")
+        remote_script = cmd[5]
+        # The remote pipeline must do all of these:
+        self.assertIn("mktemp -d", remote_script)
+        self.assertIn("yt-dlp", remote_script)
+        self.assertIn("--write-auto-subs", remote_script)
+        # /dev/null redirect is non-negotiable — without it the yt-dlp
+        # extractor log lines corrupt the captured VTT.
+        self.assertIn(">/dev/null 2>&1", remote_script)
+        self.assertIn("cat", remote_script)
+        self.assertIn("rm -rf", remote_script)
+        # The video URL must be shell-quoted to survive the remote shell.
+        self.assertIn("'https://www.youtube.com/watch?v=vid1'", remote_script)
+
+    def test_ssh_helper_returns_none_when_stdout_not_webvtt(self):
+        """A successful SSH call with non-VTT stdout returns None (no captions)."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        # rc=0 but no VTT in stdout — captions just don't exist for this video
+        fake_result = SubprocResult(returncode=0, stdout="", stderr="")
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid2", "macmini")
+        self.assertIsNone(out)
+
+    def test_ssh_helper_returns_none_on_ssh_failure(self):
+        """SSH connection failures return None so the caller can fall back."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        from lib.subproc import SubprocResult
+        fake_result = SubprocResult(
+            returncode=255,
+            stdout="",
+            stderr="ssh: connect to host macmini port 22: Connection refused\n",
+        )
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               return_value=fake_result):
+            out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid3", "macmini")
+        self.assertIsNone(out)
+
+    def test_ssh_helper_rejects_invalid_host_alias_defense_in_depth(self):
+        """Even if a bad host slips past the caller, the helper rejects it."""
+        # Caller validates too, but defense-in-depth means the helper
+        # also matches against _SSH_HOST_ALIAS_RE before issuing ssh.
+        out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid4", "-oProxyCommand=evil")
+        self.assertIsNone(out)
+        out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid5", "host;rm -rf /")
+        self.assertIsNone(out)
+
+    def test_ssh_helper_handles_timeout(self):
+        """SubprocTimeout returns None, doesn't raise."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               side_effect=youtube_yt.subproc.SubprocTimeout("test")):
+            out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid6", "macmini")
+        self.assertIsNone(out)
+
+    def test_ssh_helper_handles_missing_ssh_executable(self):
+        """FileNotFoundError (ssh not on PATH) returns None, doesn't raise."""
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+                               side_effect=FileNotFoundError("ssh")):
+            out = youtube_yt._fetch_transcript_ytdlp_via_ssh("vid7", "macmini")
+        self.assertIsNone(out)
+
+    def test_fetch_transcript_uses_ssh_helper_when_routing_on(self):
+        """fetch_transcript dispatches to _fetch_transcript_ytdlp_via_ssh when SSH is on.
+
+        Before this PR, fetch_transcript fell back to HTTP when SSH routing
+        was on (with the comment "works fine from datacenter IPs"). That
+        was wrong on datacenter VPS — the HTTP transcript endpoint is also
+        IP-walled. This test verifies the dispatch now prefers the SSH path.
+        """
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        fake_vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nhello there friends\n"
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True), \
+             mock.patch.object(youtube_yt, "_fetch_transcript_ytdlp_via_ssh",
+                               return_value=fake_vtt) as ssh_mock, \
+             mock.patch.object(youtube_yt, "_fetch_transcript_ytdlp") as local_mock, \
+             mock.patch.object(youtube_yt, "_fetch_transcript_direct") as direct_mock:
+            result = youtube_yt.fetch_transcript("vidX", "/tmp/test")
+        ssh_mock.assert_called_once_with("vidX", "macmini")
+        local_mock.assert_not_called()
+        direct_mock.assert_not_called()
+        self.assertIn("hello there friends", result)
+
+    def test_fetch_transcript_falls_back_to_http_when_ssh_returns_none(self):
+        """If the SSH transcript fetch returns None, HTTP fallback still runs.
+
+        Belt and suspenders: even though SSH is the preferred path on
+        datacenter VPS, some videos won't have auto-captions or yt-dlp
+        will fail on them. The HTTP fallback is the last chance and
+        sometimes works (it's just unreliable enough that it can't be the
+        primary path when SSH routing is configured).
+        """
+        os.environ["LAST30DAYS_YOUTUBE_SSH_HOST"] = "macmini"
+        http_vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nhttp fallback content\n"
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True), \
+             mock.patch.object(youtube_yt, "_fetch_transcript_ytdlp_via_ssh",
+                               return_value=None) as ssh_mock, \
+             mock.patch.object(youtube_yt, "_fetch_transcript_direct",
+                               return_value=http_vtt) as direct_mock:
+            result = youtube_yt.fetch_transcript("vidY", "/tmp/test")
+        ssh_mock.assert_called_once()
+        direct_mock.assert_called_once()
+        self.assertIn("http fallback content", result)
+
+    def test_fetch_transcript_local_path_unchanged_when_ssh_unset(self):
+        """Without SSH routing, local yt-dlp + HTTP fallback path is unchanged.
+
+        Regression guard for users not on SSH routing — the new dispatch
+        branch must not perturb their behavior.
+        """
+        # No env var set in setUp
+        fake_vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nlocal yt-dlp output\n"
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True), \
+             mock.patch.object(youtube_yt, "_fetch_transcript_ytdlp_via_ssh") as ssh_mock, \
+             mock.patch.object(youtube_yt, "_fetch_transcript_ytdlp",
+                               return_value=fake_vtt) as local_mock, \
+             mock.patch.object(youtube_yt, "_fetch_transcript_direct") as direct_mock:
+            result = youtube_yt.fetch_transcript("vidZ", "/tmp/test")
+        ssh_mock.assert_not_called()
+        local_mock.assert_called_once_with("vidZ", "/tmp/test")
+        direct_mock.assert_not_called()
+        self.assertIn("local yt-dlp output", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -602,20 +602,34 @@ class TestYtdlpSSHRouting(unittest.TestCase):
 
         The error-surfacing branch is gated on ssh_host being set. Local
         yt-dlp non-zero exits keep the original "0 results" behavior to avoid
-        a behavior change for users not on SSH routing.
+        a behavior change for users not on SSH routing. The assertion is
+        narrow on purpose — we only want to confirm the new SSH-error
+        message isn't synthesized; the upstream "yt-dlp not installed"
+        early-return error (which fires on CI where yt-dlp is genuinely
+        absent) is unrelated and acceptable here.
         """
-        # No env var set in setUp
+        # No env var set in setUp; mock yt-dlp as installed locally so we
+        # actually reach the empty-stdout branch (CI runners don't have
+        # yt-dlp on PATH and would short-circuit before run_with_timeout).
         from lib.subproc import SubprocResult
         fake_result = SubprocResult(
             returncode=1,
             stdout="",
             stderr="some local yt-dlp warning\n",
         )
-        with mock.patch.object(youtube_yt.subproc, "run_with_timeout",
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed",
+                               return_value=True), \
+             mock.patch.object(youtube_yt.subproc, "run_with_timeout",
                                return_value=fake_result):
             out = youtube_yt.search_youtube("test", "2026-02-01", "2026-03-01")
         self.assertEqual(out["items"], [])
-        self.assertNotIn("error", out)
+        # The error-surfacing branch must NOT have fired — no SSH-related
+        # error string should appear in the output.
+        self.assertNotIn(
+            "SSH routing",
+            out.get("error", ""),
+            "Local non-zero exit should not synthesize an SSH-routing error",
+        )
 
 
 class TestTranscriptSSHRouting(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #376. Two related fixes for the `LAST30DAYS_YOUTUBE_SSH_HOST` SSH-routing path: addresses Greptile's P1 from the original review, and adds the missing transcript-path support so SSH routing actually fixes YouTube end-to-end on datacenter VPS.

Each fix is a separate commit so they can be cherry-picked individually.

---

## Commit 1 — `fix(youtube): surface SSH routing errors instead of swallowing as 0 results`

Greptile flagged this as P1 on #376 ("Confidence 4/5, safe to merge with the SSH error-propagation gap addressed") and it didn't make the merge.

**Problem.** `subproc.run_with_timeout` doesn't raise on a non-zero exit — it returns a `SubprocResult` with `returncode` and `stderr` populated. When SSH routing is on and the command fails (auth rejected, host unreachable, `yt-dlp` not found on remote, etc.), `result.stdout == ""` and the existing empty-stdout branch logs `"YouTube search returned 0 results"` and discards `result.stderr` entirely. SSH-routing failures are indistinguishable from a legitimate empty search.

**Fix.** Add a new branch gated on `(ssh_host AND result.returncode != 0 AND empty stdout)` that surfaces the first stderr line in both the log and the returned `error` field:

```python
{"items": [], "error": "SSH routing to 'macmini' failed: ssh: connect to host macmini port 22: Connection refused"}
```

The branch is intentionally **gated on `ssh_host` being set**, so users on the local-yt-dlp path see no behavior change. A successful SSH call (rc=0) with empty stdout still returns the existing "0 results" empty-items response without an error key, distinguishing a healthy empty search from a transport-layer failure.

**Tests added** (`TestYtdlpSSHRouting`, 4 new):
- `test_search_ssh_failure_surfaces_error_not_empty_results` — rc=255 + connection-refused stderr → error populated
- `test_search_ssh_yt_dlp_missing_on_remote_surfaces_error` — rc=127 + command-not-found → error populated
- `test_search_ssh_success_with_empty_results_does_not_synthesize_error` — rc=0 + empty stdout → no synthesized error
- `test_search_local_nonzero_does_not_synthesize_ssh_error` — non-zero exit without SSH routing → original behavior preserved

---

## Commit 2 — `feat(youtube): route yt-dlp transcript fetch through SSH`

#376 routed YouTube **search** through SSH but left **transcript** fetch on direct-HTTP fallback, with the comment *"different YouTube endpoint, less bot-walled, works fine from datacenter IPs."* That comment is wrong on Hetzner.

**Verified on a Hetzner VPS** with `LAST30DAYS_YOUTUBE_SSH_HOST=macmini`:

| | Before this PR | After this PR |
|---|---|---|
| Search | 8+ videos returned ✅ | 8+ videos returned ✅ |
| Transcripts | `Got transcripts for 0/6 videos (6 failed)` | `Got transcripts for 6/6 videos (0 failed)` |

Same engine version, same topic, same `LAST30DAYS_YOUTUBE_SSH_HOST` value. The HTTP transcript endpoint is also IP-walled on datacenter ASNs.

**Why the naive fix doesn't work.** Wrapping `_fetch_transcript_ytdlp` in `ssh <host> ...` writes the .vtt file to the *remote* filesystem where the local code can't read it back. The `yt-dlp -o -` stdout idea also fails — `--write-auto-subs` writes to a file regardless of the `-o` template (with `-o -` it either writes a literal `-.en.vtt` file or produces no output). I lost 30 minutes to that one and noted it in the docstring so future contributors don't.

**The pattern that works** is a small shell pipeline on the remote host:

```sh
set -e; TMPD=$(mktemp -d);
yt-dlp ... -o "$TMPD/%(id)s" <url> >/dev/null 2>&1 || true;
VTT=$(ls "$TMPD"/*.vtt 2>/dev/null | head -1);
[ -n "$VTT" ] && cat "$VTT";
rm -rf "$TMPD"
```

The local side captures stdout (the VTT bytes), verifies it starts with `WEBVTT`, and returns it. One ssh round-trip per video, deterministic remote cleanup. The `>/dev/null 2>&1` redirect on the yt-dlp call is non-negotiable — without it the player extractor logs (`[youtube] Solving JS challenges using deno`, etc.) pollute stdout and corrupt the captured VTT.

**Why not reuse `_wrap_ytdlp_cmd`?** The remote shell needs `mktemp + ls + cat + rm` orchestration around the yt-dlp invocation, not a single yt-dlp call. Keeping search and transcript paths in separate helpers avoids a shared abstraction that would have to know about all current and future remote-shell patterns.

**Why not `scp` the file back?** Adds connection setup latency for every transcript fetch (search routes 6-40 videos through this) and requires a writable local `temp_dir` contract that the wrapper would have to honor. Single ssh + cat is simpler and faster.

**Dispatch update.** `fetch_transcript` now prefers `_fetch_transcript_ytdlp_via_ssh` when `LAST30DAYS_YOUTUBE_SSH_HOST` is set, falling back to `_fetch_transcript_direct` (HTTP) only when the SSH helper returns None. Without SSH routing the local-yt-dlp + HTTP-fallback path is byte-identical to before this PR.

**Defense-in-depth.** The helper re-validates the host alias against `_SSH_HOST_ALIAS_RE` before issuing ssh, mirroring the search path's guardrail.

**Tests added** (`TestTranscriptSSHRouting`, 9 new):
- Remote shell pipeline construction (mktemp + yt-dlp + cat + cleanup + `>/dev/null 2>&1` redirect + shell-quoted URL)
- Non-VTT stdout returns None (no captions for this video)
- SSH connection failures return None so caller can fall back to HTTP
- Invalid host aliases (dash-prefix, shell metacharacters) rejected by the helper's own validator
- `SubprocTimeout` and `FileNotFoundError` return None, don't raise
- `fetch_transcript` dispatches to the SSH helper when routing is on
- HTTP fallback still runs when the SSH helper returns None
- Local path unchanged when SSH routing is off

---

## Test status

```
1564 passed, 4 skipped, 1 failed
```

The 1 failure (`test_versions_match_across_manifests`) is **pre-existing on `main`** — `gemini-extension.json` wasn't bumped to 3.3.0 in the release commit. Unrelated to this PR. Baselined on `main` before any changes.

`tests/test_youtube_yt.py` specifically: **57/57 passing** (44 prior + 4 P1 fix + 9 transcript SSH).

## CHANGELOG

Both entries added under `[Unreleased]` per Keep a Changelog format. PR description copy is also fine to use as the merged-commit description if you squash.
