### PR TITLE
fix(hooks): SessionStart check-config.sh exits 1 when no last-run.json

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -109,7 +109,7 @@ if [[ -z "$SETUP_COMPLETE" && -z "$CONFIG_FILE" && -z "${OPENAI_API_KEY:-}" && -
 Reddit, Hacker News, and Polymarket work out of the box.
 The setup wizard can unlock X/Twitter, YouTube, and more.
 EOF
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then echo "$LAST_RUN_LINE"; fi
   exit 0
 fi
 
@@ -161,12 +161,12 @@ if [[ -n "$HAS_SCRAPECREATORS" ]]; then
   # Fully configured — compact ready message
   echo "/last30days: Ready — ${SOURCE_COUNT} sources active."
   echo "  Research any topic across social + market + web sources (last 30 days)."
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then echo "$LAST_RUN_LINE"; fi
 else
   # Setup done but missing ScrapeCreators — recommend it
   echo "/last30days: Ready — ${SOURCE_COUNT} sources active."
   echo "  Research any topic across social + market + web sources (last 30 days)."
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then echo "$LAST_RUN_LINE"; fi
   echo "  Tip: Add ScrapeCreators for Reddit comments + TikTok + Instagram."
   echo "  100 free credits, no credit card — scrapecreators.com"
   echo "  last30days has no affiliation with any API provider."


### PR DESCRIPTION
Fixes #424.

## Problem

`hooks/scripts/check-config.sh` exits **1** on every session start when `~/.config/last30days/last-run.json` is absent. Claude Code then shows `SessionStart:startup hook — Failed with non-blocking status code`. stdout is correct; only the exit code is wrong.

Root cause: under `set -euo pipefail`, the **last command** in the configured branches is

```bash
[[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
```

With no last-run file, `$LAST_RUN_LINE` is empty → `[[ -n "" ]]` is false → the `&&` list returns 1 → the script exits 1.

## Fix

Convert the three `[[ … ]] && echo` lines to explicit `if` blocks so the script always exits 0 (the hook is informational; the payload is on stdout).

## Verification

```
# configured, no last-run.json
echo '{...}' | SCRAPECREATORS_API_KEY=x bash hooks/scripts/check-config.sh; echo $?   # -> 0
# new user (no config)
bash hooks/scripts/check-config.sh; echo $?                                            # -> 0
```

`bash -n` clean. No behaviour change to printed output.