### PR TITLE
fix(subproc): guard os.killpg on Windows in timeout cleanup

### DIFF
--- a/skills/last30days/scripts/lib/subproc.py
+++ b/skills/last30days/scripts/lib/subproc.py
@@ -81,7 +81,10 @@ def run_with_timeout(
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            if hasattr(os, "killpg"):
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            else:
+                proc.kill()
         except (ProcessLookupError, PermissionError, OSError):
             proc.kill()
         proc.wait(timeout=5)

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -4,10 +4,24 @@ Covers the process-group cleanup path, timeout behavior, success path,
 PID callback wiring, and environment inheritance.
 """
 
+import os as _real_os
 import unittest
 from unittest.mock import patch
 
 from lib import subproc
+
+
+class _NoKillpgOS:
+    """Stand-in for the ``os`` module on Windows: ``setsid``, ``killpg`` and
+    ``getpgid`` do not exist there. Every other attribute proxies to the real
+    ``os`` module so spawning still works."""
+
+    _ABSENT = {"setsid", "killpg", "getpgid"}
+
+    def __getattr__(self, name):
+        if name in self._ABSENT:
+            raise AttributeError(name)
+        return getattr(_real_os, name)
 
 
 class TestRunWithTimeout(unittest.TestCase):
@@ -50,6 +64,16 @@ class TestRunWithTimeout(unittest.TestCase):
                 ["sh", "-c", "sleep 10 & wait"],
                 timeout=1,
             )
+
+    def test_timeout_without_killpg_falls_back_to_proc_kill(self):
+        """On platforms without os.killpg (Windows), a timeout must still raise
+        SubprocTimeout via proc.kill() instead of leaking an AttributeError."""
+        with patch.object(subproc, "os", _NoKillpgOS()):
+            with self.assertRaises(subproc.SubprocTimeout):
+                subproc.run_with_timeout(
+                    ["sh", "-c", "sleep 10"],
+                    timeout=1,
+                )
 
     def test_missing_command_raises_oserror(self):
         """Missing executables raise FileNotFoundError (or PermissionError on


### PR DESCRIPTION
## Summary

On Windows, a subprocess timeout in `subproc.run_with_timeout()` raised an unhandled `AttributeError` instead of cleaning up, because the cleanup path called `os.killpg`/`os.getpgid` — neither of which exists on Windows. This guards the call with `hasattr(os, "killpg")` and falls back to `proc.kill()`, matching the pattern already used in `last30days.py`.

## Changes

- `skills/last30days/scripts/lib/subproc.py`: in the `TimeoutExpired` handler, only call `os.killpg(os.getpgid(proc.pid), signal.SIGTERM)` when `hasattr(os, "killpg")`; otherwise call `proc.kill()`. The `os.setsid` spawn path was already guarded with `hasattr(os, "setsid")` (line 61), so this makes the cleanup path consistent. `last30days.py:_cleanup_children()` already uses the same `hasattr(os, "killpg")` guard.
- `tests/test_subproc.py`: add `test_timeout_without_killpg_falls_back_to_proc_kill`, which patches `subproc.os` with a Windows-like stand-in lacking `setsid`/`killpg`/`getpgid` and asserts a timeout raises `SubprocTimeout` (not `AttributeError`).

### Root cause

In `run_with_timeout`, `preexec_fn` is correctly guarded with `hasattr(os, "setsid")`, so on Windows the child is *not* placed in its own process group. But the timeout cleanup unconditionally called `os.killpg(os.getpgid(proc.pid), signal.SIGTERM)`. On Windows `os.killpg`/`os.getpgid` do not exist, raising `AttributeError` — which the surrounding `except (ProcessLookupError, PermissionError, OSError)` clause does not catch. The exception escaped the handler, never reached the `proc.kill()` fallback, and propagated up through callers (`bird_x.py`, `youtube_yt.py`, `digg.py`) that only catch `SubprocTimeout`. Per the linked issue's real-world repro, a single `digg-pp-cli` enrichment timeout took down the entire HTML render pipeline instead of skipping just that cluster.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` — `1618 passed, 4 skipped, 2 subtests passed`.
- [x] New test fails on `main` (unfixed) with `AttributeError: killpg` at `subproc.py:84`, and passes with the fix.
- [x] `tests/test_subproc.py`: 10 passed (was 9, +1).

The fix is POSIX-no-op: on Linux/macOS `hasattr(os, "killpg")` is `True`, so behavior is unchanged (verified by the existing process-group cleanup tests still passing). The fallback uses `proc.kill()`, the same Windows-safe termination already chosen by the existing `except` clause.

## Related Issues

Fixes #110
Relates to #91, #156
