### PR TITLE
ci: attest build provenance for the released .skill asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-release:
@@ -21,6 +23,11 @@ jobs:
         run: |
           bash skills/last30days/scripts/build-skill.sh
           test -f dist/last30days.skill
+
+      - name: Attest .skill artifact provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/last30days.skill
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

Adds a GitHub artifact attestation for `dist/last30days.skill` in the release workflow, so the published release asset carries a verifiable provenance record tying it to the exact workflow run and tagged commit that built it. As noted in #528, the workflow currently uploads the asset with no first-party integrity signal, which matters for a repo distributing an executable agent skill that users install into local AI-agent hosts.

## Changes

- `.github/workflows/release.yml`:
  - Add `id-token: write` and `attestations: write` to the workflow permissions (required by the attestation action; `contents: write` unchanged).
  - Add an `actions/attest-build-provenance@v4` step between the artifact build and the release upload, with `subject-path: dist/last30days.skill`.

Consumers can then verify a downloaded asset with:

```bash
gh attestation verify last30days.skill -R mvanhorn/last30days-skill
```

Notes:
- Referenced the action by major version tag (`@v4`, current latest is v4.1.0), matching the repo's existing convention (`actions/checkout@v4`, `softprops/action-gh-release@v2`). If #472 (supply-chain hardening / SHA pinning) lands, this step should be SHA-pinned the same way — the attestation is independent of which upload mechanism is used.
- No change to the build or upload steps themselves.

## Testing

- [ ] Ran `uv run python -m pytest -q --tb=short` — not applicable: CI-workflow-only change, no Python code touched.
- [x] YAML validated with `yaml.safe_load` on the modified workflow.
- [x] Permissions/step shape follows GitHub's artifact-attestation baseline for build provenance (`id-token: write` + `attestations: write` + `attest-build-provenance` with `subject-path`).
- Full end-to-end verification happens on the next `v*` tag push, which will produce the attestation alongside the release.

## Related Issues

Fixes #528