### PR TITLE
refactor: route 4 stderr-bypass modules through log.source_log

### DIFF
--- a/skills/last30days/scripts/lib/competitors.py
+++ b/skills/last30days/scripts/lib/competitors.py
@@ -13,11 +13,10 @@ the caller's requested count.
 from __future__ import annotations
 
 import re
-import sys
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from . import dates, grounding
+from . import dates, grounding, log
 from .resolve import _has_backend
 
 # A "brand-shaped" token starts with uppercase OR is camelCase with an
@@ -62,7 +61,7 @@ _STOPWORD_TOKENS: frozenset[str] = frozenset(
 
 
 def _log(msg: str) -> None:
-    print(f"[Competitors] {msg}", file=sys.stderr)
+    log.source_log("Competitors", msg, tty_only=False)
 
 
 def _topic_tokens(topic: str) -> set[str]:

--- a/skills/last30days/scripts/lib/fanout.py
+++ b/skills/last30days/scripts/lib/fanout.py
@@ -13,11 +13,10 @@ config, depth, and overrides for each entity.
 
 from __future__ import annotations
 
-import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable
 
-from . import schema
+from . import log, schema
 
 # Sub-runs hit the same upstream APIs as the main topic. Cap parallelism so a
 # 6-way fan-out does not stampede a single backend's rate limit.
@@ -25,7 +24,7 @@ MAX_PARALLEL_SUBRUNS = 6
 
 
 def _log(msg: str) -> None:
-    print(f"[Fanout] {msg}", file=sys.stderr)
+    log.source_log("Fanout", msg, tty_only=False)
 
 
 def run_competitor_fanout(

--- a/skills/last30days/scripts/lib/resolve.py
+++ b/skills/last30days/scripts/lib/resolve.py
@@ -8,18 +8,17 @@ before the planner runs. This is the engine-side equivalent of SKILL.md Steps
 from __future__ import annotations
 
 import re
-import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Optional
 
-from . import categories, dates, grounding
+from . import categories, dates, grounding, log
 
 MAX_SUBS = 10
 
 
 def _log(msg: str) -> None:
-    print(f"[Resolve] {msg}", file=sys.stderr)
+    log.source_log("Resolve", msg, tty_only=False)
 
 
 def _merge_category_peers(topic: str, subreddits: list[str]) -> tuple[list[str], Optional[str]]:

--- a/skills/last30days/scripts/lib/xurl_x.py
+++ b/skills/last30days/scripts/lib/xurl_x.py
@@ -13,15 +13,14 @@ Priority: xAI API > Bird/GraphQL > xurl > web-only fallback
 import json
 import re
 import subprocess
-import sys
 from typing import Any, Dict, List, Optional
 
+from . import log
 from .relevance import token_overlap_relevance as _compute_relevance
 
 
 def _log(msg: str) -> None:
-    sys.stderr.write(f"[xurl] {msg}\n")
-    sys.stderr.flush()
+    log.source_log("xurl", msg, tty_only=False)
 
 
 # Depth configurations: number of results to request


### PR DESCRIPTION
## Summary

Four modules wrote directly to `sys.stderr` instead of routing through `log.source_log`: `competitors.py`, `fanout.py`, `resolve.py`, and `xurl_x.py`. Every other source adapter goes through `log.source_log`. This is the same finding from the review (SIMP-7 + ARCH-F6/SIMP-F9). One issue class across four modules, so one PR with the same one-line fix in each.

## What changed

For each module, replace:

```python
def _log(msg: str) -> None:
    print(f"[Name] {msg}", file=sys.stderr)
```

with:

```python
def _log(msg: str) -> None:
    log.source_log("Name", msg, tty_only=False)
```

Drop the now-unused `import sys`, add `log` to the relative imports.

`tty_only=False` matches the existing always-on adapters (`reddit`, `bird_x`, `youtube_yt`, `github`). The logs from these four modules are mostly error paths: web-search backend missing, sub-run crashed, classification failed. These should stay visible in non-interactive runs. If we later decide to TTY-gate them, flip the kwarg.

## Test plan

- [x] No behavior change in interactive mode: prefix and message text identical.
- [x] `sys.*` references in all four modules dropped to zero (verified by grep).
- [x] Full suite: `pytest tests/ --ignore=tests/test_exa_search.py`: 1552 passed, 4 skipped.
- [x] Mock smoke with competitors mode: `last30days.py "claude code" --emit=compact --mock --quick --competitors-list "openai,anthropic"` still emits `[Competitors] Comparing: ...` to stderr as expected.