### PR TITLE
fix: add Hermes skill scan ignore

### DIFF
--- a/skills/last30days/.skillignore
+++ b/skills/last30days/.skillignore
@@ -1,0 +1,10 @@
+# Hermes scans from this skill directory, not the repository root.
+# Keep non-runtime packaging/dev/eval artifacts out of install-time security scans.
+assets/
+agents/
+scripts/build-skill.sh
+scripts/compare.sh
+scripts/evaluate_search_quality.py
+scripts/test_device_auth.py
+scripts/test-v1-vs-v2.sh
+scripts/verify_v3.py

--- a/tests/test_hermes_skillignore.py
+++ b/tests/test_hermes_skillignore.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills" / "last30days"
+
+
+def _skillignore_entries() -> set[str]:
+    text = (SKILL_ROOT / ".skillignore").read_text(encoding="utf-8")
+    return {
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def test_hermes_skillignore_excludes_non_runtime_scan_surface() -> None:
+    entries = _skillignore_entries()
+
+    expected = {
+        "assets/",
+        "agents/",
+        "scripts/build-skill.sh",
+        "scripts/compare.sh",
+        "scripts/evaluate_search_quality.py",
+        "scripts/test_device_auth.py",
+        "scripts/test-v1-vs-v2.sh",
+        "scripts/verify_v3.py",
+    }
+
+    assert expected <= entries
+
+
+def test_hermes_skillignore_keeps_runtime_contract_scannable() -> None:
+    entries = _skillignore_entries()
+
+    assert "SKILL.md" not in entries
+    assert "scripts/last30days.py" not in entries
+    assert "scripts/lib/" not in entries


### PR DESCRIPTION
## Summary
- Add a `skills/last30days/.skillignore` because Hermes scans from the skill directory, not the repo root
- Exclude non-runtime assets, packaging helpers, eval helpers, and local test helpers from install-time security scans
- Add a regression test that keeps runtime files scannable while preserving the scan-surface exclusions

## Test Plan
- `uv run pytest tests/test_hermes_skillignore.py tests/test_version_consistency.py -q`
- `PYTHONPATH=/Users/maxsmacmini/.hermes/hermes-agent uv run python - <<'PY' ... scan_skill(Path('skills/last30days')) ... PY`

Notes: this trims the repo-controlled Hermes scan surface for #464. The remaining dangerous verdict is still driven by runtime secret-named env reads and scanner/trust policy, matching the scanner-side note on the issue.

Closes #464
