### PR TITLE
fix: remove duplicate /last30days command wrapper (#461)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-05-30
+
+### Fixed
+
+- Removed the redundant `commands/last30days.md` wrapper so the plugin exposes only the skill ([#461](https://github.com/mvanhorn/last30days-skill/issues/461)). Previously the plugin shipped both a command wrapper and the skill under the same name, so `/last30` surfaced two `last30days` entries with two different descriptions. The skill already carries its own `argument-hint`, so the `/last30days <topic>` picker UX is unchanged.
+- Corrected the README install note that claimed Claude Code dedupes the slash command across install methods; it does not, so having both the marketplace plugin and the `npx skills` copy active shows two entries.
+
 ## [3.3.0] - 2026-05-17
 
 A week-long shipping cycle: ~75 PRs merged plus 7 community fixes salvaged through PR triage. Big themes: install story modernized for the multi-harness world (Claude Code, Codex, Cursor, Gemini CLI, Copilot, Windsurf, and 50+ Agent Skills hosts), new emit and source modes, and a substantial reliability sweep across Reddit, X, Windows, YouTube, and the planner.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you'd rather use the agent-skills install path on Claude Code, that's also su
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-The native plugin and the `npx skills` install can coexist; Claude Code dedupes the slash command.
+The native plugin and the `npx skills` install can coexist. Note that Claude Code does not dedupe across install methods: if you have both the marketplace plugin and the `npx skills` copy active, `/last30days` will show two entries. Use one install method per machine.
 
 ### Codex, Cursor, Copilot, Gemini CLI, and other Agent Skills hosts
 

--- a/commands/last30days.md
+++ b/commands/last30days.md
@@ -1,9 +1,0 @@
----
-description: Research what people actually say about any topic in the last 30 days across Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web.
-argument-hint: <topic> — e.g. "nvidia earnings reaction" or "best noise cancelling headphones"
-allowed-tools: [Bash, Read, Write, AskUserQuestion, WebSearch]
----
-
-Invoke the `last30days` skill with the user's arguments: $ARGUMENTS
-
-Use the skill's canonical pipeline (plan → retrieve → normalize → fuse → rerank → cluster → render). If the user provided no arguments, ask them for a topic before proceeding.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "last30days-skill"
-version = "3.3.0"
+version = "3.3.1"
 description = "Multi-source last-30-days research skill"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: last30days
-version: "3.3.0"
+version: "3.3.1"
 description: "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web."
 argument-hint: 'last30days nvidia earnings reaction | last30days AI video tools | last30days what users want in react'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
@@ -243,7 +243,7 @@ If your Bash call to `last30days.py` does NOT include the FULL pre-flight checkl
 
 ---
 
-# last30days v3.3.0: Research Any Topic from the Last 30 Days
+# last30days v3.3.1: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `LAST30DAYS_MEMORY_DIR` (defaults to `~/Documents/Last30Days`). X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 
@@ -596,8 +596,8 @@ When the user asks "X vs Y" (or "X vs Y vs Z"), the engine fans out N full `pipe
 # the Read tool result. Examples:
 #   Read ~/.claude/skills/last30days/SKILL.md      → SKILL_DIR=$HOME/.claude/skills/last30days
 #   Read ~/.codex/skills/last30days/SKILL.md       → SKILL_DIR=$HOME/.codex/skills/last30days
-#   Read ~/.claude/plugins/cache/last30days-skill/last30days/3.3.0/skills/last30days/SKILL.md
-#     → SKILL_DIR=$HOME/.claude/plugins/cache/last30days-skill/last30days/3.3.0/skills/last30days
+#   Read ~/.claude/plugins/cache/last30days-skill/last30days/3.3.1/skills/last30days/SKILL.md
+#     → SKILL_DIR=$HOME/.claude/plugins/cache/last30days-skill/last30days/3.3.1/skills/last30days
 # scripts/last30days.py is always a direct child of SKILL_DIR (every install layout
 # packages SKILL.md and scripts/ as siblings).
 SKILL_DIR="<absolute path of the directory containing the SKILL.md you Read>"
@@ -914,8 +914,8 @@ Store your plan as `QUERY_PLAN_JSON` - you'll pass it to the script in the next 
 # the Read tool result. Examples:
 #   Read ~/.claude/skills/last30days/SKILL.md      → SKILL_DIR=$HOME/.claude/skills/last30days
 #   Read ~/.codex/skills/last30days/SKILL.md       → SKILL_DIR=$HOME/.codex/skills/last30days
-#   Read ~/.claude/plugins/cache/last30days-skill/last30days/3.3.0/skills/last30days/SKILL.md
-#     → SKILL_DIR=$HOME/.claude/plugins/cache/last30days-skill/last30days/3.3.0/skills/last30days
+#   Read ~/.claude/plugins/cache/last30days-skill/last30days/3.3.1/skills/last30days/SKILL.md
+#     → SKILL_DIR=$HOME/.claude/plugins/cache/last30days-skill/last30days/3.3.1/skills/last30days
 # scripts/last30days.py is always a direct child of SKILL_DIR (every install layout
 # packages SKILL.md and scripts/ as siblings).
 SKILL_DIR="<absolute path of the directory containing the SKILL.md you Read>"

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.3.0"
+version = "3.3.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #461.

## What

The plugin shipped **both** `commands/last30days.md` and `skills/last30days/SKILL.md` under the same name, so `/last30` surfaced two `last30days` entries with two different descriptions. This removes the redundant command wrapper so the plugin exposes only the skill.

Per @tmchow's note on the issue: removing the command is the short-term solve for the double mention, ahead of any move to the agent-skills install path.

## The picker UX is preserved

The open question on the issue was whether removing the wrapper degrades the `/last30days <topic>` argument-hint UX. It does not — `skills/last30days/SKILL.md` already carries its own `argument-hint`, so the skill is directly invocable as `/last30days <topic>` with the hint intact.

## Changes

- Delete `commands/last30days.md`.
- Correct the README note that claimed Claude Code dedupes the slash command across install methods — it does not; running both the marketplace plugin and the `npx skills` copy still shows two entries.
- Bump `3.3.0` → `3.3.1` across `plugin.json`, `marketplace.json`, `gemini-extension.json`, and `SKILL.md` (frontmatter, heading, cache-path examples).
- CHANGELOG `[3.3.1]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)