### PR TITLE
fix: count Xquik in X quality nudges

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -55,7 +55,7 @@ The project-scoped file is the cleanest pattern for **per-client setups**: drop 
 | Polymarket | none | always on | yes |
 | GitHub | `gh` CLI installed (uses your GitHub auth) | always on if `gh` present | yes |
 | YouTube | `yt-dlp` CLI installed | always on if `yt-dlp` present | yes |
-| X / Twitter | one of: `AUTH_TOKEN` + `CT0` (browser cookies, Bird CLI), `XAI_API_KEY`, `SCRAPECREATORS_API_KEY`, or `FROM_BROWSER` (cookie-jar auth) | X items in results | cookie-jar / Bird = free; xAI / ScrapeCreators = paid |
+| X / Twitter | one of: `AUTH_TOKEN` + `CT0` (browser cookies, Bird CLI), `XAI_API_KEY`, `XQUIK_API_KEY`, `SCRAPECREATORS_API_KEY`, or `FROM_BROWSER` (cookie-jar auth) | X items in results | cookie-jar / Bird = free; Xquik / xAI / ScrapeCreators = key-based |
 | TikTok | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `tiktok` | TikTok items | 10K free calls |
 | Instagram | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `instagram` | Instagram Reels | 10K free calls; raise `LAST30DAYS_TRANSCRIPT_TIMEOUT` (default 30s) if SC is slow on your network |
 | Threads | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `threads` | Threads items | 10K free calls |
@@ -81,6 +81,8 @@ INCLUDE_SOURCES=tiktok,instagram
 
 # X authentication (one option only)
 XAI_API_KEY=<your-xai-key>
+# OR Xquik key-based X search
+# XQUIK_API_KEY=<your-xquik-key>
 # OR cookie-jar (no key needed; logs in via your browser session)
 # FROM_BROWSER=firefox
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ Enable "Code execution and file creation" under Capabilities first — skills wo
 clawhub install last30days-official
 ```
 
+For X/Twitter action workflows outside `/last30days` research, such as posting
+tweets or replies, follower export, media handling, monitors, and giveaway
+draws, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) as the companion
+OpenClaw plugin. TweetClaw is maintained by Xquik-dev and is listed only as an
+optional companion path, not a last30days dependency or endorsement.
+
 ### Manual (developer)
 
 ```bash
@@ -256,7 +262,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | Sources | What you need | Cost |
 |---------|---------------|------|
 | Reddit (with comments) + HN + Polymarket + GitHub | Nothing | Free |
-| X / Twitter | Log into x.com in any browser | Free |
+| X / Twitter | Log into x.com in any browser, or set `XQUIK_API_KEY` / `XAI_API_KEY` | Browser cookies are free; keys are provider-specific |
 | YouTube | `brew install yt-dlp` | Free |
 | Bluesky | App password from bsky.app | Free |
 | TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 100 free credits, then PAYG |

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1684,7 +1684,7 @@ Want another prompt? Just tell me what you're creating next.
 **What this skill does:**
 - Sends search queries to ScrapeCreators API (`api.scrapecreators.com`) for TikTok and Instagram search, and as a Reddit backup when public Reddit is unavailable (requires SCRAPECREATORS_API_KEY)
 - Legacy: Sends search queries to OpenAI's Responses API (`api.openai.com`) for Reddit discovery (fallback if no SCRAPECREATORS_API_KEY)
-- Sends search queries to Twitter's GraphQL API (via optional user-provided AUTH_TOKEN/CT0 env vars - no browser session access), xAI's API (`api.x.ai`), or the official X API v2 via xurl CLI (OAuth2, auto-detected when installed and authenticated) for X search
+- Sends search queries to Twitter's GraphQL API (via optional user-provided AUTH_TOKEN/CT0 env vars - no browser session access), xAI's API (`api.x.ai`), Xquik's API (`xquik.com`), or the official X API v2 via xurl CLI (OAuth2, auto-detected when installed and authenticated) for X search
 - Sends search queries to Algolia HN Search API (`hn.algolia.com`) for Hacker News story and comment discovery (free, no auth)
 - Sends search queries to Polymarket Gamma API (`gamma-api.polymarket.com`) for prediction market discovery (free, no auth)
 - Runs `yt-dlp` locally for YouTube search and transcript extraction (no API key, public data)

--- a/skills/last30days/scripts/lib/quality_nudge.py
+++ b/skills/last30days/scripts/lib/quality_nudge.py
@@ -22,13 +22,22 @@ SOURCE_LABELS = {
 
 def _is_x_active(config: dict, research_results: dict) -> bool:
     """Check if X source is active (has credentials AND didn't error)."""
-    has_creds = bool(config.get("AUTH_TOKEN") or config.get("XAI_API_KEY"))
+    has_creds = _has_x_credentials(config)
     if not has_creds:
         return False
     # If X errored this run, it's configured but broken
     if research_results.get("x_error"):
         return False
     return True
+
+
+def _has_x_credentials(config: dict) -> bool:
+    """Return True when any X/Twitter source credential is configured."""
+    return bool(
+        config.get("AUTH_TOKEN")
+        or config.get("XAI_API_KEY")
+        or config.get("XQUIK_API_KEY")
+    )
 
 
 def _is_youtube_active(config: dict, research_results: dict) -> bool:
@@ -146,7 +155,7 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
     core_active.append("reddit")
 
     # X
-    has_x_creds = bool(config.get("AUTH_TOKEN") or config.get("XAI_API_KEY"))
+    has_x_creds = _has_x_credentials(config)
     if _is_x_active(config, research_results):
         core_active.append("x")
     else:
@@ -257,9 +266,10 @@ def _build_nudge_text(
         else:
             free_suggestions.append(
                 "X/Twitter: real-time posts with likes and reposts - the fastest "
-                "signal for breaking topics. Two options: log into x.com in your "
+                "signal for breaking topics. Three options: log into x.com in your "
                 "browser and re-run (cookies detected automatically), or add "
-                "XAI_API_KEY to your .env (no browser access, get key at api.x.ai)."
+                "XAI_API_KEY to your .env (get key at api.x.ai), or add "
+                "XQUIK_API_KEY to your .env (get key at xquik.com)."
             )
 
     if "youtube" in core_missing:

--- a/tests/test_quality_nudge.py
+++ b/tests/test_quality_nudge.py
@@ -19,6 +19,7 @@ def _base_config(**overrides):
         "AUTH_TOKEN": None,
         "CT0": None,
         "XAI_API_KEY": None,
+        "XQUIK_API_KEY": None,
         "SCRAPECREATORS_API_KEY": None,
     }
     config.update(overrides)
@@ -101,6 +102,20 @@ class TestXCookies:
         assert "X/Twitter" not in q["nudge_text"]
 
 
+class TestXquikKey:
+    """+Xquik key -> 80% without browser-cookie or xAI credentials."""
+
+    def test_score_80(self):
+        q = _compute(config_overrides={"XQUIK_API_KEY": "xq_test"})
+        assert q["score_pct"] == 80
+        assert "x" in q["core_active"]
+
+    def test_nudge_mentions_yt_only(self):
+        q = _compute(config_overrides={"XQUIK_API_KEY": "xq_test"})
+        assert "YouTube" in q["nudge_text"]
+        assert "X/Twitter" not in q["nudge_text"]
+
+
 class TestXPlusYtdlp:
     """+X + yt-dlp -> 100%. No SC needed for full core coverage."""
 
@@ -166,6 +181,7 @@ class TestSCDoesNotAffectCoreScore:
         )
         assert q["nudge_text"] is not None
         assert "x.com" in q["nudge_text"].lower()
+        assert "XQUIK_API_KEY" in q["nudge_text"]
 
 
 class TestDisclaimerAlwaysPresent:
@@ -571,4 +587,3 @@ class TestInstagramSilentFailure:
             result_overrides={"instagram_items_count": 0},
         )
         assert "instagram" in q["bonus_errored"]
-


### PR DESCRIPTION
## Summary
- Treat `XQUIK_API_KEY` as an X/Twitter credential in the post-run quality scorer.
- Update the X setup docs so the implemented Xquik source is visible in the source matrix and README.
- Add a focused regression test for Xquik-only X coverage.
- Mention TweetClaw only as the OpenClaw companion for X/Twitter action workflows outside `/last30days` research.

## Duplicate and policy checks
- Local repo scan found no existing TweetClaw mention before this branch.
- `gh pr list --repo mvanhorn/last30days-skill --state all --limit 100` found no TweetClaw or Xquik PR duplicate.
- `gh issue list --repo mvanhorn/last30days-skill --state all --limit 100` found only closed Xquik issue #319, which is related source-wiring history rather than a duplicate.
- Target is public, MIT licensed, and active on `main`.

## Validation
- `git diff --check`
- `uv run pytest tests/test_quality_nudge.py tests/test_xquik.py` - 78 passed
- `python3 -m py_compile skills/last30days/scripts/lib/quality_nudge.py skills/last30days/scripts/lib/xquik.py`
- Link check: `https://github.com/Xquik-dev/tweetclaw` 200, `https://xquik.com` 200
- `npm view @xquik/tweetclaw version --json` - 1.6.31