### PR TITLE
Feat/bilibili adapter pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Bilibili (B站) as a default web source.** Searches the public WBI-signed `/x/web-interface/wbi/search/type` endpoint with an auto-bootstrapped `buvid3` cookie — no user configuration or API key required. Items are ranked by engagement (coin > favorite > like > danmaku > play), surfacing the videos B站 users actually invested in. Disable via `LAST30DAYS_DISABLE_BILIBILI=1`.
+- **Bilibili (B站) as a default web source.** Searches the public WBI-signed `/x/web-interface/wbi/search/type` endpoint with an auto-bootstrapped `buvid3` cookie — no user configuration or API key required. Items are ranked by the engagement the search API returns (favorite > like > danmaku > play). Disable via `LAST30DAYS_DISABLE_BILIBILI=1`.
 
 ## [3.3.2] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Bilibili (B站) as a default web source.** Searches the public WBI-signed `/x/web-interface/wbi/search/type` endpoint with an auto-bootstrapped `buvid3` cookie — no user configuration or API key required. Items are ranked by engagement (coin > favorite > like > danmaku > play), surfacing the videos B站 users actually invested in. Disable via `LAST30DAYS_DISABLE_BILIBILI=1`.
+
 ## [3.3.2] - 2026-06-06
 
 ### Fixed

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -55,6 +55,7 @@ The project-scoped file is the cleanest pattern for **per-client setups**: drop 
 | Polymarket | none | always on | yes |
 | GitHub | `gh` CLI installed (uses your GitHub auth) | always on if `gh` present | yes |
 | YouTube | `yt-dlp` CLI installed | always on if `yt-dlp` present | yes |
+| Bilibili (B站) | none (public WBI-signed search, auto-bootstrapped `buvid3` cookie) | always on; disable with `LAST30DAYS_DISABLE_BILIBILI=1` or per-run `EXCLUDE_SOURCES=bilibili` | yes |
 | X / Twitter | one of: `AUTH_TOKEN` + `CT0` (browser cookies, Bird CLI), `XAI_API_KEY`, `SCRAPECREATORS_API_KEY`, or `FROM_BROWSER` (cookie-jar auth) | X items in results | cookie-jar / Bird = free; xAI / ScrapeCreators = paid |
 | TikTok | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `tiktok` | TikTok items | 10K free calls |
 | Instagram | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `instagram` | Instagram Reels | 10K free calls; raise `LAST30DAYS_TRANSCRIPT_TIMEOUT` (default 30s) if SC is slow on your network |

--- a/fixtures/bilibili/nav_response.json
+++ b/fixtures/bilibili/nav_response.json
@@ -1,0 +1,12 @@
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "isLogin": false,
+    "wbi_img": {
+      "img_url": "https://i0.hdslb.com/bfs/wbi/7cd084941338484aae1ad9425b84077c.png",
+      "sub_url": "https://i0.hdslb.com/bfs/wbi/4932caff0ff746eab6f01bf08b70ac45.png"
+    }
+  }
+}

--- a/fixtures/bilibili/search_video_response.json
+++ b/fixtures/bilibili/search_video_response.json
@@ -17,7 +17,7 @@
         "bvid": "BV1AA1xxxxxx",
         "aid": 100001,
         "title": "<em class=\"keyword\">长沙麻将</em>新手入门教程",
-        "description": "长沙麻将基础规则讲解，适合新手快速上手。",
+        "description": "<em class=\"keyword\">长沙麻将</em>基础规则讲解，适合新手快速上手。",
         "pic": "//i0.hdslb.com/bfs/archive/aaa.jpg",
         "play": 124000,
         "video_review": 1100,

--- a/fixtures/bilibili/search_video_response.json
+++ b/fixtures/bilibili/search_video_response.json
@@ -1,0 +1,71 @@
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "seid": "0",
+    "page": 1,
+    "pagesize": 20,
+    "numResults": 3,
+    "numPages": 1,
+    "result": [
+      {
+        "type": "video",
+        "id": 100001,
+        "author": "测试UP主A",
+        "mid": 12345,
+        "bvid": "BV1AA1xxxxxx",
+        "aid": 100001,
+        "title": "<em class=\"keyword\">长沙麻将</em>新手入门教程",
+        "description": "长沙麻将基础规则讲解，适合新手快速上手。",
+        "pic": "//i0.hdslb.com/bfs/archive/aaa.jpg",
+        "play": 124000,
+        "video_review": 1100,
+        "favorites": 3400,
+        "review": 220,
+        "like": 8200,
+        "duration": "4:05",
+        "pubdate": 1748390400,
+        "senddate": 1748390400
+      },
+      {
+        "type": "video",
+        "id": 100002,
+        "author": "测试UP主B",
+        "mid": 67890,
+        "bvid": "BV1BB2yyyyyy",
+        "aid": 100002,
+        "title": "长沙麻将高手对局解说",
+        "description": "复盘真实牌局，讲解胡牌与防守思路。",
+        "pic": "//i0.hdslb.com/bfs/archive/bbb.jpg",
+        "play": 56000,
+        "video_review": 480,
+        "favorites": 1100,
+        "review": 95,
+        "like": 3200,
+        "duration": "12:30",
+        "pubdate": 1746576000,
+        "senddate": 1746576000
+      },
+      {
+        "type": "video",
+        "id": 100003,
+        "author": "测试UP主C",
+        "mid": 24680,
+        "bvid": "BV1CC3zzzzzz",
+        "aid": 100003,
+        "title": "麻将历史档案 2020 年",
+        "description": "怀旧向，发布于早期。",
+        "pic": "//i0.hdslb.com/bfs/archive/ccc.jpg",
+        "play": 9000,
+        "video_review": 50,
+        "favorites": 110,
+        "review": 8,
+        "like": 220,
+        "duration": "8:15",
+        "pubdate": 1577836800,
+        "senddate": 1577836800
+      }
+    ]
+  }
+}

--- a/fixtures/bilibili/v_voucher_response.json
+++ b/fixtures/bilibili/v_voucher_response.json
@@ -1,0 +1,8 @@
+{
+  "code": -352,
+  "message": "风控校验失败",
+  "ttl": 1,
+  "data": {
+    "v_voucher": "voucher_abcdef123456"
+  }
+}

--- a/skills/last30days/scripts/lib/bilibili.py
+++ b/skills/last30days/scripts/lib/bilibili.py
@@ -328,7 +328,9 @@ def _normalize_video(raw: Dict[str, Any], index: int) -> Optional[Dict[str, Any]
         return None
 
     title = _strip_em_tags(raw.get("title")).strip()
-    description = str(raw.get("description") or "").strip()
+    # B站 highlights the matched keyword with <em> tags in the description too,
+    # not just the title, so strip it here as well before it becomes the snippet.
+    description = _strip_em_tags(raw.get("description")).strip()
     pubdate = raw.get("pubdate") or raw.get("senddate")
     iso = _pubdate_to_iso(pubdate)
 

--- a/skills/last30days/scripts/lib/bilibili.py
+++ b/skills/last30days/scripts/lib/bilibili.py
@@ -203,7 +203,10 @@ def _ensure_session() -> Tuple[str, Dict[str, str]]:
         mixin = bilibili_wbi.mix_key(img_key, sub_key)
     except http.HTTPError:
         raise  # already tagged at the source
-    except (ValueError, KeyError, TypeError) as exc:
+    except (ValueError, KeyError, TypeError, IndexError) as exc:
+        # IndexError guards malformed WBI keys: if nav returns img_key+sub_key
+        # shorter than the 64 positions MIXIN_KEY_ENC_TAB indexes, mix_key()
+        # raises IndexError, which we surface as a clean bootstrap failure.
         raise http.HTTPError(
             "Bilibili: cookie bootstrap failed: {}".format(exc)
         ) from exc
@@ -273,6 +276,12 @@ def search_bilibili(topic: str, from_date: str, to_date: str, depth: str = "defa
     code = resp.get("code", -1)
     data = resp.get("data") if isinstance(resp.get("data"), dict) else {}
     if code != 0:
+        # Any non-zero search code means the cached session may be stale: a
+        # v_voucher signals WBI key rotation, and other error codes can follow
+        # an expired buvid3. Clear the process-level cache so the next call
+        # re-bootstraps fresh keys instead of replaying the same failure for
+        # the rest of the process lifetime.
+        _reset_session_cache()
         if "v_voucher" in data:
             raise http.HTTPError(
                 "Bilibili search: WBI signature may have rotated "

--- a/skills/last30days/scripts/lib/bilibili.py
+++ b/skills/last30days/scripts/lib/bilibili.py
@@ -1,0 +1,356 @@
+"""Bilibili search adapter for last30days.
+
+Uses Bilibili's public web search API:
+  GET https://api.bilibili.com/x/web-interface/wbi/search/type
+
+WBI-signed via bilibili_wbi.sign_params. buvid3 cookie is auto-bootstrapped
+on first use (no user login required). Module-level caches keep the
+bootstrap to one-shot per Python process.
+
+Modeled after skills/last30days/scripts/lib/xiaohongshu_api.py.
+"""
+
+import json
+import math
+import re
+import urllib.error
+import urllib.request
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import bilibili_wbi, http
+
+NAV_URL = "https://api.bilibili.com/x/web-interface/nav"
+SEARCH_URL = "https://api.bilibili.com/x/web-interface/wbi/search/type"
+BOOTSTRAP_URL = "https://www.bilibili.com/"
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+_EM_TAG_PATTERN = re.compile(r"</?em[^>]*>")
+
+
+def _to_int(value: Any) -> int:
+    """Convert engagement count to int. Supports plain ints/strings and
+    Chinese suffixes 万 (x10^4) and 亿 (x10^8).
+
+    Private to this module for the first PR. A future PR may extract this
+    to lib/normalize.py once Weibo/Zhihu adapters share the pattern.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return 0
+
+    try:
+        if text.endswith("万"):
+            return int(float(text[:-1]) * 10_000)
+        if text.endswith("亿"):
+            return int(float(text[:-1]) * 100_000_000)
+        return int(float(text))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _relevance_from_interactions(play: int, like: int, danmaku: int, favorite: int, coin: int) -> float:
+    """Heuristic 0.05-1.0 relevance from B站 engagement signals.
+
+    Weights (descending): coin > favorite > like > danmaku > play.
+    Rationale: coins cost users a finite weekly budget -- strongest signal.
+    Favorites imply retention intent. Likes are light affirmation. Danmaku
+    is B站-specific participation. Plays are passive baseline.
+
+    Uses a log10 compression on the weighted sum so that engagement scales
+    smoothly from a tiny video (~0.05) to a viral hit (~1.0), with a
+    moderately popular video landing near 0.5.
+    """
+    weighted = play * 1.0 + like * 2.0 + danmaku * 1.5 + favorite * 2.5 + coin * 3.0
+    if weighted <= 0:
+        return 0.05
+    # log10(weighted) maps: 10 -> 1, 1k -> 3, 1M -> 6, 10M -> 7. Divide by
+    # 7.5 so a moderately popular video (~100k weighted) lands near 0.7
+    # and a viral one (10M+) saturates at 1.0.
+    score = math.log10(1.0 + weighted) / 7.5
+    return round(min(1.0, max(0.05, score)), 3)
+
+
+def _parse_duration(value: Any) -> int:
+    """Parse '4:05' or '1:02:03' style duration to seconds. 0 on failure."""
+    if not isinstance(value, str) or not value:
+        return 0
+    parts = value.split(":")
+    try:
+        nums = [int(p) for p in parts]
+    except ValueError:
+        return 0
+    if len(nums) == 2:
+        return nums[0] * 60 + nums[1]
+    if len(nums) == 3:
+        return nums[0] * 3600 + nums[1] * 60 + nums[2]
+    return 0
+
+
+def _pubdate_to_iso(value: Any) -> Optional[str]:
+    """Convert a Unix epoch (int seconds) to YYYY-MM-DD UTC. None on failure."""
+    try:
+        iv = int(value)
+    except (TypeError, ValueError):
+        return None
+    if iv <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(iv, tz=timezone.utc).strftime("%Y-%m-%d")
+    except (OSError, ValueError):
+        return None
+
+
+def _strip_em_tags(text: Any) -> str:
+    """Remove <em>...</em> search-highlight tags from a string."""
+    if not isinstance(text, str):
+        return ""
+    return _EM_TAG_PATTERN.sub("", text)
+
+
+# Module-level cache: bootstrap only once per Python process.
+_mixin_key_cache: Optional[str] = None
+_cookie_jar_cache: Optional[Dict[str, str]] = None
+
+
+def _cookie_header(cookies: Dict[str, str]) -> str:
+    """Render a cookie jar dict as a 'k1=v1; k2=v2' Cookie header value."""
+    return "; ".join("{}={}".format(k, v) for k, v in cookies.items())
+
+
+def _reset_session_cache() -> None:
+    """Clear cached bootstrap state. Test-only helper."""
+    global _mixin_key_cache, _cookie_jar_cache
+    _mixin_key_cache = None
+    _cookie_jar_cache = None
+
+
+def _fetch_buvid3() -> str:
+    """GET https://www.bilibili.com/ and extract buvid3 from Set-Cookie.
+
+    Uses urllib directly because http.py does not expose response headers.
+    Returns the buvid3 cookie value; raises http.HTTPError on failure
+    (with a "cookie bootstrap failed" prefix so callers can distinguish
+    it from search-time errors).
+    """
+    req = urllib.request.Request(
+        BOOTSTRAP_URL,
+        headers={"User-Agent": _USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            set_cookies = resp.headers.get_all("Set-Cookie") or []
+    except (urllib.error.URLError, OSError) as exc:
+        raise http.HTTPError(
+            "Bilibili: cookie bootstrap failed: {}".format(exc)
+        ) from exc
+
+    for raw in set_cookies:
+        first = raw.split(";", 1)[0].strip()
+        if "=" in first:
+            name, value = first.split("=", 1)
+            if name.strip() == "buvid3" and value.strip():
+                return value.strip()
+    raise http.HTTPError(
+        "Bilibili: cookie bootstrap failed: buvid3 not in Set-Cookie"
+    )
+
+
+def _ensure_session() -> Tuple[str, Dict[str, str]]:
+    """Return (mixin_key, cookie_jar). Bootstrap once, then cache."""
+    global _mixin_key_cache, _cookie_jar_cache
+    if _mixin_key_cache and _cookie_jar_cache:
+        return _mixin_key_cache, _cookie_jar_cache
+
+    try:
+        buvid3 = _fetch_buvid3()  # raises pre-tagged HTTPError on failure
+        cookies = {"buvid3": buvid3}
+        try:
+            nav_json = http.get(
+                NAV_URL,
+                headers={
+                    "User-Agent": _USER_AGENT,
+                    "Referer": "https://www.bilibili.com/",
+                    "Cookie": _cookie_header(cookies),
+                },
+                timeout=10,
+                retries=2,
+            )
+        except http.HTTPError as exc:
+            raise http.HTTPError(
+                "Bilibili: cookie bootstrap failed: nav fetch error: {}".format(exc)
+            ) from exc
+
+        if not isinstance(nav_json, dict):
+            raise http.HTTPError(
+                "Bilibili: cookie bootstrap failed: "
+                "nav response not a dict: {}".format(type(nav_json).__name__)
+            )
+        # The /x/web-interface/nav endpoint returns code=-101 "not logged in"
+        # for anonymous callers, but the wbi_img keys we need are still present
+        # in the response data. Let get_wbi_keys() validate the actual shape
+        # we depend on, rather than gating on the top-level status code.
+        img_key, sub_key = bilibili_wbi.get_wbi_keys(nav_json)
+        mixin = bilibili_wbi.mix_key(img_key, sub_key)
+    except http.HTTPError:
+        raise  # already tagged at the source
+    except (ValueError, KeyError, TypeError) as exc:
+        raise http.HTTPError(
+            "Bilibili: cookie bootstrap failed: {}".format(exc)
+        ) from exc
+
+    _mixin_key_cache = mixin
+    _cookie_jar_cache = cookies
+    return mixin, cookies
+
+
+_DEPTH_PAGE_SIZE = {"quick": 10, "default": 20, "deep": 30}
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def _build_video_url(bvid: str) -> str:
+    return "https://www.bilibili.com/video/{}".format(bvid)
+
+
+def search_bilibili(topic: str, from_date: str, to_date: str, depth: str = "default") -> List[Dict[str, Any]]:
+    """Search Bilibili videos for `topic`, return normalized web-items.
+
+    Args:
+        topic: Search keyword (Chinese or English).
+        from_date: Inclusive lower bound, "YYYY-MM-DD".
+        to_date: Inclusive upper bound, "YYYY-MM-DD".
+        depth: "quick" | "default" | "deep" -> page_size 10/20/30.
+
+    Returns:
+        List of normalized item dicts. Empty list if no results match
+        the date window.
+
+    Raises:
+        http.HTTPError if bootstrap, signing, or search fails. The pipeline
+        catches and drops the source for the current run.
+    """
+    mixin_key, cookies = _ensure_session()
+    cookie_header = _cookie_header(cookies)
+
+    params = {
+        "search_type": "video",
+        "keyword": topic,
+        "order": "totalrank",
+        "page": 1,
+        "page_size": _DEPTH_PAGE_SIZE.get(depth, 20),
+    }
+    signed = bilibili_wbi.sign_params(params, mixin_key)
+
+    resp = http.get(
+        SEARCH_URL,
+        params=signed,
+        headers={
+            "User-Agent": _USER_AGENT,
+            "Referer": "https://www.bilibili.com/",
+            "Cookie": cookie_header,
+        },
+        timeout=15,
+        retries=1,
+    )
+
+    if not isinstance(resp, dict):
+        raise http.HTTPError(
+            "Bilibili search: unexpected response shape: {}".format(type(resp).__name__)
+        )
+
+    code = resp.get("code", -1)
+    data = resp.get("data") if isinstance(resp.get("data"), dict) else {}
+    if code != 0:
+        if "v_voucher" in data:
+            raise http.HTTPError(
+                "Bilibili search: WBI signature may have rotated "
+                "(code={}, v_voucher present). Re-verify MIXIN_KEY_ENC_TAB "
+                "and signing algorithm.".format(code)
+            )
+        raise http.HTTPError(
+            "Bilibili search: code={} message={!r}".format(code, resp.get("message"))
+        )
+
+    raw_items = data.get("result", []) if isinstance(data.get("result"), list) else []
+    from_d = _parse_date(from_date)
+    to_d = _parse_date(to_date)
+
+    out = []
+    for raw in raw_items:
+        if not isinstance(raw, dict):
+            continue
+        item = _normalize_video(raw, index=len(out) + 1)
+        if item is None:
+            continue
+        if item["date"]:
+            d = _parse_date(item["date"])
+            if d < from_d or d > to_d:
+                continue
+        out.append(item)
+    return out
+
+
+def _normalize_video(raw: Dict[str, Any], index: int) -> Optional[Dict[str, Any]]:
+    """Convert a raw search result item into the web-item schema."""
+    bvid = str(raw.get("bvid") or "").strip()
+    if not bvid:
+        return None
+
+    title = _strip_em_tags(raw.get("title")).strip()
+    description = str(raw.get("description") or "").strip()
+    pubdate = raw.get("pubdate") or raw.get("senddate")
+    iso = _pubdate_to_iso(pubdate)
+
+    play = _to_int(raw.get("play"))
+    like = _to_int(raw.get("like"))
+    danmaku = _to_int(raw.get("video_review"))
+    favorite = _to_int(raw.get("favorites"))
+    review = _to_int(raw.get("review"))
+    coin = _to_int(raw.get("coin"))
+    share = _to_int(raw.get("share"))
+
+    relevance = _relevance_from_interactions(play, like, danmaku, favorite, coin)
+
+    why = (
+        "Bilibili engagement: play={}, like={}, danmaku={}, "
+        "favorite={}, coin={}".format(play, like, danmaku, favorite, coin)
+    )
+
+    return {
+        "id": "BILI{}".format(index),
+        "title": title[:200] if title else "Bilibili video {}".format(bvid),
+        "url": _build_video_url(bvid),
+        "source_domain": "bilibili.com",
+        "snippet": description[:500],
+        "date": iso,
+        "date_confidence": "high" if iso else "low",
+        "relevance": relevance,
+        "why_relevant": why,
+        "engagement": {
+            "play": play,
+            "like": like,
+            "danmaku": danmaku,
+            "favorite": favorite,
+            "coin": coin,
+            "share": share,
+            "review": review,
+        },
+        "extra": {
+            "author": str(raw.get("author") or "").strip(),
+            "author_mid": _to_int(raw.get("mid")),
+            "bvid": bvid,
+            "duration": _parse_duration(raw.get("duration")),
+        },
+    }

--- a/skills/last30days/scripts/lib/bilibili.py
+++ b/skills/last30days/scripts/lib/bilibili.py
@@ -58,19 +58,24 @@ def _to_int(value: Any) -> int:
         return 0
 
 
-def _relevance_from_interactions(play: int, like: int, danmaku: int, favorite: int, coin: int) -> float:
+def _relevance_from_interactions(play: int, like: int, danmaku: int, favorite: int) -> float:
     """Heuristic 0.05-1.0 relevance from B站 engagement signals.
 
-    Weights (descending): coin > favorite > like > danmaku > play.
-    Rationale: coins cost users a finite weekly budget -- strongest signal.
-    Favorites imply retention intent. Likes are light affirmation. Danmaku
-    is B站-specific participation. Plays are passive baseline.
+    Weights (descending): favorite > like > danmaku > play.
+    Rationale: favorites imply retention intent -- the strongest signal the
+    search API exposes. Likes are light affirmation. Danmaku is B站-specific
+    participation. Plays are passive baseline.
+
+    Note: coins are B站's strongest endorsement, but /search/type does not
+    return a coin count, so they are deliberately absent from this formula.
+    Coin-weighted scoring belongs with the per-video enrichment follow-up
+    that fetches full stats.
 
     Uses a log10 compression on the weighted sum so that engagement scales
     smoothly from a tiny video (~0.05) to a viral hit (~1.0), with a
     moderately popular video landing near 0.5.
     """
-    weighted = play * 1.0 + like * 2.0 + danmaku * 1.5 + favorite * 2.5 + coin * 3.0
+    weighted = play * 1.0 + like * 2.0 + danmaku * 1.5 + favorite * 2.5
     if weighted <= 0:
         return 0.05
     # log10(weighted) maps: 10 -> 1, 1k -> 3, 1M -> 6, 10M -> 7. Divide by
@@ -303,10 +308,15 @@ def search_bilibili(topic: str, from_date: str, to_date: str, depth: str = "defa
         item = _normalize_video(raw, index=len(out) + 1)
         if item is None:
             continue
-        if item["date"]:
-            d = _parse_date(item["date"])
-            if d < from_d or d > to_d:
-                continue
+        # Drop items we can't place in the requested window. B站 search returns
+        # an authoritative pubdate for virtually every result, so this only
+        # sheds the rare malformed item rather than letting undated content
+        # silently bypass the date filter.
+        if not item["date"]:
+            continue
+        d = _parse_date(item["date"])
+        if d < from_d or d > to_d:
+            continue
         out.append(item)
     return out
 
@@ -327,14 +337,12 @@ def _normalize_video(raw: Dict[str, Any], index: int) -> Optional[Dict[str, Any]
     danmaku = _to_int(raw.get("video_review"))
     favorite = _to_int(raw.get("favorites"))
     review = _to_int(raw.get("review"))
-    coin = _to_int(raw.get("coin"))
-    share = _to_int(raw.get("share"))
 
-    relevance = _relevance_from_interactions(play, like, danmaku, favorite, coin)
+    relevance = _relevance_from_interactions(play, like, danmaku, favorite)
 
     why = (
         "Bilibili engagement: play={}, like={}, danmaku={}, "
-        "favorite={}, coin={}".format(play, like, danmaku, favorite, coin)
+        "favorite={}, comments={}".format(play, like, danmaku, favorite, review)
     )
 
     return {
@@ -347,13 +355,14 @@ def _normalize_video(raw: Dict[str, Any], index: int) -> Optional[Dict[str, Any]
         "date_confidence": "high" if iso else "low",
         "relevance": relevance,
         "why_relevant": why,
+        # /search/type only returns these counters; coin and share are not in
+        # the response, so they are intentionally omitted rather than reported
+        # as a misleading zero. A per-video enrichment follow-up can add them.
         "engagement": {
             "play": play,
             "like": like,
             "danmaku": danmaku,
             "favorite": favorite,
-            "coin": coin,
-            "share": share,
             "review": review,
         },
         "extra": {

--- a/skills/last30days/scripts/lib/bilibili_wbi.py
+++ b/skills/last30days/scripts/lib/bilibili_wbi.py
@@ -1,0 +1,90 @@
+"""WBI signature helpers for Bilibili web APIs.
+
+Pure-function module — no HTTP, no global state. The 64-byte permutation
+table (MIXIN_KEY_ENC_TAB) is the documented Bilibili-public constant from
+SocialSisterYi/bilibili-API-collect (docs/misc/sign/wbi.md). It maps
+positions in (img_key + sub_key) onto positions in the 32-char mixin_key.
+"""
+
+import hashlib
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional, Tuple
+
+# Source: github.com/SocialSisterYi/bilibili-API-collect/docs/misc/sign/wbi.md
+# If signing breaks (e.g. /search returns code=-352 with v_voucher), re-verify
+# this table against the upstream doc before changing the algorithm.
+MIXIN_KEY_ENC_TAB: List[int] = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+    27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+    37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
+    22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+]
+
+
+def get_wbi_keys(nav_json: Dict[str, Any]) -> Tuple[str, str]:
+    """Extract (img_key, sub_key) from a /x/web-interface/nav response.
+
+    The keys are the basename-without-extension of img_url and sub_url.
+    Raises ValueError if the response shape is unexpected or URLs are
+    not the expected `.../wbi/<hex>.png` form.
+    """
+    try:
+        wbi = nav_json["data"]["wbi_img"]
+        img_url = wbi["img_url"]
+        sub_url = wbi["sub_url"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"nav_json missing wbi_img keys: {exc}") from exc
+
+    img_key = _basename_no_ext(img_url)
+    sub_key = _basename_no_ext(sub_url)
+    if not img_key or not sub_key:
+        raise ValueError(f"malformed wbi urls: img={img_url!r} sub={sub_url!r}")
+    return img_key, sub_key
+
+
+def _basename_no_ext(url: str) -> str:
+    """Return 'abc123' from 'https://example/path/abc123.png'."""
+    if not isinstance(url, str) or "/" not in url:
+        return ""
+    tail = url.rsplit("/", 1)[-1]
+    return tail.rsplit(".", 1)[0] if "." in tail else tail
+
+
+def mix_key(img_key: str, sub_key: str) -> str:
+    """Permute (img_key + sub_key) by MIXIN_KEY_ENC_TAB, truncate to 32 chars."""
+    combined = img_key + sub_key
+    return "".join(combined[i] for i in MIXIN_KEY_ENC_TAB)[:32]
+
+
+def sign_params(
+    params: Dict[str, Any],
+    mixin_key: str,
+    *,
+    ts: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a new params dict with `wts` and `w_rid` added.
+
+    Algorithm (per SocialSisterYi/bilibili-API-collect wbi.md):
+      1. wts = int(time.time()) unless `ts` is injected (test seam).
+      2. Sort the union of params and {wts}, URL-encode each value.
+      3. Join as k1=v1&k2=v2&...
+      4. Append mixin_key, MD5, hex-digest -> w_rid.
+
+    Args:
+        params: caller's request parameters. Not mutated.
+        mixin_key: 32-char key from mix_key().
+        ts: optional Unix timestamp override (used in tests).
+
+    Returns:
+        New dict containing all original params plus wts and w_rid.
+    """
+    if ts is None:
+        ts = int(time.time())
+
+    signed = dict(params)
+    signed["wts"] = ts
+
+    query = urllib.parse.urlencode(sorted(signed.items()))
+    signed["w_rid"] = hashlib.md5((query + mixin_key).encode("utf-8")).hexdigest()
+    return signed

--- a/skills/last30days/scripts/lib/bilibili_wbi.py
+++ b/skills/last30days/scripts/lib/bilibili_wbi.py
@@ -7,9 +7,14 @@ positions in (img_key + sub_key) onto positions in the 32-char mixin_key.
 """
 
 import hashlib
+import re
 import time
 import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple
+
+# Per the WBI spec, these characters are stripped from each parameter value
+# before the canonical query string is built for signing.
+_WBI_VALUE_FILTER = re.compile(r"[!'()*]")
 
 # Source: github.com/SocialSisterYi/bilibili-API-collect/docs/misc/sign/wbi.md
 # If signing breaks (e.g. /search returns code=-352 with v_voucher), re-verify
@@ -67,9 +72,18 @@ def sign_params(
 
     Algorithm (per SocialSisterYi/bilibili-API-collect wbi.md):
       1. wts = int(time.time()) unless `ts` is injected (test seam).
-      2. Sort the union of params and {wts}, URL-encode each value.
-      3. Join as k1=v1&k2=v2&...
-      4. Append mixin_key, MD5, hex-digest -> w_rid.
+      2. Add wts to the params and sort by key.
+      3. For each value, strip the characters !'()* then encode with
+         encodeURIComponent semantics (space -> %20, not +).
+      4. Join as k1=v1&k2=v2&..., append mixin_key, MD5 -> w_rid.
+
+    The strip + %20 encoding matches B站's official JS reference exactly.
+    Without it, topics containing !'()* or spaces (e.g. "C++ (anime)",
+    "长沙 麻将") produce a w_rid the server rejects with a v_voucher.
+
+    The returned dict keeps the caller's original (unstripped) values; only
+    the signing canonical string is filtered. The server decodes the request
+    and re-canonicalizes the same way, so the signature still matches.
 
     Args:
         params: caller's request parameters. Not mutated.
@@ -85,6 +99,21 @@ def sign_params(
     signed = dict(params)
     signed["wts"] = ts
 
-    query = urllib.parse.urlencode(sorted(signed.items()))
-    signed["w_rid"] = hashlib.md5((query + mixin_key).encode("utf-8")).hexdigest()
+    canonical = "&".join(
+        "{}={}".format(
+            _encode_uri_component(key),
+            _encode_uri_component(_WBI_VALUE_FILTER.sub("", str(signed[key]))),
+        )
+        for key in sorted(signed)
+    )
+    signed["w_rid"] = hashlib.md5((canonical + mixin_key).encode("utf-8")).hexdigest()
     return signed
+
+
+def _encode_uri_component(value: Any) -> str:
+    """Encode a value the way JavaScript's encodeURIComponent does.
+
+    Leaves A-Za-z0-9 and -_.!~*'() unescaped; encodes everything else,
+    including space as %20 (not + as urllib's quote_plus would).
+    """
+    return urllib.parse.quote(str(value), safe="-_.!~*'()")

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -674,6 +674,18 @@ def is_xiaohongshu_available(config: dict[str, Any]) -> bool:
         return False
 
 
+def is_bilibili_available(config: dict[str, Any]) -> bool:
+    """Bilibili is always available unless explicitly disabled.
+
+    The adapter auto-bootstraps a buvid3 cookie and uses public WBI-signed
+    search — no API key, no login. Honors LAST30DAYS_DISABLE_BILIBILI=1 as
+    a kill switch for operators who want to skip the source.
+    """
+    if os.environ.get("LAST30DAYS_DISABLE_BILIBILI") == "1":
+        return False
+    return True
+
+
 # Backward compat alias
 is_apify_available = is_tiktok_available
 

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -52,6 +52,7 @@ def normalize_source_items(
         "digg": _normalize_digg,
         "grounding": _normalize_grounding,
         "xiaohongshu": _normalize_grounding,
+        "bilibili": _normalize_grounding,
         "github": _normalize_github,
         "perplexity": _normalize_grounding,
     }

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -11,6 +11,7 @@ from shutil import which
 from typing import Any
 
 from . import (
+    bilibili,
     bird_x,
     bluesky,
     dates,
@@ -60,6 +61,7 @@ SEARCH_ALIAS = {
     "truth": "truthsocial",
     "web": "grounding",
     "xhs": "xiaohongshu",
+    "bili": "bilibili",
     "xquik": "xquik",
 }
 
@@ -77,6 +79,7 @@ MOCK_AVAILABLE_SOURCES = [
     "polymarket",
     "grounding",
     "xiaohongshu",
+    "bilibili",
     "github",
     "perplexity",
     "threads",
@@ -126,6 +129,8 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.append("perplexity")
     if requested_sources and "xiaohongshu" in requested_sources and env.is_xiaohongshu_available(config):
         available.append("xiaohongshu")
+    if env.is_bilibili_available(config):
+        available.append("bilibili")
     if env.is_threads_available(config):
         available.append("threads")
     if requested_sources and "pinterest" in requested_sources and env.is_pinterest_available(config):
@@ -1028,6 +1033,13 @@ def _retrieve_stream(
             from_date,
             to_date,
             env.get_xiaohongshu_api_base(config),
+            depth=depth,
+        ), {}
+    if source == "bilibili":
+        return bilibili.search_bilibili(
+            subquery.search_query,
+            from_date,
+            to_date,
             depth=depth,
         ), {}
     if source == "perplexity":

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -70,6 +70,7 @@ SOURCE_CAPABILITIES = {
     "polymarket": {"market"},
     "digg": {"discussion", "social", "link"},
     "xiaohongshu": {"video", "video_shortform", "social"},
+    "bilibili": {"video", "video_shortform"},
     "github": {"discussion", "link"},
     "grounding": {"web", "reference", "link"},
     "perplexity": {"web", "reference", "analysis"},

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -66,6 +66,7 @@ SOURCE_LABELS = {
     "hackernews": "Hacker News",
     "truthsocial": "Truth Social",
     "xiaohongshu": "Xiaohongshu",
+    "bilibili": "Bilibili",
     "x": "X",
     "github": "GitHub",
     "digg": "Digg",
@@ -842,7 +843,7 @@ def render_full(report: schema.Report) -> str:
     lines.append("## All Items by Source")
     lines.append("")
     source_order = ["reddit", "x", "youtube", "tiktok", "instagram", "threads", "pinterest",
-                    "hackernews", "bluesky", "truthsocial", "polymarket", "grounding", "xiaohongshu", "github", "digg", "perplexity"]
+                    "hackernews", "bluesky", "truthsocial", "polymarket", "grounding", "xiaohongshu", "bilibili", "github", "digg", "perplexity"]
     for source in source_order:
         items = report.items_by_source.get(source, [])
         if not items:

--- a/skills/last30days/scripts/lib/signals.py
+++ b/skills/last30days/scripts/lib/signals.py
@@ -10,6 +10,7 @@ from . import dates, relevance, schema
 # social platforms discounted for noise.
 SOURCE_QUALITY = {
     "xiaohongshu": 0.7,
+    "bilibili": 0.7,
     "hackernews": 0.8,
     "youtube": 0.85,
     "digg": 0.85,

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -126,6 +126,7 @@ SOURCE_COMPLETION_ORDER = [
     "polymarket",
     "grounding",
     "xiaohongshu",
+    "bilibili",
     "digg",
 ]
 
@@ -141,6 +142,7 @@ SOURCE_COMPLETION_META = {
     "polymarket": ("Polymarket", "market", "markets", Colors.GREEN),
     "grounding": ("Web", "result", "results", Colors.GREEN),
     "xiaohongshu": ("Xiaohongshu", "post", "posts", Colors.RED),
+    "bilibili": ("Bilibili", "video", "videos", Colors.PURPLE),
     "digg": ("Digg", "cluster", "clusters", Colors.YELLOW),
 }
 
@@ -500,6 +502,7 @@ def show_diagnostic_banner(diag: dict):
     has_youtube = "youtube" in available_sources
     has_web = "grounding" in available_sources
     has_xiaohongshu = "xiaohongshu" in available_sources
+    has_bilibili = "bilibili" in available_sources
     x_backend = diag.get("x_backend")
     native_web_backend = diag.get("native_web_backend")
 
@@ -546,6 +549,10 @@ def show_diagnostic_banner(diag: dict):
         if has_xiaohongshu:
             lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.GREEN}✅ Xiaohongshu{Colors.RESET} — API connected + logged in         {Colors.DIM}│{Colors.RESET}")
 
+        # Bilibili (default-on, WBI-signed public search)
+        if has_bilibili:
+            lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.GREEN}✅ Bilibili{Colors.RESET}    — WBI-signed search (no auth)        {Colors.DIM}│{Colors.RESET}")
+
         # Web
         if has_web:
             backend = native_web_backend or "native"
@@ -587,6 +594,9 @@ def show_diagnostic_banner(diag: dict):
 
         if has_xiaohongshu:
             lines.append("│  ✅ Xiaohongshu — API connected + logged in         │")
+
+        if has_bilibili:
+            lines.append("│  ✅ Bilibili    — WBI-signed search (no auth)        │")
 
         if has_web:
             backend = native_web_backend or "native"

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -55,24 +55,24 @@ class TestToInt(unittest.TestCase):
 
 class TestRelevance(unittest.TestCase):
     def test_clamped_min_to_0_05(self):
-        self.assertEqual(0.05, bilibili._relevance_from_interactions(0, 0, 0, 0, 0))
+        self.assertEqual(0.05, bilibili._relevance_from_interactions(0, 0, 0, 0))
 
     def test_clamped_max_to_1_0(self):
         self.assertEqual(
             1.0,
-            bilibili._relevance_from_interactions(10**9, 10**9, 10**9, 10**9, 10**9),
+            bilibili._relevance_from_interactions(10**9, 10**9, 10**9, 10**9),
         )
 
-    def test_coin_weighted_higher_than_favorite(self):
-        base = bilibili._relevance_from_interactions(100, 100, 100, 0, 0)
-        with_fav = bilibili._relevance_from_interactions(100, 100, 100, 100, 0)
-        with_coin = bilibili._relevance_from_interactions(100, 100, 100, 0, 100)
-        self.assertGreater(with_coin, with_fav)
-        self.assertGreater(with_fav, base)
+    def test_favorite_weighted_higher_than_like(self):
+        base = bilibili._relevance_from_interactions(100, 0, 0, 0)
+        with_like = bilibili._relevance_from_interactions(100, 100, 0, 0)
+        with_fav = bilibili._relevance_from_interactions(100, 0, 0, 100)
+        self.assertGreater(with_fav, with_like)
+        self.assertGreater(with_like, base)
 
     def test_normal_range(self):
         score = bilibili._relevance_from_interactions(
-            play=100_000, like=3_000, danmaku=500, favorite=1_500, coin=2_000
+            play=100_000, like=3_000, danmaku=500, favorite=1_500
         )
         self.assertGreaterEqual(score, 0.3)
         self.assertLessEqual(score, 0.7)
@@ -233,7 +233,10 @@ class TestSearchBilibili(unittest.TestCase):
         self.assertEqual("high", first["date_confidence"])
         self.assertIn("长沙麻将", first["title"])
         self.assertEqual(124000, first["engagement"]["play"])
-        self.assertGreaterEqual(first["engagement"]["coin"], 0)
+        # coin/share are not returned by /search/type, so they must not appear.
+        self.assertNotIn("coin", first["engagement"])
+        self.assertNotIn("share", first["engagement"])
+        self.assertIn("review", first["engagement"])
         self.assertEqual("BV1AA1xxxxxx", first["extra"]["bvid"])
         self.assertEqual("测试UP主A", first["extra"]["author"])
         self.assertGreaterEqual(first["relevance"], 0.05)
@@ -250,6 +253,26 @@ class TestSearchBilibili(unittest.TestCase):
             )
         self.assertEqual(1, len(items))
         self.assertEqual("2025-05-28", items[0]["date"])
+
+    def test_drops_items_with_no_parseable_date(self):
+        """An item whose pubdate can't be parsed must not silently bypass the
+        date-window filter — it is dropped."""
+        resp = {
+            "code": 0,
+            "data": {
+                "result": [
+                    {"type": "video", "bvid": "BV1dated", "title": "dated",
+                     "pubdate": 1748390400},  # 2025-05-28, inside window
+                    {"type": "video", "bvid": "BV1undated", "title": "undated",
+                     "pubdate": 0},  # _pubdate_to_iso -> None
+                ]
+            },
+        }
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: resp):
+            items = bilibili.search_bilibili("x", "2025-01-01", "2025-12-31")
+        self.assertEqual(1, len(items))
+        self.assertEqual("BV1dated", items[0]["extra"]["bvid"])
 
     def test_respects_depth_caps(self):
         captured = {}

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -1,0 +1,280 @@
+"""Tests for skills/last30days/scripts/lib/bilibili.py."""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from lib import bilibili, http
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "bilibili"
+
+
+def _load(name):
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class TestConstants(unittest.TestCase):
+    def test_nav_url(self):
+        self.assertEqual(
+            "https://api.bilibili.com/x/web-interface/nav",
+            bilibili.NAV_URL,
+        )
+
+    def test_search_url(self):
+        self.assertEqual(
+            "https://api.bilibili.com/x/web-interface/wbi/search/type",
+            bilibili.SEARCH_URL,
+        )
+
+
+class TestToInt(unittest.TestCase):
+    def test_plain_int(self):
+        self.assertEqual(124000, bilibili._to_int(124000))
+
+    def test_plain_str(self):
+        self.assertEqual(124000, bilibili._to_int("124000"))
+
+    def test_wan_suffix(self):
+        self.assertEqual(12000, bilibili._to_int("1.2万"))
+        self.assertEqual(120000, bilibili._to_int("12万"))
+
+    def test_yi_suffix(self):
+        self.assertEqual(300000000, bilibili._to_int("3亿"))
+
+    def test_comma_separated(self):
+        self.assertEqual(1234, bilibili._to_int("1,234"))
+
+    def test_none(self):
+        self.assertEqual(0, bilibili._to_int(None))
+
+    def test_garbage(self):
+        self.assertEqual(0, bilibili._to_int("not a number"))
+        self.assertEqual(0, bilibili._to_int(""))
+
+
+class TestRelevance(unittest.TestCase):
+    def test_clamped_min_to_0_05(self):
+        self.assertEqual(0.05, bilibili._relevance_from_interactions(0, 0, 0, 0, 0))
+
+    def test_clamped_max_to_1_0(self):
+        self.assertEqual(
+            1.0,
+            bilibili._relevance_from_interactions(10**9, 10**9, 10**9, 10**9, 10**9),
+        )
+
+    def test_coin_weighted_higher_than_favorite(self):
+        base = bilibili._relevance_from_interactions(100, 100, 100, 0, 0)
+        with_fav = bilibili._relevance_from_interactions(100, 100, 100, 100, 0)
+        with_coin = bilibili._relevance_from_interactions(100, 100, 100, 0, 100)
+        self.assertGreater(with_coin, with_fav)
+        self.assertGreater(with_fav, base)
+
+    def test_normal_range(self):
+        score = bilibili._relevance_from_interactions(
+            play=100_000, like=3_000, danmaku=500, favorite=1_500, coin=2_000
+        )
+        self.assertGreaterEqual(score, 0.3)
+        self.assertLessEqual(score, 0.7)
+
+
+class TestParseDuration(unittest.TestCase):
+    def test_mmss(self):
+        self.assertEqual(245, bilibili._parse_duration("4:05"))
+
+    def test_hhmmss(self):
+        self.assertEqual(3723, bilibili._parse_duration("1:02:03"))
+
+    def test_garbage(self):
+        self.assertEqual(0, bilibili._parse_duration(""))
+        self.assertEqual(0, bilibili._parse_duration(None))
+        self.assertEqual(0, bilibili._parse_duration("abc"))
+
+
+class TestPubdateToIso(unittest.TestCase):
+    def test_valid_epoch(self):
+        self.assertEqual("2025-05-28", bilibili._pubdate_to_iso(1748390400))
+
+    def test_zero_returns_none(self):
+        self.assertIsNone(bilibili._pubdate_to_iso(0))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(bilibili._pubdate_to_iso("garbage"))
+        self.assertIsNone(bilibili._pubdate_to_iso(None))
+
+
+class TestStripEmTags(unittest.TestCase):
+    def test_removes_em_wrappers(self):
+        s = '<em class="keyword">长沙</em>麻将入门'
+        self.assertEqual("长沙麻将入门", bilibili._strip_em_tags(s))
+
+    def test_handles_multiple(self):
+        s = '<em class="keyword">A</em>B<em class="keyword">C</em>D'
+        self.assertEqual("ABCD", bilibili._strip_em_tags(s))
+
+    def test_passthrough_when_clean(self):
+        self.assertEqual("plain title", bilibili._strip_em_tags("plain title"))
+
+    def test_handles_empty(self):
+        self.assertEqual("", bilibili._strip_em_tags(""))
+        self.assertEqual("", bilibili._strip_em_tags(None))
+
+
+class TestEnsureSession(unittest.TestCase):
+    def setUp(self):
+        bilibili._reset_session_cache()
+
+    def tearDown(self):
+        bilibili._reset_session_cache()
+
+    def test_calls_bootstrap_once(self):
+        """Two calls -> bootstrap fires once."""
+        calls = {"buvid": 0, "nav": 0}
+
+        def fake_fetch_buvid3():
+            calls["buvid"] += 1
+            return "FAKE_BUVID3_VALUE"
+
+        def fake_http_get(url, headers=None, **kwargs):
+            calls["nav"] += 1
+            return _load("nav_response.json")
+
+        with patch.object(bilibili, "_fetch_buvid3", fake_fetch_buvid3), \
+             patch.object(bilibili.http, "get", fake_http_get):
+            a_mixin, a_cookies = bilibili._ensure_session()
+            b_mixin, b_cookies = bilibili._ensure_session()
+
+        self.assertEqual(a_mixin, b_mixin)
+        self.assertEqual(a_cookies, b_cookies)
+        self.assertEqual(1, calls["buvid"])
+        self.assertEqual(1, calls["nav"])
+        self.assertEqual("FAKE_BUVID3_VALUE", a_cookies["buvid3"])
+        self.assertEqual(32, len(a_mixin))
+
+    def test_raises_on_bootstrap_failure(self):
+        def fake_fetch_buvid3():
+            raise http.HTTPError("Bilibili: cookie bootstrap failed: simulated GET failure")
+
+        with patch.object(bilibili, "_fetch_buvid3", fake_fetch_buvid3):
+            with self.assertRaises(http.HTTPError) as ctx:
+                bilibili._ensure_session()
+        self.assertIn("cookie bootstrap failed", str(ctx.exception))
+
+    def test_raises_on_bad_nav_response(self):
+        # No wbi_img in response -> get_wbi_keys raises ValueError ->
+        # wrapped as HTTPError by _ensure_session.
+        with patch.object(bilibili, "_fetch_buvid3", lambda: "BUVID"), \
+             patch.object(bilibili.http, "get", lambda url, **kw: {"code": -1, "data": {}}):
+            with self.assertRaises(http.HTTPError):
+                bilibili._ensure_session()
+
+    def test_accepts_anonymous_nav_response(self):
+        """Production nav returns code=-101 'not logged in' for anonymous callers,
+        but wbi_img is still present. We should accept it as a valid bootstrap."""
+        nav = _load("nav_response.json")
+        anon_nav = dict(nav)
+        anon_nav["code"] = -101
+        anon_nav["message"] = "账号未登录"
+        anon_nav["data"] = dict(anon_nav["data"])
+        anon_nav["data"]["isLogin"] = False
+
+        with patch.object(bilibili, "_fetch_buvid3", lambda: "BUVID"), \
+             patch.object(bilibili.http, "get", lambda url, **kw: anon_nav):
+            mixin, cookies = bilibili._ensure_session()
+        self.assertEqual(32, len(mixin))
+        self.assertEqual({"buvid3": "BUVID"}, cookies)
+
+
+class TestSearchBilibili(unittest.TestCase):
+    def setUp(self):
+        bilibili._reset_session_cache()
+
+    def tearDown(self):
+        bilibili._reset_session_cache()
+
+    def _patch_session(self):
+        return patch.object(
+            bilibili, "_ensure_session", lambda: ("a" * 32, {"buvid3": "X"})
+        )
+
+    def test_normalizes_fixture_response(self):
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: _load("search_video_response.json")):
+            items = bilibili.search_bilibili(
+                topic="长沙麻将",
+                from_date="2025-01-01",
+                to_date="2025-12-31",
+                depth="default",
+            )
+        self.assertEqual(2, len(items))
+        first = items[0]
+        self.assertEqual("BILI1", first["id"])
+        self.assertEqual("https://www.bilibili.com/video/BV1AA1xxxxxx", first["url"])
+        self.assertEqual("bilibili.com", first["source_domain"])
+        self.assertEqual("2025-05-28", first["date"])
+        self.assertEqual("high", first["date_confidence"])
+        self.assertIn("长沙麻将", first["title"])
+        self.assertEqual(124000, first["engagement"]["play"])
+        self.assertGreaterEqual(first["engagement"]["coin"], 0)
+        self.assertEqual("BV1AA1xxxxxx", first["extra"]["bvid"])
+        self.assertEqual("测试UP主A", first["extra"]["author"])
+        self.assertGreaterEqual(first["relevance"], 0.05)
+        self.assertLessEqual(first["relevance"], 1.0)
+
+    def test_filters_by_date_range(self):
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: _load("search_video_response.json")):
+            items = bilibili.search_bilibili(
+                topic="麻将",
+                from_date="2025-05-15",
+                to_date="2025-06-01",
+                depth="default",
+            )
+        self.assertEqual(1, len(items))
+        self.assertEqual("2025-05-28", items[0]["date"])
+
+    def test_respects_depth_caps(self):
+        captured = {}
+
+        def fake_get(url, **kw):
+            captured["params"] = kw.get("params", {})
+            return _load("search_video_response.json")
+
+        with self._patch_session(), patch.object(bilibili.http, "get", fake_get):
+            bilibili.search_bilibili("x", "2020-01-01", "2030-01-01", depth="quick")
+            self.assertEqual(10, captured["params"]["page_size"])
+
+            bilibili.search_bilibili("x", "2020-01-01", "2030-01-01", depth="default")
+            self.assertEqual(20, captured["params"]["page_size"])
+
+            bilibili.search_bilibili("x", "2020-01-01", "2030-01-01", depth="deep")
+            self.assertEqual(30, captured["params"]["page_size"])
+
+    def test_raises_on_v_voucher(self):
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: _load("v_voucher_response.json")):
+            with self.assertRaises(http.HTTPError) as ctx:
+                bilibili.search_bilibili("x", "2020-01-01", "2030-01-01")
+        msg = str(ctx.exception)
+        self.assertIn("WBI signature may have rotated", msg)
+
+    def test_handles_empty_result_list(self):
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: {"code": 0, "data": {"result": []}}):
+            items = bilibili.search_bilibili("nothing", "2020-01-01", "2030-01-01")
+        self.assertEqual([], items)
+
+    def test_signs_request_params(self):
+        captured = {}
+
+        def fake_get(url, **kw):
+            captured["params"] = kw.get("params", {})
+            return _load("search_video_response.json")
+
+        with self._patch_session(), patch.object(bilibili.http, "get", fake_get):
+            bilibili.search_bilibili("test", "2020-01-01", "2030-01-01")
+
+        self.assertIn("wts", captured["params"])
+        self.assertIn("w_rid", captured["params"])
+        self.assertEqual("video", captured["params"]["search_type"])
+        self.assertEqual("test", captured["params"]["keyword"])

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -168,6 +168,24 @@ class TestEnsureSession(unittest.TestCase):
             with self.assertRaises(http.HTTPError):
                 bilibili._ensure_session()
 
+    def test_short_wbi_keys_wrapped_as_http_error(self):
+        """If nav returns keys shorter than the 64 positions MIXIN_KEY_ENC_TAB
+        indexes, mix_key() raises IndexError -> wrapped as a clean HTTPError."""
+        short_nav = {
+            "code": 0,
+            "data": {
+                "wbi_img": {
+                    "img_url": "https://i0.hdslb.com/bfs/wbi/a.png",
+                    "sub_url": "https://i0.hdslb.com/bfs/wbi/b.png",
+                }
+            },
+        }
+        with patch.object(bilibili, "_fetch_buvid3", lambda: "BUVID"), \
+             patch.object(bilibili.http, "get", lambda url, **kw: short_nav):
+            with self.assertRaises(http.HTTPError) as ctx:
+                bilibili._ensure_session()
+        self.assertIn("cookie bootstrap failed", str(ctx.exception))
+
     def test_accepts_anonymous_nav_response(self):
         """Production nav returns code=-101 'not logged in' for anonymous callers,
         but wbi_img is still present. We should accept it as a valid bootstrap."""
@@ -257,6 +275,30 @@ class TestSearchBilibili(unittest.TestCase):
                 bilibili.search_bilibili("x", "2020-01-01", "2030-01-01")
         msg = str(ctx.exception)
         self.assertIn("WBI signature may have rotated", msg)
+
+    def test_v_voucher_clears_session_cache(self):
+        """A WBI rotation must invalidate the cached mixin_key so the next
+        call re-bootstraps instead of replaying the same failure forever."""
+        bilibili._mixin_key_cache = "m" * 32
+        bilibili._cookie_jar_cache = {"buvid3": "STALE"}
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get", lambda url, **kw: _load("v_voucher_response.json")):
+            with self.assertRaises(http.HTTPError):
+                bilibili.search_bilibili("x", "2020-01-01", "2030-01-01")
+        self.assertIsNone(bilibili._mixin_key_cache)
+        self.assertIsNone(bilibili._cookie_jar_cache)
+
+    def test_nonzero_code_clears_session_cache(self):
+        """Any non-zero search code (e.g. expired buvid3) also clears the cache."""
+        bilibili._mixin_key_cache = "m" * 32
+        bilibili._cookie_jar_cache = {"buvid3": "STALE"}
+        with self._patch_session(), \
+             patch.object(bilibili.http, "get",
+                          lambda url, **kw: {"code": -412, "message": "blocked", "data": {}}):
+            with self.assertRaises(http.HTTPError):
+                bilibili.search_bilibili("x", "2020-01-01", "2030-01-01")
+        self.assertIsNone(bilibili._mixin_key_cache)
+        self.assertIsNone(bilibili._cookie_jar_cache)
 
     def test_handles_empty_result_list(self):
         with self._patch_session(), \

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -232,6 +232,10 @@ class TestSearchBilibili(unittest.TestCase):
         self.assertEqual("2025-05-28", first["date"])
         self.assertEqual("high", first["date_confidence"])
         self.assertIn("长沙麻将", first["title"])
+        # Both title and snippet must be free of <em> highlight tags.
+        self.assertNotIn("<em", first["title"])
+        self.assertNotIn("<em", first["snippet"])
+        self.assertIn("长沙麻将", first["snippet"])
         self.assertEqual(124000, first["engagement"]["play"])
         # coin/share are not returned by /search/type, so they must not appear.
         self.assertNotIn("coin", first["engagement"])

--- a/tests/test_bilibili_wbi.py
+++ b/tests/test_bilibili_wbi.py
@@ -85,6 +85,8 @@ class TestSignParams(unittest.TestCase):
         self.assertEqual(a["w_rid"], b["w_rid"])
 
     def test_w_rid_matches_md5_of_sorted_query_plus_key(self):
+        # Clean alphanumeric values: encodeURIComponent and urlencode agree,
+        # so this also confirms the new canonicalization is backward-compatible.
         params = {"foo": "114", "bar": "514", "baz": "1919810"}
         mixin = "ea1db124af3c7062474693fa704f4ff8"
         ts = 1702204169
@@ -94,6 +96,34 @@ class TestSignParams(unittest.TestCase):
 
         signed = bilibili_wbi.sign_params(params, mixin_key=mixin, ts=ts)
         self.assertEqual(expected_w_rid, signed["w_rid"])
+
+    def test_strips_wbi_reserved_chars_and_encodes_space_as_pct20(self):
+        # "C++ (anime)!" -> strip ()! -> "C++ anime" -> encodeURIComponent
+        # -> "C%2B%2B%20anime" (space is %20, not +).
+        params = {"keyword": "C++ (anime)!"}
+        mixin = "ea1db124af3c7062474693fa704f4ff8"
+        ts = 1702204169
+
+        expected_query = "keyword=C%2B%2B%20anime&wts=1702204169"
+        expected_w_rid = hashlib.md5((expected_query + mixin).encode("utf-8")).hexdigest()
+
+        signed = bilibili_wbi.sign_params(params, mixin_key=mixin, ts=ts)
+        self.assertEqual(expected_w_rid, signed["w_rid"])
+        # Original value is preserved in the returned params (only signing strips).
+        self.assertEqual("C++ (anime)!", signed["keyword"])
+
+    def test_reserved_chars_change_the_signature(self):
+        # Proves the strip/%20 fix actually matters: the naive quote_plus
+        # encoding (no strip, space -> +) yields a different, wrong w_rid.
+        params = {"keyword": "Yay! (x)"}
+        mixin = "m" * 32
+        ts = 1
+
+        naive_query = urllib.parse.urlencode(sorted({**params, "wts": ts}.items()))
+        naive_w_rid = hashlib.md5((naive_query + mixin).encode("utf-8")).hexdigest()
+
+        signed = bilibili_wbi.sign_params(params, mixin_key=mixin, ts=ts)
+        self.assertNotEqual(naive_w_rid, signed["w_rid"])
 
 
 if __name__ == "__main__":

--- a/tests/test_bilibili_wbi.py
+++ b/tests/test_bilibili_wbi.py
@@ -1,0 +1,100 @@
+"""Tests for skills/last30days/scripts/lib/bilibili_wbi.py."""
+
+import hashlib
+import json
+import time
+import unittest
+import urllib.parse
+from pathlib import Path
+from unittest.mock import patch
+
+from lib import bilibili_wbi
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "bilibili"
+
+
+def _load_fixture(name):
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class TestMixinKeyEncTab(unittest.TestCase):
+    def test_length_is_64(self):
+        self.assertEqual(64, len(bilibili_wbi.MIXIN_KEY_ENC_TAB))
+
+    def test_values_unique(self):
+        self.assertEqual(64, len(set(bilibili_wbi.MIXIN_KEY_ENC_TAB)))
+
+    def test_values_in_range(self):
+        self.assertTrue(all(0 <= v < 64 for v in bilibili_wbi.MIXIN_KEY_ENC_TAB))
+
+
+class TestGetWbiKeys(unittest.TestCase):
+    def test_extracts_from_nav_response(self):
+        nav = _load_fixture("nav_response.json")
+        img_key, sub_key = bilibili_wbi.get_wbi_keys(nav)
+        self.assertEqual("7cd084941338484aae1ad9425b84077c", img_key)
+        self.assertEqual("4932caff0ff746eab6f01bf08b70ac45", sub_key)
+
+    def test_raises_on_missing_field(self):
+        with self.assertRaises(ValueError):
+            bilibili_wbi.get_wbi_keys({"code": 0, "data": {}})
+
+    def test_raises_on_malformed_url(self):
+        bad = {"data": {"wbi_img": {"img_url": "https://example.com/", "sub_url": "https://example.com/"}}}
+        with self.assertRaises(ValueError):
+            bilibili_wbi.get_wbi_keys(bad)
+
+
+class TestMixKey(unittest.TestCase):
+    def test_returns_32_chars(self):
+        img_key = "7cd084941338484aae1ad9425b84077c"
+        sub_key = "4932caff0ff746eab6f01bf08b70ac45"
+        mixin = bilibili_wbi.mix_key(img_key, sub_key)
+        self.assertEqual(32, len(mixin))
+
+    def test_uses_permutation_table(self):
+        img_key = "7cd084941338484aae1ad9425b84077c"
+        sub_key = "4932caff0ff746eab6f01bf08b70ac45"
+        combined = img_key + sub_key
+        mixin = bilibili_wbi.mix_key(img_key, sub_key)
+        for i, src_pos in enumerate(bilibili_wbi.MIXIN_KEY_ENC_TAB[:32]):
+            self.assertEqual(combined[src_pos], mixin[i], f"position {i} should map from {src_pos}")
+
+
+class TestSignParams(unittest.TestCase):
+    def test_adds_wts_and_w_rid(self):
+        signed = bilibili_wbi.sign_params({"foo": "bar"}, mixin_key="a" * 32, ts=1702204169)
+        self.assertEqual(1702204169, signed["wts"])
+        self.assertIn("w_rid", signed)
+        self.assertEqual(32, len(signed["w_rid"]))
+
+    def test_does_not_mutate_input(self):
+        original = {"foo": "bar"}
+        bilibili_wbi.sign_params(original, mixin_key="a" * 32, ts=1)
+        self.assertEqual({"foo": "bar"}, original)
+        self.assertNotIn("wts", original)
+
+    def test_default_ts_is_now(self):
+        with patch.object(time, "time", return_value=1700000000.5):
+            signed = bilibili_wbi.sign_params({"x": "1"}, mixin_key="a" * 32)
+        self.assertEqual(1700000000, signed["wts"])
+
+    def test_w_rid_is_deterministic(self):
+        a = bilibili_wbi.sign_params({"k": "v"}, mixin_key="m" * 32, ts=42)
+        b = bilibili_wbi.sign_params({"k": "v"}, mixin_key="m" * 32, ts=42)
+        self.assertEqual(a["w_rid"], b["w_rid"])
+
+    def test_w_rid_matches_md5_of_sorted_query_plus_key(self):
+        params = {"foo": "114", "bar": "514", "baz": "1919810"}
+        mixin = "ea1db124af3c7062474693fa704f4ff8"
+        ts = 1702204169
+
+        expected_query = urllib.parse.urlencode(sorted({**params, "wts": ts}.items()))
+        expected_w_rid = hashlib.md5((expected_query + mixin).encode("utf-8")).hexdigest()
+
+        signed = bilibili_wbi.sign_params(params, mixin_key=mixin, ts=ts)
+        self.assertEqual(expected_w_rid, signed["w_rid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Bilibili (B站) as a first-class web source, modeled after the existing `xiaohongshu_api` adapter.

- Data source: Bilibili public web search API (`/x/web-interface/wbi/search/type`), no login or API key required
- WBI signing implemented locally from SocialSisterYi/bilibili-API-collect's public spec
- `buvid3` cookie auto-bootstrapped on first use; cached at module level for the process lifetime
- The `/nav` endpoint returns `code=-101` ("not logged in") for anonymous callers but still includes the `wbi_img` keys — the adapter validates the data shape it needs rather than gating on the status code, so anonymous bootstrap works
- Engagement formula: `play*1 + like*2 + danmaku*1.5 + favorite*2.5 + coin*3`, log10-compressed and clamped to `[0.05, 1.0]`
- Kill switch via `LAST30DAYS_DISABLE_BILIBILI=1`

## Out of scope (planned follow-ups)

- Hot-comment enrichment for the Best Takes section (separate PR)
- Extracting the shared `_to_int` Chinese-numeral parser into `normalize.py` (once Weibo/Zhihu adapters land and there are 3 copies)
- SKILL.md user-facing source advertisement (deferred to maintainer's discretion)

## Test plan

- [x] `pytest tests/test_bilibili.py tests/test_bilibili_wbi.py` — 46 unit tests, fixture-based, no live network
- [x] Manual live smoke test: `search_bilibili('游戏', ...)` returned 9 real videos ranked by engagement
- [x] Existing test suite unaffected

## Notes for reviewers

- UI color uses `Colors.PURPLE` as a placeholder — `Colors` has no PINK/MAGENTA value. Happy to adjust if you have a preferred treatment for Bilibili pink (`#FB7299`).