### PR TITLE
fix(cli): set allow_abbrev=False so `setup --github` parses (#456)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -236,7 +236,15 @@ def persist_report(report: schema.Report) -> dict[str, int]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Research a topic across live social, market, and grounded web sources.")
+    # allow_abbrev=False so prefix-matching never hijacks setup sub-flags that
+    # main() pulls out of parse_known_args() (e.g. `setup --github`). With the
+    # default (True), argparse treats `--github` as an ambiguous abbreviation of
+    # the registered `--github-user`/`--github-repo` and hard-exits before the
+    # flag can pass through to extra_argv. No caller relies on abbreviated flags.
+    parser = argparse.ArgumentParser(
+        description="Research a topic across live social, market, and grounded web sources.",
+        allow_abbrev=False,
+    )
     parser.add_argument("topic", nargs="*", help="Research topic")
     parser.add_argument("--emit", default="compact", choices=["compact", "json", "context", "md", "html"])
     parser.add_argument("--search", help="Comma-separated source list")

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -102,6 +102,19 @@ class CliV3Tests(unittest.TestCase):
         self.assertEqual(["biosecurity", "ai", "agents"], args.topic)
         self.assertEqual([], extra)
 
+    def test_build_parser_passes_setup_github_flag_through_without_abbrev_collision(self):
+        # Regression for #456: `setup --github` must reach extra_argv intact.
+        # With argparse's default prefix-matching, `--github` was treated as an
+        # ambiguous abbreviation of --github-user/--github-repo and hard-exited.
+        parser = cli.build_parser()
+        args, extra = parser.parse_known_args(["setup", "--github"])
+        self.assertEqual(["setup"], args.topic)
+        self.assertIn("--github", extra)
+        # The registered full-length flags must still parse normally.
+        args, extra = parser.parse_known_args(["claude", "--github-user", "steipete"])
+        self.assertEqual("steipete", args.github_user)
+        self.assertEqual([], extra)
+
     def test_ensure_supported_python_rejects_old_interpreter_with_actionable_error(self):
         stderr = io.StringIO()
         with redirect_stderr(stderr):


### PR DESCRIPTION
## Summary

Fixes #456. `setup --github` crashed at the argparse layer with `error: ambiguous option: --github could match --github-user, --github-repo`, so the GitHub-CLI PAT registration flow was completely unreachable.

`build_parser()` used argparse's default `allow_abbrev=True`, which treats `--github` as an abbreviation of the registered `--github-user`/`--github-repo` flags. `parse_known_args()` raised the ambiguity error before the setup sub-flag could pass through to `extra_argv` and be dispatched in `main()`. The sibling sub-flags `--device-auth`/`--openclaw` worked only because they share no prefix with a registered option.

## Changes

- `skills/last30days/scripts/last30days.py` — set `allow_abbrev=False` on the parser in `build_parser()` (the issue's recommended long-term fix). Verified no caller relies on abbreviated flags: internal subprocess invocations (`watchlist.py`, `evaluate_search_quality.py`), `SKILL.md`, and the tests all use full flag names.
- `tests/test_cli_v3.py` — regression test asserting `setup --github` reaches `extra_argv` while `--github-user` still parses normally.

## Testing

- [x] Ran `uv run --python 3.13 --with pytest python -m pytest -q --ignore=tests/test_bird_x.py` → all green. (`test_bird_x.py` fails on `main` too, independent of this change — local Node ESM `Unexpected token 'with'`.)
- [x] End-to-end: `python skills/last30days/scripts/last30days.py setup --github` now reaches `run_github_auth()` instead of erroring at argparse.

## Related Issues

Fixes #456