### PR TITLE
feat: add Hacker News as a first-class source via Algolia API

### DIFF
--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -100,6 +100,7 @@ from lib import (
     dedupe,
     entity_extract,
     env,
+    hacker_news,
     http,
     models,
     normalize,
@@ -303,6 +304,34 @@ def _search_youtube(
     return youtube_items, youtube_error
 
 
+def _search_hn(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str,
+) -> tuple:
+    """Search Hacker News via Algolia API (runs in thread).
+
+    Returns:
+        Tuple of (hn_items, hn_error)
+    """
+    hn_error = None
+
+    try:
+        raw_response = hacker_news.search_hacker_news(
+            topic, from_date, to_date, depth=depth,
+        )
+    except Exception as e:
+        return [], f"{type(e).__name__}: {e}"
+
+    hn_items = hacker_news.parse_hn_response(raw_response)
+
+    if raw_response.get("error") and not hn_error:
+        hn_error = raw_response["error"]
+
+    return hn_items, hn_error
+
+
 def _search_web(
     topic: str,
     config: dict,
@@ -501,9 +530,9 @@ def run_research(
     """Run the research pipeline.
 
     Returns:
-        Tuple of (reddit_items, x_items, youtube_items, web_items, web_needed,
+        Tuple of (reddit_items, x_items, youtube_items, web_items, hn_items, web_needed,
                   raw_openai, raw_xai, raw_reddit_enriched,
-                  reddit_error, x_error, youtube_error, web_error)
+                  reddit_error, x_error, youtube_error, web_error, hn_error)
 
     Note: web_needed is True when web search should be performed by the assistant
     (i.e., no native web search API keys are configured). When native web search
@@ -517,6 +546,7 @@ def run_research(
     x_items = []
     youtube_items = []
     web_items = []
+    hn_items = []
     raw_openai = None
     raw_xai = None
     raw_reddit_enriched = []
@@ -524,6 +554,7 @@ def run_research(
     x_error = None
     youtube_error = None
     web_error = None
+    hn_error = None
 
     # Determine web search mode
     do_web = sources in ("all", "web", "reddit-web", "x-web")
@@ -565,16 +596,17 @@ def run_research(
                     progress.show_error(f"YouTube error: {e}")
             if progress:
                 progress.end_youtube(len(youtube_items))
-        return reddit_items, x_items, youtube_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error
+        return reddit_items, x_items, youtube_items, web_items, hn_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error, hn_error
 
     # Determine which searches to run
     do_reddit = sources in ("both", "reddit", "all", "reddit-web")
     do_x = sources in ("both", "x", "all", "x-web")
 
-    # Run Reddit, X, YouTube, and Web searches in parallel
+    # Run Reddit, X, YouTube, HN, and Web searches in parallel
     reddit_future = None
     x_future = None
     youtube_future = None
+    hn_future = None
     web_future = None
     max_workers = 2 + (1 if run_youtube else 0) + (1 if web_backend else 0)
 
@@ -602,6 +634,11 @@ def run_research(
             youtube_future = executor.submit(
                 _search_youtube, topic, from_date, to_date, depth
             )
+
+        # HN is always searched (no API key needed)
+        hn_future = executor.submit(
+            _search_hn, topic, from_date, to_date, depth
+        )
 
         if web_backend:
             sys.stderr.write(f"[web] Searching via {web_backend}\n")
@@ -676,6 +713,21 @@ def run_research(
                     progress.show_error(f"Web error: {e}")
             sys.stderr.write(f"[web] {len(web_items)} results\n")
             sys.stderr.flush()
+
+        # Collect HN results
+        if hn_future:
+            try:
+                hn_items, hn_error = hn_future.result(timeout=future_timeout)
+                if hn_error and progress:
+                    progress.show_error(f"HN error: {hn_error}")
+            except TimeoutError:
+                hn_error = f"HN search timed out after {future_timeout}s"
+                if progress:
+                    progress.show_error(hn_error)
+            except Exception as e:
+                hn_error = f"{type(e).__name__}: {e}"
+                if progress:
+                    progress.show_error(f"HN error: {e}")
 
     # Enrich Reddit items with real data (parallel, capped)
     enrich_max = timeouts["enrich_max_items"]
@@ -760,7 +812,7 @@ def run_research(
         if sup_x:
             x_items.extend(sup_x)
 
-    return reddit_items, x_items, youtube_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error
+    return reddit_items, x_items, youtube_items, web_items, hn_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error, hn_error
 
 
 def main():
@@ -982,7 +1034,7 @@ def main():
         mode = sources
 
     # Run research
-    reddit_items, x_items, youtube_items, web_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error = run_research(
+    reddit_items, x_items, youtube_items, web_items, hn_items, web_needed, raw_openai, raw_xai, raw_reddit_enriched, reddit_error, x_error, youtube_error, web_error, hn_error = run_research(
         args.topic,
         sources,
         config,
@@ -1005,6 +1057,7 @@ def main():
     normalized_x = normalize.normalize_x_items(x_items, from_date, to_date)
     normalized_youtube = normalize.normalize_youtube_items(youtube_items, from_date, to_date) if youtube_items else []
     normalized_web = websearch.normalize_websearch_items(web_items, from_date, to_date) if web_items else []
+    normalized_hn = normalize.normalize_hn_items(hn_items, from_date, to_date) if hn_items else []
 
     # Hard date filter: exclude items with verified dates outside the range
     # This is the safety net - even if prompts let old content through, this filters it
@@ -1015,24 +1068,28 @@ def main():
     # YouTube content has a longer shelf life than tweets/posts.
     filtered_youtube = normalized_youtube
     filtered_web = normalize.filter_by_date_range(normalized_web, from_date, to_date) if normalized_web else []
+    filtered_hn = normalize.filter_by_date_range(normalized_hn, from_date, to_date) if normalized_hn else []
 
     # Score items
     scored_reddit = score.score_reddit_items(filtered_reddit)
     scored_x = score.score_x_items(filtered_x)
     scored_youtube = score.score_youtube_items(filtered_youtube) if filtered_youtube else []
     scored_web = score.score_websearch_items(filtered_web) if filtered_web else []
+    scored_hn = score.score_hn_items(filtered_hn) if filtered_hn else []
 
     # Sort items
     sorted_reddit = score.sort_items(scored_reddit)
     sorted_x = score.sort_items(scored_x)
     sorted_youtube = score.sort_items(scored_youtube) if scored_youtube else []
     sorted_web = score.sort_items(scored_web) if scored_web else []
+    sorted_hn = score.sort_items(scored_hn) if scored_hn else []
 
     # Dedupe items
     deduped_reddit = dedupe.dedupe_reddit(sorted_reddit)
     deduped_x = dedupe.dedupe_x(sorted_x)
     deduped_youtube = dedupe.dedupe_youtube(sorted_youtube) if sorted_youtube else []
     deduped_web = websearch.dedupe_websearch(sorted_web) if sorted_web else []
+    deduped_hn = dedupe.dedupe_hn(sorted_hn) if sorted_hn else []
 
     # Minimum result guarantee: if all Reddit results were filtered out but
     # we had raw results, keep top 3 by relevance regardless of score
@@ -1056,10 +1113,12 @@ def main():
     report.x = deduped_x
     report.youtube = deduped_youtube
     report.web = deduped_web
+    report.hn = deduped_hn
     report.reddit_error = reddit_error
     report.x_error = x_error
     report.youtube_error = youtube_error
     report.web_error = web_error
+    report.hn_error = hn_error
 
     # Generate context snippet
     report.context_snippet_md = render.render_context_snippet(report)

--- a/scripts/lib/dedupe.py
+++ b/scripts/lib/dedupe.py
@@ -36,12 +36,14 @@ def jaccard_similarity(set1: Set[str], set2: Set[str]) -> float:
     return intersection / union if union > 0 else 0.0
 
 
-def get_item_text(item: Union[schema.RedditItem, schema.XItem, schema.YouTubeItem]) -> str:
+def get_item_text(item: Union[schema.RedditItem, schema.XItem, schema.YouTubeItem, schema.HackerNewsItem]) -> str:
     """Get comparable text from an item."""
     if isinstance(item, schema.RedditItem):
         return item.title
     elif isinstance(item, schema.YouTubeItem):
         return f"{item.title} {item.channel_name}"
+    elif isinstance(item, schema.HackerNewsItem):
+        return item.title
     else:
         return item.text
 
@@ -127,4 +129,12 @@ def dedupe_youtube(
     threshold: float = 0.7,
 ) -> List[schema.YouTubeItem]:
     """Dedupe YouTube items."""
+    return dedupe_items(items, threshold)
+
+
+def dedupe_hn(
+    items: List[schema.HackerNewsItem],
+    threshold: float = 0.7,
+) -> List[schema.HackerNewsItem]:
+    """Dedupe HN items by title similarity."""
     return dedupe_items(items, threshold)

--- a/scripts/lib/hacker_news.py
+++ b/scripts/lib/hacker_news.py
@@ -4,6 +4,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 from . import http
 
@@ -54,7 +55,7 @@ def search_hacker_news(
 
     # Algolia search endpoint
     # Use story type filter to exclude comments
-    params = f"query={topic}&tags=story&hitsPerPage={hits_per_page}&numericFilters=created_at_i>={from_ts},created_at_i<={to_ts}"
+    params = f"query={quote(topic)}&tags=story&hitsPerPage={hits_per_page}&numericFilters=created_at_i>={from_ts},created_at_i<={to_ts}"
     url = f"{HN_ALGOLIA_URL}/search?{params}"
 
     _log_info(f"Searching HN Algolia: {topic}")

--- a/scripts/lib/hacker_news.py
+++ b/scripts/lib/hacker_news.py
@@ -1,0 +1,127 @@
+"""Hacker News search via Algolia HN API."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import http
+
+HN_ALGOLIA_URL = "https://hn.algolia.com/api/v1"
+
+
+def _log_error(msg: str):
+    """Log error to stderr."""
+    sys.stderr.write(f"[HN ERROR] {msg}\n")
+    sys.stderr.flush()
+
+
+def _log_info(msg: str):
+    """Log info to stderr."""
+    sys.stderr.write(f"[HN] {msg}\n")
+    sys.stderr.flush()
+
+
+def search_hacker_news(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str = "default",
+) -> Dict[str, Any]:
+    """Search Hacker News via Algolia API.
+
+    Args:
+        topic: Search topic
+        from_date: Start date (YYYY-MM-DD)
+        to_date: End date (YYYY-MM-DD)
+        depth: 'quick', 'default', or 'deep'
+
+    Returns:
+        Raw Algolia response dict
+    """
+    # Build date filter for Algolia
+    # Algolia uses Unix timestamps
+    from_ts = int(datetime.fromisoformat(from_date).timestamp())
+    to_ts = int(datetime.fromisoformat(to_date).timestamp()) + 86400  # Include full end day
+
+    # Map depth to hits per page
+    hits_map = {
+        "quick": 15,
+        "default": 30,
+        "deep": 60,
+    }
+    hits_per_page = hits_map.get(depth, 30)
+
+    # Algolia search endpoint
+    # Use story type filter to exclude comments
+    params = f"query={topic}&tags=story&hitsPerPage={hits_per_page}&numericFilters=created_at_i>={from_ts},created_at_i<={to_ts}"
+    url = f"{HN_ALGOLIA_URL}/search?{params}"
+
+    _log_info(f"Searching HN Algolia: {topic}")
+
+    try:
+        response = http.get(url, timeout=30)
+        return response  # http.get already returns parsed JSON
+    except http.HTTPError as e:
+        _log_error(f"HTTP error: {e}")
+        return {"error": str(e)}
+    except Exception as e:
+        _log_error(f"Unexpected error: {e}")
+        return {"error": str(e)}
+
+
+def parse_hn_response(raw_response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Parse Algolia HN response into normalized item dicts.
+
+    Args:
+        raw_response: Raw response from search_hacker_news
+
+    Returns:
+        List of normalized HN item dicts ready for HackerNewsItem creation
+    """
+    if raw_response.get("error"):
+        return []
+
+    hits = raw_response.get("hits", [])
+    items = []
+
+    for i, hit in enumerate(hits):
+        # Skip、脱出 posts (Ask HN, Show HN without external URL)
+        # Only include stories with external URLs
+        url = hit.get("url", "")
+        if not url:
+            # This is a Ask HN or self-post without external link
+            # Use the HN discussion link instead
+            object_id = hit.get("objectID", "")
+            url = f"https://news.ycombinator.com/item?id={object_id}"
+
+        # Parse created_at timestamp
+        created_at = hit.get("created_at", "")
+        date = ""
+        if created_at:
+            try:
+                dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+                date = dt.strftime("%Y-%m-%d")
+            except (ValueError, TypeError):
+                date = ""
+
+        # Extract points (upvotes) and comments
+        points = hit.get("points", 0)
+        num_comments = hit.get("num_comments", 0)
+
+        item = {
+            "id": hit.get("objectID", f"HN{i+1}"),
+            "title": hit.get("title", ""),
+            "url": url,
+            "author": hit.get("author", ""),
+            "date": date,
+            "date_confidence": "high",
+            "points": points,
+            "num_comments": num_comments,
+            "relevance": 0.5,
+            "why_relevant": "",
+        }
+
+        items.append(item)
+
+    return items

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -200,6 +200,50 @@ def normalize_youtube_items(
     return normalized
 
 
+def normalize_hn_items(
+    items: List[Dict[str, Any]],
+    from_date: str,
+    to_date: str,
+) -> List[schema.HackerNewsItem]:
+    """Normalize raw HN items to schema.
+
+    Args:
+        items: Raw HN items from Algolia API
+        from_date: Start of date range
+        to_date: End of date range
+
+    Returns:
+        List of HackerNewsItem objects
+    """
+    normalized = []
+
+    for item in items:
+        # Parse engagement (points = upvotes on HN)
+        engagement = None
+        points = item.get("points", 0) or item.get("score", 0)
+        if points:
+            engagement = schema.Engagement(score=points)
+
+        # Determine date confidence
+        date_str = item.get("date")
+        date_confidence = dates.get_date_confidence(date_str, from_date, to_date)
+
+        normalized.append(schema.HackerNewsItem(
+            id=item.get("id", ""),
+            title=item.get("title", ""),
+            url=item.get("url", ""),
+            author=item.get("author", ""),
+            date=date_str,
+            date_confidence=date_confidence,
+            engagement=engagement,
+            num_comments=item.get("num_comments", 0),
+            relevance=item.get("relevance", 0.5),
+            why_relevant=item.get("why_relevant", ""),
+        ))
+
+    return normalized
+
+
 def items_to_dicts(items: List) -> List[Dict[str, Any]]:
     """Convert schema items to dicts for JSON serialization."""
     return [item.to_dict() for item in items]

--- a/scripts/lib/render.py
+++ b/scripts/lib/render.py
@@ -215,6 +215,27 @@ def render_compact(report: schema.Report, limit: int = 15, missing_keys: str = "
             lines.append(f"  *{item.why_relevant}*")
             lines.append("")
 
+    # Hacker News items
+    if report.hn_error:
+        lines.append("### Hacker News")
+        lines.append("")
+        lines.append(f"**ERROR:** {report.hn_error}")
+        lines.append("")
+    elif report.hn:
+        lines.append("### Hacker News")
+        lines.append("")
+        for item in report.hn[:limit]:
+            eng_str = ""
+            if item.engagement:
+                eng_str = f" [{item.engagement.score} pts, {item.num_comments} comments]"
+            date_str = f" ({item.date})" if item.date else ""
+
+            lines.append(f"**{item.id}** (score:{item.score}) {item.author}{date_str}{eng_str}")
+            lines.append(f"  {item.title}")
+            lines.append(f"  {item.url}")
+            lines.append(f"  *{item.why_relevant}*")
+            lines.append("")
+
     # Web items (if any - populated by the assistant)
     if report.web_error:
         lines.append("### Web Results")

--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -175,6 +175,39 @@ class WebSearchItem:
 
 
 @dataclass
+class HackerNewsItem:
+    """Normalized Hacker News item."""
+    id: str  # story_id from Algolia
+    title: str
+    url: str
+    author: str
+    date: Optional[str] = None
+    date_confidence: str = "high"  # HN Algolia provides reliable timestamps
+    engagement: Optional[Engagement] = None
+    num_comments: int = 0
+    relevance: float = 0.5
+    why_relevant: str = ""
+    subs: SubScores = field(default_factory=SubScores)
+    score: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'title': self.title,
+            'url': self.url,
+            'author': self.author,
+            'date': self.date,
+            'date_confidence': self.date_confidence,
+            'engagement': self.engagement.to_dict() if self.engagement else None,
+            'num_comments': self.num_comments,
+            'relevance': self.relevance,
+            'why_relevant': self.why_relevant,
+            'subs': self.subs.to_dict(),
+            'score': self.score,
+        }
+
+
+@dataclass
 class YouTubeItem:
     """Normalized YouTube item."""
     id: str  # video_id
@@ -221,6 +254,7 @@ class Report:
     x: List[XItem] = field(default_factory=list)
     web: List[WebSearchItem] = field(default_factory=list)
     youtube: List[YouTubeItem] = field(default_factory=list)
+    hn: List["HackerNewsItem"] = field(default_factory=list)
     best_practices: List[str] = field(default_factory=list)
     prompt_pack: List[str] = field(default_factory=list)
     context_snippet_md: str = ""
@@ -229,6 +263,7 @@ class Report:
     x_error: Optional[str] = None
     web_error: Optional[str] = None
     youtube_error: Optional[str] = None
+    hn_error: Optional[str] = None
     # Cache info
     from_cache: bool = False
     cache_age_hours: Optional[float] = None
@@ -248,6 +283,7 @@ class Report:
             'x': [x.to_dict() for x in self.x],
             'web': [w.to_dict() for w in self.web],
             'youtube': [y.to_dict() for y in self.youtube],
+            'hn': [h.to_dict() for h in self.hn],
             'best_practices': self.best_practices,
             'prompt_pack': self.prompt_pack,
             'context_snippet_md': self.context_snippet_md,
@@ -260,6 +296,8 @@ class Report:
             d['web_error'] = self.web_error
         if self.youtube_error:
             d['youtube_error'] = self.youtube_error
+        if self.hn_error:
+            d['hn_error'] = self.hn_error
         if self.from_cache:
             d['from_cache'] = self.from_cache
         if self.cache_age_hours is not None:
@@ -359,6 +397,28 @@ class Report:
                 score=y.get('score', 0),
             ))
 
+        # Reconstruct HN items
+        hn_items = []
+        for h in data.get('hn', []):
+            eng = None
+            if h.get('engagement'):
+                eng = Engagement(**h['engagement'])
+            subs = SubScores(**h.get('subs', {})) if h.get('subs') else SubScores()
+            hn_items.append(HackerNewsItem(
+                id=h['id'],
+                title=h['title'],
+                url=h.get('url', ''),
+                author=h.get('author', ''),
+                date=h.get('date'),
+                date_confidence=h.get('date_confidence', 'high'),
+                engagement=eng,
+                num_comments=h.get('num_comments', 0),
+                relevance=h.get('relevance', 0.5),
+                why_relevant=h.get('why_relevant', ''),
+                subs=subs,
+                score=h.get('score', 0),
+            ))
+
         return cls(
             topic=data['topic'],
             range_from=range_from,
@@ -371,6 +431,7 @@ class Report:
             x=x_items,
             web=web_items,
             youtube=youtube_items,
+            hn=hn_items,
             best_practices=data.get('best_practices', []),
             prompt_pack=data.get('prompt_pack', []),
             context_snippet_md=data.get('context_snippet_md', ''),
@@ -378,6 +439,7 @@ class Report:
             x_error=data.get('x_error'),
             web_error=data.get('web_error'),
             youtube_error=data.get('youtube_error'),
+            hn_error=data.get('hn_error'),
             from_cache=data.get('from_cache', False),
             cache_age_hours=data.get('cache_age_hours'),
         )

--- a/scripts/lib/score.py
+++ b/scripts/lib/score.py
@@ -337,6 +337,76 @@ def score_websearch_items(items: List[schema.WebSearchItem]) -> List[schema.WebS
     return items
 
 
+def score_hn_items(items: List[schema.HackerNewsItem]) -> List[schema.HackerNewsItem]:
+    """Compute scores for Hacker News items.
+
+    Uses engagement (points) and comments for weighting, similar to Reddit.
+    HN items don't get a source penalty since HN is a first-class source.
+
+    Date confidence adjustments:
+    - High confidence (Algolia timestamp): +10 bonus
+    - Med confidence: no change
+    - Low confidence: -15 penalty
+
+    Args:
+        items: List of HN items
+
+    Returns:
+        Items with updated scores
+    """
+    if not items:
+        return items
+
+    for item in items:
+        # Relevance subscore (model-provided, convert to 0-100)
+        rel_score = int(item.relevance * 100)
+
+        # Recency subscore
+        rec_score = dates.recency_score(item.date)
+
+        # Engagement: points + comments factor
+        eng_score = 0
+        if item.engagement and item.engagement.score:
+            # Normalize points to 0-100 (log scale for large values)
+            pts = item.engagement.score
+            if pts <= 100:
+                eng_score = pts
+            elif pts <= 1000:
+                eng_score = 100 + (pts - 100) * 0.1
+            else:
+                eng_score = 100 + 90 + (pts - 1000) * 0.01
+                eng_score = min(eng_score, 200)
+
+        # Comments factor
+        comments_score = 0
+        if item.num_comments:
+            if item.num_comments <= 10:
+                comments_score = item.num_comments * 2
+            elif item.num_comments <= 100:
+                comments_score = 20 + (item.num_comments - 10) * 0.5
+            else:
+                comments_score = 65 + (item.num_comments - 100) * 0.02
+                comments_score = min(comments_score, 100)
+
+        # HN weights: engagement-heavy
+        overall = (
+            WEIGHT_RELEVANCE * rel_score +
+            WEIGHT_RECENCY * rec_score +
+            WEIGHT_ENGAGEMENT * eng_score +
+            0.15 * comments_score
+        )
+
+        # Apply date confidence adjustments
+        if item.date_confidence == "high":
+            overall += 10
+        elif item.date_confidence == "low":
+            overall -= 15
+
+        item.score = max(0, min(100, int(overall)))
+
+    return items
+
+
 def sort_items(items: List[Union[schema.RedditItem, schema.XItem, schema.WebSearchItem, schema.YouTubeItem]]) -> List:
     """Sort items by score (descending), then date, then source priority.
 

--- a/scripts/lib/websearch.py
+++ b/scripts/lib/websearch.py
@@ -201,7 +201,7 @@ def extract_date_signals(
     return None, "low"
 
 
-# Domains to exclude (Reddit and X are handled separately)
+# Domains to exclude (Reddit, X, and HN are handled as separate first-class sources)
 EXCLUDED_DOMAINS = {
     "reddit.com",
     "www.reddit.com",
@@ -211,6 +211,8 @@ EXCLUDED_DOMAINS = {
     "x.com",
     "www.x.com",
     "mobile.twitter.com",
+    "news.ycombinator.com",
+    "hn.algolia.com",
 }
 
 


### PR DESCRIPTION
## Summary
- Adds Hacker News search using the free Algolia HN API (hn.algolia.com)
- HN runs in parallel with other sources — no API key required
- HN items are normalized, scored (engagement-heavy), deduplicated by title similarity, and rendered in output
- HN domains (news.ycombinator.com, hn.algolia.com) are excluded from web search results to avoid duplication

## Files Changed
- `scripts/lib/hacker_news.py` — New module with `search_hacker_news()` and `parse_hn_response()`
- `scripts/lib/schema.py` — Added `HackerNewsItem` dataclass and `hn` field in `Report`
- `scripts/lib/normalize.py` — Added `normalize_hn_items()` with date confidence scoring
- `scripts/lib/score.py` — Added `score_hn_items()` with engagement-heavy weighting (points + comments)
- `scripts/lib/dedupe.py` — Added `dedupe_hn()` wrapper using title similarity
- `scripts/lib/websearch.py` — Excluded HN domains from web search results
- `scripts/lib/render.py` — Added HN section in `render_compact()` output
- `scripts/last30days.py` — Wired HN into search pipeline with thread pool

## Test
```
python3 scripts/last30days.py "claude code minimax setup"
```
Verified: HN search → parse → normalize → score → dedupe → render pipeline works end-to-end.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)