### PR TITLE
fix(hooks/check-config): exit 0 explicitly to stop SessionStart non-blocking error

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -171,3 +171,8 @@ else
   echo "  100 free credits, no credit card — scrapecreators.com"
   echo "  last30days has no affiliation with any API provider."
 fi
+
+# The branches above end with `[[ -n "$LAST_RUN_LINE" ]] && echo ...`. When
+# LAST_RUN_LINE is empty, that test returns 1 and is the script's last command,
+# leaking exit=1 to callers (e.g. SessionStart hook drivers) despite no error.
+exit 0


### PR DESCRIPTION
## Summary

- `hooks/scripts/check-config.sh` exits 1 on a normal "configured user" code path because its last command is `[[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"`. When `LAST_RUN_LINE` is empty (first session before any `/last30days` run has written `last-run.json`), the `[[ ]]` test returns 1, `&&` short-circuits, and bash uses that as the script's exit status.
- Output is correct ("Ready — N sources active"), so no user-visible problem — but SessionStart hook drivers log a non-blocking error every session start. Add a trailing `exit 0` to match the welcome branch's semantics.

## Reproduction

```
$ SCRAPECREATORS_API_KEY=fake AUTH_TOKEN=fake bash hooks/scripts/check-config.sh
/last30days: Ready — 6 sources active.
  Research any topic across social + market + web sources (last 30 days).
$ echo $?
1
```

With the patch: same stdout, `echo $?` → `0`.

## Test plan

- [x] Configured-user branch (`SCRAPECREATORS_API_KEY` set, no `last-run.json`): exits 0
- [x] Welcome branch (no env vars set): unchanged, exits 0
- [x] No stdout/stderr change in either branch
- [x] `shellcheck hooks/scripts/check-config.sh` (no new warnings introduced)