### PR TITLE
chore: clean Windows test runs and sync v3.3.0 manifest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,11 @@ uv.lock            export-ignore
 .clawhubignore  export-ignore
 .gitignore      export-ignore
 .gitattributes  export-ignore
+
+# Shell scripts must remain LF on every contributor's working tree.
+# Without this, git's `core.autocrlf=true` (Windows default) converts blobs
+# from LF on checkout, which makes bash reject lines like `set -o pipefail`
+# because the option name carries a trailing `\r`. Affects hooks invoked
+# via subprocess (e.g. tests/test_last_run_state.py) and any direct bash
+# invocation from a Windows process. LF preserves cross-platform correctness.
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -44,8 +44,8 @@ uv.lock            export-ignore
 .gitattributes  export-ignore
 
 # Shell scripts must remain LF on every contributor's working tree.
-# Without this, git's `core.autocrlf=true` (Windows default) converts blobs
-# from LF on checkout, which makes bash reject lines like `set -o pipefail`
+# Without this, git's `core.autocrlf=true` (a common Windows setting) converts
+# blobs from LF on checkout, which makes bash reject lines like `set -o pipefail`
 # because the option name carries a trailing `\r`. Affects hooks invoked
 # via subprocess (e.g. tests/test_last_run_state.py) and any direct bash
 # invocation from a Windows process. LF preserves cross-platform correctness.

--- a/skills/last30days/scripts/lib/skill_meta.py
+++ b/skills/last30days/scripts/lib/skill_meta.py
@@ -24,7 +24,7 @@ def read_skill_version(skill_md_path: Path) -> str | None:
     or unquoted YAML version scalars.
     """
     try:
-        text = skill_md_path.read_text()
+        text = skill_md_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
     match = _VERSION_RE.search(text)

--- a/tests/test_env_keychain.py
+++ b/tests/test_env_keychain.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -20,6 +21,15 @@ import pytest
 from lib import env
 
 SETUP_KEYCHAIN_SH = Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts" / "setup-keychain.sh"
+
+# Tests below exercise `_load_keychain`'s Darwin path (via `mock.patch("platform.system", return_value="Darwin")`),
+# which performs `import pwd` inside the function. `pwd` is a POSIX-only stdlib module and does not exist on Windows,
+# so these tests fail with ModuleNotFoundError when run on Windows even though the actual platform check is mocked.
+requires_pwd_module = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Mocked Darwin path triggers `import pwd`, which is POSIX-only stdlib",
+)
+
 
 # ---------------------------------------------------------------------------
 # _load_keychain unit tests
@@ -41,6 +51,7 @@ def _run_result(returncode: int, stdout: str = "") -> subprocess.CompletedProces
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
 
 
+@requires_pwd_module
 def test_load_keychain_loads_present_keys_skips_missing():
     def fake_run(cmd, **kwargs):
         service = cmd[cmd.index("-s") + 1]
@@ -58,6 +69,7 @@ def test_load_keychain_loads_present_keys_skips_missing():
     assert result == {"XAI_API_KEY": "xai-abc", "BRAVE_API_KEY": "brv-xyz"}
 
 
+@requires_pwd_module
 def test_load_keychain_strips_whitespace_and_newlines():
     with mock.patch("platform.system", return_value="Darwin"), \
          mock.patch("shutil.which", return_value="/usr/bin/security"), \
@@ -66,6 +78,7 @@ def test_load_keychain_strips_whitespace_and_newlines():
     assert result == {"FOO": "hello-key"}
 
 
+@requires_pwd_module
 def test_load_keychain_swallows_subprocess_errors():
     def fake_run(cmd, **kwargs):
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
@@ -76,6 +89,7 @@ def test_load_keychain_swallows_subprocess_errors():
         assert env._load_keychain(["XAI_API_KEY"]) == {}
 
 
+@requires_pwd_module
 def test_load_keychain_swallows_oserror():
     with mock.patch("platform.system", return_value="Darwin"), \
          mock.patch("shutil.which", return_value="/usr/bin/security"), \
@@ -83,6 +97,7 @@ def test_load_keychain_swallows_oserror():
         assert env._load_keychain(["XAI_API_KEY"]) == {}
 
 
+@requires_pwd_module
 def test_load_keychain_skips_empty_stdout():
     with mock.patch("platform.system", return_value="Darwin"), \
          mock.patch("shutil.which", return_value="/usr/bin/security"), \

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -140,13 +140,12 @@ class EvaluatorV3Tests(unittest.TestCase):
 
     def test_create_eval_env_and_run_last30days(self):
         with mock.patch.object(evaluator.envlib, "get_config", return_value={"OPENAI_API_KEY": "config-openai"}):
-            with mock.patch.dict("os.environ", {"PATH": "/bin", "GOOGLE_API_KEY": "env-google"}, clear=False):
-                # Clear any real OPENAI_API_KEY from env so the config mock's
-                # placeholder is observable. Without this, a developer with a
-                # real OPENAI_API_KEY in their .env sees the assertion fail
-                # against their actual key value - both a test failure and
-                # a secret leak via AssertionError diff output.
-                os.environ.pop("OPENAI_API_KEY", None)
+            # clear=True gives the test a hermetic env: only PATH and
+            # GOOGLE_API_KEY exist for the duration. Without it, any real
+            # API key in the developer's `.env` (OPENAI, ANTHROPIC, GEMINI,
+            # SCRAPECREATORS, etc.) leaks through `os.environ` and can
+            # surface in AssertionError diff output if expectations diverge.
+            with mock.patch.dict("os.environ", {"PATH": "/bin", "GOOGLE_API_KEY": "env-google"}, clear=True):
                 created = evaluator.create_eval_env()
         self.assertEqual("/bin", created["PATH"])
         self.assertEqual("env-google", created["GOOGLE_API_KEY"])

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -141,6 +141,12 @@ class EvaluatorV3Tests(unittest.TestCase):
     def test_create_eval_env_and_run_last30days(self):
         with mock.patch.object(evaluator.envlib, "get_config", return_value={"OPENAI_API_KEY": "config-openai"}):
             with mock.patch.dict("os.environ", {"PATH": "/bin", "GOOGLE_API_KEY": "env-google"}, clear=False):
+                # Clear any real OPENAI_API_KEY from env so the config mock's
+                # placeholder is observable. Without this, a developer with a
+                # real OPENAI_API_KEY in their .env sees the assertion fail
+                # against their actual key value - both a test failure and
+                # a secret leak via AssertionError diff output.
+                os.environ.pop("OPENAI_API_KEY", None)
                 created = evaluator.create_eval_env()
         self.assertEqual("/bin", created["PATH"])
         self.assertEqual("env-google", created["GOOGLE_API_KEY"])

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -62,7 +62,7 @@ class TestRunOpenclawSetup:
     def test_openclaw_metadata_keeps_scrapecreators_optional(self):
         """OpenClaw metadata should not hard-require the ScrapeCreators key."""
         skill_md = Path(__file__).parent.parent / "skills" / "last30days" / "SKILL.md"
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         assert "SCRAPECREATORS_API_KEY" in text
         expected = (
             "requires:\n"

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -4,6 +4,7 @@ Covers the process-group cleanup path, timeout behavior, success path,
 PID callback wiring, and environment inheritance.
 """
 
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -34,6 +35,10 @@ class TestRunWithTimeout(unittest.TestCase):
         )
         self.assertEqual(result.stderr.strip(), "err")
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "Tests POSIX process-group + sh-based shell timeout semantics not available on Windows",
+    )
     def test_timeout_raises_subproctimeout(self):
         with self.assertRaises(subproc.SubprocTimeout):
             subproc.run_with_timeout(
@@ -41,6 +46,10 @@ class TestRunWithTimeout(unittest.TestCase):
                 timeout=1,
             )
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "Tests POSIX process-group cleanup (sh `&` backgrounding + os.setsid) not available on Windows",
+    )
     def test_timeout_kills_process_group(self):
         """A slow child inside a shell should be killed when the group is signaled."""
         with self.assertRaises(subproc.SubprocTimeout):

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -62,7 +62,7 @@ class TestVersionConsistency(unittest.TestCase):
         offenders = []
 
         raw = subprocess.check_output(
-            ["git", "ls-files", "-z"], cwd=str(ROOT), text=True
+            ["git", "ls-files", "-z"], cwd=str(ROOT), text=True, encoding="utf-8"
         )
         tracked = [entry for entry in raw.split("\0") if entry]
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -45,16 +46,34 @@ class TestVersionConsistency(unittest.TestCase):
         self.assertIn('--save-dir="${LAST30DAYS_MEMORY_DIR}"', skill_text)
 
     def test_no_stray_hardcoded_memory_dir_paths(self) -> None:
+        # Scan only git-tracked files (`git ls-files`) so the test governs what
+        # ships to upstream, not what sits in a contributor's local working
+        # tree. Any untracked file is excluded (whether gitignored or never
+        # added), so user-local artifact directories (work/, print/, .venv/,
+        # .playwright-mcp/, etc.) are never in scope - no per-directory
+        # maintenance required.
+        #
+        # `-z` flag with NUL-delimited output keeps the scan safe against
+        # filenames containing newlines.
         allowed_suffixes = {".md", ".py", ".sh", ".txt", ".yml", ".yaml", ".json"}
-        skip_dirs = {".git", "assets", "fixtures", "docs"}
+        # Tracked directories whose content is intentionally exempt from the
+        # memory-dir-anchoring convention.
+        skip_dirs = {"assets", "fixtures", "docs"}
         offenders = []
 
-        for path in ROOT.rglob("*"):
-            if not path.is_file() or path.suffix not in allowed_suffixes:
+        raw = subprocess.check_output(
+            ["git", "ls-files", "-z"], cwd=str(ROOT), text=True
+        )
+        tracked = [entry for entry in raw.split("\0") if entry]
+
+        for rel_path in tracked:
+            rel = Path(rel_path)
+            path = ROOT / rel
+            if not path.is_file() or rel.suffix not in allowed_suffixes:
                 continue
-            if skip_dirs.intersection(path.relative_to(ROOT).parts):
+            if skip_dirs.intersection(rel.parts):
                 continue
-            if path.relative_to(ROOT) == Path("tests/test_version_consistency.py"):
+            if rel == Path("tests/test_version_consistency.py"):
                 continue
 
             try:
@@ -70,7 +89,7 @@ class TestVersionConsistency(unittest.TestCase):
                     and ("defaults to" in line or "${LAST30DAYS_MEMORY_DIR:-$HOME/Documents/Last30Days}" in line)
                 )
                 if not allowed_default:
-                    offenders.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
+                    offenders.append(f"{rel}:{line_number}: {line.strip()}")
 
         self.assertEqual([], offenders)
 


### PR DESCRIPTION
## Summary

Restores a clean pytest run on Windows by addressing 12 of 16 pre-existing failures. Includes a one-character version sync to `gemini-extension.json` that was missed during the v3.3.0 release prep.

## Test impact (Windows)

Before: 16 failures. After: 4 failures (deliberately out of scope, follow-up PR planned).

## What changed (6 atomic commits)

1. **`chore(tests): scan only git-tracked files in memory-dir audit`** ([78bb9e3](https://github.com/dzivkovi/last30days-skill/commit/78bb9e3)) replaces `ROOT.rglob` with `git ls-files -z` so the audit governs only files that ship to upstream. Untracked local directories (`work/`, `print/`, `.venv/`, etc.) no longer trip the test. `skip_dirs` shrinks to the tracked-content exemptions (`assets`, `fixtures`, `docs`).

2. **`chore(tests): platform-guard POSIX-only test paths on Windows`** ([166e4a1](https://github.com/dzivkovi/last30days-skill/commit/166e4a1)) adds `@pytest.mark.skipif(sys.platform == "win32", ...)` to 5 `_load_keychain` tests that mock the Darwin path and hit `import pwd` (POSIX-only stdlib). Same skip pattern on 2 `test_subproc` tests that exercise POSIX process-group cleanup and `sh`-based shell timeout semantics. POSIX platforms unaffected.

3. **`fix(tests): isolate OPENAI_API_KEY in test_create_eval_env_and_run_last30days`** ([883f2b3](https://github.com/dzivkovi/last30days-skill/commit/883f2b3)) pops `OPENAI_API_KEY` from `os.environ` inside the test so the placeholder from the `get_config` mock can be observed. Without isolation, a contributor with a real key in `.env` sees the assertion fail against their actual key value, both failing the test and leaking the secret via the `AssertionError` diff output. Observed in practice.

4. **`fix(skill_meta,tests): read SKILL.md with explicit utf-8 encoding`** ([fd08836](https://github.com/dzivkovi/last30days-skill/commit/fd08836)) upgrades two `Path.read_text()` calls to `encoding="utf-8"`. Python defaults to the platform locale on Windows (cp1252) which cannot decode `SKILL.md`'s non-ASCII characters.

5. **`fix(gitattributes): force LF for shell scripts to keep bash hooks portable`** ([60895a4](https://github.com/dzivkovi/last30days-skill/commit/60895a4)) adds `*.sh text eol=lf` so shell scripts stay LF in every contributor's working tree regardless of `core.autocrlf`. Some bash builds (notably the one Python's `subprocess.run` finds at `C:\Program Files\Git\usr\bin\bash.EXE` on Windows, and Ubuntu's `dash`) reject `set -o pipefail` when the option name carries a trailing `\r` from CRLF endings.

6. **`fix(release): bump gemini-extension.json version to 3.3.0`** ([49a455a](https://github.com/dzivkovi/last30days-skill/commit/49a455a)) aligns with `SKILL.md`, `pyproject.toml`, and `.claude-plugin/plugin.json`. The miss was masked on Windows by the cp1252 read failure in commit 4 and only surfaced on Linux where `SKILL.md` reads cleanly.

## A pattern worth noting

Earlier failures masked later ones. Commit 4 (encoding fix) unmasks the version mismatch in commit 6. Commit 5 (LF fix) unmasks an unrelated env-isolation bug in `test_last_run_state.py` (Git Bash on Windows does not propagate `LAST30DAYS_CONFIG_DIR` from `subprocess.run`'s `env=` argument). That env-isolation case is the follow-up PR candidate, not bundled here to keep this PR's review surface focused.

## Out of scope (follow-up PR)

The 4 remaining Windows failures share two roots:

- 3 in `test_footer_nudge_suppression.py`: subprocess returns `stdout=None` on Windows.
- 1 in `test_last_run_state.py`: env-isolation issue uncovered by commit 5.

Different shape from these 6 commits, easier to review on their own.

## Verification

Tested on Windows (primary platform). Linux CI runs on this branch as part of opening the PR. Each commit was authored individually so any commit can be reverted or cherry-picked without affecting the others.
