### PR TITLE
feat(cli): LAST30DAYS_DEFAULT_SEARCH env var as default source set for --search

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -103,6 +103,16 @@ The skill defaults to `api.bsky.app` for `searchPosts`, which is the canonical a
 BSKY_SEARCH_HOST=api.bsky.app   # default — change only if Bluesky moves
 ```
 
+### Default source set (`LAST30DAYS_DEFAULT_SEARCH`)
+
+By default the engine decides the source set per query (everything available, minus `EXCLUDE_SOURCES`). To pin a **fixed** source set for every run without passing `--search` each time — and without patching `SKILL.md`, which a release would overwrite — set:
+
+```bash
+LAST30DAYS_DEFAULT_SEARCH=reddit,x,youtube,hn
+```
+
+Accepts the same comma-separated names and aliases as `--search` (`web` → grounding, `hn` → hackernews, `bsky` → bluesky). Precedence: an explicit `--search` on the command line always wins; `LAST30DAYS_DEFAULT_SEARCH` applies only when the flag is omitted; when neither is set, per-query behavior is unchanged. `INCLUDE_SOURCES` / `EXCLUDE_SOURCES` keep their existing additive/subtractive roles on whichever set is selected.
+
 ---
 
 ## Reasoning provider priority

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -74,7 +74,7 @@ def _cleanup_children() -> None:
 atexit.register(_cleanup_children)
 
 
-def parse_search_flag(raw: str) -> list[str]:
+def parse_search_flag(raw: str, flag_name: str = "--search") -> list[str]:
     sources = []
     for source in raw.split(","):
         source = source.strip().lower()
@@ -82,12 +82,26 @@ def parse_search_flag(raw: str) -> list[str]:
             continue
         normalized = pipeline.SEARCH_ALIAS.get(source, source)
         if normalized not in pipeline.MOCK_AVAILABLE_SOURCES:
-            raise SystemExit(f"Unknown search source: {source}")
+            raise SystemExit(f"Unknown search source in {flag_name}: {source}")
         if normalized not in sources:
             sources.append(normalized)
     if not sources:
-        raise SystemExit("--search requires at least one source.")
+        raise SystemExit(f"{flag_name} requires at least one source.")
     return sources
+
+
+def resolve_requested_sources(args_search: str | None, config: dict) -> list[str] | None:
+    """Resolve the requested source set: explicit --search wins, then the
+    LAST30DAYS_DEFAULT_SEARCH config key (env var or .env file), then None
+    (per-query default behavior). The config fallback lets users pin a fixed
+    source set that survives upgrades without patching SKILL.md (#442).
+    """
+    if args_search:
+        return parse_search_flag(args_search)
+    default_search = (config.get("LAST30DAYS_DEFAULT_SEARCH") or "").strip()
+    if default_search:
+        return parse_search_flag(default_search, flag_name="LAST30DAYS_DEFAULT_SEARCH")
+    return None
 
 
 def slugify(value: str) -> str:
@@ -597,7 +611,7 @@ def main() -> int:
         sys.stderr.write(setup_wizard.get_setup_status_text(results) + "\n")
         return 0
 
-    requested_sources = parse_search_flag(args.search) if args.search else None
+    requested_sources = resolve_requested_sources(args.search, config)
     diag = pipeline.diagnose(config, requested_sources)
 
     if args.diagnose:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -335,6 +335,7 @@ def get_config() -> dict[str, Any]:
         ('SETUP_COMPLETE', None),
         ('INCLUDE_SOURCES', ''),
         ('EXCLUDE_SOURCES', ''),
+        ('LAST30DAYS_DEFAULT_SEARCH', ''),
         ('LAST30DAYS_YOUTUBE_SSH_HOST', None),
         ('LAST30DAYS_TRANSCRIPT_TIMEOUT', None),
     ]

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -95,6 +95,34 @@ class CliV3Tests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             cli.parse_search_flag(" , ")
 
+    def test_resolve_requested_sources_flag_wins_over_config_default(self):
+        sources = cli.resolve_requested_sources(
+            "reddit", {"LAST30DAYS_DEFAULT_SEARCH": "x,youtube"},
+        )
+        self.assertEqual(["reddit"], sources)
+
+    def test_resolve_requested_sources_falls_back_to_config_default(self):
+        sources = cli.resolve_requested_sources(
+            None, {"LAST30DAYS_DEFAULT_SEARCH": "web, reddit, hn"},
+        )
+        self.assertEqual(["grounding", "reddit", "hackernews"], sources)
+
+    def test_resolve_requested_sources_none_when_neither_set(self):
+        self.assertIsNone(cli.resolve_requested_sources(None, {}))
+        self.assertIsNone(
+            cli.resolve_requested_sources(None, {"LAST30DAYS_DEFAULT_SEARCH": ""})
+        )
+        self.assertIsNone(
+            cli.resolve_requested_sources(None, {"LAST30DAYS_DEFAULT_SEARCH": "  "})
+        )
+
+    def test_resolve_requested_sources_invalid_config_default_names_env_var(self):
+        with self.assertRaises(SystemExit) as exc:
+            cli.resolve_requested_sources(
+                None, {"LAST30DAYS_DEFAULT_SEARCH": "notasource"},
+            )
+        self.assertIn("LAST30DAYS_DEFAULT_SEARCH", str(exc.exception))
+
     def test_build_parser_accepts_days_alias_and_preserves_topic_tokens(self):
         parser = cli.build_parser()
         args, extra = parser.parse_known_args(["--days", "7", "biosecurity", "ai", "agents"])

--- a/tests/test_env_default_search.py
+++ b/tests/test_env_default_search.py
@@ -1,0 +1,34 @@
+from lib import env
+
+
+def test_default_search_defaults_to_empty_string(monkeypatch, tmp_path):
+    # Ensure the env var is not set
+    monkeypatch.delenv("LAST30DAYS_DEFAULT_SEARCH", raising=False)
+
+    # Avoid reading any real user config file by patching the resolved module path directly
+    monkeypatch.setattr(env, "CONFIG_FILE", tmp_path / "does-not-exist.env")
+
+    cfg = env.get_config()
+
+    assert "LAST30DAYS_DEFAULT_SEARCH" in cfg
+    assert cfg["LAST30DAYS_DEFAULT_SEARCH"] == ""
+
+
+def test_default_search_read_from_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAST30DAYS_DEFAULT_SEARCH", "reddit,x,youtube")
+    monkeypatch.setattr(env, "CONFIG_FILE", tmp_path / "does-not-exist.env")
+
+    cfg = env.get_config()
+
+    assert cfg["LAST30DAYS_DEFAULT_SEARCH"] == "reddit,x,youtube"
+
+
+def test_default_search_read_from_env_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("LAST30DAYS_DEFAULT_SEARCH", raising=False)
+    env_file = tmp_path / "config.env"
+    env_file.write_text("LAST30DAYS_DEFAULT_SEARCH=reddit,hn\n")
+    monkeypatch.setattr(env, "CONFIG_FILE", env_file)
+
+    cfg = env.get_config()
+
+    assert cfg["LAST30DAYS_DEFAULT_SEARCH"] == "reddit,hn"


### PR DESCRIPTION
## Summary

Implements #442: a configuration knob to pin a fixed default source set when `--search` is omitted, so users no longer have to patch `SKILL.md`'s engine-invocation line (which every upstream release overwrites).

Of the shapes the issue lists, this takes the least invasive one — a config key read through the existing `lib/env.py` machinery — and the issue author explicitly left the design call open, so happy to rename the key or reshape precedence if you'd prefer one of the other options.

## Changes

- `skills/last30days/scripts/lib/env.py`: add `LAST30DAYS_DEFAULT_SEARCH` (default `''`) next to `INCLUDE_SOURCES`/`EXCLUDE_SOURCES`. The existing precedence (os.environ > project `.claude/last30days.env` > global `~/.config/last30days/.env` > keychain > default) applies with no new code.
- `skills/last30days/scripts/last30days.py`: new `resolve_requested_sources()` — explicit `--search` wins; otherwise a non-empty `LAST30DAYS_DEFAULT_SEARCH` is parsed with the same `parse_search_flag()` validation and alias expansion (`web` → grounding, `hn` → hackernews, …); with neither set, per-query behavior is unchanged. `parse_search_flag()` gained a `flag_name` parameter so a bad `.env` value errors with `LAST30DAYS_DEFAULT_SEARCH` named, not `--search`.
- `CONFIGURATION.md`: documented in the API-keys/`.env` section (per the AGENTS.md rule that new env vars are mirrored there in the same PR), including precedence and the interaction with `INCLUDE_SOURCES`/`EXCLUDE_SOURCES`.
- `INCLUDE_SOURCES`/`EXCLUDE_SOURCES` keep their existing additive/subtractive roles on whichever set is selected.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` — full suite green: **1624 passed, 4 skipped, 2 subtests passed**.
- New tests: `tests/test_env_default_search.py` (default empty, read from environment, read from `.env` file) and four `resolve_requested_sources` cases in `tests/test_cli_v3.py` (flag wins over config, config fallback with alias expansion, None when neither set, invalid config value names the env var in the error).
- Mock smoke tests:
  - `LAST30DAYS_DEFAULT_SEARCH=reddit,hn … --mock --emit=json` → output candidates restricted to the configured set.
  - same env var plus `--search=x` → output is `x` only (flag wins).
  - no env var, no flag → per-query default unchanged.

## Related Issues

Fixes #442