### PR TITLE
fix: preserve requested sources in quick plans

### DIFF
--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -274,7 +274,15 @@ def _sanitize_plan(
         freshness_mode=freshness_mode,
         cluster_mode=cluster_mode,
         raw_topic=topic,
-        subqueries=_normalize_subquery_weights(_trim_subqueries_for_depth(subqueries, intent, depth, eligible_sources)),
+        subqueries=_normalize_subquery_weights(
+            _trim_subqueries_for_depth(
+                subqueries,
+                intent,
+                depth,
+                eligible_sources,
+                requested_sources=requested_sources,
+            )
+        ),
         source_weights=source_weights,
         notes=[str(note).strip() for note in raw.get("notes") or [] if str(note).strip()],
     )
@@ -307,6 +315,7 @@ def _trim_subqueries_for_depth(
     intent: str,
     depth: str,
     available_sources: list[str],
+    requested_sources: list[str] | None = None,
 ) -> list[schema.SubQuery]:
     # At non-quick depth, expand sources: use capability routing for intents
     # that define it, or all available sources otherwise. The LLM planner may
@@ -336,6 +345,15 @@ def _trim_subqueries_for_depth(
     for subquery in subqueries:
         if depth in {"quick", "default"}:
             preferred_sources = ranked_sources[:limit]
+            if requested_sources:
+                requested = [
+                    source
+                    for source in requested_sources
+                    if source in available_sources and source in subquery.sources
+                ]
+                for source in requested:
+                    if source not in preferred_sources:
+                        preferred_sources.append(source)
         else:
             preferred_sources = [source for source in ranked_sources if source in subquery.sources][:limit]
             if len(preferred_sources) < limit:
@@ -428,7 +446,13 @@ def _fallback_plan(
         cluster_mode=_default_cluster_mode(intent),
         raw_topic=topic,
         subqueries=_normalize_subquery_weights(
-            _trim_subqueries_for_depth(subqueries[:_max_subqueries(intent, topic)], intent, depth, list(source_weights))
+            _trim_subqueries_for_depth(
+                subqueries[:_max_subqueries(intent, topic)],
+                intent,
+                depth,
+                list(source_weights),
+                requested_sources=requested_sources,
+            )
         ),
         source_weights=_normalize_weights(source_weights),
         notes=[note],

--- a/tests/test_planner_v3.py
+++ b/tests/test_planner_v3.py
@@ -96,6 +96,30 @@ class PlannerV3Tests(unittest.TestCase):
         self.assertEqual(1, len(plan.subqueries))
         self.assertEqual(["reddit", "x"], plan.subqueries[0].sources)
 
+    def test_quick_mode_preserves_explicit_requested_sources(self):
+        raw = {
+            "intent": "product",
+            "freshness_mode": "balanced_recent",
+            "cluster_mode": "debate",
+            "subqueries": [
+                {
+                    "label": "primary",
+                    "search_query": "AI coding agents",
+                    "ranking_query": "What are people saying about AI coding agents?",
+                    "sources": ["reddit", "youtube", "grounding", "digg"],
+                    "weight": 1.0,
+                }
+            ],
+        }
+        plan = planner._sanitize_plan(
+            raw,
+            "AI coding agents",
+            ["reddit", "youtube", "grounding", "digg"],
+            ["reddit", "youtube", "grounding", "digg"],
+            "quick",
+        )
+        self.assertIn("digg", plan.subqueries[0].sources)
+
     def test_default_comparison_uses_all_capable_sources(self):
         plan = planner.plan_query(
             topic="codex vs claude code",

--- a/tests/test_planner_v3.py
+++ b/tests/test_planner_v3.py
@@ -120,6 +120,17 @@ class PlannerV3Tests(unittest.TestCase):
         )
         self.assertIn("digg", plan.subqueries[0].sources)
 
+    def test_quick_mode_preserves_explicit_requested_sources_in_fallback_plan(self):
+        plan = planner.plan_query(
+            topic="AI coding agents",
+            available_sources=["reddit", "youtube", "github"],
+            requested_sources=["reddit", "github"],
+            depth="quick",
+            provider=None,
+            model=None,
+        )
+        self.assertIn("github", plan.subqueries[0].sources)
+
     def test_default_comparison_uses_all_capable_sources(self):
         plan = planner.plan_query(
             topic="codex vs claude code",


### PR DESCRIPTION
## Summary
- preserve explicitly requested sources when quick-mode source trimming runs
- add a regression test covering `digg` in a quick external plan
- verifies a quick run with `--search reddit,digg,grounding` now includes Digg results

## Context
This is stacked on #421 because `main` currently has the v3.3 manifest/lockfile version mismatch, which makes the full test suite fail. Once #421 lands, this PR can be rebased/squashed down to only the quick-source change.

## Why
During dogfooding, `digg` was available and present in the external plan, but `--quick` trimmed the retrieval sources back to the default priority set and dropped Digg. That made `--quick --search reddit,digg,grounding` report `Digg: 0 clusters` even though `digg-pp-cli` worked.

Explicit `--search` choices should be respected. Quick mode can still use priority sources first, but it should not silently discard a source the caller explicitly asked for.

## Test plan
- `uv run pytest tests/test_planner_v3.py tests/test_digg.py`
  - Result: `66 passed, 4 skipped`
- `uv run pytest`
  - Result: `1553 passed, 4 skipped, 2 subtests passed`
- Dogfood smoke:
  - `uv run python skills/last30days/scripts/last30days.py "AI coding agents" --emit=json --quick --search reddit,digg,grounding --plan <plan>`
  - Result: `Reddit: 6 threads, Web: 5 results, Digg: 6 clusters`

