### PR TITLE
Fix heredoc/plan writes blocked by zsh noclobber

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -617,7 +617,9 @@ fi
 # GNU; BSD only substitutes X's at the end of the template.
 COMPETITORS_PLAN_FILE=$(mktemp "${TMPDIR:-/tmp}/last30days-competitors.XXXXXX")
 trap 'rm -f "$COMPETITORS_PLAN_FILE"' EXIT
-cat > "$COMPETITORS_PLAN_FILE" <<'PLAN_EOF'
+# >| not >: mktemp already created the file, so a plain > is refused under
+# `set -o noclobber` (leaving the plan empty -> deterministic fallback).
+cat >| "$COMPETITORS_PLAN_FILE" <<'PLAN_EOF'
 {
   "{TOPIC_B}": {"x_handle":"{TOPIC_B_HANDLE}","subreddits":["{TOPIC_B_SUB_1}","{TOPIC_B_SUB_2}"],"github_user":"{TOPIC_B_GH}","context":"{TOPIC_B_CONTEXT}"},
   "{TOPIC_C}": {"x_handle":"{TOPIC_C_HANDLE}","subreddits":["{TOPIC_C_SUB_1}"],"github_user":"{TOPIC_C_GH}","context":"{TOPIC_C_CONTEXT}"}
@@ -940,7 +942,9 @@ fi
 # X's at the end of the template.
 QUERY_PLAN_FILE=$(mktemp "${TMPDIR:-/tmp}/last30days-plan.XXXXXX")
 trap 'rm -f "$QUERY_PLAN_FILE"' EXIT
-cat > "$QUERY_PLAN_FILE" <<'PLAN_EOF'
+# >| not >: mktemp already created the file, so a plain > is refused under
+# `set -o noclobber` (leaving the plan empty -> deterministic fallback).
+cat >| "$QUERY_PLAN_FILE" <<'PLAN_EOF'
 {QUERY_PLAN_JSON_FROM_STEP_0.75}
 PLAN_EOF
 ```

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -81,7 +81,7 @@ If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, an
 - Do NOT save HTML if the user didn't ask. The sparse mode (no synthesis) produces a thin file; not useful as a shareable.
 - Do NOT add content to the temp file beyond your synthesis prose. The badge / footer / colophon come from the engine.
 - Do NOT change the file path convention. `${LAST30DAYS_MEMORY_DIR}/${SLUG}-brief.html` is the canonical location.
-- Do NOT silently overwrite an existing file without telling the user. If `$HTML_PATH` already exists from a prior run, the engine will pick a date-suffixed name (`{slug}-brief-YYYY-MM-DD.html`) automatically; just print whichever path the redirect produced.
+- Do NOT hide the save path from the user. The `>|` redirect always writes to the fixed `$HTML_PATH`, overwriting any earlier brief for the same topic — that is intentional (the brief is a regenerated artifact for the latest run, not an archive). The engine writes HTML to stdout, so it has no say over the filename; the shell redirect owns it. Always surface the path via the `📎` line in step 3 so the user knows what was written.
 - Do NOT include the data quality warning text in the temp file or in your final chat line. Warnings are an engine-stderr concern, not an artifact concern.
 
 ## Edge cases

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -22,7 +22,9 @@ The contract: the synthesis still appears in chat as the primary output. The HTM
 #    summarize, do not reorder. The HTML must read identically to the chat
 #    response in voice and citations.
 SYNTHESIS_FILE="/tmp/last30days-synthesis-${CLAUDE_SESSION_ID}.md"
-cat > "$SYNTHESIS_FILE" <<'SYNTHESIS_EOF'
+# >| not >: fixed path may already exist on a same-session re-run; a plain >
+# is refused under `set -o noclobber`.
+cat >| "$SYNTHESIS_FILE" <<'SYNTHESIS_EOF'
 What I learned:
 
 **{First headline}** - {body with [name](url) inline citations}
@@ -45,7 +47,7 @@ HTML_PATH="${LAST30DAYS_MEMORY_DIR}/${SLUG}-brief.html"
 "${LAST30DAYS_PYTHON}" "${SKILL_ROOT}/scripts/last30days.py" "${TOPIC}" \
   --emit=html \
   --synthesis-file "$SYNTHESIS_FILE" \
-  > "$HTML_PATH"
+  >| "$HTML_PATH"   # >| not >: re-running the same topic overwrites an existing brief, refused under `set -o noclobber`
 
 # 3. Append ONE line to your already-emitted chat response, after the
 #    invitation block. Use a paperclip emoji as a visible signal that an


### PR DESCRIPTION
## Problem

The query plan, competitor plan, and HTML/synthesis outputs are written with a plain `>` redirect, which fails under `set -o noclobber`:

- The plan tmpfiles are created by `mktemp` **before** the `cat >` heredoc runs, so the target already exists and `>` is refused (`zsh: file exists`).
- The synthesis file (`/tmp/last30days-synthesis-$CLAUDE_SESSION_ID.md`) and the HTML brief (`$SLUG-brief.html`) are fixed, non-unique paths that collide on a re-run / repeated topic.

When the plan heredoc is blocked, the file stays empty, `--plan` reads nothing, and the engine silently falls back to its deterministic single-concept query — degraded, off-target results with no error surfaced to the user.

`noclobber` is a common safety setting (it's on in my interactive shell), and the Bash tool that runs these snippets inherits the user's interactive shell options, so it bites real users.

## Fix

Switch the four agent-executed redirects to `>|`, which explicitly overrides `noclobber` and behaves identically to `>` when it isn't set. No behavior change for users without `noclobber`.

Files:
- `skills/last30days/SKILL.md` — competitor plan + query plan heredocs
- `skills/last30days/references/save-html-brief.md` — synthesis heredoc + HTML emit redirect