### PR TITLE
docs: add TrendPulse to Community Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,15 @@ Built with Python 3.12+, yt-dlp, Node.js (vendored Bird client for X search), an
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
 
-## Star History
+## Community Projects
+
+Projects built by the community that extend or complement `/last30days`:
+
+| Project | Description | Author |
+|---------|-------------|--------|
+| [TrendPulse](https://trendpulse-green.vercel.app) | Web UI for last30days — search Web, Reddit, HN, YouTube from your browser. Zero API keys, open source. | [@mustafabozkaya](https://github.com/mustafabozkaya) |
+
+*Have a project to add? Open a PR!*
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>


### PR DESCRIPTION
## What

Added TrendPulse — a community-built web UI for `/last30days` — to the README under a new **Community Projects** section.

## Why

As discussed in issue #511, community projects that extend `/last30days` belong in the README rather than the issue tracker. TrendPulse provides a browser-based interface for searching Web, Reddit, HN, and YouTube using the last30days concept — zero API keys required.

## Details

- New **Community Projects** section between "Open source" and "Star History"
- Links to [TrendPulse](https://trendpulse-green.vercel.app) (live demo) and [GitHub repo](https://github.com/mustafabozkaya/trendpulse)
- Fresh contributors welcome invite at the bottom

---

Created from a suggestion in https://github.com/mvanhorn/last30days-skill/issues/511