### PR TITLE
feat: Hebrew / non-Latin language support

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -387,8 +387,18 @@ Known keyword-trap classes and how to handle each:
 - Action: Ask for specificity before running:
   > "{TOPIC} is a huge category - are you asking about {specific-facet-A}, {specific-facet-B}, or {specific-facet-C}? Each is a different community. Pick one or tell me the angle."
 
+**Class 5: Non-English / non-Latin-script topic (Hebrew, Arabic, Chinese, Japanese, etc.)**
+- Pattern: topic contains non-Latin characters (Hebrew [\u0590-\u05FF], Arabic [\u0600-\u06FF], CJK [\u4E00-\u9FFF], etc.).
+- Why it fails without intervention: Reddit, HackerNews, GitHub, and Polymarket are English-dominant platforms. A Hebrew brand like "קפה עלית" scores zero entity-matches across all four sources and returns only English-language noise as fallback padding.
+- Action: **Mandatory pre-flight steps for non-English topics:**
+  1. **Force `--web-backend brave`** in the engine command. Brave indexes non-English web (Ynet/Walla/Mako for Hebrew; Haber7/Hurriyet for Turkish; etc.) and is the only available source with real-language coverage.
+  2. **Skip `--subreddits` targeting unless the topic has a known English-speaking community.** Generic subreddits (r/food, r/Israel) return English noise; omit them or scope tightly to known bilingual communities.
+  3. **Note in the Resolved block:** "Non-English topic detected ([language]). Routing to `--web-backend brave`; Reddit/HN/GitHub will likely return zero on-topic results."
+  4. **X/Twitter and YouTube are the highest-value missing sources for non-English topics.** Surface this clearly in the output so the user knows what would unlock deeper coverage.
+- Do NOT skip this class check for mixed-script queries (e.g. "קפה עלית Elite Coffee") - if any non-Latin characters are present, Class 5 applies.
+
 **Pre-Flight decision flow (do this BEFORE any WebSearch):**
-1. Read the topic. Match against Classes 1-4 above.
+1. Read the topic. Match against Classes 1-5 above.
 2. If the topic matches a class, ALWAYS emit a visible pre-flight note before the Resolved block:
    - `Pre-Flight: topic matches {Class N} ({class name}). {Action: clarifying question / reframe / specificity ask}.`
 3. If the action is a clarifying question, STOP after emitting it. Wait for the user response before any engine work.
@@ -416,6 +426,7 @@ Before running the engine, determine which flags apply to this topic and resolve
 | `--tiktok-hashtags={h1,h2,...}` | Step 0.55 | Always — inferred from topic |
 | `--tiktok-creators={c1,c2,...}` | Step 0.55 | Creator / influencer / brand topics |
 | `--ig-creators={c1,c2,...}` | Step 0.55 | Creator / brand topics |
+| `--web-backend brave` | Step 0.45 Class 5 | **MANDATORY** for non-Latin-script topics (Hebrew, Arabic, CJK, etc.) — Brave is the only source that indexes non-English web |
 | `--auto-resolve` | Fallback | WebSearch is available but Step 0.55 could not resolve everything cleanly — use as belt-and-suspenders |
 
 **Checkpoint before running the engine:** your Bash command must include every flag from the checklist that applies to this topic. For a person who ships code (the Peter Steinberger class), that is MINIMUM `--x-handle` AND `--github-user` AND `--subreddits`, and typically `--x-related` too. A command with only `--x-handle` on a person topic is a pre-flight skip and a Step 0.5 regression.

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 
 from . import http, providers, query, schema
+
+# Hebrew Unicode block: U+0590–U+05FF
+_HEBREW_RE = re.compile(r'[\u0590-\u05FF]')
+
+
+def detect_language(text: str) -> str | None:
+    """Return 'he' if the text contains Hebrew characters, else None."""
+    return 'he' if _HEBREW_RE.search(text) else None
 
 ALLOWED_INTENTS = {
     "factual",
@@ -383,6 +392,14 @@ def _fallback_plan(
     note: str = "fallback-plan",
 ) -> schema.QueryPlan:
     intent = _infer_intent(topic)
+    # Hebrew-language topics: elevate web search (grounding) to the front of
+    # the source list since Reddit/HN/GitHub are English-dominant platforms.
+    # Grounding covers Ynet, Walla, Mako, N12 etc. if a web search key is set.
+    if detect_language(topic) == 'he' and 'grounding' in available_sources:
+        ordered = ['grounding'] + [s for s in available_sources if s != 'grounding']
+        available_sources = ordered
+        if requested_sources:
+            requested_sources = ['grounding'] + [s for s in requested_sources if s != 'grounding']
     allowed_sources = requested_sources or available_sources
     source_weights = _default_source_weights(intent, allowed_sources)
     core = query.extract_core_subject(topic, max_words=6, strip_suffixes=True)

--- a/skills/last30days/scripts/lib/query.py
+++ b/skills/last30days/scripts/lib/query.py
@@ -10,6 +10,10 @@ PREFIXES = [
     'what are people saying about', 'what do people think about',
     'how do i use', 'how to use', 'how to',
     'what are', 'what is', 'tips for', 'best practices for',
+    # Hebrew question/meta prefixes
+    'מה יש חדש ב', 'מה יש חדש על', 'מה אנשים אומרים על',
+    'מה חדש ב', 'מה חדש על', 'איך להשתמש ב',
+    'מהם המוצרים של', 'מה הם', 'מהם',
 ]
 
 # Multi-word suffixes (used by bird_x)
@@ -41,6 +45,12 @@ NOISE_WORDS = frozenset({
     'using', 'uses', 'use',
     # Misc filler
     'people', 'saying', 'think', 'said', 'lately',
+    # Hebrew function words / prepositions / filler
+    'מה', 'מי', 'איך', 'למה', 'איפה', 'מתי', 'כמה', 'האם',
+    'של', 'על', 'עם', 'אל', 'את', 'בין', 'כי', 'כן', 'לא',
+    'יש', 'אין', 'כבר', 'רק', 'גם', 'אבל', 'כך', 'זה', 'זו',
+    'חדש', 'חדשים', 'טוב', 'טובים', 'הכי', 'ביותר',
+    'מוצרים', 'מבצע', 'מבצעים', 'חדשות', 'עדכונים',
 })
 
 

--- a/skills/last30days/scripts/lib/relevance.py
+++ b/skills/last30days/scripts/lib/relevance.py
@@ -16,6 +16,13 @@ STOPWORDS = frozenset({
     'your', 'i', 'me', 'we', 'you', 'what', 'are', 'do', 'can',
     'its', 'be', 'or', 'not', 'no', 'so', 'if', 'but', 'about',
     'all', 'just', 'get', 'has', 'have', 'was', 'will',
+    # Hebrew function words / prepositions / conjunctions
+    'את', 'של', 'על', 'עם', 'אל', 'כי', 'לא', 'הוא', 'היא', 'הם',
+    'הן', 'אנו', 'אנחנו', 'זה', 'זו', 'זאת', 'כל', 'יש', 'אין',
+    'כבר', 'רק', 'גם', 'כן', 'אם', 'או', 'אבל', 'כך', 'מה', 'מי',
+    'איך', 'למה', 'כמה', 'היה', 'הייתה', 'היו', 'יהיה', 'יהיו',
+    # Hebrew definite article / prefixes appearing as standalone tokens after split
+    'ה', 'ב', 'ל', 'מ', 'כ', 'ו', 'ש',
 })
 
 # Synonym groups for relevance scoring (bidirectional expansion)


### PR DESCRIPTION
## What

Extends the skill to handle Hebrew (and other non-Latin-script) topics correctly across all four touch points: AI agent behavior (SKILL.md), source routing (planner.py), query extraction (query.py), and relevance scoring (relevance.py).

## Why

Before this fix, a Hebrew consumer brand query like `קפה עלית` returned 12 English-language noise posts (Jamaican beef patties, backyard pizza, r/pokemongo) all scoring 0, because:
1. The engine routed to Reddit/HN which have no Hebrew content
2. Hebrew stopwords like של/על/את inflated token counts and caused entity-miss demotions
3. The AI agent had no instruction to force `--web-backend brave` for non-Latin topics

## Changes

### `SKILL.md`
- Add **Class 5** to Step 0.45 pre-flight: non-Latin-script topics (Hebrew [\u0590-\u05FF], Arabic [\u0600-\u06FF], CJK [\u4E00-\u9FFF]) are now a named keyword-trap class
- Mandatory actions: force `--web-backend brave`, skip English-only subreddits, surface X/Twitter + YouTube as key missing sources
- Add `--web-backend brave` row to Pre-Flight Checklist flag table (MANDATORY for non-Latin topics)

### `scripts/lib/planner.py`
- Add `detect_language()` using Hebrew Unicode block regex (`[\u0590-\u05FF]`)
- In `_fallback_plan()`: elevate `grounding` to first source when Hebrew detected, so Brave (Ynet, Walla, Mako, N12) runs before Reddit/HN

### `scripts/lib/query.py`
- Add Hebrew question/meta prefixes to `PREFIXES` strip list (e.g. `מה יש חדש ב`, `מה אנשים אומרים על`)
- Add Hebrew function words, prepositions, and filler to `NOISE_WORDS` so natural-language Hebrew queries extract the correct core subject

### `scripts/lib/relevance.py`
- Add Hebrew function words and standalone prefix tokens (ה/ב/ל/מ/כ/ו/ש) to `STOPWORDS` to prevent entity-miss demotions on Hebrew topics

## Test results

| Run | Source | Results | Signal |
|-----|--------|---------|--------|
| Before fix | Reddit + HN | 12 threads | 0 on-topic (all English noise, score 0) |
| After fix | Brave web | 1 page | Real Hebrew news: נס קפה עלית factory sold for ₪150M (score 35) |

The fix correctly eliminates all noise and returns only on-topic Hebrew content.

## Notes

- `detect_language()` currently only detects Hebrew. The SKILL.md Class 5 description covers the broader non-Latin case (Arabic, CJK) to guide future extension — the engine fix is Hebrew-specific for now.
- The Brave web backend requires `BRAVE_API_KEY` (free tier: 2,000 queries/month at api.search.brave.com). Without a key, the engine falls back to existing behavior.