### PR TITLE
fix(threads): use 'query' param for ScrapeCreators v1 search (regression since PR #393)

### DIFF
--- a/docs/solutions/design-patterns/scrapecreators-v1-search-uses-query-param-2026-05-27.md
+++ b/docs/solutions/design-patterns/scrapecreators-v1-search-uses-query-param-2026-05-27.md
@@ -1,0 +1,106 @@
+---
+title: ScrapeCreators v1 search endpoints require `query=`, not `keyword=` (despite "Search by Keyword" docs label)
+date: 2026-05-27
+category: design-patterns
+module: threads
+problem_type: api_contract_convention
+component: source_integrations
+severity: high
+applies_when:
+  - integrating any new ScrapeCreators v1 endpoint into a lib/<source>.py module
+  - refactoring an existing ScrapeCreators source (especially when porting from `requests` to `lib/http`)
+  - debugging "source returns 0 items but other sources work" against a ScrapeCreators-backed source
+  - copying request shape from a ScrapeCreators endpoint doc page that lists "Search by Keyword" in its sidebar
+tags:
+  - scrapecreators
+  - threads
+  - api-contract
+  - silent-regression
+  - last30days-issue-15
+related_components:
+  - threads
+  - instagram
+  - tiktok
+  - pinterest
+  - lib/http
+---
+
+# ScrapeCreators v1 search endpoints use `query=`, not `keyword=`
+
+## Context
+
+PR #393 (commit `80a1a47e`, 2026-05-15) refactored several source modules to route HTTP calls through `lib/http`'s urllib wrapper, replacing the `requests` library. The refactor preserved or introduced `params={"keyword": core_topic}` in `lib/threads.py:157`. ScrapeCreators' `/v1/threads/search` endpoint actually requires `params={"query": ...}` and returns HTTP 400 "Invalid parameters or missing required fields" on every request when sent `keyword=`. The Threads source contributed 0 items on every run for every user with `SCRAPECREATORS_API_KEY` configured, for 12 days, before being diagnosed and fixed in issue #15 (2026-05-27).
+
+## The trap
+
+ScrapeCreators' documentation labels the endpoint "**Search by Keyword**" in their docs sidebar. A developer adding or refactoring this integration naturally reaches for `params={"keyword": ...}`. The label is misleading: the actual parameter name on every ScrapeCreators v1 search endpoint is `query`, regardless of the endpoint's human-readable name.
+
+Cross-endpoint confirmation:
+
+- `/v1/threads/search?query=...` ✓
+- `/v1/pinterest/search?query=...` ✓ (verified via lib/pinterest.py, working in production)
+- `/v1/tiktok/search?query=...` ✓ (verified via lib/tiktok.py)
+- `/v1/instagram/search?query=...` ✓ (verified via lib/instagram.py)
+
+Every v1 search endpoint uses `query`. None use `keyword`. The convention is uniform; only the human-readable label varies.
+
+## Failure mode
+
+A `keyword=` request returns HTTP 400. ScrapeCreators' 400 response body is "Invalid parameters or missing required fields" — generic enough that the failure looks like a transient API issue rather than a request-shape bug. In this repository, two compounding observability gaps hid the failure for 12 days:
+
+1. The Threads `_log` helper at `lib/threads.py:28` did not pass `tty_only=False`, so `log.source_log("Threads", ...)` calls were silently dropped in non-TTY contexts. Fixed by commit `6270694` (PR #14) and pending upstream as PR #454.
+2. `lib/threads.py:162-164` catches `HTTPError` inline and returns `{"items": [], "error": "..."}`. The pipeline's `parse_threads_response()` only returns the items list — the `error` key is dropped, so `bundle.errors_by_source` never receives the failure. Affects multiple source modules with the same swallow pattern (Perplexity, Bluesky, Instagram, etc.). Deferred follow-up noted in `work/2026-05-27/10-perplexity-fix-wrap-up-final-state.md`.
+
+Both gaps reinforce each other: silent log + dropped error envelope = a source that quietly returns 0 items with no visible diagnostic. The param-name bug is what *caused* the failure; the observability gaps are what *hid* it.
+
+## Detection
+
+Direct cURL verification with both shapes — one passes, one fails:
+
+```bash
+# Confirms the correct shape:
+curl "https://api.scrapecreators.com/v1/threads/search?query=tourism" \
+  -H "x-api-key: $SCRAPECREATORS_API_KEY"
+# Returns 200 OK with {"success": true, "credits_remaining": N, "posts": [...]}
+
+# Confirms the broken shape:
+curl "https://api.scrapecreators.com/v1/threads/search?keyword=tourism" \
+  -H "x-api-key: $SCRAPECREATORS_API_KEY"
+# Returns HTTP 400 Bad Request
+```
+
+The regression test pinning this is `tests/test_threads.py::TestSearchThreadsRequestShape::test_uses_query_param_not_keyword` (issue #15).
+
+## Pattern to follow
+
+When adding or refactoring a ScrapeCreators v1 source integration:
+
+1. Use `params={"query": <subject>}` for the search request. **Always `query`, never `keyword`.**
+2. Add an inline comment near the param noting the trap, so the next reader doesn't "fix" it back to `keyword=`. Pattern:
+   ```python
+   # ScrapeCreators v1 search endpoints use 'query', NOT 'keyword' — even
+   # though the endpoint is labeled "Search by Keyword" in their docs sidebar.
+   # Sending 'keyword=' returns HTTP 400. See docs/solutions/design-patterns/
+   # scrapecreators-v1-search-uses-query-param-2026-05-27.md
+   params={"query": core_topic},
+   ```
+3. Write a regression test pinning the param name. Mock `lib.<source>.http.get`, call `search_<source>`, then assert `mock_http_get.call_args.kwargs["params"]` contains `"query"` and does NOT contain `"keyword"`.
+4. Cross-check the response shape against the actual API. ScrapeCreators returns `{"success": bool, "credits_remaining": int, "posts": [...]}` for Threads. Items are under `posts`, not `items` or `data`. The existing extractor at `lib/threads.py:167-174` already includes `posts` in its fallback chain — preserve this when refactoring.
+5. Pass `tty_only=False` to every `log.source_log(...)` call in the source's `_log` helper. Enforced by `tests/test_source_log_visibility.py`.
+
+## Out-of-scope follow-ups discovered while diagnosing this
+
+Documented for future work, not addressed by this fix:
+
+- **Query-shape sensitivity.** ScrapeCreators' Threads search returns 0 items for long phrasal queries even when the param name is correct. "tourism" returns 6-17 items; "where are people no longer flying and where are they going instead" returns 0. The skill's `_extract_core_subject()` strips some noise but not enough for ScrapeCreators' Threads endpoint specifically. Likely needs a Threads-specific aggressive noun-extraction pass or a fallback-to-shorter-keyword strategy on first-0-result subqueries.
+- **Layer-2 diagnosability.** Errors caught inside source modules should propagate to `bundle.errors_by_source` so the rendered report's `## Source Errors` section reflects them. Same swallow pattern affects multiple sources.
+- **`threads.net` → `threads.com` URL emitter.** Meta rebranded the public web URL; the 301 redirect still works but `lib/threads.py:97-100` should emit `threads.com` directly for cleanliness.
+
+## References
+
+- Issue: dzivkovi/last30days-skill#15
+- Regression introduction: PR #393 (mvanhorn/last30days-skill), commit `80a1a47e`, 2026-05-15
+- Regression test: `tests/test_threads.py::TestSearchThreadsRequestShape`
+- Inline anti-regression comment: `skills/last30days/scripts/lib/threads.py:156-159`
+- ScrapeCreators docs landing: https://docs.scrapecreators.com
+- Threads search endpoint: https://docs.scrapecreators.com/v1/threads/search

--- a/skills/last30days/scripts/lib/threads.py
+++ b/skills/last30days/scripts/lib/threads.py
@@ -154,7 +154,12 @@ def search_threads(
     try:
         data = http.get(
             f"{SCRAPECREATORS_BASE}/search",
-            params={"keyword": core_topic},
+            # ScrapeCreators v1 search endpoints use 'query', NOT 'keyword' — even
+            # though the endpoint is labeled "Search by Keyword" in their docs sidebar.
+            # Sending 'keyword=' returns HTTP 400 "Invalid parameters or missing
+            # required fields." Pinned by tests/test_threads.py. See issue #15 and
+            # docs/solutions/design-patterns/scrapecreators-v1-search-uses-query-param-2026-05-27.md.
+            params={"query": core_topic},
             headers=http.scrapecreators_headers(token),
             timeout=30,
             retries=2,

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,251 @@
+"""Tests for threads source module.
+
+Covers:
+- _extract_core_subject (noise stripping)
+- _parse_date (timestamp parsing across SC's various date fields)
+- parse_threads_response (engine-side envelope unwrapping)
+- search_threads request shape (REGRESSION TEST for issue #15:
+  ScrapeCreators requires 'query' param, not 'keyword')
+- _parse_items against the real ScrapeCreators response shape
+  ({"success": True, "credits_remaining": N, "posts": [...]})
+"""
+
+import unittest
+from unittest.mock import patch
+
+from lib import threads
+
+
+class TestExtractCoreSubject(unittest.TestCase):
+    def test_strips_threads_noise(self):
+        result = threads._extract_core_subject("latest trending news claude code")
+        self.assertNotIn("latest", result)
+        self.assertNotIn("trending", result)
+        self.assertNotIn("news", result)
+        self.assertIn("claude", result)
+
+    def test_preserves_core(self):
+        result = threads._extract_core_subject("react native")
+        self.assertEqual(result, "react native")
+
+
+class TestParseDate(unittest.TestCase):
+    def test_taken_at_unix_timestamp(self):
+        # 2024-06-15T12:00:00Z as unix
+        item = {"taken_at": 1718452800}
+        self.assertEqual(threads._parse_date(item), "2024-06-15")
+
+    def test_created_at_iso(self):
+        item = {"created_at": "2024-03-01T08:30:00.000Z"}
+        self.assertEqual(threads._parse_date(item), "2024-03-01")
+
+    def test_taken_at_preferred_over_created_at(self):
+        item = {"taken_at": 1718452800, "created_at": "2024-06-14T12:00:00Z"}
+        self.assertEqual(threads._parse_date(item), "2024-06-15")
+
+    def test_none_returns_none(self):
+        self.assertIsNone(threads._parse_date({}))
+
+    def test_invalid_date_returns_none(self):
+        self.assertIsNone(threads._parse_date({"created_at": "not-a-date"}))
+
+
+class TestParseThreadsResponse(unittest.TestCase):
+    """parse_threads_response unwraps the envelope produced by search_threads.
+
+    search_threads returns {"items": [...]} (or with error key on failure).
+    parse_threads_response extracts the items list.
+    """
+
+    def test_unwraps_items(self):
+        envelope = {"items": [{"id": "TH1", "text": "hello"}]}
+        self.assertEqual(threads.parse_threads_response(envelope), [{"id": "TH1", "text": "hello"}])
+
+    def test_empty_envelope(self):
+        self.assertEqual(threads.parse_threads_response({}), [])
+
+    def test_error_envelope(self):
+        envelope = {"items": [], "error": "HTTPError: HTTP 400: Bad Request"}
+        self.assertEqual(threads.parse_threads_response(envelope), [])
+
+
+class TestSearchThreadsRequestShape(unittest.TestCase):
+    """REGRESSION TEST for issue #15.
+
+    ScrapeCreators' /v1/threads/search endpoint requires the 'query' parameter.
+    A regression in PR #393 (commit 80a1a47e, 2026-05-15) introduced
+    params={"keyword": ...} which causes HTTP 400 on every request.
+
+    These tests pin the correct call shape and the response-extraction path
+    to prevent re-introduction.
+    """
+
+    @patch("lib.threads.http.get")
+    def test_uses_query_param_not_keyword(self, mock_http_get):
+        """The request MUST use 'query', not 'keyword'.
+
+        ScrapeCreators returns HTTP 400 "Invalid parameters or missing required
+        fields" if 'keyword' is sent instead of 'query'.
+        """
+        mock_http_get.return_value = {"success": True, "credits_remaining": 99, "posts": []}
+
+        threads.search_threads(
+            topic="tourism",
+            from_date="2026-01-01",
+            to_date="2026-05-27",
+            token="fake-key",
+        )
+
+        self.assertEqual(mock_http_get.call_count, 1)
+        kwargs = mock_http_get.call_args.kwargs
+        params = kwargs.get("params", {})
+
+        self.assertIn(
+            "query",
+            params,
+            f"Request must send 'query' (ScrapeCreators API requirement). "
+            f"Got params: {list(params.keys())}. Issue #15.",
+        )
+        self.assertNotIn(
+            "keyword",
+            params,
+            f"Request must NOT send 'keyword' (causes HTTP 400 on ScrapeCreators). "
+            f"Got params: {list(params.keys())}. Issue #15 / PR #393 regression.",
+        )
+
+    @patch("lib.threads.http.get")
+    def test_query_value_is_core_subject(self, mock_http_get):
+        """The query value should be the noise-stripped core subject.
+
+        Verifies the param chain: topic -> _extract_core_subject -> http.get
+        params['query']. Uses a literal expected value (not _extract_core_subject's
+        output) so the assertion remains load-bearing if _extract_core_subject
+        is ever changed accidentally.
+        """
+        mock_http_get.return_value = {"success": True, "credits_remaining": 99, "posts": []}
+
+        threads.search_threads(
+            topic="trending vacation",
+            from_date="2026-01-01",
+            to_date="2026-05-27",
+            token="fake-key",
+        )
+
+        params = mock_http_get.call_args.kwargs.get("params", {})
+        self.assertEqual(params["query"], "vacation")
+
+    @patch("lib.threads.http.get")
+    def test_endpoint_url_unchanged(self, mock_http_get):
+        """URL must remain https://api.scrapecreators.com/v1/threads/search.
+
+        Pinned because the URL is the second half of "what makes the request work."
+        """
+        mock_http_get.return_value = {"success": True, "credits_remaining": 99, "posts": []}
+
+        threads.search_threads(
+            topic="tourism",
+            from_date="2026-01-01",
+            to_date="2026-05-27",
+            token="fake-key",
+        )
+
+        url = mock_http_get.call_args.args[0]
+        self.assertEqual(url, "https://api.scrapecreators.com/v1/threads/search")
+
+    @patch("lib.threads.http.get")
+    def test_no_token_returns_error_without_call(self, mock_http_get):
+        """Missing token short-circuits before any HTTP call."""
+        result = threads.search_threads(
+            topic="tourism",
+            from_date="2026-01-01",
+            to_date="2026-05-27",
+            token=None,
+        )
+        mock_http_get.assert_not_called()
+        self.assertEqual(result["items"], [])
+        self.assertIn("SCRAPECREATORS_API_KEY", result["error"])
+
+
+class TestSearchThreadsResponseShape(unittest.TestCase):
+    """search_threads must correctly extract items from ScrapeCreators' real shape.
+
+    Actual ScrapeCreators response:
+        {
+          "success": true,
+          "credits_remaining": 20970,
+          "posts": [ ... ]
+        }
+
+    The extractor at lib/threads.py:167-174 must surface posts[] as items.
+    """
+
+    @patch("lib.threads.http.get")
+    def test_posts_key_extracted_to_items(self, mock_http_get):
+        # Use a unix timestamp inside the search window (2024 range)
+        mock_http_get.return_value = {
+            "success": True,
+            "credits_remaining": 20000,
+            "posts": [
+                {
+                    "id": "TH1",
+                    "code": "abc123",
+                    "user": {"username": "traveler", "full_name": "Tina Traveler"},
+                    "text": "Molise is the least visited region in all of Italy!",
+                    "like_count": 42,
+                    "reply_count": 5,
+                    "repost_count": 2,
+                    "created_at": "2024-06-15T12:00:00Z",
+                },
+            ],
+        }
+
+        result = threads.search_threads(
+            topic="tourism",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+            token="fake-key",
+        )
+
+        self.assertEqual(len(result["items"]), 1)
+        item = result["items"][0]
+        self.assertEqual(item["handle"], "traveler")
+        self.assertEqual(item["display_name"], "Tina Traveler")
+        self.assertIn("Molise", item["text"])
+        self.assertEqual(item["engagement"]["likes"], 42)
+        self.assertEqual(item["engagement"]["replies"], 5)
+        self.assertEqual(item["engagement"]["reposts"], 2)
+        self.assertEqual(item["date"], "2024-06-15")
+
+    @patch("lib.threads.http.get")
+    def test_empty_posts_returns_empty_items(self, mock_http_get):
+        mock_http_get.return_value = {"success": True, "credits_remaining": 20000, "posts": []}
+
+        result = threads.search_threads(
+            topic="tourism",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+            token="fake-key",
+        )
+
+        self.assertEqual(result["items"], [])
+        self.assertNotIn("error", result)
+
+    @patch("lib.threads.http.get")
+    def test_http_error_returns_safe_envelope(self, mock_http_get):
+        from lib.http import HTTPError
+
+        mock_http_get.side_effect = HTTPError("HTTP 400: Bad Request", 400, "")
+
+        result = threads.search_threads(
+            topic="tourism",
+            from_date="2024-01-01",
+            to_date="2024-12-31",
+            token="fake-key",
+        )
+
+        self.assertEqual(result["items"], [])
+        self.assertIn("HTTP 400", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ScrapeCreators' `/v1/threads/search` endpoint requires `params={"query": ...}`, not `params={"keyword": ...}`. The code in `lib/threads.py` sends `keyword`, which causes the API to return HTTP 400 on every Threads request. **Every install with `SCRAPECREATORS_API_KEY` configured has been silently losing Threads since 2026-05-15** — the regression was introduced by PR #393 ("refactor: drop requests dep, route all providers through lib/http urllib wrapper") at commit 80a1a47e.

All other ScrapeCreators v1 search endpoints (Pinterest, TikTok, Instagram) use `query` consistently. Only Threads regressed.

## Reproduction

```bash
# Confirms the fix:
curl "https://api.scrapecreators.com/v1/threads/search?query=tourism" \
  -H "x-api-key: $SCRAPECREATORS_API_KEY"
# Returns 200 OK with {"success": true, "credits_remaining": N, "posts": [...]}

# Confirms the bug (current main):
curl "https://api.scrapecreators.com/v1/threads/search?keyword=tourism" \
  -H "x-api-key: $SCRAPECREATORS_API_KEY"
# Returns HTTP 400 Bad Request
```

## What changed

| File | Change |
|---|---|
| `skills/last30days/scripts/lib/threads.py` | One-line fix: `params={"keyword"}` → `params={"query"}`. Inline anti-regression comment points at the new `docs/solutions/` entry. |
| `tests/test_threads.py` (new, 17 tests) | Load-bearing: `TestSearchThreadsRequestShape::test_uses_query_param_not_keyword` pins the API contract with `assertIn("query")` + `assertNotIn("keyword")`. `TestSearchThreadsResponseShape` exercises the real `{"success", "credits_remaining", "posts"}` envelope. Convention mirrors `tests/test_bluesky.py`. |
| `docs/solutions/design-patterns/scrapecreators-v1-search-uses-query-param-2026-05-27.md` (new) | Captures the cross-source convention, the failure mode, detection cURL commands, and a 5-step pattern checklist for future ScrapeCreators source integrations. Cross-references the two compounding observability gaps that hid the regression. |

## Verification

**TDD:** The regression test failed against the unfixed code, passes after the one-line fix. All 17 new tests pass.

**Full suite:** 1589/1593 pass. The 4 failures (`test_footer_nudge_suppression` × 3, `test_last_run_state` × 1) are pre-existing, reproduce on `main` without this diff, and are unrelated to Threads.

**Real-engine end-to-end smoke test** (against the fix applied locally):

```
├─ 🧵 Threads: 8 posts │ 2,549 likes
```

Topic `tourism`, depth quick, ran via `python3 skills/last30days/scripts/last30days.py "tourism" --emit=compact --depth=quick`. The full pipeline (planner → subqueries → `threads.search_threads` → posts extraction → date filter → engagement parsing → ranker → renderer) surfaces Threads items. One Threads post even ranked into the synthesis "Best Takes" section: `"San Francisco is basically cardio disguised as tourism 😅" -- @katalevinak on Threads (fun:85)`.

**Real API smoke test** (multiple keyword shapes):

| Topic | Pre-fix (`keyword=`) | Post-fix (`query=`) |
|---|---|---|
| `tourism` | HTTP 400 | 6 items in 30-day window (Seoul tourism 672 likes, Malaysia Tourism 293 likes) |
| `travel` | HTTP 400 | 3 items in window (adventure travel creator 6341 likes, Switzerland 989 likes) |
| Long phrasal queries (e.g. "where are people no longer flying...") | HTTP 400 | 200 OK, 0 items |

The phrasal-query-returns-0 behavior is a separate concern — ScrapeCreators' Threads endpoint appears to favor short keywords — and is documented in the new `docs/solutions/` entry as a future follow-up. **Out of scope for this PR.**

## Review trail

This fix was validated through a multi-pass review chain on the contributor's fork before this upstream PR:

- **Sonnet 7-reviewer panel** (correctness, testing, maintainability, project-standards, agent-native, learnings-researcher, kieran-python): 2 cross-reviewer findings applied in-commit. 1 P2 pre-existing finding deferred (`token: str = None` should be `Optional[str]` — original signature from commit 0a9ff16d, not introduced by this diff).
- **Codex peer review** (non-Anthropic second opinion via `codex:codex-rescue`): verdict `Ready to merge`. 4 P2/P3 findings, all Codex-itself recommended "defer" (cross-layer reasoning, fallback-chain test, etc.). Verifications passed: mock target correct, regression-test pinning sound, response-shape extraction correct.

## Out of scope (deferred follow-ups)

Documented in the new `docs/solutions/` entry as future work, **not** addressed by this PR:

1. **`threads.net` → `threads.com` URL emitter** at `lib/threads.py:97-100`. Meta rebranded the public web URL; the 301 redirect still works. Cosmetic.
2. **Query-shape sensitivity** — long phrasal queries return 0 items even with the param fix. The engine planner generates such queries. Needs a Threads-specific aggressive noun extraction or fallback strategy.
3. **Surface caught-in-source errors into `errors_by_source`** — affects multiple source modules with the same swallow pattern (Threads, Perplexity, Bluesky, Instagram). Deferred follow-up.

The observability compounding factor (`source_log` `tty_only=True` default suppressing stderr in non-TTY contexts) is already addressed by open PR #454 from the same contributor.

## Risk

Low. One-line semantic change; the function shape, error envelope, and downstream parser are unchanged. The regression test prevents accidental revert. Verified end-to-end against the real ScrapeCreators API on multiple keyword shapes and through the full engine.
