### PR TITLE
tests: centralize script path setup in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "skills" / "last30days" / "scripts"))

--- a/tests/test_adversarial_v3.py
+++ b/tests/test_adversarial_v3.py
@@ -5,11 +5,7 @@ comparisons, 'difference between X and Y' phrasing, trailing context
 leaking into entities, degenerate inputs, and false-positive resistance.
 """
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import planner
 
@@ -192,7 +188,6 @@ class TestNoiseWordEntities(unittest.TestCase):
     def test_go_not_stripped(self):
         entities = planner._comparison_entities("Swift vs Rust vs Go")
         self.assertTrue(any("Go" in e for e in entities))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -2,15 +2,11 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import textwrap
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
-
 from lib.bird_x import parse_bird_response
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VENDORED_BIRD = REPO_ROOT / "skills" / "last30days" / "scripts" / "lib" / "vendor" / "bird-search" / "bird-search.mjs"
@@ -30,7 +26,6 @@ class TestBirdXEngagementZero(unittest.TestCase):
         items = parse_bird_response(tweets, "test query")
         self.assertEqual(0, items[0]["engagement"]["likes"])
         self.assertEqual(5, items[0]["engagement"]["reposts"])
-
 
 @unittest.skipUnless(shutil.which("node"), "node is required for vendored Bird tests")
 class TestVendoredBirdRuntime(unittest.TestCase):
@@ -304,7 +299,6 @@ class TestRunBirdSearchJsonDecodeRetry(unittest.TestCase):
 
         self.assertEqual(response, timeout_error)
         mock_sleep.assert_not_called()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -1,12 +1,9 @@
 """Tests for bluesky module."""
 
 import os
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 from lib import bluesky
 
 
@@ -356,7 +353,6 @@ class TestAppPasswordFormat(unittest.TestCase):
     def test_rejects_list(self):
         # Defensive: don't crash on iterables
         self.assertFalse(bluesky._validate_app_password_format(["wfwp", "cq7o", "5six", "7wy5"]))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_briefing_v3.py
+++ b/tests/test_briefing_v3.py
@@ -1,10 +1,7 @@
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 import briefing
 import store
@@ -51,7 +48,6 @@ class BriefingV3Tests(unittest.TestCase):
                 self.assertEqual("utf-8", kwargs["encoding"])
             finally:
                 briefing.BRIEFS_DIR = old_briefs_dir
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -7,11 +7,7 @@ where prompting techniques actually live.
 """
 
 import re
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import categories
 from lib.categories import CATEGORY_PEERS, detect_category, peer_subs_for
@@ -148,7 +144,6 @@ class CategoryMapInvariants(unittest.TestCase):
         # Sanity check: the map is intentionally small and curated.
         self.assertGreaterEqual(len(CATEGORY_PEERS), 8)
         self.assertLessEqual(len(CATEGORY_PEERS), 20)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_category_integration.py
+++ b/tests/test_category_integration.py
@@ -13,16 +13,11 @@ Fixture reference: `tests/fixtures/prompting-gpt-image-2-resolved-block.md`.
 """
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
-
 from lib import resolve
-
 
 OPENAI_BRAND_SUBREDDIT_RESULTS = [
     {
@@ -139,7 +134,6 @@ class PromptingGptImage2RegressionGuard(unittest.TestCase):
         self.assertEqual(result["subreddits"], ["Kanye"])
         self.assertIsNone(result["category"])
         self.assertNotIn("Matched category=", buf.getvalue())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -1,19 +1,15 @@
 """Tests for Chrome cookie extraction on macOS."""
 
 import hashlib
-import os
 import sqlite3
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days"))
-
-from scripts.lib.chrome_cookies import (
+from lib.chrome_cookies import (
     CHROME_COOKIES_DB,
     CHROME_IV_HEX,
     CHROME_KEY_LENGTH,
@@ -26,7 +22,6 @@ from scripts.lib.chrome_cookies import (
     _decrypt_v10_value,
     extract_chrome_cookies_macos,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers — create real encrypted cookie values using known key + system openssl
@@ -112,10 +107,10 @@ def _create_chrome_cookies_db(path: str, cookies: list[tuple], db_version: int =
     conn.commit()
     conn.close()
 
-
 # ---------------------------------------------------------------------------
 # PKCS7 padding tests
 # ---------------------------------------------------------------------------
+
 
 class TestPkcs7Padding:
     def test_valid_padding_1(self):
@@ -143,10 +138,10 @@ class TestPkcs7Padding:
     def test_empty_data(self):
         assert _remove_pkcs7_padding(b"") is None
 
-
 # ---------------------------------------------------------------------------
 # Key derivation test
 # ---------------------------------------------------------------------------
+
 
 class TestKeyDerivation:
     def test_derive_aes_key_deterministic(self):
@@ -160,10 +155,10 @@ class TestKeyDerivation:
         key2 = _derive_aes_key(b"passphrase_b")
         assert key1 != key2
 
-
 # ---------------------------------------------------------------------------
 # Decryption test (real openssl, known key)
 # ---------------------------------------------------------------------------
+
 
 class TestDecryption:
     def test_decrypt_v10_roundtrip(self):
@@ -197,28 +192,28 @@ class TestDecryption:
         """v10 prefix with no ciphertext should return None."""
         assert _decrypt_v10_value(b"v10", KNOWN_AES_KEY, db_version=20) is None
 
-
 # ---------------------------------------------------------------------------
 # Chrome not installed → returns None
 # ---------------------------------------------------------------------------
 
+
 class TestChromeNotInstalled:
     def test_db_not_found(self):
         with mock.patch(
-            "scripts.lib.chrome_cookies.CHROME_COOKIES_DB",
+            "lib.chrome_cookies.CHROME_COOKIES_DB",
             Path("/nonexistent/path/Cookies"),
         ):
             result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
             assert result is None
 
-
 # ---------------------------------------------------------------------------
 # Keychain access denied → returns None
 # ---------------------------------------------------------------------------
 
+
 class TestKeychainDenied:
     def test_security_command_fails(self):
-        with mock.patch("scripts.lib.chrome_cookies.subprocess.run") as mock_run:
+        with mock.patch("lib.chrome_cookies.subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[], returncode=44, stdout="", stderr="security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain."
             )
@@ -226,26 +221,26 @@ class TestKeychainDenied:
             assert result is None
 
     def test_security_command_not_found(self):
-        with mock.patch("scripts.lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
+        with mock.patch("lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
             result = _get_chrome_encryption_key()
             assert result is None
-
 
 # ---------------------------------------------------------------------------
 # openssl not found → returns None
 # ---------------------------------------------------------------------------
 
+
 class TestOpensslNotFound:
     def test_openssl_missing(self):
         encrypted = _encrypt_value_v10("test", KNOWN_AES_KEY)
-        with mock.patch("scripts.lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
+        with mock.patch("lib.chrome_cookies.subprocess.run", side_effect=FileNotFoundError):
             result = _decrypt_v10_value(encrypted, KNOWN_AES_KEY, db_version=20)
             assert result is None
-
 
 # ---------------------------------------------------------------------------
 # Unencrypted cookie values → returned as-is
 # ---------------------------------------------------------------------------
+
 
 class TestUnencryptedCookies:
     def test_plain_value_returned(self, tmp_path):
@@ -256,17 +251,17 @@ class TestUnencryptedCookies:
             (".x.com", "ct0", "plain_ct0_value", b""),
         ])
 
-        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+        with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
             # No keychain needed for unencrypted values
-            with mock.patch("scripts.lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+            with mock.patch("lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
 
         assert result == {"auth_token": "plain_token_value", "ct0": "plain_ct0_value"}
 
-
 # ---------------------------------------------------------------------------
 # Full integration: mock DB with real v10 encryption, mock Keychain
 # ---------------------------------------------------------------------------
+
 
 class TestFullExtraction:
     def test_encrypted_cookies_extracted(self, tmp_path):
@@ -284,9 +279,9 @@ class TestFullExtraction:
             (".other.com", "other", "", b""),  # unrelated cookie
         ])
 
-        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+        with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
             with mock.patch(
-                "scripts.lib.chrome_cookies._get_chromium_encryption_key",
+                "lib.chrome_cookies._get_chromium_encryption_key",
                 return_value=KNOWN_PASSPHRASE,
             ):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
@@ -301,8 +296,8 @@ class TestFullExtraction:
             (".other.com", "session", "val", b""),
         ])
 
-        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
-            with mock.patch("scripts.lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+        with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+            with mock.patch("lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
 
         assert result is None
@@ -317,9 +312,9 @@ class TestFullExtraction:
             (".x.com", "auth_token", "", encrypted_auth),
         ], db_version=24)
 
-        with mock.patch("scripts.lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
+        with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
             with mock.patch(
-                "scripts.lib.chrome_cookies._get_chromium_encryption_key",
+                "lib.chrome_cookies._get_chromium_encryption_key",
                 return_value=KNOWN_PASSPHRASE,
             ):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
@@ -327,10 +322,10 @@ class TestFullExtraction:
         assert result is not None
         assert result["auth_token"] == auth_val
 
-
 # ---------------------------------------------------------------------------
 # DB version detection
 # ---------------------------------------------------------------------------
+
 
 class TestDbVersion:
     def test_reads_version_from_meta(self, tmp_path):

--- a/tests/test_cli_competitors.py
+++ b/tests/test_cli_competitors.py
@@ -1,16 +1,10 @@
-# ruff: noqa: E402
 """CLI parsing and validation for --competitors / --competitors-list."""
 
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 import last30days as cli
 
@@ -131,7 +125,6 @@ class CompetitorsCliTests(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
             cli.resolve_competitors_args(args)
         self.assertEqual(cm.exception.code, 2)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 import json
 import io
 import shutil
@@ -11,12 +10,10 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
-
 import last30days as cli
 from lib import schema
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class CliV3Tests(unittest.TestCase):
@@ -304,7 +301,6 @@ class CliV3Tests(unittest.TestCase):
             f"saw {[c.kwargs.get('github_repos') for c in run_mock.call_args_list]}",
         )
         self.assertIn("[GitHub] Canonicalized repos:", stderr.getvalue())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cluster_v3.py
+++ b/tests/test_cluster_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import cluster, schema
 
@@ -195,7 +191,6 @@ class TestClusterUncertainty(unittest.TestCase):
         ]
         result = cluster._cluster_uncertainty(candidates)
         self.assertEqual("thin-evidence", result)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_competitor_fanout.py
+++ b/tests/test_competitor_fanout.py
@@ -1,19 +1,13 @@
-# ruff: noqa: E402
 """Tests for scripts/lib/fanout.run_competitor_fanout."""
 
 from __future__ import annotations
 
 import io
-import sys
 import threading
 import time
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest import mock
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 from lib import fanout
 
@@ -154,7 +148,6 @@ class FanoutOrchestratorTests(unittest.TestCase):
                 competitor_runner=comp_runner,
             )
         self.assertEqual([label for label, _ in results], ["OpenAI"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_competitor_subrun_isolation.py
+++ b/tests/test_competitor_subrun_isolation.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Regression tests: main-topic flags must not leak into competitor sub-runs.
 
 Based on 2026-04-22 Kanye West --competitors receipt where Drake and
@@ -10,14 +9,9 @@ via closure capture, config mutation, or any other path.
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest import mock
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 
 def _fake_report(topic: str):
@@ -190,7 +184,6 @@ class SubRunIsolationTests(unittest.TestCase):
             "ICEMAN",
             by_topic["Kendrick Lamar"]["config"].get("_auto_resolve_context", ""),
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -1,17 +1,11 @@
-# ruff: noqa: E402
 """Tests for scripts/lib/competitors.discover_competitors."""
 
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest import mock
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 from lib import competitors
 
@@ -22,7 +16,6 @@ def _serp(items: list[tuple[str, str]]) -> list[dict]:
         {"title": title, "snippet": snippet, "url": "https://example.test/"}
         for title, snippet in items
     ]
-
 
 OPENAI_SERP = _serp(
     [
@@ -146,7 +139,6 @@ class CompetitorDiscoveryTests(unittest.TestCase):
     def test_count_zero_returns_empty(self):
         results = self._run(OPENAI_SERP, "OpenAI", count=0)
         self.assertEqual(results, [])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_competitors_plan_threading.py
+++ b/tests/test_competitors_plan_threading.py
@@ -1,19 +1,14 @@
-# ruff: noqa: E402
 """Tests for --competitors-plan JSON parsing and per-entity kwargs threading."""
 
 from __future__ import annotations
 
 import io
 import json
-import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 from unittest import mock
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 import last30days as cli
 
@@ -174,7 +169,6 @@ class SubrunKwargsForTests(unittest.TestCase):
 
         kwargs = cli.subrun_kwargs_for("X", {}, resolved=resolved)
         self.assertEqual(kwargs["_context"], "Resolved context")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_competitors_resolve_integration.py
+++ b/tests/test_competitors_resolve_integration.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Integration tests for per-entity Step 0.55 resolution inside competitor fan-out."""
 
 from __future__ import annotations
@@ -7,11 +6,7 @@ import io
 import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest import mock
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 
 def _fake_report(topic: str):
@@ -325,7 +320,6 @@ class PerEntityResolveTests(unittest.TestCase):
             return report
 
         return [runner(c) for c in competitors]
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -2,23 +2,18 @@
 
 import configparser
 import sqlite3
-import sys
 import textwrap
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days"))
-
-from scripts.lib.cookie_extract import (
+from lib.cookie_extract import (
     extract_cookies,
     extract_firefox_cookies,
     _find_default_profile,
     _get_firefox_profiles_dir,
 )
-
 
 @pytest.fixture
 def mock_firefox_env(tmp_path):
@@ -102,7 +97,7 @@ class TestExtractFirefoxCookies:
         profiles_dir = mock_firefox_env()
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
@@ -142,7 +137,7 @@ class TestExtractFirefoxCookies:
         )
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
@@ -154,10 +149,10 @@ class TestExtractFirefoxCookies:
     def test_firefox_not_installed(self):
         """Returns None when Firefox profiles directory doesn't exist."""
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=None,
         ), patch(
-            "scripts.lib.cookie_extract._is_wsl",
+            "lib.cookie_extract._is_wsl",
             return_value=False,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token"])
@@ -171,10 +166,10 @@ class TestExtractFirefoxCookies:
         )
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ), patch(
-            "scripts.lib.cookie_extract._is_wsl",
+            "lib.cookie_extract._is_wsl",
             return_value=False,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
@@ -192,10 +187,10 @@ class TestExtractFirefoxCookies:
         )
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ), patch(
-            "scripts.lib.cookie_extract._is_wsl",
+            "lib.cookie_extract._is_wsl",
             return_value=False,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
@@ -214,7 +209,7 @@ class TestExtractFirefoxCookies:
         )
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ):
             result = extract_firefox_cookies(".x.com", ["auth_token"])
@@ -231,17 +226,17 @@ class TestExtractCookiesAuto:
         profiles_dir = mock_firefox_env()
 
         with (
-            patch("scripts.lib.cookie_extract.platform.system", return_value="Darwin"),
+            patch("lib.cookie_extract.platform.system", return_value="Darwin"),
             patch(
-                "scripts.lib.cookie_extract.extract_chrome_cookies",
+                "lib.cookie_extract.extract_chrome_cookies",
                 return_value=None,
             ),
             patch(
-                "scripts.lib.cookie_extract.extract_safari_cookies",
+                "lib.cookie_extract.extract_safari_cookies",
                 return_value=None,
             ),
             patch(
-                "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+                "lib.cookie_extract._get_firefox_profiles_dir",
                 return_value=profiles_dir,
             ),
         ):
@@ -257,9 +252,9 @@ class TestExtractCookiesAuto:
         profiles_dir = mock_firefox_env()
 
         with (
-            patch("scripts.lib.cookie_extract.platform.system", return_value="Linux"),
+            patch("lib.cookie_extract.platform.system", return_value="Linux"),
             patch(
-                "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+                "lib.cookie_extract._get_firefox_profiles_dir",
                 return_value=profiles_dir,
             ),
         ):
@@ -273,7 +268,7 @@ class TestExtractCookiesAuto:
         profiles_dir = mock_firefox_env()
 
         with patch(
-            "scripts.lib.cookie_extract._get_firefox_profiles_dir",
+            "lib.cookie_extract._get_firefox_profiles_dir",
             return_value=profiles_dir,
         ):
             result = extract_cookies("firefox", ".x.com", ["auth_token"])
@@ -289,7 +284,7 @@ class TestExtractCookiesAuto:
     def test_chrome_delegates_to_chrome_module(self):
         """Chrome extraction delegates to chrome_cookies module."""
         with patch(
-            "scripts.lib.cookie_extract.extract_chrome_cookies",
+            "lib.cookie_extract.extract_chrome_cookies",
             return_value={"auth_token": "chrome_tok"},
         ):
             result = extract_cookies("chrome", ".x.com", ["auth_token"])
@@ -298,7 +293,7 @@ class TestExtractCookiesAuto:
     def test_safari_delegates_to_safari_module(self):
         """Safari extraction delegates to safari_cookies module."""
         with patch(
-            "scripts.lib.cookie_extract.extract_safari_cookies",
+            "lib.cookie_extract.extract_safari_cookies",
             return_value={"auth_token": "safari_tok"},
         ):
             result = extract_cookies("safari", ".x.com", ["auth_token"])

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,12 +1,9 @@
 """Tests for dates module."""
 
-import sys
 import unittest
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import dates
 
@@ -108,7 +105,6 @@ class TestRecencyScore(unittest.TestCase):
     def test_none_date_is_0(self):
         result = dates.recency_score(None)
         self.assertEqual(result, 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dates_v3.py
+++ b/tests/test_dates_v3.py
@@ -1,9 +1,5 @@
-import sys
 import unittest
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import dates
 
@@ -57,7 +53,6 @@ class DatesV3Tests(unittest.TestCase):
         self.assertEqual(0, dates.recency_score(old))
         self.assertEqual(100, dates.recency_score(future))
         self.assertEqual(0, dates.recency_score(None))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dedupe_v3.py
+++ b/tests/test_dedupe_v3.py
@@ -1,10 +1,6 @@
 """Unit tests for dedupe.py: text normalization, similarity metrics, and deduplication."""
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import dedupe
 from lib.schema import SourceItem
@@ -16,10 +12,10 @@ def _item(title: str, body: str = "", source: str = "reddit", item_id: str = "t1
         url="https://example.com", engagement={}, metadata={},
     )
 
-
 # ---------------------------------------------------------------------------
 # normalize_text
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeText(unittest.TestCase):
 
@@ -35,10 +31,10 @@ class TestNormalizeText(unittest.TestCase):
     def test_empty_string(self):
         self.assertEqual(dedupe.normalize_text(""), "")
 
-
 # ---------------------------------------------------------------------------
 # get_ngrams
 # ---------------------------------------------------------------------------
+
 
 class TestGetNgrams(unittest.TestCase):
 
@@ -58,10 +54,10 @@ class TestGetNgrams(unittest.TestCase):
         ngrams = dedupe.get_ngrams("A!B")
         self.assertEqual(ngrams, {"a b"})
 
-
 # ---------------------------------------------------------------------------
 # jaccard_similarity
 # ---------------------------------------------------------------------------
+
 
 class TestJaccardSimilarity(unittest.TestCase):
 
@@ -81,10 +77,10 @@ class TestJaccardSimilarity(unittest.TestCase):
     def test_both_empty(self):
         self.assertAlmostEqual(dedupe.jaccard_similarity(set(), set()), 0.0)
 
-
 # ---------------------------------------------------------------------------
 # token_jaccard
 # ---------------------------------------------------------------------------
+
 
 class TestTokenJaccard(unittest.TestCase):
 
@@ -105,10 +101,10 @@ class TestTokenJaccard(unittest.TestCase):
         # "am" is len 2, "great"/"terrible" are content
         self.assertGreater(result, 0.0)
 
-
 # ---------------------------------------------------------------------------
 # hybrid_similarity
 # ---------------------------------------------------------------------------
+
 
 class TestHybridSimilarity(unittest.TestCase):
 
@@ -131,10 +127,10 @@ class TestHybridSimilarity(unittest.TestCase):
             max(ngram_sim, token_sim),
         )
 
-
 # ---------------------------------------------------------------------------
 # item_text
 # ---------------------------------------------------------------------------
+
 
 class TestItemText(unittest.TestCase):
 
@@ -159,10 +155,10 @@ class TestItemText(unittest.TestCase):
         self.assertIn("john", text)
         self.assertIn("r/python", text)
 
-
 # ---------------------------------------------------------------------------
 # dedupe_items
 # ---------------------------------------------------------------------------
+
 
 class TestDedupeItems(unittest.TestCase):
 
@@ -211,7 +207,6 @@ class TestDedupeItems(unittest.TestCase):
         # With threshold=0.3, these similar items collapse
         result_loose = dedupe.dedupe_items(items, threshold=0.3)
         self.assertEqual(len(result_loose), 1)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_digg.py
+++ b/tests/test_digg.py
@@ -5,20 +5,16 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
-from lib import digg  # noqa: E402
-from lib import subproc  # noqa: E402
-
+from lib import digg
+from lib import subproc
 
 # === Helpers ===
+
 
 def _cluster(
     cluster_url_id: str = "abc123xy",
@@ -66,8 +62,8 @@ def _post(
 def _stdout_for(payload: dict) -> subproc.SubprocResult:
     return subproc.SubprocResult(returncode=0, stdout=json.dumps(payload), stderr="")
 
-
 # === _parse_first_post_age ===
+
 
 def test_parse_first_post_age_days():
     today = datetime(2026, 5, 9, tzinfo=timezone.utc)
@@ -104,8 +100,8 @@ def test_parse_first_post_age_invalid():
     assert digg._parse_first_post_age("d") is None
     assert digg._parse_first_post_age("-3d") is None
 
-
 # === parse_digg_response ===
+
 
 def test_parse_response_happy_path():
     response = {
@@ -193,8 +189,8 @@ def test_parse_response_engagement_rank_score():
     assert by_id["top"]["engagement"]["rank_score"] == 50.0
     assert by_id["off-leaderboard"]["engagement"]["rank_score"] == 0.0
 
-
 # === _parse_post ===
+
 
 def test_parse_post_happy():
     out = digg._parse_post(_post(username="adam", body="Hello world"))
@@ -210,8 +206,8 @@ def test_parse_post_drops_missing_body_or_handle_or_url():
     assert digg._parse_post({"author": {"username": "x"}, "body": "txt", "xUrl": ""}) is None
     assert digg._parse_post(None) is None  # type: ignore[arg-type]
 
-
 # === _run_cli / search_digg with stubbed subprocess ===
+
 
 def test_search_digg_binary_missing_returns_empty(monkeypatch):
     monkeypatch.setattr(digg.shutil, "which", lambda _: None)
@@ -280,8 +276,8 @@ def test_search_digg_empty_query_short_circuits(monkeypatch):
     assert out["results"] == []
     called.assert_not_called()
 
-
 # === enrich_with_top_posts ===
+
 
 def test_enrich_with_top_posts_attaches_posts(monkeypatch):
     monkeypatch.setattr(digg.shutil, "which", lambda _: "/fake/path")
@@ -357,8 +353,8 @@ def test_enrich_top_k_zero_skips_all(monkeypatch):
     digg.enrich_with_top_posts(items, top_k=0)
     fake.assert_not_called()
 
-
 # === enrich_source_items (post-dedupe path) ===
+
 
 class _FakeSourceItem:
     def __init__(self, source, item_id, engagement, metadata):
@@ -410,14 +406,14 @@ def test_enrich_source_items_falls_back_to_item_id(monkeypatch):
     digg.enrich_source_items(items, top_k=1)
     assert captured["cluster_id"] == "fallbackid"
 
-
 # === Live tests (opt-in) ===
 
 LIVE = os.environ.get("LAST30DAYS_DIGG_LIVE", "").lower() in ("1", "true", "yes")
 HAVE_BIN = shutil.which(digg.CLI_BIN) is not None
 
-
 @pytest.mark.skipif(not (LIVE and HAVE_BIN), reason="LAST30DAYS_DIGG_LIVE not set or digg-pp-cli missing")
+
+
 class TestLiveDigg:
     def test_search_returns_clusters(self):
         out = digg.search_digg("claude code", "2026-04-09", "2026-05-09", depth="quick")
@@ -450,7 +446,6 @@ class TestLiveDigg:
     def test_missing_cluster_id_graceful(self):
         posts = digg.fetch_top_posts("notarealclusterid", posts_per=2)
         assert posts == []
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_entity_extract.py
+++ b/tests/test_entity_extract.py
@@ -1,11 +1,8 @@
 """Tests for entity_extract module."""
 
-import sys
 import unittest
-from pathlib import Path
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import entity_extract
 
@@ -161,7 +158,6 @@ class TestExtractEntities(unittest.TestCase):
     def test_return_keys(self):
         result = entity_extract.extract_entities([], [])
         self.assertSetEqual(set(result.keys()), {"x_handles", "x_hashtags", "reddit_subreddits"})
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_entity_extract_v3.py
+++ b/tests/test_entity_extract_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import entity_extract
 
@@ -52,7 +48,6 @@ class TestExtractSubreddits(unittest.TestCase):
 
     def test_empty_items(self):
         self.assertEqual([], entity_extract._extract_subreddits([]))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_env_cookies.py
+++ b/tests/test_env_cookies.py
@@ -1,13 +1,9 @@
 """Tests for browser cookie extraction integration in env.py."""
 
 import os
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.env import extract_browser_credentials, COOKIE_DOMAINS
 

--- a/tests/test_env_include_sources_default.py
+++ b/tests/test_env_include_sources_default.py
@@ -1,9 +1,4 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days"))
-
-from scripts.lib import env
+from lib import env
 
 
 def test_include_sources_defaults_to_empty_string(monkeypatch, tmp_path):

--- a/tests/test_env_keychain.py
+++ b/tests/test_env_keychain.py
@@ -12,18 +12,14 @@ from __future__ import annotations
 
 import re
 import subprocess
-import sys
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
-
-from lib import env  # noqa: E402
+from lib import env
 
 SETUP_KEYCHAIN_SH = Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts" / "setup-keychain.sh"
-
 
 # ---------------------------------------------------------------------------
 # _load_keychain unit tests
@@ -93,11 +89,9 @@ def test_load_keychain_skips_empty_stdout():
          mock.patch("subprocess.run", return_value=_run_result(0, "")):
         assert env._load_keychain(["XAI_API_KEY"]) == {}
 
-
 # ---------------------------------------------------------------------------
 # get_config integration tests
 # ---------------------------------------------------------------------------
-
 
 @pytest.fixture
 def clean_env(monkeypatch, tmp_path):
@@ -153,7 +147,6 @@ def test_get_config_openai_key_can_come_from_keychain(clean_env):
         cfg = env.get_config()
     assert cfg["OPENAI_API_KEY"] == "sk-from-kc"
     assert cfg["OPENAI_AUTH_SOURCE"] == "api_key"
-
 
 # ---------------------------------------------------------------------------
 # Drift guard: lib/env.py KEYCHAIN_KEYS and setup-keychain.sh ALL_KEYS must

--- a/tests/test_env_v3.py
+++ b/tests/test_env_v3.py
@@ -1,10 +1,7 @@
 import os
-import sys
 import unittest
 from pathlib import Path
 from unittest import mock
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import bird_x, env
 
@@ -68,7 +65,6 @@ class ThreadsAvailabilityTests(unittest.TestCase):
             "SCRAPECREATORS_API_KEY": "k",
             "INCLUDE_SOURCES": "",
         }))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -1,12 +1,9 @@
 import json
 import os
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 import evaluate_search_quality as evaluator
 
@@ -201,7 +198,6 @@ class EvaluatorV3Tests(unittest.TestCase):
             metrics = json.loads((tmp_path / "metrics.json").read_text())
             self.assertIn("| topic a | 0.10 | 0.30 |", summary)
             self.assertEqual("HEAD~1", metrics["baseline"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_footer_nudge_suppression.py
+++ b/tests/test_footer_nudge_suppression.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Tests for the BRAVE/SERPER web-promo suppression when hosting-model-driven."""
 
 from __future__ import annotations
@@ -11,7 +10,6 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 
 def _engine() -> Path:
@@ -89,7 +87,6 @@ class FooterNudgeSuppressionTests(unittest.TestCase):
             combined,
             msg="web promo should be suppressed when --plan is passed",
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fusion_v3.py
+++ b/tests/test_fusion_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import fusion, schema
 
@@ -51,7 +47,6 @@ class FusionV3Tests(unittest.TestCase):
         self.assertEqual(2, len(merged.native_ranks))
         self.assertEqual({"reddit", "x"}, set(merged.sources))
         self.assertEqual(2, len(merged.source_items))
-
 
     def test_diversify_pool_guarantees_min_per_qualifying_source(self):
         """Every qualifying source (local_relevance >= 0.25) gets at least 2
@@ -117,7 +112,6 @@ class FusionV3Tests(unittest.TestCase):
                 2,
                 f"Source '{src}' has {source_counts.get(src, 0)} items, expected >= 2",
             )
-
 
     def test_diversify_pool_denies_slots_for_low_relevance_source(self):
         """Sources with best local_relevance < 0.25 do not get reserved slots.
@@ -438,7 +432,6 @@ class TestUrlNormalization(unittest.TestCase):
             _normalize_url("https://Reddit.com/r/Test"),
             _normalize_url("https://reddit.com/r/test"),
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,12 +1,9 @@
 """Tests for GitHub source module."""
 
 import json
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 from lib import github
 
 
@@ -157,7 +154,6 @@ class TestComputeRelevance(unittest.TestCase):
         high = github._compute_relevance("react", "React", 0, 0, 0)
         low = github._compute_relevance("react", "React", 20, 0, 0)
         self.assertGreater(high, low)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_grounding_v3.py
+++ b/tests/test_grounding_v3.py
@@ -1,9 +1,5 @@
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import grounding
 
@@ -337,7 +333,6 @@ class RedditEnrichItemsTests(unittest.TestCase):
             any("rate-limited" in msg.lower() or "rate limited" in msg.lower() for msg in captured_stderr),
             msg=f"Expected a rate-limit stderr message, got: {captured_stderr!r}",
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hackernews.py
+++ b/tests/test_hackernews.py
@@ -1,19 +1,15 @@
 """Tests for hackernews.py - HN search via Algolia API."""
 
 import json
-import sys
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
 from lib import hackernews
 
-
 # === Helper Functions ===
+
 
 def create_mock_hit(
     object_id="12345",
@@ -40,8 +36,8 @@ def create_mock_hit(
         "url": url,
     }
 
-
 # === Tests for _date_to_unix() ===
+
 
 def test_date_to_unix_basic():
     """Test converting YYYY-MM-DD to Unix timestamp."""
@@ -59,8 +55,8 @@ def test_date_to_unix_leap_day():
     expected = datetime(2024, 2, 29, tzinfo=timezone.utc).timestamp()
     assert result == int(expected)
 
-
 # === Tests for _unix_to_date() ===
+
 
 def test_unix_to_date_basic():
     """Test converting Unix timestamp to YYYY-MM-DD."""
@@ -77,8 +73,8 @@ def test_unix_to_date_with_time():
     
     assert result == "2026-01-15"
 
-
 # === Tests for _strip_html() ===
+
 
 def test_strip_html_basic():
     """Test HTML stripping and entity decoding."""
@@ -113,8 +109,8 @@ def test_strip_html_entities():
     # Entities are decoded
     assert "&" in result or "test" in result
 
-
 # === Tests for _title_matches_query() ===
+
 
 def test_title_matches_query_basic():
     """Test basic query matching."""
@@ -199,10 +195,11 @@ def test_title_matches_query_flattens_hyphens_and_commas():
     # query 'rust, go, zig' flattens; title contains 'go'
     assert hackernews._title_matches_query("Go 1.24 generics update", "rust, go, zig") is True
 
-
 # === Tests for search_hackernews() ===
 
 @patch('lib.hackernews.http.request')
+
+
 def test_search_hackernews_basic(mock_request):
     """Test basic HN search."""
     mock_request.return_value = {
@@ -221,8 +218,9 @@ def test_search_hackernews_basic(mock_request):
     assert len(result["hits"]) == 1
     assert mock_request.called
 
-
 @patch('lib.hackernews.http.request')
+
+
 def test_search_hackernews_depth_config(mock_request):
     """Test that depth parameter controls hit count."""
     mock_request.return_value = {"hits": [], "nbHits": 0}
@@ -235,8 +233,9 @@ def test_search_hackernews_depth_config(mock_request):
     
     assert "hitsPerPage=15" in url
 
-
 @patch('lib.hackernews.http.request')
+
+
 def test_search_hackernews_date_filtering(mock_request):
     """Test that date range is applied correctly."""
     mock_request.return_value = {"hits": [], "nbHits": 0}
@@ -250,8 +249,9 @@ def test_search_hackernews_date_filtering(mock_request):
     assert "numericFilters" in url
     assert "created_at_i" in url
 
-
 @patch('lib.hackernews.http.request')
+
+
 def test_search_hackernews_http_error_handling(mock_request):
     """Test graceful handling of HTTP errors."""
     from lib.http import HTTPError
@@ -263,8 +263,9 @@ def test_search_hackernews_http_error_handling(mock_request):
     assert result["hits"] == []
     assert "error" in result
 
-
 @patch('lib.hackernews.http.request')
+
+
 def test_search_hackernews_engagement_filter(mock_request):
     """Test that low-engagement stories are filtered."""
     mock_request.return_value = {"hits": [], "nbHits": 0}
@@ -277,8 +278,8 @@ def test_search_hackernews_engagement_filter(mock_request):
     # Should filter for points > 2 (URL-encoded)
     assert "points" in url and "%3E2" in url
 
-
 # === Tests for parse_hackernews_response() ===
+
 
 def test_parse_hackernews_response_basic():
     """Test parsing basic Algolia response."""
@@ -402,8 +403,8 @@ def test_parse_hackernews_response_empty_response():
     
     assert items == []
 
-
 # === Tests for engagement scoring ===
+
 
 def test_engagement_score_calculation():
     """Test that engagement dict contains points and comments."""
@@ -434,7 +435,6 @@ def test_engagement_score_zero_values():
     engagement = items[0]["engagement"]
     assert engagement["points"] == 0
     assert engagement["comments"] == 0
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -1,16 +1,11 @@
-# ruff: noqa: E402
 """Tests for the HTML emit renderer."""
 
 from __future__ import annotations
 
-import sys
 import tempfile
 import unittest
 from html.parser import HTMLParser
 from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 import last30days as cli
 from lib import html_render, schema
@@ -296,7 +291,6 @@ class HtmlCliIntegrationTests(unittest.TestCase):
         self.assertIn("last30days · OpenClaw vs Hermes", saved)
         self.assertIn("comparing 2: OpenClaw, Hermes", saved)
         self.assertNotIn("last30days · OpenClaw</title>", saved)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_http_v3.py
+++ b/tests/test_http_v3.py
@@ -1,10 +1,6 @@
-import sys
 import urllib.error
 import unittest
-from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import http
 

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.instagram import _parse_items
 
@@ -62,7 +58,6 @@ class TestExpandInstagramQueries(unittest.TestCase):
         from lib.instagram import expand_instagram_queries
         queries = expand_instagram_queries("Kanye West", "quick")
         self.assertEqual(len(queries), 1)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_instagram_sc.py
+++ b/tests/test_instagram_sc.py
@@ -1,13 +1,10 @@
 """Tests for instagram.py — ScrapeCreators Instagram search module."""
 
 import os
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import instagram
 from lib.relevance import tokenize as _tokenize
@@ -252,7 +249,6 @@ class TestTranscriptTimeoutConfig(unittest.TestCase):
             instagram.fetch_captions(items, token="fake-token")
             kwargs = mock_http_get.call_args.kwargs
             self.assertEqual(kwargs["timeout"], 30.0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_internals_v3.py
+++ b/tests/test_internals_v3.py
@@ -5,11 +5,7 @@ tests exercise transitively but don't assert on directly. A regression in
 any of these functions would silently degrade output quality.
 """
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import planner, rerank, render, signals, schema
 
@@ -34,10 +30,10 @@ def _candidate(source: str = "reddit", **kwargs) -> schema.Candidate:
     defaults.update(kwargs)
     return schema.Candidate(**defaults)
 
-
 # ---------------------------------------------------------------------------
 # rerank._fallback_tuple
 # ---------------------------------------------------------------------------
+
 
 class TestFallbackTuple(unittest.TestCase):
 
@@ -58,10 +54,10 @@ class TestFallbackTuple(unittest.TestCase):
         low = _candidate(local_relevance=0.1, freshness=50, source_quality=0.7)
         self.assertGreater(rerank._fallback_tuple(high)[0], rerank._fallback_tuple(low)[0])
 
-
 # ---------------------------------------------------------------------------
 # rerank._normalized_rrf
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizedRrf(unittest.TestCase):
 
@@ -77,10 +73,10 @@ class TestNormalizedRrf(unittest.TestCase):
         result = rerank._normalized_rrf(1.0)
         self.assertLessEqual(result, 100.0)
 
-
 # ---------------------------------------------------------------------------
 # render._assess_data_freshness
 # ---------------------------------------------------------------------------
+
 
 class TestAssessDataFreshness(unittest.TestCase):
 
@@ -120,10 +116,10 @@ class TestAssessDataFreshness(unittest.TestCase):
         result = render._assess_data_freshness(report)
         self.assertIsNone(result)
 
-
 # ---------------------------------------------------------------------------
 # render._format_date
 # ---------------------------------------------------------------------------
+
 
 class TestFormatDate(unittest.TestCase):
 
@@ -138,10 +134,10 @@ class TestFormatDate(unittest.TestCase):
     def test_none_item(self):
         self.assertIn("unknown", render._format_date(None).lower())
 
-
 # ---------------------------------------------------------------------------
 # render._format_actor
 # ---------------------------------------------------------------------------
+
 
 class TestFormatActor(unittest.TestCase):
 
@@ -157,10 +153,10 @@ class TestFormatActor(unittest.TestCase):
         item = _item(source="youtube", author="Fireship")
         self.assertEqual(render._format_actor(item), "Fireship")
 
-
 # ---------------------------------------------------------------------------
 # render._format_engagement
 # ---------------------------------------------------------------------------
+
 
 class TestFormatEngagement(unittest.TestCase):
 
@@ -174,10 +170,10 @@ class TestFormatEngagement(unittest.TestCase):
         item = _item(engagement={})
         self.assertIsNone(render._format_engagement(item))
 
-
 # ---------------------------------------------------------------------------
 # render._format_corroboration
 # ---------------------------------------------------------------------------
+
 
 class TestFormatCorroboration(unittest.TestCase):
 
@@ -191,10 +187,10 @@ class TestFormatCorroboration(unittest.TestCase):
         c = _candidate(sources=["reddit"])
         self.assertIsNone(render._format_corroboration(c))
 
-
 # ---------------------------------------------------------------------------
 # render._format_explanation
 # ---------------------------------------------------------------------------
+
 
 class TestFormatExplanation(unittest.TestCase):
 
@@ -206,10 +202,10 @@ class TestFormatExplanation(unittest.TestCase):
         c = _candidate(explanation="Directly compares frameworks")
         self.assertEqual(render._format_explanation(c), "Directly compares frameworks")
 
-
 # ---------------------------------------------------------------------------
 # render._fmt_pairs and _format_number
 # ---------------------------------------------------------------------------
+
 
 class TestFmtPairs(unittest.TestCase):
 
@@ -231,10 +227,10 @@ class TestFormatNumber(unittest.TestCase):
     def test_small_integer(self):
         self.assertEqual(render._format_number(42), "42")
 
-
 # ---------------------------------------------------------------------------
 # render._truncate
 # ---------------------------------------------------------------------------
+
 
 class TestTruncate(unittest.TestCase):
 
@@ -246,10 +242,10 @@ class TestTruncate(unittest.TestCase):
         self.assertTrue(result.endswith("..."))
         self.assertEqual(len(result), 50)
 
-
 # ---------------------------------------------------------------------------
 # planner._normalize_subquery_weights
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeSubqueryWeights(unittest.TestCase):
 
@@ -270,10 +266,10 @@ class TestNormalizeSubqueryWeights(unittest.TestCase):
         normed = planner._normalize_subquery_weights(sqs)
         self.assertAlmostEqual(normed[0].weight / normed[1].weight, 4.0)
 
-
 # ---------------------------------------------------------------------------
 # planner._normalize_weights
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeWeights(unittest.TestCase):
 
@@ -285,10 +281,10 @@ class TestNormalizeWeights(unittest.TestCase):
         result = planner._normalize_weights({"a": 2.0, "b": -1.0})
         self.assertAlmostEqual(result["b"], 0.0)
 
-
 # ---------------------------------------------------------------------------
 # planner._trim_subqueries_for_depth
 # ---------------------------------------------------------------------------
+
 
 class TestTrimSubqueriesForDepth(unittest.TestCase):
 
@@ -318,10 +314,10 @@ class TestTrimSubqueriesForDepth(unittest.TestCase):
         # Deep comparison should also use capability expansion, not trim
         self.assertGreaterEqual(len(result[0].sources), 4)
 
-
 # ---------------------------------------------------------------------------
 # signals.annotate_stream
 # ---------------------------------------------------------------------------
+
 
 class TestAnnotateStream(unittest.TestCase):
 
@@ -345,10 +341,10 @@ class TestAnnotateStream(unittest.TestCase):
         annotated = signals.annotate_stream(items, "test query", "balanced_recent")
         self.assertEqual(annotated[0].item_id, "high")
 
-
 # ---------------------------------------------------------------------------
 # signals.prune_low_relevance
 # ---------------------------------------------------------------------------
+
 
 class TestPruneLowRelevance(unittest.TestCase):
 
@@ -369,10 +365,10 @@ class TestPruneLowRelevance(unittest.TestCase):
         result = signals.prune_low_relevance(items, minimum=0.1)
         self.assertEqual(len(result), 1)  # fallback keeps all
 
-
 # ---------------------------------------------------------------------------
 # Bug fixes found by PR review agents
 # ---------------------------------------------------------------------------
+
 
 class TestDaysAgoZeroFalsy(unittest.TestCase):
     """render._assess_data_freshness must not treat days_ago=0 as falsy."""
@@ -455,7 +451,6 @@ class TestGenericEngagementFormatter(unittest.TestCase):
             # Should contain numeric values, not dict keys as numbers
             self.assertIn("500", result)
 
-
 if __name__ == "__main__":
     unittest.main()
 
@@ -519,7 +514,6 @@ class TestDefaultDepthDoesNotCapSources(unittest.TestCase):
             model=None,
         )
         self.assertLessEqual(len(plan.subqueries[0].sources), 3)
-
 
 
 class TestRerankWeightBalance(unittest.TestCase):

--- a/tests/test_normalize_v3.py
+++ b/tests/test_normalize_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import normalize
 
@@ -224,7 +220,6 @@ class NormalizeV3Tests(unittest.TestCase):
             "2026-03-17",
         )
         self.assertEqual([], normalized)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -1,10 +1,6 @@
-import sys
 import threading
 import unittest
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import pipeline
 from lib import http
@@ -1008,7 +1004,6 @@ class TestExcludeSourcesEndToEnd(unittest.TestCase):
         sources = pipeline.available_sources(cfg)
         self.assertNotIn("tiktok", sources)
         self.assertNotIn("instagram", sources)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_planner_quiet_mode.py
+++ b/tests/test_planner_quiet_mode.py
@@ -1,16 +1,10 @@
-# ruff: noqa: E402
 """Tests for planner.plan_query internal_subrun quiet mode."""
 
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 from lib import planner
 
@@ -49,7 +43,6 @@ class PlannerQuietModeTests(unittest.TestCase):
         # The plan itself is deterministic fallback; verify note carries
         # no planner-error indication.
         self.assertGreater(len(plan.subqueries), 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_planner_v3.py
+++ b/tests/test_planner_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import planner
 
@@ -451,7 +447,6 @@ class FallbackDefaultsTests(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn("LLM planning failed", output)
         self.assertNotIn("No --plan passed", output)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -1,15 +1,12 @@
 import json
-import sys
 import tomllib
 import unittest
 from pathlib import Path
 
+from lib.skill_meta import read_skill_version
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL_ROOT = ROOT / "skills" / "last30days"
-
-sys.path.insert(0, str(SKILL_ROOT / "scripts"))
-from lib.skill_meta import read_skill_version  # noqa: E402
 
 
 def _json(path: Path) -> dict:
@@ -59,7 +56,6 @@ class TestPluginContract(unittest.TestCase):
                     offenders.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
 
         self.assertEqual([], offenders)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,18 +1,14 @@
 """Tests for polymarket.py - Polymarket prediction market search."""
 
 import json
-import sys
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
 from lib import polymarket
 
-
 # === Helper Functions ===
+
 
 def create_mock_event(
     event_id="evt-123",
@@ -60,8 +56,8 @@ def create_mock_market(
         "liquidity": liquidity,
     }
 
-
 # === Tests for _extract_core_subject() ===
+
 
 def test_extract_core_subject_basic():
     """Test basic subject extraction."""
@@ -86,8 +82,8 @@ def test_extract_core_subject_multiple_prefixes():
     result = polymarket._extract_core_subject("research AI models")
     assert result == "AI models"
 
-
 # === Tests for _expand_queries() ===
+
 
 def test_expand_queries_basic():
     """Test basic query expansion."""
@@ -132,8 +128,8 @@ def test_expand_queries_cap_at_six():
     
     assert len(queries) <= 6
 
-
 # === Tests for _passes_topic_filter() ===
+
 
 def test_passes_topic_filter_match():
     """Test that matching events pass the filter."""
@@ -194,8 +190,8 @@ def test_passes_topic_filter_multi_word_edge_exactly_three():
         "Tesla stock price", "Tesla quarterly earnings"
     ) is False  # only "tesla" matches, needs 2
 
-
 # === Tests for _parse_outcome_prices() ===
+
 
 def test_parse_outcome_prices_basic():
     """Test basic outcome price parsing."""
@@ -259,8 +255,8 @@ def test_parse_outcome_prices_invalid_json():
     
     assert result == []
 
-
 # === Tests for _format_price_movement() ===
+
 
 def test_format_price_movement_one_day():
     """Test formatting one-day price movement."""
@@ -322,8 +318,8 @@ def test_format_price_movement_missing_data():
     
     assert result is None
 
-
 # === Tests for _shorten_question() ===
+
 
 def test_shorten_question_will_pattern():
     """Test shortening 'Will X...' questions."""
@@ -354,8 +350,8 @@ def test_shorten_question_long():
     
     assert len(result) <= 40
 
-
 # === Tests for search_polymarket() ===
+
 
 def test_search_polymarket_result_cap():
     """Test that result cap configuration exists."""
@@ -385,8 +381,9 @@ def test_search_polymarket_query_expansion():
     # Should expand to multiple queries
     assert len(queries) >= 2
 
-
 @patch('lib.polymarket.http.post')
+
+
 def test_search_polymarket_http_error_handling(mock_post):
     """Test graceful handling of HTTP errors."""
     from lib.http import HTTPError
@@ -397,8 +394,8 @@ def test_search_polymarket_http_error_handling(mock_post):
     # Should return structure with error
     assert "events" in result or "error" in result
 
-
 # === Tests for parse_polymarket_response() ===
+
 
 def test_parse_polymarket_response_basic():
     """Test basic response parsing."""
@@ -472,8 +469,8 @@ def test_parse_polymarket_response_engagement():
         # Check for volume or liquidity fields
         assert "volume24hr" in items[0] or "liquidity" in items[0] or isinstance(items[0], dict)
 
-
 # === Tests for engagement scoring ===
+
 
 def test_engagement_with_volume():
     """Test engagement calculation with volume."""
@@ -491,8 +488,8 @@ def test_engagement_with_volume():
         # volume24hr should be captured
         assert "volume24hr" in engagement or isinstance(engagement, dict)
 
-
 # === Tests for noise-word query skipping ===
+
 
 def test_expand_queries_skips_noise_words():
     """Noise words like 'west' should not become standalone queries."""
@@ -520,8 +517,8 @@ def test_expand_queries_all_noise_words_keeps_phrase():
     lowered = [q.lower() for q in queries]
     assert "north" not in lowered or "north west" in lowered  # only as part of phrase
 
-
 # === Tests for per-item relevance floor ===
+
 
 def test_per_item_relevance_floor_drops_zero_items():
     """Items with relevance 0.0 should be dropped even if best item is high."""
@@ -558,7 +555,6 @@ def test_per_item_relevance_floor_no_drops_when_all_high():
     ]
     filtered = [i for i in items if i["relevance"] >= 0.10]
     assert len(filtered) == 3
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_polymarket_disambiguation.py
+++ b/tests/test_polymarket_disambiguation.py
@@ -1,14 +1,8 @@
-# ruff: noqa: E402
 """Tests for --polymarket-keywords filter and filter_items_against_keywords."""
 
 from __future__ import annotations
 
-import sys
 import unittest
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 from lib import polymarket
 
@@ -68,7 +62,6 @@ class FilterItemsAgainstKeywordsTests(unittest.TestCase):
         items = [_item("Glasgow Warriors"), _item("Rogue Warriors")]
         out = polymarket.filter_items_against_keywords(items, ["nba", "gsw"])
         self.assertEqual(out, [])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -6,11 +6,7 @@ public v3.0.8 and still returned junk for queries like 'birthday gift for
 cannot bypass by skipping SKILL.md.
 """
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import preflight
 
@@ -122,7 +118,6 @@ class TestRefuseMessage(unittest.TestCase):
         msg = preflight.check_class_1_trap("birthday gift for 40 year old")
         assert msg is not None
         self.assertIn("birthday gift for 40 year old", msg)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_providers_v3.py
+++ b/tests/test_providers_v3.py
@@ -1,9 +1,5 @@
 import json
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import providers
 
@@ -161,7 +157,6 @@ class TestParseCodexStream(unittest.TestCase):
 
     def test_done_only_stream(self):
         self.assertEqual({}, providers._parse_codex_stream("data: [DONE]\n\n"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_nudge.py
+++ b/tests/test_quality_nudge.py
@@ -5,18 +5,13 @@ HN, Polymarket, Reddit (always active), X, YouTube.
 ScrapeCreators adds TikTok + Instagram as bonus sources, not core.
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
-
 import pytest
 from unittest.mock import patch
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _base_config(**overrides):
     """Return a minimal config dict."""
@@ -52,10 +47,10 @@ def _compute(config_overrides=None, result_overrides=None, ytdlp_installed=False
     with patch.object(youtube_yt, "is_ytdlp_installed", return_value=ytdlp_installed):
         return compute_quality_score(config, results)
 
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestBaseline:
     """HN + Polymarket + Reddit always active (no X, no YT) -> 60%."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,10 +1,6 @@
 """Tests for query.py — shared query utilities."""
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib.query import NOISE_WORDS, extract_compound_terms, extract_core_subject
 
@@ -126,7 +122,6 @@ class TestNoiseWordsCompleteness(unittest.TestCase):
             self.assertIn(w, NOISE_WORDS)
 
 
-
 class TestExtractCompoundTerms(unittest.TestCase):
     """Tests for extract_compound_terms()."""
 
@@ -147,7 +142,6 @@ class TestExtractCompoundTerms(unittest.TestCase):
         terms = extract_compound_terms("vc-backed start-up")
         self.assertIn("vc-backed", terms)
         self.assertIn("start-up", terms)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_query_v3.py
+++ b/tests/test_query_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import query
 
@@ -38,7 +34,6 @@ class QueryV3Tests(unittest.TestCase):
         self.assertIn("multi-agent", terms)
         self.assertIn("Claude Code", terms)
         self.assertIn("React Native", terms)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.reddit import (
     _extract_date,
@@ -263,7 +259,6 @@ class TestEnrichmentBudget(unittest.TestCase):
         self.assertEqual(len(result), 3)
         enriched = [i for i in result if i.get("top_comments")]
         self.assertEqual(len(enriched), 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reddit_enrich.py
+++ b/tests/test_reddit_enrich.py
@@ -1,12 +1,10 @@
 """Tests for reddit_enrich.py — comment enrichment and parsing."""
 
 import json
-import sys
 import unittest
 from pathlib import Path
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import reddit_enrich
 
@@ -123,7 +121,6 @@ class TestExtractCommentInsights(unittest.TestCase):
         comments = [{"body": f"Comment number {i} " + "x" * 50} for i in range(20)]
         insights = reddit_enrich.extract_comment_insights(comments, limit=3)
         self.assertLessEqual(len(insights), 3)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reddit_public.py
+++ b/tests/test_reddit_public.py
@@ -5,18 +5,15 @@ import urllib.error
 from unittest import mock
 
 import pytest
-import sys
-import os
 
 # Ensure lib is importable
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "last30days", "scripts"))
 
 from lib import reddit_public
-
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_reddit_listing(posts):
     """Build a Reddit listing JSON structure from a list of post dicts."""
@@ -37,7 +34,6 @@ def _make_reddit_listing(posts):
             },
         })
     return {"data": {"children": children}}
-
 
 SAMPLE_LISTING = _make_reddit_listing([
     {
@@ -72,10 +68,10 @@ def _mock_urlopen_ok(listing_data):
     resp.__exit__ = mock.MagicMock(return_value=False)
     return resp
 
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestSearchReturnsCorrectFields:
     """Search query returns parsed results with correct fields."""
@@ -329,10 +325,10 @@ class TestMissingSubreddit:
         results = reddit_public.search("test", subreddit="nonexistent")
         assert results == []
 
-
 # ---------------------------------------------------------------------------
 # Tests for comment enrichment (Unit 2)
 # ---------------------------------------------------------------------------
+
 
 class TestEnrichmentIntegration:
     """search_reddit_public enriches top posts with comments."""

--- a/tests/test_reddit_sc.py
+++ b/tests/test_reddit_sc.py
@@ -1,11 +1,8 @@
 """Tests for reddit.py — ScrapeCreators Reddit search module."""
 
-import sys
 import unittest
-from pathlib import Path
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import reddit
 
@@ -175,7 +172,6 @@ class TestPostRelevance(unittest.TestCase):
             "",
         )
         self.assertGreater(score, 0.7)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -3,11 +3,7 @@
 Migrated from test_youtube_relevance.py + new hashtag/synonym tests.
 """
 
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib.relevance import STOPWORDS, SYNONYMS, token_overlap_relevance, tokenize
 
@@ -125,7 +121,6 @@ class TestHashtagRelevance(unittest.TestCase):
         rel1 = token_overlap_relevance("test query", "test content", None)
         rel2 = token_overlap_relevance("test query", "test content")
         self.assertEqual(rel1, rel2)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_relevance_core_v3.py
+++ b/tests/test_relevance_core_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import relevance
 
@@ -46,7 +42,6 @@ class RelevanceCoreV3Tests(unittest.TestCase):
             hashtags=["ClaudeCode", "BuildInPublic"],
         )
         self.assertGreater(score, 0.0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_render_comparison_multi.py
+++ b/tests/test_render_comparison_multi.py
@@ -1,15 +1,9 @@
-# ruff: noqa: E402
 """Tests for render.render_comparison_multi and emit_comparison_output."""
 
 from __future__ import annotations
 
 import json
-import sys
 import unittest
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 import last30days as cli
 from lib import render, schema
@@ -299,7 +293,6 @@ class EmitComparisonOutputTests(unittest.TestCase):
         reports = [("A", _build_report("A", ["Thing A"]))]
         with self.assertRaises(SystemExit):
             cli.emit_comparison_output(reports, emit="xml")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import render, schema
 
@@ -635,7 +631,6 @@ class YoutubeFooterTranscriptRatioTests(unittest.TestCase):
         text = render.render_compact(report)
         # No YouTube footer line at all - so no transcript segment either
         self.assertNotIn("with transcripts", text)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rerank_fun.py
+++ b/tests/test_rerank_fun.py
@@ -1,12 +1,6 @@
 """Tests for the fun judge heuristic fallback in rerank.py."""
 
-import sys
-from pathlib import Path
-
 import pytest
-
-SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "last30days" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
 
 from lib import schema
 from lib.rerank import _apply_single_fun_fallback, _extract_comment_text

--- a/tests/test_rerank_v3.py
+++ b/tests/test_rerank_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import rerank, schema
 
@@ -382,7 +378,6 @@ class ExpandedHaystackTests(unittest.TestCase):
         # Explanation does NOT contain entity-miss, so secondary penalty
         # should not fire; final_score reflects only base signal.
         self.assertNotIn("entity-miss", on_topic.explanation or "")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,11 +1,7 @@
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import resolve
 from lib.resolve import MAX_SUBS, _merge_category_peers
@@ -362,7 +358,6 @@ class AutoResolveCategoryIntegration(unittest.TestCase):
     def test_no_backend_returns_category_none(self):
         result = resolve.auto_resolve("test topic", {})
         self.assertIsNone(result["category"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_safari_cookies.py
+++ b/tests/test_safari_cookies.py
@@ -9,10 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days"))
-
 # Import the internal parser directly for testability (avoids platform check)
-from scripts.lib.safari_cookies import (
+from lib.safari_cookies import (
     _parse_binary_cookies,
     extract_safari_cookies_macos,
 )
@@ -95,8 +93,9 @@ def _build_binary_cookies_file(pages: list[bytes]) -> bytes:
 
     return data
 
-
 @pytest.fixture
+
+
 def x_cookies_file() -> bytes:
     """Build a minimal valid binary cookies file with .x.com cookies."""
     rec1 = _build_cookie_record(".x.com", "auth_token", "test_auth_abc123")
@@ -153,8 +152,8 @@ class TestMultiplePages:
 class TestErrorPaths:
     def test_file_not_found(self, tmp_path: Path):
         with patch(
-            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
-        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            "lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("lib.safari_cookies.sys") as mock_sys:
             mock_sys.platform = "darwin"
             mock_sys.stderr = sys.stderr
             result = extract_safari_cookies_macos("x.com", ["auth_token"])
@@ -183,8 +182,8 @@ class TestErrorPaths:
         (legacy_dir / "Cookies.binarycookies").write_bytes(legacy_data)
 
         with patch(
-            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
-        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            "lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("lib.safari_cookies.sys") as mock_sys:
             mock_sys.platform = "darwin"
             mock_sys.stderr = sys.stderr
             result = extract_safari_cookies_macos("x.com", ["auth_token", "ct0"])
@@ -215,8 +214,8 @@ class TestErrorPaths:
         assert not sandbox_path.exists()
 
         with patch(
-            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
-        ), patch("scripts.lib.safari_cookies.sys") as mock_sys:
+            "lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("lib.safari_cookies.sys") as mock_sys:
             mock_sys.platform = "darwin"
             mock_sys.stderr = sys.stderr
             result = extract_safari_cookies_macos("x.com", ["auth_token"])
@@ -239,8 +238,8 @@ class TestErrorPaths:
         cookie_file.write_bytes(b"cook")
 
         with patch(
-            "scripts.lib.safari_cookies.Path.home", return_value=tmp_path
-        ), patch("scripts.lib.safari_cookies.sys") as mock_sys, patch.object(
+            "lib.safari_cookies.Path.home", return_value=tmp_path
+        ), patch("lib.safari_cookies.sys") as mock_sys, patch.object(
             Path, "read_bytes", side_effect=PermissionError
         ):
             mock_sys.platform = "darwin"
@@ -275,7 +274,7 @@ class TestErrorPaths:
         assert result is None
 
     def test_non_darwin_returns_none(self):
-        with patch("scripts.lib.safari_cookies.sys") as mock_sys:
+        with patch("lib.safari_cookies.sys") as mock_sys:
             mock_sys.platform = "linux"
             result = extract_safari_cookies_macos("x.com", ["auth_token"])
         assert result is None

--- a/tests/test_save_raw_per_entity.py
+++ b/tests/test_save_raw_per_entity.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Tests for per-entity save files when running vs-mode or --competitors.
 
 Each entity's sub-run produces its own {entity-slug}-raw.md. Single-entity
@@ -15,7 +14,6 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 
 def _engine_path() -> Path:
@@ -78,7 +76,6 @@ class PerEntitySaveFilesTests(unittest.TestCase):
         content = anthropic_file.read_text()
         self.assertIn("## Resolved Entities", content)
         self.assertIn("**Anthropic**", content)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_schema_v3.py
+++ b/tests/test_schema_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import schema
 
@@ -83,7 +79,6 @@ class SchemaV3Tests(unittest.TestCase):
         self.assertEqual(0, item.engagement_score)
         self.assertEqual(0.0, item.source_quality)
         self.assertEqual(0.0, item.local_rank_score)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -1,16 +1,11 @@
 """Tests for OpenClaw setup and device auth functions."""
 
 import json
-import sys
 import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock, call
 
 import pytest
-
-# Add scripts dir to path
-SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "last30days" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
 
 from lib import setup_wizard
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,16 +1,10 @@
 """Tests for the first-run setup wizard module."""
 
-import os
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-# Add scripts dir to path
-SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "last30days" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
 
 from lib import setup_wizard
 

--- a/tests/test_signals_v3.py
+++ b/tests/test_signals_v3.py
@@ -1,9 +1,5 @@
 import math
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import schema, signals
 from lib.hackernews import parse_hackernews_response
@@ -231,7 +227,6 @@ class SignalsV3Tests(unittest.TestCase):
         )
         pruned = signals.prune_low_relevance([weak], minimum=0.1)
         self.assertEqual(["weak"], [item.item_id for item in pruned])
-
 
     # -- Iteration 1: HN engagement bug --
 
@@ -566,7 +561,6 @@ class SignalsV3Tests(unittest.TestCase):
         self.assertIn("social", ids, "Item with relevance 0.05 should survive pruning")
         self.assertIn("strong", ids)
 
-
     # -- Unit 3: YouTube high-engagement relevance floor --
 
     def test_youtube_high_engagement_gets_relevance_floor(self):
@@ -607,7 +601,6 @@ class SignalsV3Tests(unittest.TestCase):
         )
         rel = signals.local_relevance(item, "kanye west")
         self.assertLess(rel, 0.3, f"Non-YouTube item should not get YouTube floor, got {rel}")
-
 
     # -- Unit 8: Engagement floor for TikTok/Instagram --
 
@@ -708,7 +701,6 @@ class SignalsV3Tests(unittest.TestCase):
         pruned = signals.prune_low_relevance([good] + spam_items)
         aspire_ids = [item.item_id for item in pruned if item.item_id.startswith("aspire")]
         self.assertEqual(len(aspire_ids), 0, f"All @aspiresnippets items should be pruned, got {aspire_ids}")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_meta.py
+++ b/tests/test_skill_meta.py
@@ -6,15 +6,13 @@ regex coverage inside the helper could pass CI because render.py's fallback
 to "?" swallows the signal.
 """
 
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+from lib.skill_meta import read_skill_version
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "skills" / "last30days" / "scripts"))
-from lib.skill_meta import read_skill_version  # noqa: E402
 
 
 class ReadSkillVersionTests(unittest.TestCase):
@@ -55,7 +53,6 @@ class ReadSkillVersionTests(unittest.TestCase):
         path = self.tmp_path / "SKILL.md"
         path.write_bytes(bytes(range(128, 256)))
         self.assertIsNone(read_skill_version(path))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_version.py
+++ b/tests/test_skill_version.py
@@ -5,12 +5,9 @@ to SKILL.md frontmatter. These tests use monkeypatch to swap the render module's
 __file__ attribute, which controls where the walk starts.
 """
 
-import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import render
 
@@ -131,7 +128,6 @@ class SkillVersionFallbackTests(unittest.TestCase):
 
         with patch.object(render, "__file__", str(fake_render)):
             self.assertEqual("5.5.5", render._skill_version())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_snippet_v3.py
+++ b/tests/test_snippet_v3.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import schema, snippet
 
@@ -57,7 +53,6 @@ class SnippetV3Tests(unittest.TestCase):
         item = make_item(body=body)
         result = snippet.extract_best_snippet(item, "openclaw nanoclaw ironclaw", max_words=20)
         self.assertIn("openclaw nanoclaw ironclaw", result)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -9,14 +9,13 @@ from pathlib import Path
 import pytest
 
 # Import the module under test
-import sys
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 import store
 from lib import schema
 
-
 @pytest.fixture
+
+
 def temp_db():
     """Create a temporary database for testing."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -36,8 +35,9 @@ def temp_db():
     if db_path.exists():
         db_path.unlink()
 
-
 @pytest.fixture
+
+
 def sample_report():
     """Create a sample Report with multiple sources including HN and Polymarket."""
     return schema.report_from_dict({
@@ -179,8 +179,8 @@ def sample_report():
         "warnings": [],
     })
 
-
 # === Tests for findings_from_report() ===
+
 
 def test_findings_from_report_processes_all_sources(sample_report):
     """Test that findings_from_report extracts items from all sources in items_by_source."""
@@ -324,8 +324,8 @@ def test_findings_from_report_handles_missing_fields():
     assert f["relevance_score"] == 0.5
     assert f["summary"] == "Content"  # Falls back to body
 
-
 # === Tests for store_findings() ===
+
 
 def test_store_findings_basic(temp_db, sample_report):
     """Test basic storage of findings."""
@@ -565,6 +565,7 @@ def test_store_findings_updates_existing_sighting_for_same_run(temp_db):
     assert sightings[0]["source_title"] == "Reddit 1 updated"
     assert sightings[0]["engagement_score"] == 15.0
 
+
 def test_get_latest_completed_runs_returns_newest_completed_only(temp_db):
     """Test latest-run lookup ignores failed runs and orders newest first."""
     topic = store.add_topic("Test Topic")
@@ -672,8 +673,8 @@ def test_update_validates_allowed_columns(temp_db, sample_report):
     with pytest.raises(ValueError, match="invalid_finding_column"):
         store.update_finding(finding_id, invalid_finding_column="x")
 
-
 # === Tests for topic management ===
+
 
 def test_add_topic(temp_db):
     """Test adding a topic."""
@@ -742,8 +743,8 @@ def test_list_topics(temp_db):
         assert "last_run" in topic
         assert "last_status" in topic
 
-
 # === Tests for get_new_findings() ===
+
 
 def test_get_new_findings(temp_db, sample_report):
     """Test retrieving new findings for a topic."""
@@ -778,7 +779,6 @@ def test_get_new_findings_filters_by_date(temp_db, sample_report):
     new_findings = store.get_new_findings(topic["id"], since=yesterday)
 
     assert len(new_findings) == 4
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -4,12 +4,8 @@ Covers the process-group cleanup path, timeout behavior, success path,
 PID callback wiring, and environment inheritance.
 """
 
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 from lib import subproc
 
@@ -96,7 +92,6 @@ class TestRunWithTimeout(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout.strip(), "ok")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tiktok.py
+++ b/tests/test_tiktok.py
@@ -1,8 +1,4 @@
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.tiktok import _parse_items
 
@@ -233,7 +229,6 @@ class TestTikTokEnrichWithComments(unittest.TestCase):
         self.assertIn("top_comments", by_id["high"])
         self.assertIn("top_comments", by_id["mid"])
         self.assertNotIn("top_comments", by_id["low"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_truthsocial.py
+++ b/tests/test_truthsocial.py
@@ -1,10 +1,6 @@
 """Tests for Truth Social source module."""
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import truthsocial
 
@@ -228,7 +224,6 @@ class TestParseTruthSocialResponse(unittest.TestCase):
         items = truthsocial.parse_truthsocial_response(response)
         self.assertNotIn("<", items[0]["text"])
         self.assertNotIn(">", items[0]["text"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui_v3.py
+++ b/tests/test_ui_v3.py
@@ -1,12 +1,7 @@
-# ruff: noqa: E402
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
 from unittest import mock
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib import ui
 
@@ -71,7 +66,6 @@ class UiV3Tests(unittest.TestCase):
         self.assertIn("Bluesky: 3 posts", output)
         self.assertIn("Truth Social: 1 post", output)
         self.assertIn("Xiaohongshu: 4 posts", output)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,14 +1,11 @@
 import re
-import sys
 import unittest
 from pathlib import Path
 
+from lib.skill_meta import read_skill_version
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL_ROOT = ROOT / "skills" / "last30days"
-
-sys.path.insert(0, str(SKILL_ROOT / "scripts"))
-from lib.skill_meta import read_skill_version  # noqa: E402
 
 
 def _skill_version() -> str:
@@ -76,7 +73,6 @@ class TestVersionConsistency(unittest.TestCase):
                     offenders.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
 
         self.assertEqual([], offenders)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vs_mode_fanout.py
+++ b/tests/test_vs_mode_fanout.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402
 """Tests for vs-mode routing into the competitor fanout.
 
 A topic containing " vs " / " versus " triggers N-pass fanout (not the
@@ -9,13 +8,8 @@ pipeline.run() with its own Step 0.55 targeting.
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from contextlib import redirect_stderr
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "skills" / "last30days" / "scripts"))
 
 from lib import planner
 
@@ -57,7 +51,6 @@ class VsModeEntityDetectionTests(unittest.TestCase):
         # Defense against silly input — two "Drake"s should collapse.
         result = planner._comparison_entities("Drake vs Drake")
         self.assertEqual(result, ["Drake"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_watchlist_commands.py
+++ b/tests/test_watchlist_commands.py
@@ -3,21 +3,19 @@
 import json
 import sqlite3
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
 import store
 import watchlist
 from lib import schema
 
-
 @pytest.fixture
+
+
 def temp_db():
     """Create a temporary database for testing."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -37,8 +35,8 @@ def temp_db():
     if db_path.exists():
         db_path.unlink()
 
-
 # === Tests for cmd_add() ===
+
 
 def test_cmd_add_basic(temp_db, capsys):
     """Test adding a topic with default schedule."""
@@ -104,8 +102,8 @@ def test_cmd_add_with_search_queries(temp_db, capsys):
     queries = json.loads(topic["search_queries"])
     assert queries == ["query1", "query2", "query3"]
 
-
 # === Tests for cmd_remove() ===
+
 
 def test_cmd_remove_existing_topic(temp_db, capsys):
     """Test removing an existing topic."""
@@ -139,8 +137,8 @@ def test_cmd_remove_nonexistent_topic(temp_db, capsys):
     assert output["action"] == "not_found"
     assert output["topic"] == "Nonexistent Topic"
 
-
 # === Tests for cmd_list() ===
+
 
 def test_cmd_list_empty(temp_db, capsys):
     """Test listing when no topics exist."""
@@ -176,8 +174,8 @@ def test_cmd_list_with_topics(temp_db, capsys):
     topic_names = {t["name"] for t in output["topics"]}
     assert topic_names == {"Topic 1", "Topic 2", "Topic 3"}
 
-
 # === Tests for cmd_delta() ===
+
 
 def test_cmd_delta_outputs_topic_delta(temp_db, capsys):
     """Test printing the latest watchlist delta as JSON."""
@@ -231,8 +229,8 @@ def test_cmd_delta_unknown_topic_exits(temp_db):
     with pytest.raises(SystemExit):
         watchlist.cmd_delta(args)
 
-
 # === Tests for cmd_config() ===
+
 
 def test_cmd_config_delivery(temp_db, capsys):
     """Test configuring delivery channel."""
@@ -276,10 +274,11 @@ def test_cmd_config_unknown_key(temp_db):
     with pytest.raises(SystemExit):
         watchlist.cmd_config(args)
 
-
 # === Tests for _run_topic() ===
 
 @patch('watchlist.subprocess.run')
+
+
 def test_run_topic_success(mock_subprocess, temp_db):
     """Test successful topic run."""
     topic = store.add_topic("Test Topic")
@@ -364,8 +363,9 @@ def test_run_topic_success(mock_subprocess, temp_db):
     assert result["new"] == 1
     assert result["topic"] == "Test Topic"
 
-
 @patch('watchlist.subprocess.run')
+
+
 def test_run_topic_failure(mock_subprocess, temp_db):
     """Test topic run failure."""
     topic = store.add_topic("Test Topic")
@@ -381,8 +381,9 @@ def test_run_topic_failure(mock_subprocess, temp_db):
     assert result["status"] == "failed"
     assert "Error message" in result["error"]
 
-
 @patch('watchlist.subprocess.run')
+
+
 def test_run_topic_timeout(mock_subprocess, temp_db):
     """Test topic run timeout."""
     topic = store.add_topic("Test Topic")
@@ -395,9 +396,10 @@ def test_run_topic_timeout(mock_subprocess, temp_db):
     assert result["status"] == "failed"
     assert result["error"] == "timeout"
 
-
 @patch('watchlist.subprocess.run')
 @patch('watchlist._deliver_findings')
+
+
 def test_run_topic_calls_delivery(mock_deliver, mock_subprocess, temp_db):
     """Test that successful run calls delivery."""
     topic = store.add_topic("Test Topic")
@@ -484,10 +486,11 @@ def test_run_topic_calls_delivery(mock_deliver, mock_subprocess, temp_db):
     assert call_args[0] == "Test Topic"
     assert call_args[1]["new"] == 1
 
-
 # === Tests for cmd_run_one() ===
 
 @patch('watchlist._run_topic')
+
+
 def test_cmd_run_one(mock_run, temp_db, capsys):
     """Test running a single topic."""
     topic = store.add_topic("Test Topic")
@@ -521,10 +524,11 @@ def test_cmd_run_one_nonexistent_topic(temp_db, capsys):
     with pytest.raises(SystemExit):
         watchlist.cmd_run_one(args)
 
-
 # === Tests for cmd_run_all() ===
 
 @patch('watchlist._run_topic')
+
+
 def test_cmd_run_all_no_topics(mock_run, temp_db, capsys):
     """Test running all topics when none exist."""
     args = Mock()
@@ -537,8 +541,9 @@ def test_cmd_run_all_no_topics(mock_run, temp_db, capsys):
     
     assert "No enabled topics" in output["message"]
 
-
 @patch('watchlist._run_topic')
+
+
 def test_cmd_run_all_multiple_topics(mock_run, temp_db, capsys):
     """Test running multiple topics."""
     # Add topics
@@ -564,9 +569,10 @@ def test_cmd_run_all_multiple_topics(mock_run, temp_db, capsys):
     assert output["action"] == "run_all"
     assert len(output["results"]) == 2
 
-
 @patch('watchlist._run_topic')
 @patch('watchlist.store.get_daily_cost')
+
+
 def test_cmd_run_all_respects_budget(mock_cost, mock_run, temp_db, capsys):
     """Test that run-all respects daily budget."""
     # Add topics
@@ -598,7 +604,6 @@ def test_cmd_run_all_respects_budget(mock_cost, mock_run, temp_db, capsys):
     skipped = [r for r in results if r["status"] == "skipped"]
     
     assert len(skipped) == 3  # All 3 topics skipped
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_watchlist_delivery.py
+++ b/tests/test_watchlist_delivery.py
@@ -1,18 +1,14 @@
 """Tests for watchlist.py delivery functions (PR #86 feature)."""
 
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
 import watchlist
 from lib.http import HTTPError
 
-
 # === Tests for _format_delivery_message() ===
+
 
 def test_format_message_announce_mode():
     """Test announce mode formatting (default mode with emoji)."""
@@ -56,10 +52,11 @@ def test_format_message_handles_zero_counts():
     assert "0 new" in message
     assert "0 updated" in message
 
-
 # === Tests for _send_slack_webhook() ===
 
 @patch('watchlist.http.post')
+
+
 def test_send_slack_webhook_format(mock_post):
     """Test that Slack webhook uses correct format."""
     watchlist._send_slack_webhook(
@@ -74,8 +71,9 @@ def test_send_slack_webhook_format(mock_post):
     assert call_args[1]["json_data"] == {"text": "Test message"}
     assert call_args[1]["timeout"] == 10
 
-
 @patch('watchlist.http.post')
+
+
 def test_send_slack_webhook_raises_on_error(mock_post):
     """Test that Slack webhook raises on HTTP error."""
     mock_post.side_effect = HTTPError("HTTP 400", 400)
@@ -86,10 +84,11 @@ def test_send_slack_webhook_raises_on_error(mock_post):
             "Test message"
         )
 
-
 # === Tests for _send_generic_webhook() ===
 
 @patch('watchlist.http.post')
+
+
 def test_send_generic_webhook_format(mock_post):
     """Test that generic webhook uses correct format."""
     watchlist._send_generic_webhook(
@@ -108,8 +107,9 @@ def test_send_generic_webhook_format(mock_post):
     assert "timestamp" in json_data
     assert isinstance(json_data["timestamp"], float)
 
-
 @patch('watchlist.http.post')
+
+
 def test_send_generic_webhook_raises_on_error(mock_post):
     """Test that generic webhook raises on HTTP error."""
     mock_post.side_effect = HTTPError("HTTP 500", 500)
@@ -120,11 +120,12 @@ def test_send_generic_webhook_raises_on_error(mock_post):
             "Test message"
         )
 
-
 # === Tests for _deliver_findings() ===
 
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_sends_when_new_greater_than_zero(mock_post, mock_get_setting):
     """Test that delivery fires when new > 0."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -136,9 +137,10 @@ def test_deliver_findings_sends_when_new_greater_than_zero(mock_post, mock_get_s
 
     assert mock_post.called
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_skips_when_new_is_zero(mock_post, mock_get_setting):
     """Test that delivery is skipped when new=0."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -150,9 +152,10 @@ def test_deliver_findings_skips_when_new_is_zero(mock_post, mock_get_setting):
 
     assert not mock_post.called
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_skips_when_channel_empty(mock_post, mock_get_setting):
     """Test that delivery is skipped when delivery_channel is empty."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -164,9 +167,10 @@ def test_deliver_findings_skips_when_channel_empty(mock_post, mock_get_setting):
 
     assert not mock_post.called
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_uses_slack_format_for_slack_urls(mock_post, mock_get_setting):
     """Test that Slack URLs trigger Slack-specific format."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -180,9 +184,10 @@ def test_deliver_findings_uses_slack_format_for_slack_urls(mock_post, mock_get_s
     assert "text" in json_data
     assert "Test Topic" in json_data["text"]
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_uses_generic_format_for_other_urls(mock_post, mock_get_setting):
     """Test that non-Slack URLs trigger generic format."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -197,9 +202,10 @@ def test_deliver_findings_uses_generic_format_for_other_urls(mock_post, mock_get
     assert "source" in json_data
     assert "timestamp" in json_data
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_handles_failure_gracefully(mock_post, mock_get_setting, capsys):
     """Test that delivery failures don't crash the process."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -215,9 +221,10 @@ def test_deliver_findings_handles_failure_gracefully(mock_post, mock_get_setting
     captured = capsys.readouterr()
     assert "Delivery failed" in captured.err
 
-
 @patch('watchlist.store.get_setting')
 @patch('watchlist.http.post')
+
+
 def test_deliver_findings_respects_delivery_mode(mock_post, mock_get_setting):
     """Test that different delivery modes produce different messages."""
     mock_get_setting.side_effect = lambda key, default="": {
@@ -239,7 +246,6 @@ def test_deliver_findings_respects_delivery_mode(mock_post, mock_get_setting):
 
     silent_message = mock_post.call_args[1]["json_data"]["message"]
     assert "📰" not in silent_message
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_xai_x.py
+++ b/tests/test_xai_x.py
@@ -1,9 +1,5 @@
 import json
-import sys
 import unittest
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.xai_x import parse_x_response
 
@@ -62,7 +58,6 @@ class TestXaiXEngagementZero(unittest.TestCase):
         self.assertEqual(3, eng["reposts"])
         self.assertEqual(1, eng["replies"])
         self.assertEqual(0, eng["quotes"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_xquik.py
+++ b/tests/test_xquik.py
@@ -1,9 +1,5 @@
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"))
 
 from lib.xquik import (
     DEPTH_CONFIG,
@@ -269,7 +265,6 @@ class TestDepthConfig(unittest.TestCase):
 
     def test_deep_has_most_queries(self):
         self.assertGreater(DEPTH_CONFIG["deep"]["queries"], DEPTH_CONFIG["quick"]["queries"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_xurl_x.py
+++ b/tests/test_xurl_x.py
@@ -1,19 +1,15 @@
 """Tests for xurl_x module."""
 
 import json
-import sys
 import unittest
-from pathlib import Path
 from unittest import mock
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
-
 from lib import xurl_x
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_api_response(tweets=None, users=None):
     """Build a minimal X API v2 search/recent response."""
@@ -24,10 +20,10 @@ def _make_api_response(tweets=None, users=None):
         resp["includes"] = {"users": users}
     return resp
 
-
 # ---------------------------------------------------------------------------
 # is_available
 # ---------------------------------------------------------------------------
+
 
 class TestIsAvailable(unittest.TestCase):
     def test_returns_true_when_xurl_authenticated(self):
@@ -62,10 +58,10 @@ class TestIsAvailable(unittest.TestCase):
         with mock.patch("subprocess.run", return_value=completed):
             self.assertFalse(xurl_x.is_available())
 
-
 # ---------------------------------------------------------------------------
 # search_x
 # ---------------------------------------------------------------------------
+
 
 class TestSearchX(unittest.TestCase):
     def test_returns_parsed_json_on_success(self):
@@ -127,10 +123,10 @@ class TestSearchX(unittest.TestCase):
         n_idx = call_args.index("-n")
         self.assertEqual(int(call_args[n_idx + 1]), xurl_x.DEPTH_CONFIG["default"])
 
-
 # ---------------------------------------------------------------------------
 # parse_x_response
 # ---------------------------------------------------------------------------
+
 
 class TestParseXResponse(unittest.TestCase):
     def _tweet(self, id_, text, author_id, created_at=None, metrics=None):
@@ -240,10 +236,10 @@ class TestParseXResponse(unittest.TestCase):
         items = xurl_x.parse_x_response(resp)
         self.assertEqual(items[0]["why_relevant"], "")
 
-
 # ---------------------------------------------------------------------------
 # DEPTH_CONFIG
 # ---------------------------------------------------------------------------
+
 
 class TestDepthConfig(unittest.TestCase):
     def test_all_standard_depths_present(self):
@@ -255,7 +251,6 @@ class TestDepthConfig(unittest.TestCase):
             xurl_x.DEPTH_CONFIG["deep"],
             xurl_x.DEPTH_CONFIG["quick"],
         )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_relevance.py
+++ b/tests/test_youtube_relevance.py
@@ -1,11 +1,8 @@
 """Tests for YouTube relevance scoring."""
 
-import sys
 import unittest
-from pathlib import Path
 
 # Add lib to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib.relevance import token_overlap_relevance as _compute_relevance, tokenize as _tokenize
 
@@ -104,7 +101,6 @@ class TestComputeRelevance(unittest.TestCase):
     def test_single_word_no_match(self):
         result = _compute_relevance("Seedance", "Random cooking video")
         self.assertEqual(result, 0.0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -2,14 +2,10 @@
 
 import json
 import os
-import sys
 import tempfile
 import unittest
 import urllib.error
-from pathlib import Path
 from unittest import mock
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "last30days" / "scripts"))
 
 from lib import youtube_yt
 
@@ -535,7 +531,6 @@ class TestYtdlpSSHRouting(unittest.TestCase):
         self.assertIn("yt-dlp", cmd[5])
         self.assertIn("--ignore-config", cmd[5])
         self.assertIn("--no-cookies-from-browser", cmd[5])
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #411.

Adds `tests/conftest.py` as the single pytest-discovered place that inserts
`skills/last30days/scripts` into `sys.path`.

Then removes the duplicated per-file `sys.path.insert(...)` boilerplate from
tests and drops the corresponding `# noqa: E402` suppressions. A few tests that
previously imported via `scripts.lib.*` now import via `lib.*`, matching the
shared scripts path.

Although #411 estimated ~20 files, the current test suite had 83 per-file path
insertions. This PR removes all of them so only `tests/conftest.py` owns test
import path setup.

## Testing

- `rg "sys.path.insert" tests` confirms only `tests/conftest.py` contains `sys.path.insert`
- `rg "scripts\.lib" tests` returns no matches
- `rg "noqa: E402|ruff: noqa: E402" tests` returns no matches
- `git diff --check` passes
- `python -m compileall tests -q` passes
- Python 3.12.10: `pytest --collect-only -q` completes successfully
- Python 3.12.10 with `PYTHONUTF8=1`: `pytest tests/test_plugin_contract.py tests/test_skill_meta.py tests/test_version_consistency.py -q --tb=short` passes: 14 passed
- Python 3.12.10 with `PYTHONUTF8=1`: `pytest tests/test_env_include_sources_default.py tests/test_digg.py -q --tb=short` passes: 29 passed, 4 skipped
- Full Python 3.12.10 `pytest -q --tb=short` was attempted, but the local Windows run timed out after 10 minutes after hitting environment-specific failures in `tests/test_chrome_cookies.py` because `openssl` is not installed on PATH
- `uv run python -m pytest -q --tb=short` was not run locally because `uv` is not installed in this environment