### PR TITLE
fix(digg): reject non-http xUrl to close stored-XSS in HTML report

### DIFF
--- a/skills/last30days/scripts/lib/digg.py
+++ b/skills/last30days/scripts/lib/digg.py
@@ -22,6 +22,7 @@ import json
 import shutil
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from . import log, subproc
 from .relevance import token_overlap_relevance
@@ -296,6 +297,20 @@ def parse_digg_response(
     return items
 
 
+def _is_safe_http_url(url: str) -> bool:
+    """True iff ``url`` parses with an http or https scheme.
+
+    Used to reject upstream-supplied post URLs whose scheme would be
+    dangerous in a rendered ``<a href>`` (``javascript:``, ``data:``,
+    ``file:``, ``vbscript:``, ``about:``).
+    """
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except ValueError:
+        return False
+    return scheme in ("http", "https")
+
+
 def _parse_post(raw_post: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Reduce a digg post payload into the small dict render uses.
 
@@ -314,7 +329,7 @@ def _parse_post(raw_post: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not username:
         return None
     x_url = str(raw_post.get("xUrl") or "").strip()
-    if not x_url:
+    if not x_url or not _is_safe_http_url(x_url):
         return None
     return {
         "username": username,

--- a/skills/last30days/scripts/lib/digg.py
+++ b/skills/last30days/scripts/lib/digg.py
@@ -329,7 +329,18 @@ def _parse_post(raw_post: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not username:
         return None
     x_url = str(raw_post.get("xUrl") or "").strip()
-    if not x_url or not _is_safe_http_url(x_url):
+    if not x_url:
+        return None
+    if not _is_safe_http_url(x_url):
+        # Security-class drop: an upstream-supplied URL with a dangerous
+        # scheme. Force tty_only=False so the rejection is visible in
+        # non-interactive runs (Claude Code), which is the actual attack
+        # surface — the default tty_only=True would suppress it there.
+        log.source_log(
+            "Digg",
+            f"dropped post with unsafe xUrl scheme: {x_url!r}",
+            tty_only=False,
+        )
         return None
     return {
         "username": username,

--- a/tests/test_digg.py
+++ b/tests/test_digg.py
@@ -206,6 +206,30 @@ def test_parse_post_drops_missing_body_or_handle_or_url():
     assert digg._parse_post({"author": {"username": "x"}, "body": "txt", "xUrl": ""}) is None
     assert digg._parse_post(None) is None  # type: ignore[arg-type]
 
+
+def test_parse_post_drops_non_http_scheme_xurl():
+    """Any non-http(s) scheme on xUrl yields no post.
+
+    A malicious Digg API response (or compromised upstream) could set xUrl to
+    javascript:, data:text/html;..., file:, vbscript:, etc. The HTML report
+    renders the xUrl into an <a href> attribute, so any non-web scheme is a
+    stored-XSS or local-file vector when the user clicks the attribution.
+    """
+    for bad_url in (
+        "javascript:alert(1)",
+        "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+        "vbscript:msgbox(1)",
+        "file:///etc/passwd",
+        "about:blank",
+    ):
+        out = digg._parse_post(_post(x_url=bad_url))
+        assert out is None, f"expected non-http xUrl to be dropped, got: {out}"
+
+    # http and https remain accepted.
+    assert digg._parse_post(_post(x_url="https://x.com/a/status/1")) is not None
+    assert digg._parse_post(_post(x_url="http://x.com/a/status/1")) is not None
+
+
 # === _run_cli / search_digg with stubbed subprocess ===
 
 

--- a/tests/test_digg.py
+++ b/tests/test_digg.py
@@ -230,6 +230,19 @@ def test_parse_post_drops_non_http_scheme_xurl():
     assert digg._parse_post(_post(x_url="http://x.com/a/status/1")) is not None
 
 
+def test_parse_post_logs_unsafe_xurl_rejection_even_in_non_tty(capsys):
+    """Security-class drops must be observable in non-interactive runs.
+
+    The default ``log.source_log`` path is TTY-gated; without forcing
+    ``tty_only=False`` the rejection is invisible in Claude Code runs,
+    which is exactly the attack surface. Guard against silent regression.
+    """
+    digg._parse_post(_post(x_url="javascript:alert(1)"))
+    err = capsys.readouterr().err
+    assert "[Digg] dropped post with unsafe xUrl scheme" in err
+    assert "javascript:alert(1)" in err
+
+
 # === _run_cli / search_digg with stubbed subprocess ===
 
 


### PR DESCRIPTION
## Summary

A malicious Digg API response can set `xUrl` to a `javascript:` or `data:text/html;...` URL. `_format_digg_quote` renders that into a markdown link, which the HTML report's `_inline_markdown` regex copies verbatim into `<a href="...">`. Clicking the Digg attribution in the saved `.html` then executes script in the `file://` origin.

## Reachability

1. `digg.py:_parse_post` accepts any non-empty `xUrl` string with no scheme validation.
2. `digg.enrich_source_items` is wired into `pipeline.py:550`, so any query that activates Digg can pull attacker-controlled URLs.
3. `render.py:_format_digg_quote` emits `[@handle]({xurl}) via Digg: ...`.
4. `html_render.py:_inline_markdown` runs `html.escape(text, quote=True)` first, but `html.escape` does NOT touch `:` or `;`, so `data:text/html;base64,<payload>` survives. The regex then substitutes the URL into `<a href="...">` raw.

I ran a `javascript:alert(1)` reproducer against `_parse_post` on main; the malicious URL flows through unimpeded. After the fix, all five dangerous schemes I tested (`javascript:`, `data:`, `vbscript:`, `file:`, `about:`) are rejected and the post is dropped.

## The fix

In `digg.py`, validate the scheme before accepting `xUrl`. If the scheme is not `http` or `https`, treat the post as if `xUrl` were missing and drop it. One private helper, one extra check.

Reject-at-source matches the existing "post requires a usable X URL" contract (the function already returns None for empty URLs). The HTML renderer's `_inline_markdown` regex accepts any scheme as a defense-in-depth concern, and I'm tracking that as a separate follow-up PR so this diff stays scoped.

## Test plan

- [x] New `test_parse_post_drops_non_http_scheme_xurl` fails on main, passes here. Covers `javascript:`, `data:`, `vbscript:`, `file:`, `about:`.
- [x] Existing happy-path test (`https://x.com/...`) still passes; bare strings without a scheme remain rejected.
- [x] `pytest tests/test_digg.py`: 29 passed, 4 skipped (no new skips).
- [x] Full suite: `pytest tests/ --ignore=tests/test_exa_search.py`: 1553 passed, 4 skipped.
- [x] No live smoke against `digg-pp-cli`: the binary is not on this box. Mock end-to-end run via `last30days.py ... --mock --quick` is clean.