### PR TITLE
ci: harden GitHub Actions supply chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,10 @@ jobs:
           test -f dist/last30days.skill
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          files: dist/last30days.skill
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            dist/last30days.skill \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,19 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build .skill artifact
         run: |
@@ -23,7 +25,7 @@ jobs:
           test -f dist/last30days.skill
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: dist/last30days.skill
           generate_release_notes: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,48 +7,42 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   dependency-audit:
     name: Dependency audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Export locked dependency set
-        run: |
-          uv export \
-            --locked \
-            --all-groups \
-            --no-hashes \
-            --format requirements.txt \
-            --output-file /tmp/last30days-requirements.txt
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       # Advisory-first: visibility before enforcement. This repo handles API keys,
       # cookies, browser tokens, and local env files, so dependency CVEs should be
       # visible in CI logs even before the project has a clean blocking baseline.
       # Set continue-on-error: false once a clean baseline run is confirmed.
-      - name: Run pip-audit against locked dependencies
+      - name: Run uv audit against locked dependencies
         continue-on-error: true
-        run: uvx --python 3.12 pip-audit -r /tmp/last30days-requirements.txt --progress-spinner=off
+        run: uv audit --locked
 
   secret-scan:
     name: Secret scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout full history for diff-aware scanning
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Advisory-first: this reports verified secrets in pull requests and pushes to
       # main, but does not block merges until maintainers confirm a clean baseline.
@@ -59,7 +53,7 @@ jobs:
       # examples; use obvious dummy values and env-based auth patterns instead.
       - name: Run TruffleHog OSS secret scan
         if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: trufflesecurity/trufflehog@v3.95.2
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         continue-on-error: true
         with:
           path: ./

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,18 +6,21 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/tests/test_security_workflow.py
+++ b/tests/test_security_workflow.py
@@ -20,7 +20,7 @@ def test_security_workflow_runs_dependency_audit_advisory_first() -> None:
     text = _workflow_text()
 
     assert "dependency-audit:" in text
-    assert "pip-audit" in text
+    assert "uv audit --locked" in text
     assert "continue-on-error: true" in text
     assert "Set continue-on-error: false once a clean baseline run is confirmed" in text
 


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions workflows with mostly no-op supply-chain improvements: pin existing third-party actions to commit SHAs, narrow workflow permissions, avoid persisting checkout credentials, add [zizmor](https://github.com/zizmorcore/zizmor) workflow scanning, and reduce CI dependency surface area.

[zizmor](https://github.com/zizmorcore/zizmor) is a static analyzer for GitHub Actions workflows. It catches common CI/CD security issues like unpinned action refs, overly broad token permissions, template injection, and other workflow footguns.

## Changes

- Pin existing third-party Actions to full commit SHAs with version comments
  - `actions/checkout@v4` -> pinned SHA for `v4.3.1`
  - `astral-sh/setup-uv@v5` -> pinned SHA for `v5.4.2`
  - `trufflesecurity/trufflehog@v3.95.2` -> pinned SHA for `v3.95.2`
- Add `persist-credentials: false` to checkout steps
- Move top-level workflow permissions to `permissions: {}` and grant job-scoped permissions only where needed
- Add a dedicated [zizmor](https://github.com/zizmorcore/zizmor) workflow for GitHub Actions security analysis
- Replace the security audit’s export + `uvx pip-audit` path with built-in `uv audit --locked`
- Replace `softprops/action-gh-release` with the runner-provided `gh release create`

### Why

#### SHA pinning

GitHub’s own hardening guidance recommends pinning third-party actions to full-length commit SHAs because tags and branches are mutable. A tag like `@v4` can be moved upstream; a commit SHA is immutable.

This is not theoretical. The [tj-actions/changed-files compromise](https://arstechnica.com/information-technology/2025/03/supply-chain-attack-exposing-credentials-affects-23k-users-of-tj-actions/) involved attackers moving action refs to malicious code that scraped CI memory and leaked secrets. The later [Trivy GitHub Actions compromise](https://snyk.io/articles/trivy-github-actions-supply-chain-compromise/) similarly reinforced that mutable action tags are a real CI supply-chain risk.

These pins are intentionally no-op version freezes, not version bumps. The comments next to the SHAs record the version each SHA corresponds to.

##### Version comments stay auditable

The version comments are not just decorative. `zizmor` has a `ref-version-mismatch` audit that checks whether hash-pinned action references and their adjacent version comments agree. That means future SHA updates can keep the human-readable version comment in sync, and CI can catch drift.

Follow-up: I recommend enabling Dependabot for `github-actions` and `uv` so these pinned SHAs and comments update over time in reviewed PRs. I split that into a separate pending PR so this change can stay focused:.

#### Checkout credential persistence

`actions/checkout` persists credentials by default. That leaves a token available in the git config for later steps in the job. Setting `persist-credentials: false` reduces the blast radius if a later step or third-party action is compromised.

#### Job-scoped permissions

The workflows now start from `permissions: {}` and grant only what each job needs. GitHub recommends least-privilege `GITHUB_TOKEN` permissions because actions can access the token through the `github.token` context even when it is not explicitly passed.

#### Built-in `uv audit`

The old workflow exported the lockfile to requirements format, then installed and ran `pip-audit` at CI time via `uvx`. This PR uses `uv audit --locked` instead.

That reduces moving parts:
- no extra audit tool installed at runtime
- no requirements export step
- audit remains tied to the committed `uv.lock`
- `--locked` makes stale lockfiles fail instead of silently relocking

#### Built-in `gh release`

The release workflow now uses the GitHub-hosted runner’s `gh` CLI instead of a third-party release action.

Equivalent behavior retained:
- generated release notes via `--generate-notes`
- normal non-draft, non-prerelease release by default
- tag-triggered workflow uses `${GITHUB_REF_NAME}`

Additional hardening:
- `--verify-tag` makes the workflow fail closed if the expected tag is missing instead of creating one implicitly.

One semantic difference: `softprops/action-gh-release` can update an existing release/assets, while `gh release create ... --verify-tag` will fail if the release already exists. For a tag-triggered release workflow, I think failing closed is preferable.

## Testing

- [x] Ran `uv run pytest`

Static/workflow validation:

- Parsed workflow YAML with PyYAML
- `actionlint`
- `uvx zizmor --gh-token "$(gh auth token)" .github/workflows`

`zizmor` result:

```text
No findings to report. Good job! (9 suppressed)
```