### PR TITLE
fix(hooks): skip perms warning on Windows in check-config.sh (noacl)

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -11,6 +11,13 @@ GLOBAL_ENV="$HOME/.config/last30days/.env"
 check_perms() {
   local file="$1"
   if [[ ! -f "$file" ]]; then return; fi
+  # Windows (Git Bash/MSYS/Cygwin): drives mount `noacl`, so `stat` derives the
+  # POSIX mode from the DOS read-only bit — a writable file always reads 644 and
+  # `chmod 600` is a no-op. NTFS ACLs already protect the file, so skip the
+  # POSIX-perms warning here (it can never be satisfied — a false positive).
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win*) return ;;
+  esac
   local perms
   # Try GNU stat first (Linux), fall back to BSD stat (macOS).
   # On Linux, `stat -f` prints filesystem info (not permissions) and exits 0,


### PR DESCRIPTION
## What
`hooks/scripts/check-config.sh` warns at every SessionStart that the config `.env`
"has permissions 644 (should be 600)" on Windows (Git Bash / MSYS / Cygwin). On those
shells the drive is mounted `noacl`, so `stat` synthesizes the POSIX mode from the DOS
read-only bit — a writable file always reports `644` and `chmod 600` is a no-op. The
check can therefore never be satisfied on Windows; it prints a false-positive WARNING
on every session start.

This skips the POSIX-perms check when `$OSTYPE` indicates a Windows shell. NTFS ACLs
already restrict the file.

## Why — bash counterpart of an already-merged fix
#357 ("fix: skip POSIX secret warning on Windows", merged) fixed the **Python**
equivalent in `scripts/lib/env.py::_check_file_permissions` via `if os.name == "nt":
return` (issue #325). That fix did not cover the **bash** SessionStart hook
`hooks/scripts/check-config.sh`, which has its own `chmod 600` perms check and still
false-positives. This closes that gap with the bash analog of `os.name == "nt"`.

## Change
```diff
 check_perms() {
   local file="$1"
   if [[ ! -f "$file" ]]; then return; fi
+  # Windows (Git Bash/MSYS/Cygwin): drives mount `noacl`, so `stat` derives the
+  # POSIX mode from the DOS read-only bit — a writable file always reads 644 and
+  # `chmod 600` is a no-op. NTFS ACLs already protect the file, so skip the
+  # POSIX-perms warning here (it can never be satisfied — a false positive).
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win*) return ;;
+  esac
   local perms
```

## Testing
- Git Bash on Windows 11 (`/c` mounted `binary,noacl,posix=0`): the false WARNING no
  longer prints at SessionStart; source detection and the ready message are unchanged.
- WSL / Linux / macOS unaffected — `$OSTYPE` is `linux-gnu` / `darwin*`, not matched.
