### PR TITLE
fix(setup): auto-mint ScrapeCreators API key

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -44,6 +44,8 @@ The skill reads keys from a `.env` file. Two locations are supported, in priorit
 
 Override the global location with `LAST30DAYS_CONFIG_DIR=/path` (or `LAST30DAYS_CONFIG_DIR=""` for no-config mode). File permissions should be `600` on POSIX hosts - the engine warns on every run if they aren't.
 
+First-run setup auto-mints `SCRAPECREATORS_API_KEY` when it is missing by calling the existing GitHub auth flow (`gh auth token` first, GitHub device auth fallback) and persisting the returned key to the selected `.env`. Set `LAST30DAYS_NO_AUTO_AUTH=1` to skip this attempt and keep ScrapeCreators manual-only.
+
 The project-scoped file is the cleanest pattern for **per-client setups**: drop a `.claude/last30days.env` into each client folder (`SCRAPECREATORS_API_KEY`, `INCLUDE_SOURCES`, `LAST30DAYS_MEMORY_DIR`, `BSKY_HANDLE`, etc), `cd` into that folder, and the skill picks up that client's configuration automatically. No wrapper scripts needed for the common case.
 
 **Source-by-source** - what each key unlocks:
@@ -77,6 +79,7 @@ BRAVE_API_KEY=<your-brave-key>
 
 # Optional sources
 SCRAPECREATORS_API_KEY=<your-scrapecreators-key>
+# Set LAST30DAYS_NO_AUTO_AUTH=1 to skip first-run GitHub auto-minting
 INCLUDE_SOURCES=tiktok,instagram
 
 # X authentication (one option only)

--- a/HERMES_SETUP.md
+++ b/HERMES_SETUP.md
@@ -48,11 +48,12 @@ On first run, the skill will guide you through setup:
    - Scans browser cookies for X/Twitter
    - Checks/installs yt-dlp for YouTube
    - Configures free sources (Reddit, HN, Polymarket)
+   - If `SCRAPECREATORS_API_KEY` is missing, tries to mint one from your GitHub identity via the existing `gh` CLI auth first, then GitHub device auth fallback
 
-2. **Optional: ScrapeCreators**
+2. **Optional: ScrapeCreators fallback**
    - Adds TikTok, Instagram, Reddit backup
    - 100 free credits (no expiration)
-   - Sign up at scrapecreators.com
+   - If auto-auth fails or you opt out with `LAST30DAYS_NO_AUTO_AUTH=1`, sign up at scrapecreators.com and set `SCRAPECREATORS_API_KEY` manually
 
 3. **Optional: API Keys**
    - XAI_API_KEY for X/Twitter (alternative to browser cookies)

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1683,6 +1683,7 @@ Want another prompt? Just tell me what you're creating next.
 
 **What this skill does:**
 - Sends search queries to ScrapeCreators API (`api.scrapecreators.com`) for TikTok and Instagram search, and as a Reddit backup when public Reddit is unavailable (requires SCRAPECREATORS_API_KEY)
+- During first-run setup, may use GitHub auth (`gh auth token` or GitHub device auth) to mint and persist a ScrapeCreators API key when `SCRAPECREATORS_API_KEY` is missing; set `LAST30DAYS_NO_AUTO_AUTH=1` to opt out
 - Legacy: Sends search queries to OpenAI's Responses API (`api.openai.com`) for Reddit discovery (fallback if no SCRAPECREATORS_API_KEY)
 - Sends search queries to Twitter's GraphQL API (via optional user-provided AUTH_TOKEN/CT0 env vars - no browser session access), xAI's API (`api.x.ai`), or the official X API v2 via xurl CLI (OAuth2, auto-detected when installed and authenticated) for X search
 - Sends search queries to Algolia HN Search API (`hn.algolia.com`) for Hacker News story and comment discovery (free, no auth)

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -588,12 +588,19 @@ def main() -> int:
             return 0
         sys.stderr.write("Running auto-setup...\n")
         results = setup_wizard.run_auto_setup(config)
+        config_file = setup_wizard.resolve_env_path(config, env.CONFIG_FILE)
+        results["scrapecreators_auto_auth"] = setup_wizard.auto_auth_scrapecreators(
+            config, config_file,
+        )
         from_browser = "auto"
         if results.get("cookies_found"):
             first_browser = next(iter(results["cookies_found"].values()))
             from_browser = first_browser
-        setup_wizard.write_setup_config(env.CONFIG_FILE, from_browser=from_browser)
-        results["env_written"] = True
+        if config_file:
+            setup_wizard.write_setup_config(config_file, from_browser=from_browser)
+            results["env_written"] = True
+        else:
+            results["env_written"] = False
         sys.stderr.write(setup_wizard.get_setup_status_text(results) + "\n")
         return 0
 

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -315,6 +315,7 @@ def get_config() -> dict[str, Any]:
         ('LAST30DAYS_X_MODEL', None),
         ('LAST30DAYS_X_BACKEND', None),
         ('LAST30DAYS_STORE', None),
+        ('LAST30DAYS_NO_AUTO_AUTH', None),
         ('OPENAI_MODEL_PIN', None),
         ('XAI_MODEL_PIN', None),
         ('SCRAPECREATORS_API_KEY', None),
@@ -371,6 +372,9 @@ def get_config() -> dict[str, Any]:
         config['_CONFIG_SOURCE'] = 'keychain'
     else:
         config['_CONFIG_SOURCE'] = 'env_only'
+    active_config_file = project_env_path or CONFIG_FILE
+    if active_config_file:
+        config['_CONFIG_FILE'] = str(active_config_file)
 
     # Extract browser credentials if configured
     browser_creds = extract_browser_credentials(config)

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -9,6 +9,7 @@ import json
 import logging
 import shutil
 import subprocess
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -98,6 +99,119 @@ def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
     return results
 
 
+def _existing_env_keys(env_path: Path) -> Tuple[set, str]:
+    """Return existing .env keys and content without exposing values."""
+    existing_keys: set = set()
+    existing_content = ""
+    if env_path.exists():
+        existing_content = env_path.read_text(encoding="utf-8")
+        for line in existing_content.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                key = stripped.split("=", 1)[0].strip()
+                existing_keys.add(key)
+    return existing_keys, existing_content
+
+
+def _env_value_has_content(raw_value: str) -> bool:
+    """Return True when a raw .env value is semantically non-empty."""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = value[1:-1].strip()
+    return bool(value)
+
+
+def _chmod_private(env_path: Path) -> None:
+    """Restrict an env file containing minted secrets to the current user."""
+    env_path.chmod(0o600)
+
+
+def resolve_env_path(config: Dict[str, Any], fallback: Optional[Path]) -> Optional[Path]:
+    """Return the active env file path for persistence."""
+    configured = config.get("_CONFIG_FILE")
+    return Path(configured) if configured else fallback
+
+
+def write_env_key(env_path: Optional[Path], key: str, value: str) -> bool:
+    """Persist a single env key without overwriting non-empty values."""
+    if not env_path or not key or not value:
+        return False
+    try:
+        env_path = Path(env_path)
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_keys, existing_content = _existing_env_keys(env_path)
+        if key in existing_keys:
+            lines = existing_content.splitlines(keepends=True)
+            for idx, line in enumerate(lines):
+                stripped = line.strip()
+                if stripped.startswith("#") or "=" not in stripped:
+                    continue
+                existing_key, existing_value = stripped.split("=", 1)
+                if existing_key.strip() != key:
+                    continue
+                if _env_value_has_content(existing_value):
+                    return True
+                newline = "\n" if line.endswith("\n") else ""
+                lines[idx] = f"{key}={value}{newline}"
+                env_path.write_text("".join(lines), encoding="utf-8")
+                _chmod_private(env_path)
+                return True
+            return True
+        with open(env_path, "a", encoding="utf-8") as f:
+            if existing_content and not existing_content.endswith("\n"):
+                f.write("\n")
+            f.write(f"{key}={value}\n")
+        _chmod_private(env_path)
+        return True
+    except OSError as exc:
+        logger.error("Failed to write %s to %s: %s", key, env_path, exc)
+        return False
+
+
+def _auto_auth_disabled(config: Dict[str, Any]) -> bool:
+    """Return True when the user deliberately opted out of auto-auth."""
+    raw = os.environ.get("LAST30DAYS_NO_AUTO_AUTH") or config.get("LAST30DAYS_NO_AUTO_AUTH")
+    return str(raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def auto_auth_scrapecreators(config: Dict[str, Any], env_path: Optional[Path]) -> Dict[str, Any]:
+    """Mint and persist SCRAPECREATORS_API_KEY when it is missing.
+
+    The returned dict is safe for JSON/probe output: it never includes the
+    minted API key, only status/method/persistence metadata.
+    """
+    if config.get("SCRAPECREATORS_API_KEY"):
+        return {"attempted": False, "status": "present", "persisted": True}
+    if _auto_auth_disabled(config):
+        return {
+            "attempted": False,
+            "status": "skipped",
+            "reason": "LAST30DAYS_NO_AUTO_AUTH",
+            "persisted": False,
+        }
+
+    result = run_github_auth()
+    status = str(result.get("status") or "error")
+    api_key = result.get("api_key")
+    persisted = False
+    if status == "success" and api_key:
+        config["SCRAPECREATORS_API_KEY"] = api_key
+        persisted = write_env_key(env_path, "SCRAPECREATORS_API_KEY", api_key)
+
+    safe: Dict[str, Any] = {
+        "attempted": True,
+        "status": status,
+        "persisted": persisted,
+    }
+    if result.get("method"):
+        safe["method"] = result.get("method")
+    if result.get("user_code"):
+        safe["user_code"] = result.get("user_code")
+    if result.get("message"):
+        safe["message"] = result.get("message")
+    return safe
+
+
 def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
     """Write SETUP_COMPLETE and FROM_BROWSER to the .env file.
 
@@ -116,15 +230,7 @@ def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
         env_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Read existing content to avoid overwriting keys
-        existing_keys: set = set()
-        existing_content = ""
-        if env_path.exists():
-            existing_content = env_path.read_text(encoding="utf-8")
-            for line in existing_content.splitlines():
-                stripped = line.strip()
-                if stripped and not stripped.startswith("#") and "=" in stripped:
-                    key = stripped.split("=", 1)[0].strip()
-                    existing_keys.add(key)
+        existing_keys, existing_content = _existing_env_keys(env_path)
 
         lines_to_add = []
         if "SETUP_COMPLETE" not in existing_keys:
@@ -182,6 +288,15 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
     else:
         lines.append("  - yt-dlp not found (install with: brew install yt-dlp)")
 
+    scrapecreators_auth = results.get("scrapecreators_auto_auth") or {}
+    if scrapecreators_auth.get("status") == "success" and scrapecreators_auth.get("persisted"):
+        method = scrapecreators_auth.get("method") or "GitHub"
+        lines.append(f"  - ScrapeCreators API key auto-configured via GitHub {method} auth")
+    elif scrapecreators_auth.get("status") == "skipped":
+        lines.append("  - ScrapeCreators auto-auth skipped")
+    elif scrapecreators_auth.get("attempted"):
+        lines.append("  - ScrapeCreators auto-auth did not complete; set SCRAPECREATORS_API_KEY manually if needed")
+
     env_written = results.get("env_written", False)
     if env_written:
         lines.append("")
@@ -205,7 +320,7 @@ _OPENCLAW_KEY_NAMES = [
 ]
 
 
-def run_openclaw_setup(config: Dict[str, Any]) -> Dict[str, Any]:
+def run_openclaw_setup(config: Dict[str, Any], env_path: Optional[Path] = None) -> Dict[str, Any]:
     """Server-side setup probe: no cookies, just tool + key availability.
 
     Returns a dict suitable for JSON output to stdout so that SKILL.md
@@ -214,6 +329,15 @@ def run_openclaw_setup(config: Dict[str, Any]) -> Dict[str, Any]:
     yt_dlp = shutil.which("yt-dlp") is not None
     node = shutil.which("node") is not None
     python3 = shutil.which("python3") is not None
+
+    if env_path is None:
+        try:
+            from . import env as env_module
+            env_path = env_module.CONFIG_FILE
+        except Exception:
+            env_path = None
+
+    scrapecreators_auto_auth = auto_auth_scrapecreators(config, resolve_env_path(config, env_path))
 
     keys: Dict[str, bool] = {}
     for key_name in _OPENCLAW_KEY_NAMES:
@@ -235,6 +359,7 @@ def run_openclaw_setup(config: Dict[str, Any]) -> Dict[str, Any]:
         "python3": python3,
         "keys": keys,
         "x_method": x_method,
+        "scrapecreators_auto_auth": scrapecreators_auto_auth,
     }
 
 

--- a/tests/test_env_keychain.py
+++ b/tests/test_env_keychain.py
@@ -138,6 +138,34 @@ def test_get_config_global_file_outranks_keychain(clean_env, tmp_path, monkeypat
         cfg = env.get_config()
     assert cfg["XAI_API_KEY"] == "xai-from-file"
     assert cfg["_CONFIG_SOURCE"].startswith("global:")
+    assert cfg["_CONFIG_FILE"] == str(cfg_file)
+
+
+def test_get_config_records_project_env_as_active_config_file(clean_env, tmp_path, monkeypatch):
+    global_file = tmp_path / "global.env"
+    global_file.write_text("SCRAPECREATORS_API_KEY=sc_global\n")
+    project_dir = tmp_path / "project"
+    project_env = project_dir / ".claude" / "last30days.env"
+    project_env.parent.mkdir(parents=True)
+    project_env.write_text("SCRAPECREATORS_API_KEY=\n")
+    monkeypatch.setattr(env, "CONFIG_FILE", global_file)
+    monkeypatch.chdir(project_dir)
+
+    with mock.patch.object(env, "_load_keychain", return_value={}):
+        cfg = env.get_config()
+
+    assert cfg["_CONFIG_SOURCE"] == f"project:{project_env}"
+    assert cfg["_CONFIG_FILE"] == str(project_env)
+    assert cfg["SCRAPECREATORS_API_KEY"] == "sc_global"
+
+
+def test_get_config_loads_no_auto_auth_from_env_file(clean_env, tmp_path, monkeypatch):
+    cfg_file = tmp_path / "global.env"
+    cfg_file.write_text("LAST30DAYS_NO_AUTO_AUTH=1\n")
+    monkeypatch.setattr(env, "CONFIG_FILE", cfg_file)
+    with mock.patch.object(env, "_load_keychain", return_value={}):
+        cfg = env.get_config()
+    assert cfg["LAST30DAYS_NO_AUTO_AUTH"] == "1"
 
 
 def test_get_config_openai_key_can_come_from_keychain(clean_env):

--- a/tests/test_setup_openclaw.py
+++ b/tests/test_setup_openclaw.py
@@ -17,7 +17,7 @@ class TestRunOpenclawSetup:
     def test_all_tools_present_no_keys(self, mock_which):
         """All CLI tools found, no API keys configured."""
         mock_which.side_effect = lambda cmd: f"/usr/bin/{cmd}"
-        config = {}
+        config = {"LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -35,7 +35,7 @@ class TestRunOpenclawSetup:
                 return None
             return f"/usr/bin/{cmd}"
         mock_which.side_effect = which_side
-        config = {}
+        config = {"LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -51,6 +51,7 @@ class TestRunOpenclawSetup:
             "XAI_API_KEY": "xai-abc123",
             "BRAVE_API_KEY": "brav-xyz",
             "SCRAPECREATORS_API_KEY": "",  # empty = falsy
+            "LAST30DAYS_NO_AUTO_AUTH": "1",
         }
 
         result = setup_wizard.run_openclaw_setup(config)
@@ -58,6 +59,133 @@ class TestRunOpenclawSetup:
         assert result["keys"]["xai"] is True
         assert result["keys"]["brave"] is True
         assert result["keys"]["scrapecreators"] is False
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_missing_scrapecreators_key_auto_auths_and_persists(self, mock_which, mock_auth, tmp_path):
+        """OpenClaw first-run mints and persists ScrapeCreators when absent."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_auth.return_value = {
+            "status": "success",
+            "method": "pat",
+            "api_key": "sc_live_auto_minted",
+            "github_username": "octocat",
+        }
+        env_path = tmp_path / ".env"
+
+        result = setup_wizard.run_openclaw_setup({}, env_path=env_path)
+
+        mock_auth.assert_called_once()
+        assert result["keys"]["scrapecreators"] is True
+        assert result["scrapecreators_auto_auth"] == {
+            "attempted": True,
+            "status": "success",
+            "method": "pat",
+            "persisted": True,
+        }
+        content = env_path.read_text()
+        assert "SCRAPECREATORS_API_KEY=sc_live_auto_minted" in content
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_auto_auth_replaces_blank_existing_env_key(self, mock_which, mock_auth, tmp_path):
+        """A blank existing ScrapeCreators key is replaced with the minted key."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_auth.return_value = {
+            "status": "success",
+            "method": "device",
+            "api_key": "sc_live_from_blank",
+        }
+        env_path = tmp_path / ".env"
+        env_path.write_text("SCRAPECREATORS_API_KEY=\nFROM_BROWSER=chrome\n")
+
+        result = setup_wizard.run_openclaw_setup({}, env_path=env_path)
+
+        assert result["keys"]["scrapecreators"] is True
+        assert result["scrapecreators_auto_auth"]["persisted"] is True
+        assert env_path.read_text().splitlines() == [
+            "SCRAPECREATORS_API_KEY=sc_live_from_blank",
+            "FROM_BROWSER=chrome",
+        ]
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_auto_auth_replaces_quoted_blank_existing_env_key(self, mock_which, mock_auth, tmp_path):
+        """A quoted blank ScrapeCreators key is also replaced."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_auth.return_value = {
+            "status": "success",
+            "method": "device",
+            "api_key": "sc_live_from_quoted_blank",
+        }
+        env_path = tmp_path / ".env"
+        env_path.write_text('SCRAPECREATORS_API_KEY=""\nFROM_BROWSER=chrome\n')
+
+        result = setup_wizard.run_openclaw_setup({}, env_path=env_path)
+
+        assert result["keys"]["scrapecreators"] is True
+        assert result["scrapecreators_auto_auth"]["persisted"] is True
+        assert env_path.read_text().splitlines() == [
+            "SCRAPECREATORS_API_KEY=sc_live_from_quoted_blank",
+            "FROM_BROWSER=chrome",
+        ]
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_auto_auth_persists_key_with_private_permissions(self, mock_which, mock_auth, tmp_path):
+        """A newly persisted ScrapeCreators key is written mode 0600."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_auth.return_value = {
+            "status": "success",
+            "method": "pat",
+            "api_key": "sc_live_private_mode",
+        }
+        env_path = tmp_path / ".env"
+
+        result = setup_wizard.run_openclaw_setup({}, env_path=env_path)
+
+        assert result["scrapecreators_auto_auth"]["persisted"] is True
+        assert oct(env_path.stat().st_mode & 0o777) == "0o600"
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_auto_auth_prefers_project_env_path_from_config(self, mock_which, mock_auth, tmp_path):
+        """Project-scoped config receives minted keys instead of the global fallback."""
+        mock_which.return_value = "/usr/bin/tool"
+        mock_auth.return_value = {
+            "status": "success",
+            "method": "pat",
+            "api_key": "sc_live_project_env",
+        }
+        global_env = tmp_path / "global.env"
+        project_env = tmp_path / ".claude" / "last30days.env"
+        project_env.parent.mkdir()
+        project_env.write_text("SCRAPECREATORS_API_KEY=\n")
+        config = {"_CONFIG_FILE": str(project_env)}
+
+        result = setup_wizard.run_openclaw_setup(config, env_path=global_env)
+
+        assert result["scrapecreators_auto_auth"]["persisted"] is True
+        assert "SCRAPECREATORS_API_KEY=sc_live_project_env" in project_env.read_text()
+        assert not global_env.exists()
+
+    @patch("lib.setup_wizard.run_github_auth")
+    @patch("shutil.which")
+    def test_auto_auth_opt_out_leaves_scrapecreators_missing(self, mock_which, mock_auth, tmp_path):
+        """LAST30DAYS_NO_AUTO_AUTH skips the OpenClaw auto-auth attempt."""
+        mock_which.return_value = "/usr/bin/tool"
+        config = {"LAST30DAYS_NO_AUTO_AUTH": "1"}
+
+        result = setup_wizard.run_openclaw_setup(config, env_path=tmp_path / ".env")
+
+        mock_auth.assert_not_called()
+        assert result["keys"]["scrapecreators"] is False
+        assert result["scrapecreators_auto_auth"] == {
+            "attempted": False,
+            "status": "skipped",
+            "reason": "LAST30DAYS_NO_AUTO_AUTH",
+            "persisted": False,
+        }
 
     def test_openclaw_metadata_keeps_scrapecreators_optional(self):
         """OpenClaw metadata should not hard-require the ScrapeCreators key."""
@@ -76,7 +204,7 @@ class TestRunOpenclawSetup:
     def test_x_method_xai(self, mock_which):
         """x_method is 'xai' when XAI_API_KEY is set."""
         mock_which.return_value = None
-        config = {"XAI_API_KEY": "xai-key"}
+        config = {"XAI_API_KEY": "xai-key", "LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -86,7 +214,7 @@ class TestRunOpenclawSetup:
     def test_x_method_cookies(self, mock_which):
         """x_method is 'cookies' when AUTH_TOKEN + CT0 are set."""
         mock_which.return_value = None
-        config = {"AUTH_TOKEN": "tok", "CT0": "ct0val"}
+        config = {"AUTH_TOKEN": "tok", "CT0": "ct0val", "LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -96,7 +224,7 @@ class TestRunOpenclawSetup:
     def test_x_method_xai_over_cookies(self, mock_which):
         """XAI takes priority over cookies for x_method."""
         mock_which.return_value = None
-        config = {"XAI_API_KEY": "xai-key", "AUTH_TOKEN": "tok", "CT0": "ct0val"}
+        config = {"XAI_API_KEY": "xai-key", "AUTH_TOKEN": "tok", "CT0": "ct0val", "LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -106,7 +234,7 @@ class TestRunOpenclawSetup:
     def test_x_method_null_when_nothing(self, mock_which):
         """x_method is None when no X access configured."""
         mock_which.return_value = None
-        config = {}
+        config = {"LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
 
@@ -116,7 +244,7 @@ class TestRunOpenclawSetup:
     def test_output_is_json_serializable(self, mock_which):
         """Result can be serialized to JSON without errors."""
         mock_which.return_value = "/usr/bin/something"
-        config = {"XAI_API_KEY": "k", "OPENAI_API_KEY": "ok"}
+        config = {"XAI_API_KEY": "k", "OPENAI_API_KEY": "ok", "LAST30DAYS_NO_AUTO_AUTH": "1"}
 
         result = setup_wizard.run_openclaw_setup(config)
         serialized = json.dumps(result)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -3,6 +3,9 @@
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+import sys
+
+import last30days
 
 import pytest
 
@@ -299,6 +302,16 @@ class TestGetSetupStatusText:
         text = setup_wizard.get_setup_status_text(results)
         assert "Installed yt-dlp via Homebrew" in text
 
+    def test_status_text_scrapecreators_auto_auth_success(self):
+        """Status text reports successful ScrapeCreators auto-auth."""
+        results = {
+            "cookies_found": {},
+            "ytdlp_installed": True,
+            "scrapecreators_auto_auth": {"attempted": True, "status": "success", "method": "pat", "persisted": True},
+        }
+        text = setup_wizard.get_setup_status_text(results)
+        assert "ScrapeCreators API key auto-configured via GitHub pat auth" in text
+
     def test_status_text_install_failed(self):
         """Status text for failed yt-dlp install."""
         results = {
@@ -334,3 +347,35 @@ class TestSetupSubcommand:
         args = parser.parse_args(["AI", "video", "tools"])
         topic = " ".join(args.topic) if args.topic else None
         assert topic.strip().lower() != "setup"
+
+    @patch("lib.setup_wizard.run_auto_setup", return_value={"cookies_found": {}, "ytdlp_installed": True, "ytdlp_action": "already_installed", "env_written": False})
+    @patch("lib.setup_wizard.auto_auth_scrapecreators", return_value={"attempted": True, "status": "success", "method": "device", "persisted": True})
+    @patch("lib.setup_wizard.write_setup_config", return_value=True)
+    @patch("lib.env.CONFIG_FILE", Path("/tmp/last30days-test.env"))
+    def test_default_setup_auto_auths_scrapecreators_before_persisting_setup(self, mock_write, mock_auth, mock_setup, monkeypatch):
+        """Hermes/default first-run setup auto-auths ScrapeCreators when missing."""
+        monkeypatch.setattr(sys, "argv", ["last30days.py", "setup"])
+
+        rc = last30days.main()
+
+        assert rc == 0
+        mock_auth.assert_called_once()
+        auth_config, auth_env_path = mock_auth.call_args.args
+        assert auth_config.get("SCRAPECREATORS_API_KEY") is None
+        assert auth_env_path == Path("/tmp/last30days-test.env")
+        mock_write.assert_called_once_with(Path("/tmp/last30days-test.env"), from_browser="auto")
+
+    @patch("lib.env.get_config", return_value={"_CONFIG_FILE": "/tmp/project/.claude/last30days.env"})
+    @patch("lib.setup_wizard.run_auto_setup", return_value={"cookies_found": {}, "ytdlp_installed": True, "ytdlp_action": "already_installed", "env_written": False})
+    @patch("lib.setup_wizard.auto_auth_scrapecreators", return_value={"attempted": True, "status": "success", "method": "device", "persisted": True})
+    @patch("lib.setup_wizard.write_setup_config", return_value=True)
+    @patch("lib.env.CONFIG_FILE", Path("/tmp/global.env"))
+    def test_default_setup_persists_auto_auth_to_active_project_env(self, mock_write, mock_auth, mock_setup, mock_config, monkeypatch):
+        """Hermes/default setup writes minted keys to the active project env."""
+        monkeypatch.setattr(sys, "argv", ["last30days.py", "setup"])
+
+        rc = last30days.main()
+
+        assert rc == 0
+        assert mock_auth.call_args.args[1] == Path("/tmp/project/.claude/last30days.env")
+        mock_write.assert_called_once_with(Path("/tmp/project/.claude/last30days.env"), from_browser="auto")


### PR DESCRIPTION
## Summary

Fixes #401 by auto-minting a ScrapeCreators API key during first-run setup for both Hermes/default setup and OpenClaw setup when `SCRAPECREATORS_API_KEY` is missing.

What changed:
- Default `last30days.py setup` and `setup --openclaw` now attempt the existing GitHub-backed `run_github_auth()` path when ScrapeCreators is unconfigured.
- Auto-auth persists the minted key to the active env file, including project-scoped `.claude/last30days.env` when that is the selected config source.
- `LAST30DAYS_NO_AUTO_AUTH=1` disables the auth attempt from either process env or `.env`.
- Persistence avoids overwriting non-empty keys, replaces blank and quoted blank keys, and chmods secret-bearing env files to `0600`.
- Setup/OpenClaw output only reports safe metadata, not the API key.

## Verification

- `uv run pytest tests/test_env_keychain.py::test_get_config_loads_no_auto_auth_from_env_file tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_auto_auth_replaces_quoted_blank_existing_env_key tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_auto_auth_persists_key_with_private_permissions -q`
- `uv run pytest tests/test_env_keychain.py::test_get_config_records_project_env_as_active_config_file tests/test_setup_openclaw.py::TestRunOpenclawSetup::test_auto_auth_prefers_project_env_path_from_config tests/test_setup_wizard.py::TestSetupSubcommand::test_default_setup_persists_auto_auth_to_active_project_env -q`
- `uv run pytest tests/test_setup_openclaw.py tests/test_setup_wizard.py tests/test_env_keychain.py -q`
- `uv run pytest -q`
- `python3 -m py_compile skills/last30days/scripts/last30days.py skills/last30days/scripts/lib/setup_wizard.py skills/last30days/scripts/lib/env.py`
- `git diff --check`
- CLI smoke: default setup with `LAST30DAYS_NO_AUTO_AUTH=1` skips ScrapeCreators auto-auth and exits 0.
- CLI smoke: project `.claude/last30days.env` remains the active write target while global env stays absent.

## Review

- Fresh local reviewer pass after fixes: CLEAN, no blocking issues.
- Duplicate PR scan: no open PR found for #401 or this branch.
