### PR TITLE
fix(security): allowlist link URL schemes in HTML report renderer

### DIFF
--- a/skills/last30days/scripts/lib/html_render.py
+++ b/skills/last30days/scripts/lib/html_render.py
@@ -595,6 +595,48 @@ def _promote_meta_marker(body: str) -> str:
 
 _ENGINE_FOOTER_STORE: dict[str, str] = {}
 
+# Schemes allowed in synthesized markdown links. The HTML artifact is opened in
+# a browser, so a permissive link parser exposes a stored-XSS vector: a
+# `[label](javascript:...)` or `[label](data:text/html,...)` link surviving the
+# LLM synthesis would render as a clickable script payload in the saved file.
+# Restrict link URLs to a small allowlist of schemes and accept relative URLs
+# (no scheme, no `:` before the first `/` or `?`). Anything else is rendered as
+# plain bracketed text so the label remains readable.
+_SAFE_LINK_SCHEMES = frozenset({"http", "https", "mailto"})
+
+
+def _is_safe_link_url(url: str) -> bool:
+    """Return True if a markdown link URL is safe to render as an `<a href>`.
+
+    A URL is safe if it either:
+    - has no scheme (relative URL, fragment, or path-only), or
+    - uses a scheme in the allowlist (http, https, mailto).
+
+    The scheme check is case-insensitive and tolerant of surrounding
+    whitespace per RFC 3986.
+    """
+    stripped = url.strip()
+    if not stripped:
+        return False
+    # Reject any control characters (e.g. `javascript&#x3a;alert(1)` decoded
+    # to a literal CR/LF that the browser would treat as a scheme separator).
+    if any(ord(ch) < 0x20 for ch in stripped):
+        return False
+    # No scheme — relative URL or fragment. Allow.
+    colon = stripped.find(":")
+    if colon == -1:
+        return True
+    slash = stripped.find("/")
+    question = stripped.find("?")
+    hash_ = stripped.find("#")
+    # The first `:` that comes after a `/`, `?`, or `#` is path/query/fragment,
+    # not a scheme separator. e.g. `/path:with:colons` is a relative URL.
+    earlier = [pos for pos in (slash, question, hash_) if 0 <= pos < colon]
+    if earlier:
+        return True
+    scheme = stripped[:colon].lower()
+    return scheme in _SAFE_LINK_SCHEMES
+
 
 def _inline_markdown(text: str) -> str:
     escaped = html.escape(text, quote=True)
@@ -607,11 +649,20 @@ def _inline_markdown(text: str) -> str:
 
     escaped = re.sub(r"`([^`]+)`", code_replace, escaped)
     escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
-    escaped = re.sub(
-        r"\[([^\]]+)\]\(([^)\s]+)\)",
-        r'<a href="\2">\1</a>',
-        escaped,
-    )
+
+    def link_replace(match: re.Match[str]) -> str:
+        label = match.group(1)
+        url = match.group(2)
+        # `url` is HTML-escaped (so `"` is `&quot;`, etc.) but
+        # `html.unescape` decoding before the scheme check would let a
+        # `javascript&#58;alert(1)` payload through. Inspect the literal
+        # bytes the regex captured instead — that matches what the browser
+        # ultimately sees in the href attribute.
+        if not _is_safe_link_url(url):
+            return f"[{label}]({url})"
+        return f'<a href="{url}" rel="noopener noreferrer">{label}</a>'
+
+    escaped = re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", link_replace, escaped)
     for token, value in code_tokens.items():
         escaped = escaped.replace(token, value)
     return escaped

--- a/skills/last30days/scripts/lib/html_render.py
+++ b/skills/last30days/scripts/lib/html_render.py
@@ -614,6 +614,14 @@ def _is_safe_link_url(url: str) -> bool:
 
     The scheme check is case-insensitive and tolerant of surrounding
     whitespace per RFC 3986.
+
+    Precondition: ``url`` must already have been through ``html.escape`` (as it
+    is at the sole caller in ``_inline_markdown``). The safety of the no-scheme
+    branch relies on ``&`` having been escaped to ``&amp;`` so an entity-encoded
+    colon like ``&#58;`` cannot survive into the rendered ``href`` and be
+    decoded back to ``:`` by the browser. Passing a *raw* URL here (e.g.
+    ``javascript&#58;alert(1)``) would see no literal ``:``, return ``True``,
+    and emit a clickable payload — do not call this on un-escaped input.
     """
     stripped = url.strip()
     if not stripped:

--- a/skills/last30days/scripts/lib/html_render.py
+++ b/skills/last30days/scripts/lib/html_render.py
@@ -618,8 +618,8 @@ def _is_safe_link_url(url: str) -> bool:
     stripped = url.strip()
     if not stripped:
         return False
-    # Reject any control characters (e.g. `javascript&#x3a;alert(1)` decoded
-    # to a literal CR/LF that the browser would treat as a scheme separator).
+    # Reject any control characters (e.g. `java\x0Dscript:` where a bare CR is
+    # smuggled into the scheme name and stripped by the browser's URL parser).
     if any(ord(ch) < 0x20 for ch in stripped):
         return False
     # No scheme — relative URL or fragment. Allow.

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -221,6 +221,8 @@ class HtmlRenderBehaviorTests(unittest.TestCase):
         )
         self.assertNotIn("<a ", rendered)
         self.assertNotIn("href=", rendered)
+        # The label still surfaces as plain text so context isn't lost.
+        self.assertIn("click", rendered)
 
     def test_markdown_links_strip_leading_whitespace_javascript(self):
         """Leading whitespace in the URL must not let a `javascript:` payload

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -190,7 +190,62 @@ class HtmlRenderBehaviorTests(unittest.TestCase):
 
     def test_markdown_links_convert(self):
         rendered = html_render._markdown_to_html("[name](https://example.test/path)")
-        self.assertIn('<a href="https://example.test/path">name</a>', rendered)
+        self.assertIn(
+            '<a href="https://example.test/path" rel="noopener noreferrer">name</a>',
+            rendered,
+        )
+
+    def test_markdown_links_reject_javascript_scheme(self):
+        """A `[label](javascript:...)` link must NOT render as a clickable href.
+
+        The HTML artifact is opened in a browser, so allowing arbitrary URL
+        schemes turns synthesized markdown into a stored-XSS surface. External
+        sources (Reddit, X, HN, etc.) can plant such links and the LLM may
+        carry them through synthesis; the renderer is the last gate.
+        """
+        for payload in (
+            "[click](javascript:alert(1))",
+            "[click](JAVASCRIPT:alert(1))",
+            "[click](vbscript:alert(1))",
+            "[click](file:///etc/passwd)",
+        ):
+            rendered = html_render._markdown_to_html(payload)
+            self.assertNotIn("<a ", rendered, msg=f"payload accepted: {payload}")
+            self.assertNotIn("href=", rendered, msg=f"payload accepted: {payload}")
+            # The label still surfaces as plain text so context isn't lost.
+            self.assertIn("click", rendered, msg=f"label dropped: {payload}")
+
+    def test_markdown_links_reject_data_uri(self):
+        rendered = html_render._markdown_to_html(
+            "[click](data:text/html,<svg/onload=alert(1)>)"
+        )
+        self.assertNotIn("<a ", rendered)
+        self.assertNotIn("href=", rendered)
+
+    def test_markdown_links_strip_leading_whitespace_javascript(self):
+        """Leading whitespace in the URL must not let a `javascript:` payload
+        bypass the scheme check (browsers strip leading whitespace before
+        parsing the scheme)."""
+        rendered = html_render._markdown_to_html("[click](\tjavascript:alert(1))")
+        # `[^)\\s]+` already rejects whitespace inside the URL, so the regex
+        # doesn't match and the label is left as plain text. The point of the
+        # assertion is to pin that behavior: NO `<a href>` is produced.
+        self.assertNotIn("<a ", rendered)
+        self.assertNotIn("href=", rendered)
+
+    def test_markdown_links_allow_relative_url(self):
+        rendered = html_render._markdown_to_html("[home](/path?x=1#section)")
+        self.assertIn(
+            '<a href="/path?x=1#section" rel="noopener noreferrer">home</a>',
+            rendered,
+        )
+
+    def test_markdown_links_allow_mailto(self):
+        rendered = html_render._markdown_to_html("[mail](mailto:a@example.com)")
+        self.assertIn(
+            '<a href="mailto:a@example.com" rel="noopener noreferrer">mail</a>',
+            rendered,
+        )
 
     def test_no_file_header_h1(self):
         rendered = html_render.render_html(_report("AI agent frameworks", ["One"]))
@@ -207,7 +262,10 @@ class HtmlRenderBehaviorTests(unittest.TestCase):
             synthesis_md=synthesis,
         )
         self.assertIn("<strong>Test brief</strong> - body content per", rendered)
-        self.assertIn('<a href="https://example.com">@example</a>', rendered)
+        self.assertIn(
+            '<a href="https://example.com" rel="noopener noreferrer">@example</a>',
+            rendered,
+        )
         metadata_index = rendered.index('<div class="meta">')
         synthesis_index = rendered.index("<strong>Test brief</strong>")
         footer_index = rendered.index('<div class="engine-footer">')


### PR DESCRIPTION
## Summary

The shareable HTML emit path (`--emit=html`) renders synthesized markdown
into an `<a href="...">` without filtering the link URL scheme
(`skills/last30days/scripts/lib/html_render.py:_inline_markdown`). The
synthesized markdown is the LLM's brief, which carries text and links
through from external sources (Reddit, X, HN, TikTok, Polymarket, etc.) —
none of which are trusted to omit `javascript:` or `data:text/html` URIs
in their post bodies.

Saved HTML reports open in the user's browser, typically under `file://`,
where a `javascript:` link executes JavaScript in the file's origin on
click, and a `data:text/html,...` URI renders attacker-controlled HTML
in the same context. The pre-link `html.escape()` pass doesn't help: the
URL portion of `[label](javascript:...)` contains no characters that
`html.escape` rewrites, so the malicious scheme survives intact into the
`href` attribute.

## Impact

A click on a malicious link in a generated report runs JavaScript in the
user's local-file origin. From there, the standard `file://` exploit
chain applies (read other files in the same directory tree on
Chromium-based browsers, exfiltrate via `fetch` / form POST, plant a
persistent payload via `localStorage` against any same-origin page the
user opens later, etc.). The route to the renderer is the regular
`/last30days <topic> --emit=html` path — no special engine flag, no
authentication boundary in front of it.

## Location

`skills/last30days/scripts/lib/html_render.py:599` (`_inline_markdown`).
The vulnerable substitution is the markdown-link rewrite at the end of
that function:

```python
escaped = re.sub(
    r"\[([^\]]+)\]\(([^)\s]+)\)",
    r'<a href="\2">\1</a>',
    escaped,
)
```

## Fix

Add a small `_is_safe_link_url` helper that accepts:

- relative URLs (no scheme, fragments, or path-only forms), and
- schemes `http`, `https`, `mailto`.

Anything else — `javascript:`, `data:`, `vbscript:`, `file:`, `ftp:`,
plus any URL containing a control character that would be stripped by the
browser's pre-scheme normalization — is rendered as plain bracketed text
(`[label](url)`). The label still surfaces, but the `<a href>` is
suppressed. Allowed links also gain `rel="noopener noreferrer"` as
defense-in-depth.

## Detected by

Aeon + semgrep (`p/security-audit`, `p/owasp-top-ten`, `p/python`,
`p/command-injection`).

- Severity: high (stored XSS in shareable artifact, exploit is a single
  click)
- CWE-79 (Improper Neutralization of Input During Web Page Generation),
  CWE-80 (Improper Neutralization of Script-Related HTML Tags in a Web
  Page).

## Verification

`python3 -m unittest -v tests.test_html_render` → **24/24 passing**
(`Ran 24 tests in 0.013s OK`). The full repo's unittest discovery runs
1200 tests with 0 failures (the only 16 errors are pre-existing pytest
import failures in test modules unrelated to this change).

New tests:

- `test_markdown_links_reject_javascript_scheme` — sweeps
  `javascript:`, `JAVASCRIPT:`, `vbscript:`, `file:///etc/passwd`.
- `test_markdown_links_reject_data_uri` — covers
  `data:text/html,<svg/onload=...>`.
- `test_markdown_links_strip_leading_whitespace_javascript` — pins the
  no-clickable-href guarantee for whitespace-prefixed URLs.
- `test_markdown_links_allow_relative_url` — guards against false
  positives on relative URLs.
- `test_markdown_links_allow_mailto` — guards against false positives
  on `mailto:`.

Updated tests:

- `test_markdown_links_convert` and `test_synthesis_md_embedded` now
  assert the new `rel="noopener noreferrer"` attribute.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
