### PR TITLE
fix(reddit): relevance-aware comment-enrichment slot selection in keyless path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keyless Reddit comment enrichment now spends its limited slots on entity-matching posts first (mirroring rerank's entity-miss demotion signal) instead of raw upvote order, so off-topic high-upvote threads from broad subreddits no longer consume the comment budget only to be demoted afterward ([#484](https://github.com/mvanhorn/last30days-skill/pull/484))
+
 ## [3.3.1] - 2026-05-30
 
 ### Fixed

--- a/skills/last30days/scripts/lib/reddit_keyless.py
+++ b/skills/last30days/scripts/lib/reddit_keyless.py
@@ -163,6 +163,45 @@ def _enrich(posts: List[Dict[str, Any]], depth: str) -> List[Dict[str, Any]]:
     return enriched + rest
 
 
+def _slot_priority(topic: str, posts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Order posts for enrichment slots: entity-matching posts first.
+
+    Comment slots (ENRICH_LIMITS) are scarce; spending them on high-upvote
+    posts that rerank later demotes as entity misses starves the on-topic
+    posts the user actually sees (2026-06-06 "OpenClaw vs Hermes" run:
+    2,000+ upvote Gemma/GPU threads took every slot, then were demoted to
+    zero). Mirror rerank's demotion signal — the topic's stripped primary
+    entity contained in the post text — so slots go to posts likely to
+    survive final ranking. Falls back to token-overlap relevance when the
+    topic yields no usable primary entity. Within each tier the incoming
+    (score-first) order is preserved. Never raises; on any failure the
+    incoming order is returned unchanged.
+    """
+    try:
+        from . import relevance, rerank
+
+        def _post_text(post: Dict[str, Any]) -> str:
+            return f"{post.get('title') or ''} {post.get('selftext') or ''}"
+
+        entity = rerank._primary_entity(topic).lower()
+        if entity:
+            def _matches(post: Dict[str, Any]) -> bool:
+                return entity in _post_text(post).lower()
+        else:
+            prepared = relevance.PreparedQuery(topic)
+
+            def _matches(post: Dict[str, Any]) -> bool:
+                return relevance.token_overlap_relevance(prepared, _post_text(post)) > 0.24
+
+        matches: List[Dict[str, Any]] = []
+        misses: List[Dict[str, Any]] = []
+        for post in posts:
+            (matches if _matches(post) else misses).append(post)
+        return matches + misses
+    except Exception:
+        return posts
+
+
 def search_and_enrich(
     topic: str,
     from_date: str,
@@ -194,9 +233,9 @@ def search_and_enrich(
         if p.get("date") is None or (from_date <= p["date"] <= to_date)
     ]
 
-    # Rank before enrichment by real upvote score (from listing cards / backfill),
-    # then query relevance, then recency. Posts without a recovered score sort by
-    # the latter two — same behavior as before scores were available.
+    # Rank by real upvote score (from listing cards / backfill), then query
+    # relevance, then recency. Posts without a recovered score sort by the
+    # latter two — same behavior as before scores were available.
     posts.sort(
         key=lambda p: (
             p.get("engagement", {}).get("score", 0) or 0,
@@ -206,7 +245,10 @@ def search_and_enrich(
         reverse=True,
     )
 
-    posts = _enrich(posts, depth)
+    # Enrichment slot selection is relevance-aware: entity-matching posts
+    # claim the scarce comment slots first (score order preserved within
+    # each tier). The score-first sort above still governs within-tier order.
+    posts = _enrich(_slot_priority(topic, posts), depth)
 
     for i, post in enumerate(posts):
         post["id"] = f"R{i + 1}"

--- a/tests/test_reddit_keyless.py
+++ b/tests/test_reddit_keyless.py
@@ -166,3 +166,101 @@ class TestSearchAndEnrich:
             reddit_keyless.search_and_enrich("t", "2026-05-01", "2026-05-31", depth="quick")
         # quick depth enriches only top 3 posts
         assert fc.call_count == reddit_keyless.ENRICH_LIMITS["quick"]
+
+
+class TestSlotPriority:
+    """Enrichment slot selection prefers entity-matching posts (R1-R3)."""
+
+    @staticmethod
+    def _titled(i, title, score=0, selftext=""):
+        p = _post(i)
+        p["title"] = title
+        p["selftext"] = selftext
+        p["score"] = score
+        p["engagement"]["score"] = score
+        return p
+
+    def test_on_topic_low_score_beats_off_topic_high_score(self):
+        # 3 off-topic monsters + 2 on-topic small threads; quick depth = 3 slots.
+        posts = [
+            self._titled(1, "Stop asking what model to run", score=2662),
+            self._titled(2, "RTX 4090 PSA", score=2068),
+            self._titled(3, "Gemma 4 release", score=997),
+            self._titled(4, "My OpenClaw self-migrated", score=73),
+            self._titled(5, "Using openclaw with Claude API key is so expensive", score=47),
+        ]
+        enriched_urls = []
+
+        def _capture(url):
+            enriched_urls.append(url)
+            return {"top_comments": [], "comment_insights": [], "num_comments": None}
+
+        with mock.patch.object(reddit_keyless, "_discover", return_value=posts), \
+             mock.patch.object(reddit_keyless.reddit_shreddit, "fetch_comments",
+                               side_effect=_capture):
+            reddit_keyless.search_and_enrich(
+                "openclaw", "2026-05-01", "2026-05-31", depth="quick")
+        assert posts[3]["url"] in enriched_urls
+        assert posts[4]["url"] in enriched_urls
+        assert len(enriched_urls) == reddit_keyless.ENRICH_LIMITS["quick"]
+
+    def test_multiword_topic_uses_substring_not_token_overlap(self):
+        # "claude tips" clears token overlap for "Claude Code" but rerank
+        # demotes it; the partition must mirror rerank's substring test.
+        token_only = self._titled(1, "claude tips", score=500)
+        full_entity = self._titled(2, "Claude Code best setup", score=5)
+        out = reddit_keyless._slot_priority("Claude Code", [token_only, full_entity])
+        assert out[0] is full_entity
+        assert out[1] is token_only
+
+    def test_intent_modifier_stripped_from_topic(self):
+        on_topic = self._titled(1, "Hermes Agent v0.13 is great", score=1)
+        off_topic = self._titled(2, "Hermes Birkin unboxing", score=900)
+        out = reddit_keyless._slot_priority("Hermes Agent review", [off_topic, on_topic])
+        assert out[0] is on_topic
+
+    def test_all_miss_keeps_score_order_and_full_slots(self):
+        posts = [self._titled(i, f"Gemma thread {i}", score=1000 - i) for i in range(5)]
+        out = reddit_keyless._slot_priority("openclaw", posts)
+        assert out == posts  # order unchanged
+        with mock.patch.object(reddit_keyless, "_discover", return_value=posts), \
+             mock.patch.object(reddit_keyless.reddit_shreddit, "fetch_comments",
+                               return_value={"top_comments": [], "comment_insights": [],
+                                             "num_comments": None}) as fc:
+            reddit_keyless.search_and_enrich(
+                "openclaw", "2026-05-01", "2026-05-31", depth="quick")
+        assert fc.call_count == reddit_keyless.ENRICH_LIMITS["quick"]
+
+    def test_same_tier_order_preserved(self):
+        posts = [self._titled(i, f"openclaw thread {i}", score=100 - i) for i in range(4)]
+        out = reddit_keyless._slot_priority("openclaw", posts)
+        assert out == posts
+
+    def test_empty_entity_falls_back_to_token_overlap(self):
+        # Pure intent-modifier topic yields no primary entity; fallback path
+        # must not raise and must keep every post.
+        posts = [self._titled(1, "Post one"), self._titled(2, "review of things")]
+        out = reddit_keyless._slot_priority("review", posts)
+        assert len(out) == 2
+        assert {p["url"] for p in out} == {p["url"] for p in posts}
+
+    def test_selftext_match_lands_in_match_tier(self):
+        body_match = self._titled(1, "Need help with my setup", score=2,
+                                  selftext="my openclaw agent keeps asking for ssh keys")
+        off_topic = self._titled(2, "Gemma 4 with QAT", score=700)
+        out = reddit_keyless._slot_priority("openclaw", [off_topic, body_match])
+        assert out[0] is body_match
+
+    def test_none_score_posts_do_not_break_partition(self):
+        p1 = self._titled(1, "openclaw tips")
+        p1["engagement"]["score"] = None
+        p2 = self._titled(2, "Gemma news")
+        p2["engagement"]["score"] = None
+        out = reddit_keyless._slot_priority("openclaw", [p2, p1])
+        assert out[0] is p1
+
+    def test_partition_never_raises(self):
+        posts = [self._titled(1, "openclaw tips", score=1)]
+        with mock.patch("lib.rerank._primary_entity", side_effect=Exception("boom")):
+            out = reddit_keyless._slot_priority("openclaw", posts)
+        assert out == posts


### PR DESCRIPTION
## Problem

The keyless Reddit path enriches only the top N posts with comments (ENRICH_LIMITS: quick=3, default=5, deep=8) under a 45s budget, and picks those N by raw upvote score before topic relevance is known. With broad subreddits in the mix, huge off-topic threads win the slots, get their comments fetched, and are then demoted to zero by rerank's entity-miss demotion - while the on-topic threads the user actually sees ship with titles only.

Observed on a 2026-06-06 "OpenClaw vs Hermes" run: r/LocalLLaMA Gemma/GPU threads (2,000+ upvotes) consumed every slot and were all tagged `fallback-local-score (entity-miss demotion)`; the 47-73 point r/openclaw threads never got their comments fetched.

## Fix

`_slot_priority()` partitions posts at the enrichment seam into entity-match and entity-miss tiers, mirroring rerank's demotion signal (stripped primary entity contained in title + selftext; token-overlap fallback when the topic yields no primary entity). Match-tier posts claim slots first; misses fill leftovers. Score order is preserved within each tier, ENRICH_LIMITS/ENRICH_BUDGET are unchanged, and the never-raise contract holds (any partition failure returns the original order).

Before/after on the real failure case (default depth, 5 slots):

| | Enrichment slate |
|---|---|
| before | 4 of 5 slots to off-topic r/LocalLLaMA monsters, 1 on-topic |
| after | all 3 on-topic r/openclaw threads enriched, leftovers to highest-score misses |

Note: the returned list now orders match-tier first, which also gives on-topic posts better RRF ranks downstream - intentional, aligned with the fix.

Known limitation: text presence cannot disambiguate homographs (a "Hermes Birkin" post still contains "hermes"); collision topics keep today's behavior rather than improving.

## Testing

- 9 new tests in `tests/test_reddit_keyless.py` (slot reallocation, multi-word substring parity with rerank, intent-modifier stripping, all-miss fallback, selftext match, never-raise)
- Full suite green, ruff clean
- Stability eval (`evaluate_search_quality.py --quick`, 9 topics incl. the "Hermes" collision topic): candidate sets identical to baseline on 8/9 topics, Hermes retention 1.00 (no regression); judge metrics unavailable locally, overlap metrics only

## Post-Deploy Monitoring & Validation

- Watch `[RedditKeyless]` stderr lines on the next few real runs
- Healthy signal: `top_comments` present on on-topic threads in saved raw output; off-topic demoted posts no longer carry fetched comments
- Failure signal: Reddit items with comment counts but no comment excerpts on on-topic threads
- Rollback: revert this commit (single-module change)
- Window/owner: next 2-3 organic /last30days runs, @mvanhorn

🤖 Generated with [Claude Code](https://claude.com/claude-code)