### PR TITLE
fix: disable argparse prefix-matching to resolve --github flag ambiguity

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -236,7 +236,10 @@ def persist_report(report: schema.Report) -> dict[str, int]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Research a topic across live social, market, and grounded web sources.")
+    parser = argparse.ArgumentParser(
+        description="Research a topic across live social, market, and grounded web sources.",
+        allow_abbrev=False,
+    )
     parser.add_argument("topic", nargs="*", help="Research topic")
     parser.add_argument("--emit", default="compact", choices=["compact", "json", "context", "md", "html"])
     parser.add_argument("--search", help="Comma-separated source list")


### PR DESCRIPTION
## Problem

`setup --github` fails immediately with:

```
last30days.py: error: ambiguous option: --github could match --github-user, --github-repo
```

`ArgumentParser` enables prefix-matching (`allow_abbrev=True`) by default. Because `--github-user` and `--github-repo` are both registered flags, argparse treats `--github` as an ambiguous abbreviation and raises an error before `parse_known_args` can route it to `extra_argv`.

Fixes #456

## Fix

Set `allow_abbrev=False` on the parser. This turns off prefix-matching entirely:

- `--github` is now treated as an exact, unrecognised flag and falls through to `extra_argv` for the setup wizard.
- `--github-user` and `--github-repo` continue to work normally with their full names.

```python
parser = argparse.ArgumentParser(
    description="...",
    allow_abbrev=False,   # ← added
)
```

One-line change, no other flags are affected.

## Testing

Manually verified that `python3 skills/last30days/scripts/last30days.py setup --github` no longer raises the ambiguity error after this change.