### PR TITLE
fix(cookies): scan non-default Firefox profiles when default lacks X auth (#498)

### DIFF
--- a/skills/last30days/scripts/lib/cookie_extract.py
+++ b/skills/last30days/scripts/lib/cookie_extract.py
@@ -8,6 +8,7 @@ Only uses Python stdlib — no external dependencies.
 
 import configparser
 import functools
+import glob
 import logging
 import platform
 import shutil
@@ -190,11 +191,29 @@ def _query_cookies_db(
 
 def _try_firefox_dir(profiles_dir: Path, domain: str, cookie_names: List[str]) -> Optional[Dict[str, str]]:
     """Try to extract cookies from a Firefox profiles directory."""
-    profile_path = _find_default_profile(profiles_dir)
-    if profile_path is None:
+    default_profile = _find_default_profile(profiles_dir)
+    if default_profile is not None:
+        result = _query_cookies_db(default_profile / "cookies.sqlite", domain, cookie_names)
+        if result is not None:
+            return result
+
+    seen: set[Path] = set()
+    if default_profile is not None:
+        seen.add(default_profile / "cookies.sqlite")
+
+    for pattern in ("Profiles/*/cookies.sqlite", "*/cookies.sqlite"):
+        for db_str in sorted(glob.glob(str(profiles_dir / pattern))):
+            db = Path(db_str)
+            if db in seen:
+                continue
+            seen.add(db)
+            result = _query_cookies_db(db, domain, cookie_names)
+            if result is not None:
+                return result
+
+    if default_profile is None:
         logger.debug("No Firefox profile found in %s", profiles_dir)
-        return None
-    return _query_cookies_db(profile_path / "cookies.sqlite", domain, cookie_names)
+    return None
 
 
 def extract_firefox_cookies(

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -107,6 +107,47 @@ class TestExtractFirefoxCookies:
         assert result["ct0"] == "ct0_xyz789"
         assert "session" not in result  # different domain cookie not included
 
+    def test_non_default_profile_fallback_when_default_has_no_domain_cookies(
+        self, mock_firefox_env
+    ):
+        """When the default profile lacks target cookies, scan other profiles."""
+        profiles_dir = mock_firefox_env(
+            profiles={
+                "bbb222.default-release": [
+                    (".example.com", "session", "sess_only"),
+                ],
+                "aaa111.other": [
+                    (".x.com", "auth_token", "logged_in_token"),
+                    (".x.com", "ct0", "logged_in_ct0"),
+                ],
+            },
+            profiles_ini=textwrap.dedent("""\
+                [General]
+                StartWithLastProfile=1
+
+                [Profile0]
+                Name=other
+                IsRelative=1
+                Path=aaa111.other
+
+                [Profile1]
+                Name=default-release
+                IsRelative=1
+                Path=bbb222.default-release
+                Default=1
+            """),
+        )
+
+        with patch(
+            "lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "logged_in_token"
+        assert result["ct0"] == "logged_in_ct0"
+
     def test_multiple_profiles_selects_default(self, mock_firefox_env):
         """When multiple profiles exist, the one with Default=1 is used."""
         profiles_dir = mock_firefox_env(


### PR DESCRIPTION
## Summary
Fixes #498. When a user is logged into x.com on a Firefox profile that is not the `profiles.ini` default, `FROM_BROWSER=auto`/`firefox` now finds `auth_token`/`ct0` by scanning the other profile databases after the default comes up empty.

## Problem
`_try_firefox_dir()` only queried the single default profile's `cookies.sqlite`. On multi-profile macOS setups where X login lives on a secondary profile (e.g. `*.default-release-1` after migration), the engine reported `X: 0 posts` despite a valid browser session.

```python
# skills/last30days/scripts/lib/cookie_extract.py (before)
profile_path = _find_default_profile(profiles_dir)
return _query_cookies_db(profile_path / "cookies.sqlite", domain, cookie_names)
```

## Solution
Keep default-profile-first behavior, then fall back to every other `cookies.sqlite` under the Firefox directory (`Profiles/*/cookies.sqlite` and `*/cookies.sqlite`). Added a regression test where the default profile holds only `.example.com` cookies but a non-default profile holds the X auth pair.

## Out of scope
- `FIREFOX_PROFILE` env override (mentioned in #498 as a nice follow-up).
- Chrome/Brave multi-profile parity — Firefox-only path per the report.

## Test plan
- [x] `python3 -m pytest tests/test_cookie_extract.py -v` (13 passed, including new `test_non_default_profile_fallback_when_default_has_no_domain_cookies`)
- [ ] CI pytest suite

## Related
- #498 — Firefox cookie extraction misses X login on multi-profile setups

Made with [Cursor](https://cursor.com)