### PR TITLE
fix(cli): preserve github setup flag

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -236,7 +236,10 @@ def persist_report(report: schema.Report) -> dict[str, int]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Research a topic across live social, market, and grounded web sources.")
+    parser = argparse.ArgumentParser(
+        description="Research a topic across live social, market, and grounded web sources.",
+        allow_abbrev=False,
+    )
     parser.add_argument("topic", nargs="*", help="Research topic")
     parser.add_argument("--emit", default="compact", choices=["compact", "json", "context", "md", "html"])
     parser.add_argument("--search", help="Comma-separated source list")

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -102,6 +102,12 @@ class CliV3Tests(unittest.TestCase):
         self.assertEqual(["biosecurity", "ai", "agents"], args.topic)
         self.assertEqual([], extra)
 
+    def test_build_parser_preserves_github_setup_subflag(self):
+        parser = cli.build_parser()
+        args, extra = parser.parse_known_args(["setup", "--github"])
+        self.assertEqual(["setup"], args.topic)
+        self.assertEqual(["--github"], extra)
+
     def test_ensure_supported_python_rejects_old_interpreter_with_actionable_error(self):
         stderr = io.StringIO()
         with redirect_stderr(stderr):


### PR DESCRIPTION
## Summary

Fixes argparse handling for the setup GitHub auth sub-flag so setup --github is preserved for setup handling instead of being treated as an ambiguous abbreviation of --github-user or --github-repo.

## Changes

- Disable argparse long-option abbreviation in the main CLI parser.
- Add regression coverage for setup --github parsing.

## Testing

- [x] Ran python3 -m pytest -q --tb=short

## Related Issues

Fixes #456