### PR TITLE
fix(openclaw): Make ScrapeCreators key optional

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -13,9 +13,9 @@ metadata:
   openclaw:
     emoji: "📰"
     requires:
-      env:
-        - SCRAPECREATORS_API_KEY
+      env: []
       optionalEnv:
+        - SCRAPECREATORS_API_KEY
         - OPENAI_API_KEY
         - XAI_API_KEY
         - OPENROUTER_API_KEY

--- a/skills/last30days/scripts/sync.sh
+++ b/skills/last30days/scripts/sync.sh
@@ -11,7 +11,7 @@ COMMON_TARGETS=(
   # but local development needs the cache kept in sync with the repo.
   # Do NOT add ~/.claude/skills/last30days - it creates a duplicate
   # /last30days-3 in the slash command menu alongside the plugin version.
-  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.0"
+  "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3/3.2.1"
   "$HOME/.claude/plugins/cache/last30days-skill-private/last30days-3-nogem/3.0.0-nogem"
   "$HOME/.agents/skills/last30days"
   "$HOME/.codex/skills/last30days"

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -64,6 +64,19 @@ class TestRunOpenclawSetup:
         assert result["keys"]["brave"] is True
         assert result["keys"]["scrapecreators"] is False
 
+    def test_openclaw_metadata_keeps_scrapecreators_optional(self):
+        """OpenClaw metadata should not hard-require the ScrapeCreators key."""
+        skill_md = Path(__file__).parent.parent / "skills" / "last30days" / "SKILL.md"
+        text = skill_md.read_text()
+        assert "SCRAPECREATORS_API_KEY" in text
+        expected = (
+            "requires:\n"
+            "      env: []\n"
+            "      optionalEnv:\n"
+            "        - SCRAPECREATORS_API_KEY"
+        )
+        assert expected in text
+
     @patch("shutil.which")
     def test_x_method_xai(self, mock_which):
         """x_method is 'xai' when XAI_API_KEY is set."""


### PR DESCRIPTION
## Summary

- move `SCRAPECREATORS_API_KEY` from required OpenClaw metadata env vars to `optionalEnv`
- keep the existing runtime setup behavior where a missing ScrapeCreators key is reported as absent but does not block setup
- add a regression test so the OpenClaw metadata keeps ScrapeCreators optional

## Verification

- `python3 -m pytest tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_openclaw_metadata_keeps_scrapecreators_optional tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_keys_detected tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_all_tools_present_no_keys -q`
- `git diff --check`

Note: the full `python3 -m pytest tests/test_setup_openclaw.py -q` currently has unrelated existing `time.time` mock exhaustion failures in three `TestPollDeviceAuth` tests, so I used the focused metadata/setup coverage above for this change.
