### PR TITLE
fix(render): label YouTube transcript text as auto-generated (#82)

### DIFF
--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -880,13 +880,13 @@ def render_full(report: schema.Report) -> str:
             # Transcript highlights for YouTube
             highlights = item.metadata.get("transcript_highlights", [])
             if highlights:
-                lines.append("  Highlights:")
+                lines.append("  Highlights (auto-generated transcript; may contain transcription errors):")
                 for hl in highlights[:5]:
                     lines.append(f'    - "{hl[:200]}"')
             # Full transcript snippet for YouTube
             transcript = item.metadata.get("transcript_snippet", "")
             if transcript and len(transcript) > 100:
-                lines.append(f"  <details><summary>Transcript ({len(transcript.split())} words)</summary>")
+                lines.append(f"  <details><summary>Transcript ({len(transcript.split())} words; auto-generated — may contain transcription errors)</summary>")
                 lines.append(f"  {transcript[:5000]}")
                 lines.append("  </details>")
             # Polymarket outcome prices and market details
@@ -999,7 +999,7 @@ def _render_candidate(candidate: schema.Candidate, prefix: str) -> list[str]:
         lines.append(f"   - Insight: {_truncate(insight, 220)}")
     highlights = _transcript_highlights(primary)
     if highlights:
-        lines.append("   - Highlights:")
+        lines.append("   - Highlights (auto-generated transcript; may contain transcription errors):")
         for hl in highlights:
             lines.append(f'     - "{_truncate(hl, 200)}"')
     return lines

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -632,5 +632,93 @@ class YoutubeFooterTranscriptRatioTests(unittest.TestCase):
         # No YouTube footer line at all - so no transcript segment either
         self.assertNotIn("with transcripts", text)
 
+
+class TranscriptCaveatTests(unittest.TestCase):
+    """Transcript-derived text must be labelled as auto-generated wherever it
+    is emitted, so the synthesizing model does not treat caption homophone
+    errors (e.g. "basil fears" for "basal fears") as verbatim quotes (#82).
+    """
+
+    def _youtube_item(self) -> schema.SourceItem:
+        return schema.SourceItem(
+            item_id="yt1",
+            source="youtube",
+            title="Interview video",
+            body="Description.",
+            url="https://youtube.com/watch?v=v1",
+            container="some-channel",
+            published_at="2026-04-15",
+            date_confidence="high",
+            engagement={"views": 1000, "likes": 100},
+            metadata={
+                "transcript_highlights": ["She identifies eight basil fears."],
+                "transcript_snippet": "And basil you mean like of the body? " * 5,
+            },
+        )
+
+    def _report(self) -> schema.Report:
+        return schema.Report(
+            topic="test topic",
+            range_from="2026-04-01",
+            range_to="2026-05-01",
+            generated_at="2026-05-01T00:00:00+00:00",
+            provider_runtime=schema.ProviderRuntime(
+                reasoning_provider="gemini",
+                planner_model="gemini",
+                rerank_model="gemini",
+            ),
+            query_plan=schema.QueryPlan(
+                intent="general",
+                freshness_mode="balanced_recent",
+                cluster_mode="none",
+                raw_topic="test topic",
+                subqueries=[schema.SubQuery(
+                    label="primary", search_query="test topic",
+                    ranking_query="What about test topic?", sources=["youtube"],
+                )],
+                source_weights={"youtube": 1.0},
+            ),
+            clusters=[],
+            ranked_candidates=[],
+            items_by_source={"youtube": [self._youtube_item()]},
+            errors_by_source={},
+        )
+
+    def test_render_full_labels_highlights_and_transcript_as_auto_generated(self):
+        text = render.render_full(self._report())
+        self.assertIn(
+            "Highlights (auto-generated transcript; may contain transcription errors):",
+            text,
+        )
+        self.assertIn("auto-generated — may contain transcription errors)</summary>", text)
+        self.assertNotIn("\n  Highlights:\n", text)
+
+    def test_render_candidate_labels_highlights_as_auto_generated(self):
+        item = self._youtube_item()
+        candidate = schema.Candidate(
+            candidate_id="c1",
+            item_id=item.item_id,
+            source="youtube",
+            title=item.title,
+            url=item.url,
+            snippet="A snippet.",
+            subquery_labels=["primary"],
+            native_ranks={"youtube": 1},
+            local_relevance=1.0,
+            freshness=1,
+            engagement=1000,
+            source_quality=1.0,
+            rrf_score=1.0,
+            sources=["youtube"],
+            source_items=[item],
+        )
+        lines = render._render_candidate(candidate, "1.")
+        text = "\n".join(lines)
+        self.assertIn(
+            "Highlights (auto-generated transcript; may contain transcription errors):",
+            text,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

YouTube transcript text (highlights and full snippets) was rendered into reports and synthesis context with no indication that it comes from auto-generated captions. As documented in #82, caption homophone errors (e.g. "basil fears" for "basal fears") were then treated as verbatim quotes by the synthesizing model, which built — and when challenged, confidently defended — analysis around a transcription error. This PR labels transcript-derived text as auto-generated at every emission point in `render.py`, the minimal mitigation the issue itself proposes (approach 3).

## Changes

- `skills/last30days/scripts/lib/render.py`:
  - `render_full`: the per-item `Highlights:` label becomes `Highlights (auto-generated transcript; may contain transcription errors):`, and the collapsible transcript summary becomes `Transcript (N words; auto-generated — may contain transcription errors)`.
  - `_render_candidate` (used by `render_compact`, `render_full`, and comparison renderers — i.e. the evidence the host model synthesizes from): same `Highlights` label change.
- `tests/test_render_v3.py`: new `TranscriptCaveatTests` class with two regression tests (report built with a transcript-bearing YouTube item; asserts the caveat appears in `render_full` output and in `_render_candidate` lines). Both tests fail on `main` and pass with the fix.

### Root cause

`youtube_yt.py` fetches captions via `yt-dlp --write-auto-subs` (auto-generated ASR), but `render.py` emitted the resulting `transcript_highlights` / `transcript_snippet` as plain quoted text indistinguishable from author-written content. Nothing in the rendered evidence told the synthesis step that these strings are machine transcription, so predictable ASR homophone errors were grounded as intentional word choices.

Blast radius (`codegraph impact "_render_candidate"`): `render_compact`, `render_full`, `_render_entity_evidence_block`, `render_comparison_multi` — all output emitters, all intended recipients of the label. `codegraph impact "render_full"`: self only.

A previous attempt at this fix (PR #107, pre-v3) was closed unmerged during the v3.0 rewrite with the maintainer noting the auto-caption warning work "looks promising"; this re-lands the minimal version against the v3 renderer.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` — full suite passes (1655 passed, 4 skipped; no failures).
- [x] New tests fail on unfixed `main` (`AssertionError: 'Highlights (auto-generated transcript; ...' not found`) and pass with the fix.
- [x] `tests/test_render_v3.py`: 37 passed (was 35, +2).

No behavior changes outside the two label strings; no UI, no new dependencies, no unrelated refactoring.

## Related Issues

Fixes #82
