### PR TITLE
ci: add dependabot update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds Dependabot configuration so GitHub Actions SHA pins and `uv` dependencies can be reviewed through normal update PRs instead of manual tracking.

There are currently quite a few stale GitHub Actions versions. I recommend merging this PR and any resulting Dependabot PRs **after** the supply-chain hardening / SHA-pinning PR (#472), if #472 is planned to merge, otherwise the workflow updates are likely to create a bunch of avoidable merge conflicts.

## Changes

- Adds `.github/dependabot.yml`
- Enables Dependabot updates for GitHub Actions workflows
- Enables Dependabot updates for `uv` dependency files
- Adds a Dependabot cooldown window to reduce exposure to dependency confusion or newly-published package/action supply-chain attacks
- Supports follow-up maintenance for the SHA-pinning work in #472

## Testing

- [X] Ran `uv run python -m pytest -q --tb=short`

## Related Issues

Relates to #472