### PR TITLE
fix(hooks): check-config.sh exits 0 when last-run.json is missing

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -109,7 +109,9 @@ if [[ -z "$SETUP_COMPLETE" && -z "$CONFIG_FILE" && -z "${OPENAI_API_KEY:-}" && -
 Reddit, Hacker News, and Polymarket work out of the box.
 The setup wizard can unlock X/Twitter, YouTube, and more.
 EOF
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then
+    echo "$LAST_RUN_LINE"
+  fi
   exit 0
 fi
 
@@ -161,12 +163,16 @@ if [[ -n "$HAS_SCRAPECREATORS" ]]; then
   # Fully configured — compact ready message
   echo "/last30days: Ready — ${SOURCE_COUNT} sources active."
   echo "  Research any topic across social + market + web sources (last 30 days)."
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then
+    echo "$LAST_RUN_LINE"
+  fi
 else
   # Setup done but missing ScrapeCreators — recommend it
   echo "/last30days: Ready — ${SOURCE_COUNT} sources active."
   echo "  Research any topic across social + market + web sources (last 30 days)."
-  [[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
+  if [[ -n "$LAST_RUN_LINE" ]]; then
+    echo "$LAST_RUN_LINE"
+  fi
   echo "  Tip: Add ScrapeCreators for Reddit comments + TikTok + Instagram."
   echo "  100 free credits, no credit card — scrapecreators.com"
   echo "  last30days has no affiliation with any API provider."

--- a/tests/test_last_run_state.py
+++ b/tests/test_last_run_state.py
@@ -49,6 +49,31 @@ class LastRunStateTests(unittest.TestCase):
             self.assertEqual(payload["topic"], "custom config query")
             self.assertGreaterEqual(payload["total"], 0)
 
+    def test_hook_exits_zero_when_configured_without_last_run(self):
+        # Regression: prior to fix, the trailing `[[ -n "$LAST_RUN_LINE" ]] && echo`
+        # in the HAS_SCRAPECREATORS branch was the last command before EOF. When
+        # last-run.json did not exist, the test returned 1, the && short-circuited,
+        # and the script exited 1 (set -e does not trip on the left of &&). Claude
+        # Code reported "SessionStart:startup hook error / No stderr output".
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env["HOME"] = str(Path(tmp) / "home")
+            env["LAST30DAYS_CONFIG_DIR"] = str(Path(tmp) / "empty-config")
+            env["SCRAPECREATORS_API_KEY"] = "dummy"
+
+            result = subprocess.run(
+                ["bash", "hooks/scripts/check-config.sh"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Ready", result.stdout)
+            self.assertNotIn("Last run", result.stdout)
+
     def test_hook_reads_last_run_from_custom_config_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
             config_dir = Path(tmp) / "custom-config"


### PR DESCRIPTION
## What
`hooks/scripts/check-config.sh` can exit **non-zero on a successful SessionStart**. The
configured-user branch ends with:

```bash
[[ -n "$LAST_RUN_LINE" ]] && echo "$LAST_RUN_LINE"
```

When there is no last-run line (first run, `python3` unavailable, or a fresh config dir),
`[[ -n "" ]]` returns 1 and the `&& echo` short-circuits. As the script's **last command**,
that exit status (1) becomes the script's exit status. `set -e` does not trip on the left of
`&&`, so it is silent. Claude Code surfaces it as:

```
SessionStart:startup hook error / No stderr output
```

(the script writes only to stdout, so the diagnostic is empty and confusing).

## Fix
Replace the three trailing `[[ -n "$LAST_RUN_LINE" ]] && echo …` patterns with explicit
`if/then/fi` blocks — functionally equivalent on the reachable branches, and it prevents
reintroduction if the script grows new tails. Adds a regression test asserting the hook
exits 0 when SCRAPECREATORS is configured but no `last-run.json` exists.

## Repro (before fix)
```bash
SCRAPECREATORS_API_KEY=dummy HOME=/tmp/empty bash hooks/scripts/check-config.sh
# exit 1, stderr empty, stdout has the ready/welcome message
```

Surfaced on Windows (Git Bash) as a startup-hook error every session, but the bug is
platform-independent.
