### PR TITLE
fix(evaluator): scrub ambient credentials in tests

### DIFF
--- a/skills/last30days/scripts/evaluate_search_quality.py
+++ b/skills/last30days/scripts/evaluate_search_quality.py
@@ -46,6 +46,19 @@ DEFAULT_TOPICS = _load_default_topics()
 DEFAULT_SEARCH = ""
 DEFAULT_JUDGE_MODEL = GEMINI_FLASH_LITE
 GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+EVAL_CREDENTIAL_ENV_KEYS = (
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENAI_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "SCRAPECREATORS_API_KEY",
+    "BSKY_HANDLE",
+    "BSKY_APP_PASSWORD",
+    "TRUTHSOCIAL_TOKEN",
+    "AUTH_TOKEN",
+    "CT0",
+)
 
 
 def stable_item_key(item: dict[str, Any]) -> str:
@@ -289,19 +302,7 @@ def create_eval_env() -> dict[str, str]:
         "PYTHONUTF8": "1",
         "LAST30DAYS_CONFIG_DIR": "",
     }
-    for key in (
-        "GOOGLE_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_GENAI_API_KEY",
-        "OPENAI_API_KEY",
-        "XAI_API_KEY",
-        "SCRAPECREATORS_API_KEY",
-        "BSKY_HANDLE",
-        "BSKY_APP_PASSWORD",
-        "TRUTHSOCIAL_TOKEN",
-        "AUTH_TOKEN",
-        "CT0",
-    ):
+    for key in EVAL_CREDENTIAL_ENV_KEYS:
         value = os.environ.get(key) or config.get(key)
         if value:
             passthrough[key] = value

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -141,18 +141,7 @@ class EvaluatorV3Tests(unittest.TestCase):
     def test_create_eval_env_and_run_last30days(self):
         credential_env = {
             key: ""
-            for key in (
-                "GEMINI_API_KEY",
-                "GOOGLE_GENAI_API_KEY",
-                "OPENAI_API_KEY",
-                "XAI_API_KEY",
-                "SCRAPECREATORS_API_KEY",
-                "BSKY_HANDLE",
-                "BSKY_APP_PASSWORD",
-                "TRUTHSOCIAL_TOKEN",
-                "AUTH_TOKEN",
-                "CT0",
-            )
+            for key in evaluator.EVAL_CREDENTIAL_ENV_KEYS
         }
         credential_env.update({"PATH": "/bin", "GOOGLE_API_KEY": "env-google"})
         with mock.patch.object(evaluator.envlib, "get_config", return_value={"OPENAI_API_KEY": "config-openai"}):

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -139,8 +139,24 @@ class EvaluatorV3Tests(unittest.TestCase):
             self.assertEqual({}, skipped)
 
     def test_create_eval_env_and_run_last30days(self):
+        credential_env = {
+            key: ""
+            for key in (
+                "GEMINI_API_KEY",
+                "GOOGLE_GENAI_API_KEY",
+                "OPENAI_API_KEY",
+                "XAI_API_KEY",
+                "SCRAPECREATORS_API_KEY",
+                "BSKY_HANDLE",
+                "BSKY_APP_PASSWORD",
+                "TRUTHSOCIAL_TOKEN",
+                "AUTH_TOKEN",
+                "CT0",
+            )
+        }
+        credential_env.update({"PATH": "/bin", "GOOGLE_API_KEY": "env-google"})
         with mock.patch.object(evaluator.envlib, "get_config", return_value={"OPENAI_API_KEY": "config-openai"}):
-            with mock.patch.dict("os.environ", {"PATH": "/bin", "GOOGLE_API_KEY": "env-google"}, clear=False):
+            with mock.patch.dict("os.environ", credential_env, clear=False):
                 created = evaluator.create_eval_env()
         self.assertEqual("/bin", created["PATH"])
         self.assertEqual("env-google", created["GOOGLE_API_KEY"])


### PR DESCRIPTION
The evaluator env test patches a dummy config value, but developer shells can still export real API keys. Since create_eval_env intentionally prefers os.environ over config, those ambient credentials can make the assertion fail and leak the key in pytest's diff output.

Patch the test's environment to blank unrelated credential variables while keeping the explicit dummy API-key coverage. Runtime configuration precedence is unchanged.

Testing: uv run python -m pytest -q --tb=short

## Summary

Prevent the evaluator env test from reading real API keys exported in a developer shell.

## Changes

  - Blank unrelated credential environment variables inside `test_create_eval_env_and_run_last30days`
  - Keep the explicit dummy `GOOGLE_API_KEY` coverage intact
  - Leave runtime configuration precedence unchanged

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short`

## Related Issues

None