### PR TITLE
fix: resolve Windows compatibility issues in tests and subprocess execution

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -130,11 +130,16 @@ def _load_keychain(keys: list[str]) -> dict[str, str]:
         return {}
 
     import subprocess
-    import pwd
     # USER can be unset under sudo, in Docker without --env USER, or in some CI
     # runners; fall back to the OS user record so lookups still match items
     # stored by setup-keychain.sh (which uses $USER).
-    user = os.environ.get("USER") or pwd.getpwuid(os.getuid()).pw_name
+    user = os.environ.get("USER")
+    if not user:
+        try:
+            import pwd
+            user = pwd.getpwuid(os.getuid()).pw_name
+        except (ImportError, AttributeError):
+            user = "unknown"
     env: dict[str, str] = {}
     for key in keys:
         try:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -137,8 +137,15 @@ def _load_keychain(keys: list[str]) -> dict[str, str]:
     if not user:
         try:
             import pwd
-            user = pwd.getpwuid(os.getuid()).pw_name
-        except (ImportError, AttributeError):
+        except ImportError:
+            pwd = None
+
+        if pwd is not None:
+            try:
+                user = pwd.getpwuid(os.getuid()).pw_name
+            except AttributeError:
+                user = "unknown"
+        else:
             user = "unknown"
     env: dict[str, str] = {}
     for key in keys:

--- a/skills/last30days/scripts/lib/skill_meta.py
+++ b/skills/last30days/scripts/lib/skill_meta.py
@@ -24,7 +24,7 @@ def read_skill_version(skill_md_path: Path) -> str | None:
     or unquoted YAML version scalars.
     """
     try:
-        text = skill_md_path.read_text()
+        text = skill_md_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
     match = _VERSION_RE.search(text)

--- a/skills/last30days/scripts/lib/subproc.py
+++ b/skills/last30days/scripts/lib/subproc.py
@@ -81,8 +81,11 @@ def run_with_timeout(
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        except (ProcessLookupError, PermissionError, OSError):
+            if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            else:
+                proc.kill()
+        except (ProcessLookupError, PermissionError, OSError, AttributeError):
             proc.kill()
         proc.wait(timeout=5)
         raise SubprocTimeout(f"Command {cmd[0]} timed out after {timeout}s")

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -2,12 +2,15 @@
 
 import hashlib
 import sqlite3
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from unittest import mock
 
 import pytest
+
+OPENSSL_AVAILABLE = shutil.which("openssl") is not None
 
 from lib.chrome_cookies import (
     CHROME_COOKIES_DB,
@@ -160,6 +163,7 @@ class TestKeyDerivation:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl not installed")
 class TestDecryption:
     def test_decrypt_v10_roundtrip(self):
         """Encrypt then decrypt — verifies the full pipeline works."""
@@ -230,6 +234,7 @@ class TestKeychainDenied:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl not installed")
 class TestOpensslNotFound:
     def test_openssl_missing(self):
         encrypted = _encrypt_value_v10("test", KNOWN_AES_KEY)
@@ -264,6 +269,7 @@ class TestUnencryptedCookies:
 
 
 class TestFullExtraction:
+    @pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl not installed")
     def test_encrypted_cookies_extracted(self, tmp_path):
         """End-to-end: create DB with real v10-encrypted values, extract them."""
         auth_val = "my_auth_token_123"
@@ -302,6 +308,7 @@ class TestFullExtraction:
 
         assert result is None
 
+    @pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl not installed")
     def test_chrome130_db_version_24(self, tmp_path):
         """Chrome 130+ with db_version >= 24 strips SHA-256 prefix."""
         auth_val = "token_for_chrome130"

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -55,6 +55,7 @@ class CliV3Tests(unittest.TestCase):
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stderr)

--- a/tests/test_footer_nudge_suppression.py
+++ b/tests/test_footer_nudge_suppression.py
@@ -49,7 +49,7 @@ class FooterNudgeSuppressionTests(unittest.TestCase):
         # .claude/last30days.env above the repo on the contributor's machine.
         with tempfile.TemporaryDirectory() as tmp:
             return subprocess.run(
-                cmd, capture_output=True, text=True, env=env, cwd=tmp,
+                cmd, capture_output=True, text=True, encoding="utf-8", env=env, cwd=tmp,
             )
 
     def test_bare_run_emits_web_promo(self):

--- a/tests/test_last_run_state.py
+++ b/tests/test_last_run_state.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,6 +19,7 @@ def run_last30days(topic: str, env: dict[str, str]) -> subprocess.CompletedProce
         env=env,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
 
@@ -49,6 +51,7 @@ class LastRunStateTests(unittest.TestCase):
             self.assertEqual(payload["topic"], "custom config query")
             self.assertGreaterEqual(payload["total"], 0)
 
+    @unittest.skipIf(shutil.which("bash") is None, "bash not available")
     def test_hook_reads_last_run_from_custom_config_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
             config_dir = Path(tmp) / "custom-config"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -14,6 +14,7 @@ def run_mock_json(topic: str) -> dict:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:

--- a/tests/test_save_raw_per_entity.py
+++ b/tests/test_save_raw_per_entity.py
@@ -33,7 +33,7 @@ class PerEntitySaveFilesTests(unittest.TestCase):
             *argv,
         ]
         env = {**os.environ, "LAST30DAYS_SKIP_PREFLIGHT": "1"}
-        result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", env=env)
         return result, save_dir
 
     def test_vs_mode_produces_per_entity_files(self):

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -62,7 +62,7 @@ class TestRunOpenclawSetup:
     def test_openclaw_metadata_keeps_scrapecreators_optional(self):
         """OpenClaw metadata should not hard-require the ScrapeCreators key."""
         skill_md = Path(__file__).parent.parent / "skills" / "last30days" / "SKILL.md"
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         assert "SCRAPECREATORS_API_KEY" in text
         expected = (
             "requires:\n"

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -4,16 +4,37 @@ Covers the process-group cleanup path, timeout behavior, success path,
 PID callback wiring, and environment inheritance.
 """
 
+import platform
 import unittest
 from unittest.mock import patch
 
 from lib import subproc
 
+IS_WINDOWS = platform.system() == "Windows"
+
+def get_shell_cmd(cmd_str: str) -> list[str]:
+    if IS_WINDOWS:
+        if cmd_str == "echo hello":
+            return ["cmd", "/c", "echo hello"]
+        elif cmd_str == "exit 3":
+            return ["cmd", "/c", "exit 3"]
+        elif cmd_str == "echo err >&2":
+            return ["cmd", "/c", "echo err 1>&2"]
+        elif cmd_str in ("sleep 10", "sleep 10 & wait"):
+            return ["powershell", "-Command", "Start-Sleep 10"]
+        elif cmd_str == "echo $LAST30DAYS_TEST_VAR":
+            return ["cmd", "/c", "echo %LAST30DAYS_TEST_VAR%"]
+        elif cmd_str == "true":
+            return ["cmd", "/c", "exit 0"]
+        elif cmd_str == "echo ok":
+            return ["cmd", "/c", "echo ok"]
+    return ["sh", "-c", cmd_str]
+
 
 class TestRunWithTimeout(unittest.TestCase):
     def test_success_returns_stdout(self):
         result = subproc.run_with_timeout(
-            ["sh", "-c", "echo hello"],
+            get_shell_cmd("echo hello"),
             timeout=5,
         )
         self.assertEqual(result.returncode, 0)
@@ -22,14 +43,14 @@ class TestRunWithTimeout(unittest.TestCase):
 
     def test_nonzero_exit_returns_returncode_not_exception(self):
         result = subproc.run_with_timeout(
-            ["sh", "-c", "exit 3"],
+            get_shell_cmd("exit 3"),
             timeout=5,
         )
         self.assertEqual(result.returncode, 3)
 
     def test_captures_stderr(self):
         result = subproc.run_with_timeout(
-            ["sh", "-c", "echo err >&2"],
+            get_shell_cmd("echo err >&2"),
             timeout=5,
         )
         self.assertEqual(result.stderr.strip(), "err")
@@ -37,7 +58,7 @@ class TestRunWithTimeout(unittest.TestCase):
     def test_timeout_raises_subproctimeout(self):
         with self.assertRaises(subproc.SubprocTimeout):
             subproc.run_with_timeout(
-                ["sh", "-c", "sleep 10"],
+                get_shell_cmd("sleep 10"),
                 timeout=1,
             )
 
@@ -47,7 +68,7 @@ class TestRunWithTimeout(unittest.TestCase):
             # Parent shell spawns a child that sleeps long.
             # Without process-group cleanup, the child would orphan.
             subproc.run_with_timeout(
-                ["sh", "-c", "sleep 10 & wait"],
+                get_shell_cmd("sleep 10 & wait"),
                 timeout=1,
             )
 
@@ -60,18 +81,25 @@ class TestRunWithTimeout(unittest.TestCase):
                 timeout=5,
             )
 
-    def test_env_is_passed_through(self):
+        import os
+        env = {"LAST30DAYS_TEST_VAR": "custom_value"}
+        if IS_WINDOWS:
+            for k in ("SystemRoot", "SystemDrive", "PATH", "COMSPEC", "TEMP", "TMP"):
+                if k in os.environ:
+                    env[k] = os.environ[k]
+        else:
+            env["PATH"] = "/usr/bin:/bin"
         result = subproc.run_with_timeout(
-            ["sh", "-c", "echo $LAST30DAYS_TEST_VAR"],
+            get_shell_cmd("echo $LAST30DAYS_TEST_VAR"),
             timeout=5,
-            env={"LAST30DAYS_TEST_VAR": "custom_value", "PATH": "/usr/bin:/bin"},
+            env=env,
         )
         self.assertEqual(result.stdout.strip(), "custom_value")
 
     def test_on_pid_callback_receives_pid(self):
         seen_pids = []
         subproc.run_with_timeout(
-            ["sh", "-c", "true"],
+            get_shell_cmd("true"),
             timeout=5,
             on_pid=lambda pid: seen_pids.append(pid),
         )
@@ -86,7 +114,7 @@ class TestRunWithTimeout(unittest.TestCase):
 
         # Should not raise, callback exception is swallowed.
         result = subproc.run_with_timeout(
-            ["sh", "-c", "echo ok"],
+            get_shell_cmd("echo ok"),
             timeout=5,
             on_pid=raising_callback,
         )

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -28,6 +28,8 @@ def get_shell_cmd(cmd_str: str) -> list[str]:
             return ["cmd", "/c", "exit 0"]
         elif cmd_str == "echo ok":
             return ["cmd", "/c", "echo ok"]
+        else:
+            raise ValueError(f"No Windows command mapping for: {cmd_str}")
     return ["sh", "-c", cmd_str]
 
 
@@ -81,6 +83,7 @@ class TestRunWithTimeout(unittest.TestCase):
                 timeout=5,
             )
 
+    def test_env_is_passed_through(self):
         import os
         env = {"LAST30DAYS_TEST_VAR": "custom_value"}
         if IS_WINDOWS:


### PR DESCRIPTION
This PR resolves multiple cross-platform compatibility issues that cause test failures when running the test suite on Windows.

### Fixes included:
1. **Keychain Import Guard**: Safely wrap UNIX-specific `import pwd` and `os.getuid` calls in a `try-except` block to prevent crashes when Darwin generic password retrieval is simulated in tests on Windows.
2. **Explicit UTF-8 Encoding**: Explicitly pass `encoding="utf-8"` to file reads and subprocess runners (using `text=True`) to avoid `UnicodeDecodeError` when Python defaults to the local ANSI code page (e.g. `gbk` on Windows).
3. **Subprocess/Command Translation**:
   - Mapped shell commands in tests (`sh`, `bash`) to Windows equivalents (`cmd` or `powershell`) on Windows.
   - Merged system environment variables (`SystemRoot`, etc.) on Windows so child processes can start correctly.
4. **Safe Timeout & Conditional Skips**:
   - Checked for availability of `os.killpg`/`os.getpgid` before calling them in `subproc.py` on timeout.
   - Automatically skip `openssl` or `bash` dependent tests if those tools are not installed.

With these changes, the entire test suite passes on Windows.
