### PR TITLE
fix(security): lock copied browser cookie temp files

### DIFF
--- a/skills/last30days/scripts/lib/chrome_cookies.py
+++ b/skills/last30days/scripts/lib/chrome_cookies.py
@@ -12,6 +12,7 @@ This is NOT affected by Windows App-Bound Encryption (v20).
 
 import hashlib
 import logging
+import os
 import shutil
 import sqlite3
 import subprocess
@@ -20,6 +21,13 @@ from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _lock_temp_cookie_copy(path: str) -> None:
+    """Restrict copied cookie DB temp files to the current user on POSIX."""
+    if os.name == "nt":
+        return
+    Path(path).chmod(0o600)
 
 # Cookie DB locations on macOS
 CHROME_COOKIES_DB = Path.home() / "Library" / "Application Support" / "Google" / "Chrome" / "Default" / "Cookies"
@@ -207,6 +215,7 @@ def _extract_chromium_cookies_macos(
     try:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
         shutil.copy2(str(db_path), tmp_path)
+        _lock_temp_cookie_copy(tmp_path)
     except Exception as e:
         logger.info("Failed to copy %s cookies database: %s", keychain_service, e)
         if tmp_path:

--- a/skills/last30days/scripts/lib/cookie_extract.py
+++ b/skills/last30days/scripts/lib/cookie_extract.py
@@ -9,6 +9,7 @@ Only uses Python stdlib — no external dependencies.
 import configparser
 import functools
 import logging
+import os
 import platform
 import shutil
 import sqlite3
@@ -17,6 +18,13 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _lock_temp_cookie_copy(path: str) -> None:
+    """Restrict copied cookie DB temp files to the current user on POSIX."""
+    if os.name == "nt":
+        return
+    Path(path).chmod(0o600)
 
 
 @functools.lru_cache(maxsize=1)
@@ -148,6 +156,7 @@ def _query_cookies_db(
     try:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
         shutil.copy2(str(db_path), tmp_path)
+        _lock_temp_cookie_copy(tmp_path)
 
         conn = sqlite3.connect(tmp_path)
         try:

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -1,6 +1,7 @@
 """Tests for Chrome cookie extraction on macOS."""
 
 import hashlib
+import os
 import sqlite3
 import subprocess
 import tempfile
@@ -19,6 +20,7 @@ from lib.chrome_cookies import (
     _get_chrome_encryption_key,
     _get_db_version,
     _remove_pkcs7_padding,
+    _extract_chromium_cookies_macos,
     _decrypt_v10_value,
     extract_chrome_cookies_macos,
 )
@@ -243,6 +245,32 @@ class TestOpensslNotFound:
 
 
 class TestUnencryptedCookies:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not reliable on Windows")
+    def test_temp_cookie_db_copy_is_owner_only(self, tmp_path):
+        """Copied Chromium cookie DB temp files are chmodded owner-only before read."""
+        db_path = tmp_path / "Cookies"
+        _create_chrome_cookies_db(str(db_path), [
+            (".x.com", "auth_token", "plain_token_value", b""),
+        ])
+        os.chmod(db_path, 0o644)
+
+        real_connect = sqlite3.connect
+
+        def assert_temp_copy_locked(path, *args, **kwargs):
+            if Path(str(path)) != db_path:
+                assert Path(str(path)).stat().st_mode & 0o777 == 0o600
+            return real_connect(path, *args, **kwargs)
+
+        with mock.patch("lib.chrome_cookies.sqlite3.connect", side_effect=assert_temp_copy_locked):
+            result = _extract_chromium_cookies_macos(
+                db_path,
+                "Chrome Safe Storage",
+                ".x.com",
+                ["auth_token"],
+            )
+
+        assert result == {"auth_token": "plain_token_value"}
+
     def test_plain_value_returned(self, tmp_path):
         """Unencrypted cookies (value column populated) returned without decryption."""
         db_path = str(tmp_path / "Cookies")

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -1,8 +1,10 @@
 """Tests for browser cookie extraction module."""
 
 import configparser
+import os
 import sqlite3
 import textwrap
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -11,6 +13,7 @@ import pytest
 from lib.cookie_extract import (
     extract_cookies,
     extract_firefox_cookies,
+    _query_cookies_db,
     _find_default_profile,
     _get_firefox_profiles_dir,
 )
@@ -91,6 +94,34 @@ def mock_firefox_env(tmp_path):
 
 class TestExtractFirefoxCookies:
     """Tests for extract_firefox_cookies."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not reliable on Windows")
+    def test_temp_cookie_db_copy_is_owner_only(self, tmp_path):
+        """Copied cookie DB temp files are chmodded owner-only before read."""
+        db_path = tmp_path / "cookies.sqlite"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE moz_cookies (name TEXT NOT NULL, value TEXT NOT NULL, host TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO moz_cookies (name, value, host) VALUES (?, ?, ?)",
+            ("auth_token", "tok_abc123", ".x.com"),
+        )
+        conn.commit()
+        conn.close()
+        os.chmod(db_path, 0o644)
+
+        real_connect = sqlite3.connect
+
+        def assert_temp_copy_locked(path, *args, **kwargs):
+            if Path(str(path)) != db_path:
+                assert Path(str(path)).stat().st_mode & 0o777 == 0o600
+            return real_connect(path, *args, **kwargs)
+
+        with patch("lib.cookie_extract.sqlite3.connect", side_effect=assert_temp_copy_locked):
+            result = _query_cookies_db(db_path, ".x.com", ["auth_token"])
+
+        assert result == {"auth_token": "tok_abc123"}
 
     def test_valid_cookies_extracted(self, mock_firefox_env):
         """Cookies for the target domain are returned correctly."""


### PR DESCRIPTION
## Summary
- chmod copied browser cookie SQLite temp files to owner-only on POSIX after `shutil.copy2`
- cover both Firefox cookie extraction and Chromium/Brave macOS cookie extraction paths

## Test Plan
- `uv run pytest tests/test_cookie_extract.py::TestExtractFirefoxCookies::test_temp_cookie_db_copy_is_owner_only tests/test_chrome_cookies.py::TestUnencryptedCookies::test_temp_cookie_db_copy_is_owner_only -q`
- `uv run pytest tests/test_cookie_extract.py tests/test_chrome_cookies.py tests/test_security_workflow.py -q`

Closes #509
