### PR TITLE
 Generalize Windows Python preflight discovery

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -254,17 +254,35 @@ Research ANY topic across Reddit, X, YouTube, and other sources. Surface what pe
 Before running any `last30days.py` command in this skill, resolve a Python 3.12+ interpreter once and keep it in `LAST30DAYS_PYTHON`:
 
 ```bash
-for py in python3.14 python3.13 python3.12 python3; do
-  command -v "$py" >/dev/null 2>&1 || continue
-  "$py" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || continue
-  LAST30DAYS_PYTHON="$py"
-  break
-done
+if [ -z "${LAST30DAYS_PYTHON:-}" ]; then
+  for py in \
+    "${LOCALAPPDATA:-}/Programs/Python/Python314/python.exe" \
+    "${LOCALAPPDATA:-}/Programs/Python/Python313/python.exe" \
+    "${LOCALAPPDATA:-}/Programs/Python/Python312/python.exe" \
+    python3.14 python3.13 python3.12 python3 python; do
+    [ -n "$py" ] || continue
+    if [ -x "$py" ]; then
+      candidate="$py"
+    elif command -v "$py" >/dev/null 2>&1; then
+      candidate="$py"
+    else
+      continue
+    fi
+    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || continue
+    LAST30DAYS_PYTHON="$candidate"
+    break
+  done
+fi
 
 if [ -z "${LAST30DAYS_PYTHON:-}" ]; then
-  echo "ERROR: last30days v3 requires Python 3.12+. Install python3.12 or python3.13 and rerun." >&2
+  echo "ERROR: last30days v3 requires Python 3.12+. Install Python 3.12+ or set LAST30DAYS_PYTHON to a supported interpreter." >&2
   exit 1
 fi
+
+"${LAST30DAYS_PYTHON}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || {
+  echo "ERROR: LAST30DAYS_PYTHON must point to Python 3.12+." >&2
+  exit 1
+}
 
 LAST30DAYS_MEMORY_DIR="${LAST30DAYS_MEMORY_DIR:-$HOME/Documents/Last30Days}"
 ```

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -254,23 +254,50 @@ Research ANY topic across Reddit, X, YouTube, and other sources. Surface what pe
 Before running any `last30days.py` command in this skill, resolve a Python 3.12+ interpreter once and keep it in `LAST30DAYS_PYTHON`:
 
 ```bash
+try_last30days_python() {
+  candidate="$1"
+  [ -n "$candidate" ] || return 1
+  if [ -x "$candidate" ]; then
+    :
+  elif command -v "$candidate" >/dev/null 2>&1; then
+    :
+  else
+    return 1
+  fi
+  "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || return 1
+  LAST30DAYS_PYTHON="$candidate"
+  return 0
+}
+
+windows_path_to_unix() {
+  path="$1"
+  [ -n "$path" ] || return 1
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$path"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
 if [ -z "${LAST30DAYS_PYTHON:-}" ]; then
-  for py in \
-    "${LOCALAPPDATA:-}/Programs/Python/Python314/python.exe" \
-    "${LOCALAPPDATA:-}/Programs/Python/Python313/python.exe" \
-    "${LOCALAPPDATA:-}/Programs/Python/Python312/python.exe" \
-    python3.14 python3.13 python3.12 python3 python; do
-    [ -n "$py" ] || continue
-    if [ -x "$py" ]; then
-      candidate="$py"
-    elif command -v "$py" >/dev/null 2>&1; then
-      candidate="$py"
-    else
-      continue
-    fi
-    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' || continue
-    LAST30DAYS_PYTHON="$candidate"
-    break
+  while IFS= read -r windows_python_root; do
+    [ -n "$windows_python_root" ] && [ -d "$windows_python_root" ] || continue
+    while IFS= read -r py; do
+      try_last30days_python "$py" && break 2
+    done <<EOF_PYTHON_CANDIDATES
+$(find "$windows_python_root" -maxdepth 2 -type f -iname python.exe 2>/dev/null | sort -r)
+EOF_PYTHON_CANDIDATES
+  done <<EOF_WINDOWS_PYTHON_ROOTS
+$([ -n "${LOCALAPPDATA:-}" ] && printf '%s\n' "$(windows_path_to_unix "$LOCALAPPDATA")/Programs/Python")
+$([ -n "${ProgramFiles:-}" ] && windows_path_to_unix "$ProgramFiles")
+$([ -n "${PROGRAMFILES:-}" ] && windows_path_to_unix "$PROGRAMFILES")
+$(program_files_x86="$(printenv 'ProgramFiles(x86)' 2>/dev/null || true)"; [ -n "$program_files_x86" ] && windows_path_to_unix "$program_files_x86")
+EOF_WINDOWS_PYTHON_ROOTS
+fi
+
+if [ -z "${LAST30DAYS_PYTHON:-}" ]; then
+  for py in python3.14 python3.13 python3.12 python3 python; do
+    try_last30days_python "$py" && break
   done
 fi
 

--- a/tests/test_runtime_preflight_contract.py
+++ b/tests/test_runtime_preflight_contract.py
@@ -1,0 +1,30 @@
+"""Contract tests for the SKILL.md runtime preflight snippet."""
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
+
+
+class RuntimePreflightContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_md = SKILL_MD.read_text(encoding="utf-8")
+
+    def test_windows_localappdata_python_paths_are_checked_first(self) -> None:
+        python314 = "${LOCALAPPDATA:-}/Programs/Python/Python314/python.exe"
+        python313 = "${LOCALAPPDATA:-}/Programs/Python/Python313/python.exe"
+        python312 = "${LOCALAPPDATA:-}/Programs/Python/Python312/python.exe"
+
+        self.assertIn(python314, self.skill_md)
+        self.assertIn(python313, self.skill_md)
+        self.assertIn(python312, self.skill_md)
+        self.assertLess(self.skill_md.index(python314), self.skill_md.index("python3.14"))
+
+    def test_preflight_allows_explicit_interpreter_override(self) -> None:
+        self.assertIn('if [ -z "${LAST30DAYS_PYTHON:-}" ]; then', self.skill_md)
+        self.assertIn('ERROR: LAST30DAYS_PYTHON must point to Python 3.12+.', self.skill_md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_preflight_contract.py
+++ b/tests/test_runtime_preflight_contract.py
@@ -11,15 +11,21 @@ class RuntimePreflightContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.skill_md = SKILL_MD.read_text(encoding="utf-8")
 
-    def test_windows_localappdata_python_paths_are_checked_first(self) -> None:
-        python314 = "${LOCALAPPDATA:-}/Programs/Python/Python314/python.exe"
-        python313 = "${LOCALAPPDATA:-}/Programs/Python/Python313/python.exe"
-        python312 = "${LOCALAPPDATA:-}/Programs/Python/Python312/python.exe"
+    def test_windows_localappdata_python_install_dir_is_scanned_first(self) -> None:
+        scan_command = 'find "$windows_python_root" -maxdepth 2 -type f -iname python.exe'
 
-        self.assertIn(python314, self.skill_md)
-        self.assertIn(python313, self.skill_md)
-        self.assertIn(python312, self.skill_md)
-        self.assertLess(self.skill_md.index(python314), self.skill_md.index("python3.14"))
+        self.assertIn('windows_path_to_unix "$LOCALAPPDATA")/Programs/Python', self.skill_md)
+        self.assertIn('windows_path_to_unix "$ProgramFiles"', self.skill_md)
+        self.assertIn("printenv 'ProgramFiles(x86)'", self.skill_md)
+        self.assertIn("cygpath -u", self.skill_md)
+        self.assertIn(scan_command, self.skill_md)
+        self.assertNotIn("/c/Users/", self.skill_md)
+        self.assertNotIn("Python314/python.exe", self.skill_md)
+        self.assertLess(self.skill_md.index(scan_command), self.skill_md.index("python3.14"))
+
+    def test_candidate_selection_accepts_any_python_3_12_or_newer(self) -> None:
+        self.assertIn("try_last30days_python()", self.skill_md)
+        self.assertIn("sys.version_info >= (3, 12)", self.skill_md)
 
     def test_preflight_allows_explicit_interpreter_override(self) -> None:
         self.assertIn('if [ -z "${LAST30DAYS_PYTHON:-}" ]; then', self.skill_md)


### PR DESCRIPTION
 ## Summary

  Generalizes the `last30days` runtime preflight so Windows Python installs are discovered from standard install roots instead of hardcoding specific
  versions like Python 3.14.

  The preflight now accepts any Python interpreter that actually passes:

  ```python
  sys.version_info >= (3, 12)

  This means future installs such as Python 3.15 or Python 3.16 will work without another SKILL.md update.

  ## Changes

  - Preserve explicit LAST30DAYS_PYTHON override.
  - Add a helper that validates a candidate interpreter by executing a Python 3.12+ version check.
  - Scan standard Windows install roots:
      - %LOCALAPPDATA%\Programs\Python
      - %ProgramFiles%
      - %ProgramFiles(x86)%

  - Convert Windows paths with cygpath when running under Git Bash/MSYS.
  - Keep PATH fallback for:
      - python3.14
      - python3.13
      - python3.12
      - python3
      - python

  - Add contract tests so the preflight does not regress to hardcoded per-version paths.

  ## Verification

  Targeted checks run locally:

  & "$env:LOCALAPPDATA\Programs\Python\Python314\python.exe" -m unittest tests.test_runtime_preflight_contract

  Result:

  Ran 3 tests in 0.004s
  OK

  Git Bash preflight snippet was also tested locally and resolved the installed Python interpreter via the generic Windows install-root scan. The resolved path was user-specific, so it is intentionally omitted from this PR description.

  Also verified:

  & "$env:LOCALAPPDATA\Programs\Python\Python314\python.exe" skills\last30days\scripts\last30days.py --help

  This successfully prints usage: last30days.py ....