### PR TITLE
[codex] Add Apify fallback support and provider tracing

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -518,6 +518,17 @@ def _show_runtime_ui(
         source_counts=counts,
         display_sources=display_sources,
     )
+    provider_parts = []
+    for source in display_sources:
+        trace = report.source_provider_runtime.get(source) or {}
+        actual = trace.get("actual_provider_used")
+        if not actual:
+            continue
+        suffix = " (fallback)" if trace.get("fallback_triggered") else ""
+        provider_parts.append(f"{source}={actual}{suffix}")
+    if provider_parts:
+        sys.stderr.write(f"[Providers] {', '.join(provider_parts)}\n")
+        sys.stderr.flush()
     promo = _missing_sources_for_promo(diag)
     # The `web` promo nudges users to set BRAVE_API_KEY / SERPER_API_KEY, which
     # is wrong advice when a hosting reasoning model (Claude Code, Codex,
@@ -547,6 +558,7 @@ def _write_last_run(topic: str, report: "schema.Report") -> None:
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "sources": counts,
             "total": sum(counts.values()),
+            "source_provider_runtime": report.source_provider_runtime,
         }
         (target / "last-run.json").write_text(json.dumps(payload, indent=2))
     except Exception:

--- a/skills/last30days/scripts/lib/apify_runner.py
+++ b/skills/last30days/scripts/lib/apify_runner.py
@@ -1,0 +1,73 @@
+"""Shared Apify actor runner helpers for social source fallbacks."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from . import http
+
+
+def build_headers(token: str) -> Dict[str, str]:
+    """Build Authorization headers for Apify API calls."""
+    return {"Authorization": f"Bearer {token}"}
+
+
+def dedupe_tokens(tokens: Iterable[str] | None) -> List[str]:
+    """Return unique, non-empty Apify tokens preserving order."""
+    seen: set[str] = set()
+    out: List[str] = []
+    for token in tokens or []:
+        token = (token or "").strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out
+
+
+def run_actor_dataset_items(
+    actor_id: str,
+    payload: Dict[str, Any],
+    tokens: Iterable[str] | None,
+    *,
+    timeout: int = 60,
+) -> list[dict[str, Any]]:
+    """Run an Apify actor and return dataset items.
+
+    If multiple tokens are provided, tries the next token when the current one
+    fails with auth / billing style errors.
+    """
+    token_list = dedupe_tokens(tokens)
+    if not token_list:
+        raise http.HTTPError("No APIFY_API_TOKEN configured")
+
+    last_error: Exception | None = None
+    retryable_statuses = {401, 402, 403, 429}
+
+    for index, token in enumerate(token_list):
+        try:
+            raw_items = http.request(
+                "POST",
+                f"https://api.apify.com/v2/acts/{actor_id}/run-sync-get-dataset-items",
+                headers=build_headers(token),
+                json_data=payload,
+                params={"clean": "true", "format": "json"},
+                timeout=timeout,
+                retries=1,
+                raw=False,
+            )
+            if isinstance(raw_items, dict):
+                raw_items = raw_items.get("items") or raw_items.get("data") or []
+            return raw_items if isinstance(raw_items, list) else []
+        except http.HTTPError as exc:
+            last_error = exc
+            if exc.status_code in retryable_statuses and index < len(token_list) - 1:
+                continue
+            raise
+        except Exception as exc:
+            last_error = exc
+            raise
+
+    if last_error:
+        raise last_error
+    return []

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -40,6 +40,7 @@ KEYCHAIN_SERVICE_PREFIX = "last30days-"
 KEYCHAIN_KEYS = (
     "OPENAI_API_KEY", "XAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
     "GOOGLE_GENAI_API_KEY", "SCRAPECREATORS_API_KEY", "APIFY_API_TOKEN",
+    "APIFY_API_TOKEN_BACKUP",
     "AUTH_TOKEN", "CT0", "BSKY_HANDLE", "BSKY_APP_PASSWORD",
     "TRUTHSOCIAL_TOKEN", "BRAVE_API_KEY", "EXA_API_KEY", "SERPER_API_KEY",
     "OPENROUTER_API_KEY", "PARALLEL_API_KEY", "XQUIK_API_KEY",
@@ -319,6 +320,7 @@ def get_config() -> dict[str, Any]:
         ('XAI_MODEL_PIN', None),
         ('SCRAPECREATORS_API_KEY', None),
         ('APIFY_API_TOKEN', None),
+        ('APIFY_API_TOKEN_BACKUP', None),
         ('AUTH_TOKEN', None),
         ('CT0', None),
         ('BSKY_HANDLE', None),
@@ -594,12 +596,22 @@ def is_tiktok_available(config: dict[str, Any]) -> bool:
 
     Returns True if SCRAPECREATORS_API_KEY or APIFY_API_TOKEN is set.
     """
-    return bool(config.get('SCRAPECREATORS_API_KEY') or config.get('APIFY_API_TOKEN'))
+    return bool(config.get('SCRAPECREATORS_API_KEY') or get_apify_tokens(config))
 
 
 def get_tiktok_token(config: dict[str, Any]) -> str:
     """Get TikTok API token, preferring ScrapeCreators over legacy Apify."""
     return config.get('SCRAPECREATORS_API_KEY') or config.get('APIFY_API_TOKEN') or ''
+
+
+def get_apify_tokens(config: dict[str, Any]) -> list[str]:
+    """Return configured Apify tokens in priority order."""
+    tokens: list[str] = []
+    for key in ('APIFY_API_TOKEN', 'APIFY_API_TOKEN_BACKUP'):
+        value = (config.get(key) or '').strip()
+        if value and value not in tokens:
+            tokens.append(value)
+    return tokens
 
 
 def _parse_include_sources(config: dict[str, Any]) -> set[str]:
@@ -616,16 +628,15 @@ def is_threads_available(config: dict[str, Any]) -> bool:
     cost shape, so the same default-on rule applies. Suppress via
     EXCLUDE_SOURCES=threads.
     """
-    return bool(config.get('SCRAPECREATORS_API_KEY'))
+    return bool(config.get('SCRAPECREATORS_API_KEY') or get_apify_tokens(config))
 
 
 def is_instagram_available(config: dict[str, Any]) -> bool:
     """Check if Instagram source is available (ScrapeCreators).
 
-    Returns True if SCRAPECREATORS_API_KEY is set.
-    Instagram uses the same key as TikTok.
+    Returns True if SCRAPECREATORS_API_KEY or APIFY_API_TOKEN is set.
     """
-    return bool(config.get('SCRAPECREATORS_API_KEY'))
+    return bool(config.get('SCRAPECREATORS_API_KEY') or get_apify_tokens(config))
 
 
 def get_instagram_token(config: dict[str, Any]) -> str:
@@ -722,7 +733,7 @@ def is_pinterest_available(config: dict[str, Any]) -> bool:
     INCLUDE_SOURCES (or requested_sources at the pipeline level).  Pinterest
     is opt-in because not every topic benefits from visual pin results.
     """
-    return bool(config.get('SCRAPECREATORS_API_KEY'))
+    return bool(config.get('SCRAPECREATORS_API_KEY') or get_apify_tokens(config))
 
 
 def get_pinterest_token(config: dict[str, Any]) -> str:

--- a/skills/last30days/scripts/lib/instagram.py
+++ b/skills/last30days/scripts/lib/instagram.py
@@ -13,10 +13,11 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
-from . import dates, http, log
+from . import apify_runner, dates, http, log
 from .relevance import token_overlap_relevance as _compute_relevance
 
 SCRAPECREATORS_BASE = "https://api.scrapecreators.com"
+APIFY_INSTAGRAM_ACTOR = "apify~instagram-hashtag-scraper"
 
 # Depth configurations: how many results to fetch / captions to extract
 DEPTH_CONFIG = {
@@ -161,7 +162,7 @@ def _parse_date(item: Dict[str, Any]) -> Optional[str]:
     Handles taken_at as ISO string (e.g. "2026-02-26T16:00:00.000Z")
     or unix timestamp.
     """
-    ts = item.get("taken_at")
+    ts = item.get("taken_at") or item.get("timestamp")
     if not ts:
         return None
 
@@ -225,7 +226,7 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
         elif isinstance(owner_raw, str):
             author_name = owner_raw
         else:
-            author_name = ""
+            author_name = raw.get("ownerUsername") or ""
 
         # Duration
         duration = raw.get("video_duration")
@@ -262,6 +263,53 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             "caption_snippet": "",  # populated by fetch_captions
         })
     return items
+
+
+def _search_instagram_apify(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str,
+    tokens: List[str] | None,
+) -> Dict[str, Any]:
+    """Search Instagram keyword results via Apify hashtag actor."""
+    if not apify_runner.dedupe_tokens(tokens):
+        return {"items": [], "error": "No APIFY_API_TOKEN configured", "provider": "apify"}
+
+    depth_cfg = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
+    core_topic = _extract_core_subject(topic)
+    payload = {
+        "hashtags": [_to_hashtag_form(core_topic)],
+        "searchType": "reels",
+        "resultsLimit": depth_cfg["results_per_page"],
+        "keywordSearch": True,
+    }
+    _log(
+        f"Searching Instagram via Apify for '{core_topic}' "
+        f"(depth={depth}, count={depth_cfg['results_per_page']})"
+    )
+
+    try:
+        raw_items = apify_runner.run_actor_dataset_items(
+            APIFY_INSTAGRAM_ACTOR,
+            payload,
+            tokens,
+            timeout=60,
+        )
+    except Exception as e:
+        _log(f"Apify error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "apify"}
+
+    items = _parse_items(raw_items[:depth_cfg["results_per_page"]], core_topic)
+    in_range = [i for i in items if i["date"] and from_date <= i["date"] <= to_date]
+    if in_range:
+        items = in_range
+    else:
+        _log(f"No Instagram reels within date range, keeping all {len(items)}")
+
+    items.sort(key=lambda x: x["engagement"]["views"], reverse=True)
+    _log(f"Found {len(items)} Instagram reels via Apify")
+    return {"items": items, "provider": "apify"}
 
 
 def _user_reels(
@@ -302,6 +350,7 @@ def search_instagram(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
 ) -> Dict[str, Any]:
     """Search Instagram Reels via ScrapeCreators API.
 
@@ -315,8 +364,10 @@ def search_instagram(
     Returns:
         Dict with 'items' list and optional 'error'.
     """
+    if not token and apify_tokens:
+        return _search_instagram_apify(topic, from_date, to_date, depth, apify_tokens)
     if not token:
-        return {"items": [], "error": "No SCRAPECREATORS_API_KEY configured"}
+        return {"items": [], "error": "No Instagram provider token configured"}
 
     config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
     core_topic = _extract_core_subject(topic)
@@ -349,11 +400,14 @@ def search_instagram(
                 _log(f"IG search retry failed: {retry_e}")
                 return {"items": [], "error": f"{type(retry_e).__name__}: {retry_e}"}
         else:
+            if getattr(e, "status_code", None) == 402 and apify_tokens:
+                _log("ScrapeCreators returned 402, falling back to Apify")
+                return _search_instagram_apify(topic, from_date, to_date, depth, apify_tokens)
             _log(f"ScrapeCreators error: {e}")
-            return {"items": [], "error": f"{type(e).__name__}: {e}"}
+            return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
     except Exception as e:
         _log(f"ScrapeCreators error: {e}")
-        return {"items": [], "error": f"{type(e).__name__}: {e}"}
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
 
     # Items are in the 'reels' array (ScrapeCreators v2 response)
     raw_items = data.get("reels") or data.get("items") or data.get("data") or []
@@ -378,7 +432,7 @@ def search_instagram(
     items.sort(key=lambda x: x["engagement"]["views"], reverse=True)
 
     _log(f"Found {len(items)} Instagram reels")
-    return {"items": items}
+    return {"items": items, "provider": "scrapecreators"}
 
 
 def fetch_captions(
@@ -469,6 +523,7 @@ def search_and_enrich(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
     ig_creators: List[str] | None = None,
 ) -> Dict[str, Any]:
     """Full Instagram search: find reels, then fetch captions for top results.
@@ -493,7 +548,9 @@ def search_and_enrich(
     last_error = None
 
     # Step 0: Creator reels (high-signal, runs first)
-    if ig_creators and token:
+    sc_enabled = bool(token)
+
+    if ig_creators and sc_enabled:
         for creator in ig_creators:
             raw_items = _user_reels(creator, token)
             parsed = _parse_items(raw_items, core_topic)
@@ -506,9 +563,10 @@ def search_and_enrich(
     # Step 1: Multi-query keyword search — run ScrapeCreators for each expanded query
     queries = expand_instagram_queries(topic, depth)
     for q in queries:
-        search_result = search_instagram(q, from_date, to_date, depth, token)
+        search_result = search_instagram(q, from_date, to_date, depth, token, apify_tokens=apify_tokens)
         if search_result.get("error"):
             last_error = search_result["error"]
+        provider = search_result.get("provider", "scrapecreators" if sc_enabled else "apify")
         for item in search_result.get("items", []):
             vid = item.get("video_id", "")
             if vid and vid not in seen_ids:
@@ -522,7 +580,7 @@ def search_and_enrich(
         return {"items": [], "error": last_error}
 
     # Step 2: Fetch captions for top N
-    captions = fetch_captions(items, token, depth)
+    captions = fetch_captions(items, token, depth) if provider == "scrapecreators" else {}
 
     # Step 3: Attach captions to items
     for item in items:
@@ -531,7 +589,7 @@ def search_and_enrich(
         if caption:
             item["caption_snippet"] = caption
 
-    return {"items": items, "error": last_error}
+    return {"items": items, "error": last_error, "provider": provider}
 
 
 def parse_instagram_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/skills/last30days/scripts/lib/pinterest.py
+++ b/skills/last30days/scripts/lib/pinterest.py
@@ -11,9 +11,10 @@ import re
 import sys
 from typing import Any, Dict, List, Optional, Set
 
-from . import dates, http, log
+from . import apify_runner, dates, http, log
 
 SCRAPECREATORS_BASE = "https://api.scrapecreators.com/v1/pinterest"
+APIFY_PINTEREST_ACTOR = "automation-lab~pinterest-scraper"
 
 # Depth configurations: how many results to fetch
 DEPTH_CONFIG = {
@@ -69,7 +70,7 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
         elif isinstance(pinner, str):
             author_name = pinner
         else:
-            author_name = ""
+            author_name = raw.get("pinnerUsername") or raw.get("pinnerName") or ""
 
         # URL
         url = raw.get("link") or raw.get("url") or ""
@@ -79,6 +80,15 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
         # Board info (container for pins)
         board = raw.get("board") or {}
         board_name = board.get("name", "") if isinstance(board, dict) else ""
+        if not board_name:
+            board_name = raw.get("boardName", "")
+
+        date_str = None
+        created_at = raw.get("createdAt")
+        if created_at:
+            parsed = dates.parse_date(str(created_at))
+            if parsed:
+                date_str = parsed.strftime("%Y-%m-%d")
 
         # Compute relevance
         relevance = _compute_relevance(core_topic, description, [])
@@ -89,6 +99,7 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             "url": url,
             "author": author_name,
             "board": board_name,
+            "date": date_str,
             "engagement": {
                 "saves": save_count,
                 "comments": comment_count,
@@ -97,6 +108,49 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             "why_relevant": f"Pinterest: {description[:60]}" if description else f"Pinterest: {core_topic}",
         })
     return items
+
+
+def _search_pinterest_apify(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str,
+    tokens: List[str] | None,
+) -> Dict[str, Any]:
+    """Search Pinterest pins via Apify actor."""
+    if not apify_runner.dedupe_tokens(tokens):
+        return {"items": [], "error": "No APIFY_API_TOKEN configured", "provider": "apify"}
+
+    config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
+    core_topic = _extract_core_subject(topic)
+    payload = {
+        "searchQueries": [core_topic],
+        "maxPins": config["results_per_page"],
+    }
+    _log(
+        f"Searching Pinterest via Apify for '{core_topic}' "
+        f"(depth={depth}, count={config['results_per_page']})"
+    )
+
+    try:
+        raw_items = apify_runner.run_actor_dataset_items(
+            APIFY_PINTEREST_ACTOR,
+            payload,
+            tokens,
+            timeout=60,
+        )
+    except Exception as e:
+        _log(f"Apify error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "apify"}
+
+    items = _parse_items(raw_items[:config["results_per_page"]], core_topic)
+    in_range = [i for i in items if i.get("date") and from_date <= i["date"] <= to_date]
+    if in_range:
+        items = in_range
+
+    items.sort(key=lambda x: x["engagement"]["saves"], reverse=True)
+    _log(f"Found {len(items)} Pinterest pins via Apify")
+    return {"items": items, "provider": "apify"}
 
 
 def parse_pinterest_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -114,6 +168,7 @@ def search_pinterest(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
 ) -> Dict[str, Any]:
     """Search Pinterest via ScrapeCreators API.
 
@@ -127,8 +182,10 @@ def search_pinterest(
     Returns:
         Dict with 'items' list and optional 'error'.
     """
+    if not token and apify_tokens:
+        return _search_pinterest_apify(topic, from_date, to_date, depth, apify_tokens)
     if not token:
-        return {"items": [], "error": "No SCRAPECREATORS_API_KEY configured"}
+        return {"items": [], "error": "No Pinterest provider token configured"}
 
     config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
     core_topic = _extract_core_subject(topic)
@@ -143,9 +200,15 @@ def search_pinterest(
             timeout=30,
             retries=2,
         )
+    except http.HTTPError as e:
+        if e.status_code == 402 and apify_tokens:
+            _log("ScrapeCreators returned 402, falling back to Apify")
+            return _search_pinterest_apify(topic, from_date, to_date, depth, apify_tokens)
+        _log(f"ScrapeCreators error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
     except Exception as e:
         _log(f"ScrapeCreators error: {e}")
-        return {"items": [], "error": f"{type(e).__name__}: {e}"}
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
 
     # Extract items from response - try common SC response shapes
     raw_items = data.get("pins") or data.get("results") or data.get("data") or data.get("items") or []
@@ -160,4 +223,4 @@ def search_pinterest(
     items.sort(key=lambda x: x["engagement"]["saves"], reverse=True)
 
     _log(f"Found {len(items)} Pinterest pins")
-    return {"items": items}
+    return {"items": items, "provider": "scrapecreators"}

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -99,9 +99,10 @@ def normalize_requested_sources(sources: list[str] | None) -> list[str] | None:
 
 def available_sources(config: dict[str, Any], requested_sources: list[str] | None = None) -> list[str]:
     available: list[str] = []
+    apify_tokens = env.get_apify_tokens(config)
     # reddit_public needs no API key - always available
     available.append("reddit")
-    if config.get("SCRAPECREATORS_API_KEY"):
+    if config.get("SCRAPECREATORS_API_KEY") or apify_tokens:
         available.extend(["tiktok", "instagram"])
     if env.get_x_source(config):
         available.append("x")
@@ -138,6 +139,143 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
     return available
 
 
+def _social_provider_status(config: dict[str, Any]) -> dict[str, Any]:
+    """Describe which provider each social source will use at runtime."""
+    has_sc = bool(config.get("SCRAPECREATORS_API_KEY"))
+    apify_tokens = env.get_apify_tokens(config)
+    has_apify = bool(apify_tokens)
+
+    def _primary(sc_first: bool = True) -> str | None:
+        if sc_first and has_sc:
+            return "scrapecreators"
+        if has_apify:
+            return "apify"
+        if has_sc:
+            return "scrapecreators"
+        return None
+
+    def _fallback(sc_first: bool = True) -> str | None:
+        primary = _primary(sc_first)
+        if primary == "scrapecreators" and has_apify:
+            return "apify"
+        if primary == "apify" and has_sc:
+            return "scrapecreators"
+        return None
+
+    return {
+        "reddit": {
+            "enabled": True,
+            "primary": "keyless_public",
+            "fallback": "rss_shreddit",
+            "apify_token_count": 0,
+        },
+        "tiktok": {
+            "enabled": env.is_tiktok_available(config),
+            "primary": _primary(sc_first=True),
+            "fallback": _fallback(sc_first=True),
+            "apify_token_count": len(apify_tokens),
+        },
+        "instagram": {
+            "enabled": env.is_instagram_available(config),
+            "primary": _primary(sc_first=True),
+            "fallback": _fallback(sc_first=True),
+            "apify_token_count": len(apify_tokens),
+        },
+        "threads": {
+            "enabled": env.is_threads_available(config),
+            "primary": _primary(sc_first=True),
+            "fallback": _fallback(sc_first=True),
+            "apify_token_count": len(apify_tokens),
+        },
+        "pinterest": {
+            "enabled": env.is_pinterest_available(config),
+            "enabled_but_opt_in": True,
+            "primary": _primary(sc_first=True),
+            "fallback": _fallback(sc_first=True),
+            "apify_token_count": len(apify_tokens),
+        },
+    }
+
+
+def _configured_source_provider_runtime(source: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Return configured primary/fallback provider info for one source."""
+    social = _social_provider_status(config)
+    if source in social:
+        status = dict(social[source])
+        return {
+            "configured_primary": status.get("primary"),
+            "configured_fallback": status.get("fallback"),
+            "enabled_but_opt_in": bool(status.get("enabled_but_opt_in")),
+        }
+    if source == "youtube":
+        primary = "yt_dlp" if which("yt-dlp") else "scrapecreators" if env.is_youtube_sc_available(config) else None
+        fallback = "scrapecreators" if primary == "yt_dlp" and env.is_youtube_sc_available(config) else None
+        return {"configured_primary": primary, "configured_fallback": fallback}
+    if source == "x":
+        backend = env.get_x_source(config)
+        return {"configured_primary": backend or None, "configured_fallback": None}
+    if source == "grounding":
+        backend = None
+        if config.get("BRAVE_API_KEY"):
+            backend = "brave"
+        elif config.get("EXA_API_KEY"):
+            backend = "exa"
+        elif config.get("SERPER_API_KEY"):
+            backend = "serper"
+        elif config.get("PARALLEL_API_KEY"):
+            backend = "parallel"
+        return {"configured_primary": backend, "configured_fallback": None}
+    return {"configured_primary": source, "configured_fallback": None}
+
+
+def _build_source_provider_trace(
+    source: str,
+    config: dict[str, Any],
+    actual_provider_used: str | None,
+    *,
+    fallback_triggered: bool | None = None,
+) -> dict[str, Any]:
+    """Construct runtime trace for the provider actually used by a source."""
+    configured = _configured_source_provider_runtime(source, config)
+    configured_primary = configured.get("configured_primary")
+    configured_fallback = configured.get("configured_fallback")
+    if fallback_triggered is None:
+        fallback_triggered = bool(
+            actual_provider_used
+            and configured_fallback
+            and actual_provider_used == configured_fallback
+            and actual_provider_used != configured_primary
+        )
+    trace = {
+        "configured_primary": configured_primary,
+        "configured_fallback": configured_fallback,
+        "actual_provider_used": actual_provider_used,
+        "fallback_triggered": bool(fallback_triggered),
+    }
+    if configured.get("enabled_but_opt_in"):
+        trace["enabled_but_opt_in"] = True
+    return trace
+
+
+def _merge_stream_artifact(bundle: schema.RetrievalBundle, artifact: dict[str, Any]) -> None:
+    """Merge source/runtime artifacts from one retrieval stream into the bundle."""
+    if not artifact:
+        return
+    if artifact.get("grounding"):
+        bundle.artifacts.setdefault("grounding", []).append(artifact["grounding"])
+    trace = artifact.get("source_provider_runtime")
+    if isinstance(trace, dict):
+        source = trace.get("source")
+        if source:
+            payload = dict(trace)
+            payload.pop("source", None)
+            existing = bundle.source_provider_runtime.get(source) or {}
+            merged = {**existing, **payload}
+            if existing.get("fallback_triggered") or payload.get("fallback_triggered"):
+                merged["fallback_triggered"] = True
+            bundle.source_provider_runtime[source] = merged
+
+
 def diagnose(config: dict[str, Any], requested_sources: list[str] | None = None) -> dict[str, Any]:
     requested_sources = normalize_requested_sources(requested_sources)
     google_key = _google_key(config)
@@ -157,6 +295,7 @@ def diagnose(config: dict[str, Any], requested_sources: list[str] | None = None)
         "xai": bool(config.get("XAI_API_KEY")),
         "openrouter": bool(config.get("OPENROUTER_API_KEY")),
     }
+    apify_tokens = env.get_apify_tokens(config)
     return {
         "providers": providers_status,
         "local_mode": not any(providers_status.values()),
@@ -167,7 +306,10 @@ def diagnose(config: dict[str, Any], requested_sources: list[str] | None = None)
         "bird_username": x_status["bird_username"],
         "native_web_backend": native_web_backend,
         "has_scrapecreators": bool(config.get("SCRAPECREATORS_API_KEY")),
+        "has_apify": bool(apify_tokens),
+        "apify_token_count": len(apify_tokens),
         "has_github": bool(config.get("GITHUB_TOKEN") or which("gh")),
+        "social_provider_status": _social_provider_status(config),
         "available_sources": available_sources(config, requested_sources),
     }
 
@@ -410,8 +552,7 @@ def run(
             )
             normalized = normalized[: settings["per_stream_limit"]]
             bundle.add_items(subquery.label, source, normalized)
-            if artifact:
-                bundle.artifacts.setdefault("grounding", []).append(artifact)
+            _merge_stream_artifact(bundle, artifact)
 
     # Phase 2: supplemental entity-based searches
     _run_supplemental_searches(
@@ -494,6 +635,7 @@ def run(
         ranked_candidates=ranked_candidates,
         items_by_source=items_by_source,
         errors_by_source=bundle.errors_by_source,
+        source_provider_runtime=bundle.source_provider_runtime,
         warnings=warnings,
         artifacts=bundle.artifacts,
     )
@@ -796,8 +938,8 @@ def _retry_thin_sources(
         weight=0.3,
     )
 
-    def _retry_one_source(source: str) -> tuple[str, list[schema.SourceItem]]:
-        raw_items, _artifact = _retrieve_stream(
+    def _retry_one_source(source: str) -> tuple[str, list[schema.SourceItem], dict]:
+        raw_items, artifact = _retrieve_stream(
             topic=topic,
             subquery=retry_subquery,
             source=source,
@@ -819,7 +961,7 @@ def _retry_thin_sources(
             freshness_mode=plan.freshness_mode,
             ranking_query=retry_subquery.ranking_query,
         )
-        return source, normalized[:settings["per_stream_limit"]]
+        return source, normalized[:settings["per_stream_limit"]], artifact
 
     retryable = [s for s in thin_sources if s not in rate_limited_sources]
 
@@ -829,7 +971,7 @@ def _retry_thin_sources(
         for future in as_completed(futures):
             source = futures[future]
             try:
-                source, normalized = future.result()
+                source, normalized, artifact = future.result()
                 existing_urls = {item.url for item in bundle.items_by_source.get(source, []) if item.url}
                 new_items = [item for item in normalized if item.url not in existing_urls]
 
@@ -837,6 +979,7 @@ def _retry_thin_sources(
                     bundle.items_by_source.setdefault(source, []).extend(new_items)
                     primary_label = plan.subqueries[0].label if plan.subqueries else "primary"
                     bundle.items_by_source_and_query.setdefault((primary_label, source), []).extend(new_items)
+                _merge_stream_artifact(bundle, artifact)
             except Exception as exc:
                 print(f"[Pipeline] Retry failed for {source}: {type(exc).__name__}: {exc}", file=sys.stderr)
 
@@ -867,8 +1010,16 @@ def _retrieve_stream(
     if mock:
         return _mock_stream_results(source, subquery)
     if source == "grounding":
-        return grounding.web_search(
+        items, grounding_artifact = grounding.web_search(
             subquery.search_query, date_range, config, backend=web_backend)
+        actual_provider = grounding_artifact.get("label") if grounding_artifact else None
+        return items, {
+            "grounding": grounding_artifact,
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, actual_provider),
+            },
+        }
     if source == "reddit":
         # Use raw_topic so expand_reddit_queries() generates diverse variants
         # from the original user topic, not the planner's narrowed search_query.
@@ -880,7 +1031,14 @@ def _retrieve_stream(
                 subreddits=subreddits,
             )
             if public_results:
-                return public_results, {}
+                return public_results, {
+                    "source_provider_runtime": {
+                        "source": source,
+                        **_build_source_provider_trace(
+                            source, config, "keyless_public", fallback_triggered=False,
+                        ),
+                    },
+                }
         except Exception as exc:
             sys.stderr.write(
                 f"[Reddit] Public search failed ({type(exc).__name__}: {exc})"
@@ -900,7 +1058,14 @@ def _retrieve_stream(
                     token=config.get("SCRAPECREATORS_API_KEY"),
                     subreddits=subreddits,
                 )
-                return reddit.parse_reddit_response(result), {}
+                return reddit.parse_reddit_response(result), {
+                    "source_provider_runtime": {
+                        "source": source,
+                        **_build_source_provider_trace(
+                            source, config, "scrapecreators", fallback_triggered=True,
+                        ),
+                    },
+                }
             except Exception as exc:
                 sys.stderr.write(
                     f"[Reddit] ScrapeCreators backup also failed "
@@ -911,7 +1076,12 @@ def _retrieve_stream(
         backend = runtime.x_search_backend or env.get_x_source(config)
         if backend == "bird":
             result = bird_x.search_x(subquery.search_query, from_date, to_date, depth=depth)
-            return bird_x.parse_bird_response(result, query=subquery.search_query), {}
+            return bird_x.parse_bird_response(result, query=subquery.search_query), {
+                "source_provider_runtime": {
+                    "source": source,
+                    **_build_source_provider_trace(source, config, "bird"),
+                },
+            }
         if backend == "xai":
             model = config.get("LAST30DAYS_X_MODEL") or config.get("XAI_MODEL_PIN") or providers.XAI_DEFAULT
             result = xai_x.search_x(
@@ -922,10 +1092,20 @@ def _retrieve_stream(
                 to_date,
                 depth=depth,
             )
-            return xai_x.parse_x_response(result), {}
+            return xai_x.parse_x_response(result), {
+                "source_provider_runtime": {
+                    "source": source,
+                    **_build_source_provider_trace(source, config, "xai"),
+                },
+            }
         if backend == "xurl":
             result = xurl_x.search_x(subquery.search_query, depth=depth)
-            return xurl_x.parse_x_response(result, topic=subquery.search_query), {}
+            return xurl_x.parse_x_response(result, topic=subquery.search_query), {
+                "source_provider_runtime": {
+                    "source": source,
+                    **_build_source_provider_trace(source, config, "xurl"),
+                },
+            }
         raise RuntimeError("No X backend is available.")
     if source == "youtube":
         # Use raw_topic so expand_youtube_queries() generates diverse variants
@@ -948,7 +1128,18 @@ def _retrieve_stream(
         if items and env.is_youtube_comments_available(config):
             sc_token = config.get("SCRAPECREATORS_API_KEY", "")
             youtube_yt.enrich_with_comments(items, token=sc_token)
-        return items, {}
+        actual_provider = "yt_dlp" if which("yt-dlp") and items else "scrapecreators" if items else None
+        return items, {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(
+                    source,
+                    config,
+                    actual_provider,
+                    fallback_triggered=bool(actual_provider == "scrapecreators" and which("yt-dlp")),
+                ),
+            },
+        }
     if source == "tiktok":
         # Use raw_topic so expand_tiktok_queries() generates diverse variants
         # from the original user topic, not the planner's narrowed search_query.
@@ -959,6 +1150,7 @@ def _retrieve_stream(
             to_date,
             depth=depth,
             token=env.get_tiktok_token(config),
+            apify_tokens=env.get_apify_tokens(config),
             hashtags=tiktok_hashtags,
             creators=tiktok_creators,
         )
@@ -966,7 +1158,12 @@ def _retrieve_stream(
         if items and env.is_tiktok_comments_available(config):
             sc_token = config.get("SCRAPECREATORS_API_KEY", "")
             tiktok.enrich_with_comments(items, token=sc_token)
-        return items, {}
+        return items, {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, result.get("provider")),
+            },
+        }
     if source == "instagram":
         # Use raw_topic so expand_instagram_queries() generates diverse variants
         # from the original user topic, not the planner's narrowed search_query.
@@ -977,35 +1174,73 @@ def _retrieve_stream(
             to_date,
             depth=depth,
             token=env.get_instagram_token(config),
+            apify_tokens=env.get_apify_tokens(config),
             ig_creators=ig_creators,
         )
-        return instagram.parse_instagram_response(result), {}
+        return instagram.parse_instagram_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, result.get("provider")),
+            },
+        }
     if source == "hackernews":
         result = hackernews.search_hackernews(subquery.search_query, from_date, to_date, depth=depth)
-        return hackernews.parse_hackernews_response(result, query=subquery.search_query), {}
+        return hackernews.parse_hackernews_response(result, query=subquery.search_query), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "hn_algolia"),
+            },
+        }
     if source == "digg":
         result = digg.search_digg(subquery.search_query, from_date, to_date, depth=depth)
         items = digg.parse_digg_response(result, query=subquery.search_query)
         # Enrichment with attached X posts is deferred to
         # _finalize_items_by_source so it runs on the items that actually
         # survive dedupe rather than on top-K of the raw fanout.
-        return items, {}
+        return items, {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "digg_pp_cli"),
+            },
+        }
     if source == "bluesky":
         result = bluesky.search_bluesky(subquery.search_query, from_date, to_date, depth=depth, config=config)
-        return bluesky.parse_bluesky_response(result), {}
+        return bluesky.parse_bluesky_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "bluesky_api"),
+            },
+        }
     if source == "threads":
+        threads_query = raw_topic or subquery.search_query
         result = threads.search_threads(
-            subquery.search_query, from_date, to_date,
+            threads_query, from_date, to_date,
             depth=depth,
             token=config.get("SCRAPECREATORS_API_KEY"),
+            apify_tokens=env.get_apify_tokens(config),
         )
-        return threads.parse_threads_response(result), {}
+        return threads.parse_threads_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, result.get("provider")),
+            },
+        }
     if source == "truthsocial":
         result = truthsocial.search_truthsocial(subquery.search_query, from_date, to_date, depth=depth, config=config)
-        return truthsocial.parse_truthsocial_response(result), {}
+        return truthsocial.parse_truthsocial_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "truthsocial_browser_token"),
+            },
+        }
     if source == "polymarket":
         result = polymarket.search_polymarket(subquery.search_query, from_date, to_date, depth=depth)
-        return polymarket.parse_polymarket_response(result, topic=subquery.search_query), {}
+        return polymarket.parse_polymarket_response(result, topic=subquery.search_query), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "polymarket_gamma"),
+            },
+        }
     if source == "github":
         # Resolve once at the pipeline boundary so search and enrich
         # share the result; otherwise each call would re-run the env
@@ -1014,31 +1249,63 @@ def _retrieve_stream(
         response = github.search_github(subquery.search_query, from_date, to_date, depth=depth, token=token)
         items = github.parse_github_response(response)
         items = github.enrich_with_comments(items, depth=depth, token=token)
-        return items, {}
+        return items, {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "github_api"),
+            },
+        }
     if source == "pinterest":
+        pinterest_query = raw_topic or subquery.search_query
         result = pinterest.search_pinterest(
-            subquery.search_query, from_date, to_date,
+            pinterest_query, from_date, to_date,
             depth=depth,
             token=env.get_pinterest_token(config),
+            apify_tokens=env.get_apify_tokens(config),
         )
-        return pinterest.parse_pinterest_response(result), {}
+        return pinterest.parse_pinterest_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, result.get("provider")),
+            },
+        }
     if source == "xiaohongshu":
-        return xiaohongshu_api.search_feeds(
+        items = xiaohongshu_api.search_feeds(
             subquery.search_query,
             from_date,
             to_date,
             env.get_xiaohongshu_api_base(config),
             depth=depth,
-        ), {}
+        )
+        return items, {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "xiaohongshu_http_api"),
+            },
+        }
     if source == "perplexity":
-        return perplexity.search(subquery.search_query, date_range, config, deep=config.get("_deep_research", False))
+        items, artifact = perplexity.search(
+            subquery.search_query, date_range, config, deep=config.get("_deep_research", False),
+        )
+        return items, {
+            **artifact,
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "perplexity_sonar"),
+            },
+        }
     if source == "xquik":
         result = xquik.search_xquik(
             subquery.search_query, from_date, to_date,
             depth=depth,
             token=env.get_xquik_token(config),
         )
-        return xquik.parse_xquik_response(result), {}
+        return xquik.parse_xquik_response(result), {
+            "source_provider_runtime": {
+                "source": source,
+                **_build_source_provider_trace(source, config, "xquik"),
+            },
+        }
     raise RuntimeError(f"Unsupported source: {source}")
 
 

--- a/skills/last30days/scripts/lib/quality_nudge.py
+++ b/skills/last30days/scripts/lib/quality_nudge.py
@@ -311,8 +311,8 @@ def _build_nudge_text(
             bonus_hints.append("Pinterest")
         if bonus_hints:
             free_suggestions.append(
-                f"Your SC key also powers {', '.join(bonus_hints)} and YouTube comments. "
-                "Add them to INCLUDE_SOURCES in your .env to enable."
+                f"Your ScrapeCreators primary path also covers {', '.join(bonus_hints)} and YouTube comments. "
+                "Add them to INCLUDE_SOURCES in your .env to enable; Apify can remain configured as fallback."
             )
 
     if free_suggestions:
@@ -324,8 +324,9 @@ def _build_nudge_text(
     # Bonus sources mention (non-blocking)
     if not has_sc:
         lines.append(
-            "Bonus: TikTok and Instagram are available with a free "
-            "ScrapeCreators key at scrapecreators.com (no affiliation)."
+            "Bonus: TikTok, Instagram, Threads, and Pinterest can use "
+            "ScrapeCreators as the primary path, with Apify available as "
+            "the fallback path when configured."
         )
     else:
         lines.append("last30days has no affiliation with any API provider.")

--- a/skills/last30days/scripts/lib/schema.py
+++ b/skills/last30days/scripts/lib/schema.py
@@ -153,6 +153,7 @@ class Report:
     ranked_candidates: list[Candidate]
     items_by_source: dict[str, list[SourceItem]]
     errors_by_source: dict[str, str]
+    source_provider_runtime: dict[str, dict[str, Any]] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
     artifacts: dict[str, Any] = field(default_factory=dict)
 
@@ -164,6 +165,7 @@ class RetrievalBundle:
     items_by_source_and_query: dict[tuple[str, str], list[SourceItem]] = field(default_factory=dict)
     items_by_source: dict[str, list[SourceItem]] = field(default_factory=dict)
     errors_by_source: dict[str, str] = field(default_factory=dict)
+    source_provider_runtime: dict[str, dict[str, Any]] = field(default_factory=dict)
     artifacts: dict[str, Any] = field(default_factory=dict)
 
     def add_items(self, label: str, source: str, items: list[SourceItem]) -> None:
@@ -287,6 +289,7 @@ def report_from_dict(payload: dict[str, Any]) -> Report:
             for source, items in (payload.get("items_by_source") or {}).items()
         },
         errors_by_source=dict(payload.get("errors_by_source") or {}),
+        source_provider_runtime=dict(payload.get("source_provider_runtime") or {}),
         warnings=list(payload.get("warnings") or []),
         artifacts=dict(payload.get("artifacts") or {}),
     )

--- a/skills/last30days/scripts/lib/threads.py
+++ b/skills/last30days/scripts/lib/threads.py
@@ -11,10 +11,11 @@ import math
 import re
 from typing import Any, Dict, List, Optional
 
-from . import dates, http, log
+from . import apify_runner, dates, http, log
 from .relevance import token_overlap_relevance as _compute_relevance
 
 SCRAPECREATORS_BASE = "https://api.scrapecreators.com/v1/threads"
+APIFY_THREADS_ACTOR = "automation-lab~threads-scraper"
 
 # Depth configurations: how many results to fetch
 DEPTH_CONFIG = {
@@ -36,6 +37,9 @@ def _extract_core_subject(topic: str) -> str:
         'latest', 'new', 'news', 'update', 'updates',
         'trending', 'hottest', 'popular', 'viral',
         'practices', 'features', 'recommendations', 'advice',
+        'relations', 'relationship', 'status', 'developments',
+        'development', 'overview', 'stance', 'policy', 'tensions',
+        'tension', 'conflict',
     })
     return extract_core_subject(topic, noise=_THREADS_NOISE)
 
@@ -47,7 +51,7 @@ def _parse_date(item: Dict[str, Any]) -> Optional[str]:
     (unix timestamps in Meta APIs), then created_at, published_at, and
     date (ISO 8601 strings). dates.parse_date() handles both.
     """
-    for key in ("taken_at", "create_time", "created_at", "published_at", "date"):
+    for key in ("taken_at", "create_time", "created_at", "published_at", "date", "timestamp"):
         val = item.get(key)
         if val is None:
             continue
@@ -80,14 +84,14 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             handle = user
             display_name = user
         else:
-            handle = ""
-            display_name = ""
+            handle = raw.get("username") or ""
+            display_name = raw.get("fullName") or handle
 
         # Engagement metrics
-        likes = raw.get("like_count") or raw.get("likes") or 0
-        replies = raw.get("reply_count") or raw.get("replies") or 0
-        reposts = raw.get("repost_count") or raw.get("reposts") or 0
-        quotes = raw.get("quote_count") or raw.get("quotes") or 0
+        likes = raw.get("like_count") or raw.get("likes") or raw.get("likeCount") or 0
+        replies = raw.get("reply_count") or raw.get("replies") or raw.get("replyCount") or 0
+        reposts = raw.get("repost_count") or raw.get("reposts") or raw.get("repostCount") or 0
+        quotes = raw.get("quote_count") or raw.get("quotes") or raw.get("quoteCount") or 0
 
         date_str = _parse_date(raw)
 
@@ -124,12 +128,59 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
     return items
 
 
+def _search_threads_apify(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str,
+    tokens: List[str] | None,
+) -> Dict[str, Any]:
+    """Search Threads posts via Apify actor."""
+    if not apify_runner.dedupe_tokens(tokens):
+        return {"items": [], "error": "No APIFY_API_TOKEN configured", "provider": "apify"}
+
+    config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
+    core_topic = _extract_core_subject(topic)
+    payload = {
+        "mode": "search",
+        "searchQueries": [core_topic],
+        "maxPosts": config["results"],
+        "includeProfile": False,
+        "postedAfter": f"{from_date}T00:00:00Z",
+        "postedBefore": f"{to_date}T23:59:59Z",
+    }
+    _log(f"Searching Threads via Apify for '{core_topic}' (depth={depth}, limit={config['results']})")
+
+    try:
+        raw_items = apify_runner.run_actor_dataset_items(
+            APIFY_THREADS_ACTOR,
+            payload,
+            tokens,
+            timeout=60,
+        )
+    except Exception as e:
+        _log(f"Apify error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "apify"}
+
+    items = _parse_items(raw_items[:config["results"]], core_topic)
+    in_range = [i for i in items if i["date"] and from_date <= i["date"] <= to_date]
+    if in_range:
+        items = in_range
+    else:
+        _log(f"No Threads posts within date range, keeping all {len(items)}")
+
+    items.sort(key=lambda x: x["engagement"]["likes"], reverse=True)
+    _log(f"Found {len(items)} Threads posts via Apify")
+    return {"items": items, "provider": "apify"}
+
+
 def search_threads(
     topic: str,
     from_date: str,
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
 ) -> Dict[str, Any]:
     """Search Threads via ScrapeCreators API.
 
@@ -143,8 +194,10 @@ def search_threads(
     Returns:
         Dict with 'items' list and optional 'error'.
     """
+    if not token and apify_tokens:
+        return _search_threads_apify(topic, from_date, to_date, depth, apify_tokens)
     if not token:
-        return {"items": [], "error": "No SCRAPECREATORS_API_KEY configured"}
+        return {"items": [], "error": "No Threads provider token configured"}
 
     config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
     core_topic = _extract_core_subject(topic)
@@ -159,9 +212,15 @@ def search_threads(
             timeout=30,
             retries=2,
         )
+    except http.HTTPError as e:
+        if e.status_code == 402 and apify_tokens:
+            _log("ScrapeCreators returned 402, falling back to Apify")
+            return _search_threads_apify(topic, from_date, to_date, depth, apify_tokens)
+        _log(f"ScrapeCreators error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
     except Exception as e:
         _log(f"ScrapeCreators error: {e}")
-        return {"items": [], "error": f"{type(e).__name__}: {e}"}
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
 
     # Extract items from response (try common SC response shapes)
     raw_items = (
@@ -193,7 +252,7 @@ def search_threads(
     items.sort(key=lambda x: x["engagement"]["likes"], reverse=True)
 
     _log(f"Found {len(items)} Threads posts")
-    return {"items": items}
+    return {"items": items, "provider": "scrapecreators"}
 
 
 def parse_threads_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/skills/last30days/scripts/lib/tiktok.py
+++ b/skills/last30days/scripts/lib/tiktok.py
@@ -9,11 +9,14 @@ API docs: https://scrapecreators.com/docs
 
 import re
 import sys
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
 from . import dates, http, log
+from . import apify_runner
 
 SCRAPECREATORS_BASE = "https://api.scrapecreators.com/v1/tiktok"
+APIFY_TIKTOK_ACTOR = "clockworks~tiktok-scraper"
 
 # Depth configurations: how many results to fetch / captions to extract
 DEPTH_CONFIG = {
@@ -104,9 +107,38 @@ def _log(msg: str):
     log.source_log("TikTok", msg)
 
 
+def _looks_like_apify_token(token: str | None) -> bool:
+    """Heuristic to distinguish Apify tokens from ScrapeCreators keys."""
+    return bool(token and token.startswith("apify_api_"))
+
+
+def _apify_date_filter(from_date: str, to_date: str) -> str:
+    """Map exact date range to Apify's coarse TikTok search filters."""
+    try:
+        start = datetime.strptime(from_date, "%Y-%m-%d").date()
+        end = datetime.strptime(to_date, "%Y-%m-%d").date()
+        span_days = max(1, (end - start).days + 1)
+    except ValueError:
+        return "PAST_MONTH"
+
+    if span_days <= 1:
+        return "PAST_24_HOURS"
+    if span_days <= 7:
+        return "PAST_WEEK"
+    if span_days <= 31:
+        return "PAST_MONTH"
+    if span_days <= 92:
+        return "PAST_3_MONTHS"
+    if span_days <= 183:
+        return "PAST_6_MONTHS"
+    return "ALL_TIME"
+
+
 def _parse_date(item: Dict[str, Any]) -> Optional[str]:
-    """Parse date from ScrapeCreators TikTok item to YYYY-MM-DD."""
+    """Parse date from TikTok item to YYYY-MM-DD."""
     ts = item.get("create_time")
+    if ts is None:
+        ts = item.get("createTime")
     if ts:
         try:
             return dates.timestamp_to_date(int(ts))
@@ -136,17 +168,33 @@ def _clean_webvtt(text: str) -> str:
 
 
 def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[str, Any]]:
-    """Parse raw TikTok items into normalized dicts."""
+    """Parse ScrapeCreators or Apify TikTok items into normalized dicts."""
     items = []
     for raw in raw_items:
-        video_id = str(raw.get("aweme_id", ""))
-        text = raw.get("desc", "")
+        video_id = str(raw.get("aweme_id") or raw.get("id") or "")
+        text = raw.get("desc") or raw.get("text") or ""
 
         stats = raw.get("statistics") if isinstance(raw.get("statistics"), dict) else {}
-        play_count = stats.get("play_count") if stats.get("play_count") is not None else 0
-        digg_count = stats.get("digg_count") if stats.get("digg_count") is not None else 0
-        comment_count = stats.get("comment_count") if stats.get("comment_count") is not None else 0
-        share_count = stats.get("share_count") if stats.get("share_count") is not None else 0
+        play_count = (
+            stats.get("play_count")
+            if stats.get("play_count") is not None
+            else (raw.get("playCount") or 0)
+        )
+        digg_count = (
+            stats.get("digg_count")
+            if stats.get("digg_count") is not None
+            else (raw.get("diggCount") or 0)
+        )
+        comment_count = (
+            stats.get("comment_count")
+            if stats.get("comment_count") is not None
+            else (raw.get("commentCount") or 0)
+        )
+        share_count = (
+            stats.get("share_count")
+            if stats.get("share_count") is not None
+            else (raw.get("shareCount") or 0)
+        )
 
         author_raw = raw.get("author")
         if isinstance(author_raw, dict):
@@ -154,14 +202,31 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
         elif isinstance(author_raw, str):
             author_name = author_raw
         else:
-            author_name = ""
+            author_meta = raw.get("authorMeta") if isinstance(raw.get("authorMeta"), dict) else {}
+            author_name = (
+                author_meta.get("name")
+                or raw.get("authorName")
+                or ""
+            )
 
-        share_url = raw.get("share_url", "")
+        share_url = raw.get("share_url") or raw.get("shareUrl") or raw.get("webVideoUrl") or ""
         text_extra = raw.get("text_extra") or []
-        hashtag_names = [t.get("hashtag_name", "") for t in text_extra
-                         if isinstance(t, dict) and t.get("hashtag_name")]
+        hashtag_names = [
+            t.get("hashtag_name", "")
+            for t in text_extra
+            if isinstance(t, dict) and t.get("hashtag_name")
+        ]
+        if not hashtag_names:
+            hashtags = raw.get("hashtags") or []
+            hashtag_names = [
+                t.get("name", "")
+                for t in hashtags
+                if isinstance(t, dict) and t.get("name")
+            ]
 
         video_raw = raw.get("video")
+        if not isinstance(video_raw, dict):
+            video_raw = raw.get("videoMeta")
         duration = video_raw.get("duration") if isinstance(video_raw, dict) else None
 
         date_str = _parse_date(raw)
@@ -193,6 +258,55 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             "caption_snippet": "",  # populated by fetch_captions
         })
     return items
+
+
+def _search_tiktok_apify(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str,
+    tokens: List[str] | None,
+) -> Dict[str, Any]:
+    """Search TikTok videos via Apify actor."""
+    if not apify_runner.dedupe_tokens(tokens):
+        return {"items": [], "error": "No APIFY_API_TOKEN configured", "provider": "apify"}
+
+    config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
+    core_topic = _extract_core_subject(topic)
+    _log(
+        f"Searching TikTok via Apify for '{core_topic}' "
+        f"(depth={depth}, count={config['results_per_page']})"
+    )
+
+    payload = {
+        "searchQueries": [core_topic],
+        "searchSection": "/video",
+        "resultsPerPage": config["results_per_page"],
+        "videoSearchSorting": "MOST_RELEVANT",
+        "videoSearchDateFilter": _apify_date_filter(from_date, to_date),
+    }
+
+    try:
+        raw_items = apify_runner.run_actor_dataset_items(
+            APIFY_TIKTOK_ACTOR,
+            payload,
+            tokens,
+            timeout=60,
+        )
+    except Exception as e:
+        _log(f"Apify error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "apify"}
+
+    items = _parse_items(raw_items[:config["results_per_page"]], core_topic)
+    in_range = [i for i in items if i["date"] and from_date <= i["date"] <= to_date]
+    if in_range:
+        items = in_range
+    else:
+        _log(f"No Apify videos within date range, keeping all {len(items)}")
+
+    items.sort(key=lambda x: x["engagement"]["views"], reverse=True)
+    _log(f"Found {len(items)} TikTok videos via Apify")
+    return {"items": items, "provider": "apify"}
 
 
 def _hashtag_search(
@@ -266,8 +380,9 @@ def search_tiktok(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
 ) -> Dict[str, Any]:
-    """Search TikTok via ScrapeCreators API.
+    """Search TikTok via ScrapeCreators, falling back to Apify when needed.
 
     Args:
         topic: Search topic
@@ -279,8 +394,13 @@ def search_tiktok(
     Returns:
         Dict with 'items' list and optional 'error'.
     """
+    if _looks_like_apify_token(token):
+        return _search_tiktok_apify(topic, from_date, to_date, depth, [token, *(apify_tokens or [])])
+
+    if not token and apify_tokens:
+        return _search_tiktok_apify(topic, from_date, to_date, depth, apify_tokens)
     if not token:
-        return {"items": [], "error": "No SCRAPECREATORS_API_KEY configured"}
+        return {"items": [], "error": "No TikTok provider token configured"}
 
     config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
     core_topic = _extract_core_subject(topic)
@@ -295,9 +415,15 @@ def search_tiktok(
             timeout=30,
             retries=2,
         )
+    except http.HTTPError as e:
+        if e.status_code == 402 and apify_tokens:
+            _log("ScrapeCreators returned 402, falling back to Apify")
+            return _search_tiktok_apify(topic, from_date, to_date, depth, apify_tokens)
+        _log(f"ScrapeCreators error: {e}")
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
     except Exception as e:
         _log(f"ScrapeCreators error: {e}")
-        return {"items": [], "error": f"{type(e).__name__}: {e}"}
+        return {"items": [], "error": f"{type(e).__name__}: {e}", "provider": "scrapecreators"}
 
     # Items are nested under aweme_info
     raw_entries = data.get("search_item_list") or data.get("data") or []
@@ -327,7 +453,7 @@ def search_tiktok(
     items.sort(key=lambda x: x["engagement"]["views"], reverse=True)
 
     _log(f"Found {len(items)} TikTok videos")
-    return {"items": items}
+    return {"items": items, "provider": "scrapecreators"}
 
 
 def fetch_captions(
@@ -408,6 +534,7 @@ def search_and_enrich(
     to_date: str,
     depth: str = "default",
     token: str = None,
+    apify_tokens: List[str] | None = None,
     hashtags: List[str] | None = None,
     creators: List[str] | None = None,
 ) -> Dict[str, Any]:
@@ -433,8 +560,10 @@ def search_and_enrich(
     items: List[Dict[str, Any]] = []
     last_error = None
 
-    # Step 0a: Hashtag search (high-signal, runs first)
-    if hashtags and token:
+    sc_enabled = bool(token and not _looks_like_apify_token(token))
+
+    # Step 0a: Hashtag search (high-signal, ScrapeCreators only)
+    if hashtags and sc_enabled:
         for hashtag in hashtags:
             raw_items = _hashtag_search(hashtag, token)
             parsed = _parse_items(raw_items, core_topic)
@@ -444,8 +573,8 @@ def search_and_enrich(
                     seen_ids.add(vid)
                     items.append(item)
 
-    # Step 0b: Creator profile videos (high-signal)
-    if creators and token:
+    # Step 0b: Creator profile videos (high-signal, ScrapeCreators only)
+    if creators and sc_enabled:
         for creator in creators:
             raw_items = _profile_videos(creator, token)
             parsed = _parse_items(raw_items, core_topic)
@@ -457,10 +586,12 @@ def search_and_enrich(
 
     # Step 1: Multi-query keyword search — run ScrapeCreators for each expanded query
     queries = expand_tiktok_queries(topic, depth)
+    used_provider = "scrapecreators" if sc_enabled else "apify"
     for q in queries:
-        search_result = search_tiktok(q, from_date, to_date, depth, token)
+        search_result = search_tiktok(q, from_date, to_date, depth, token, apify_tokens=apify_tokens)
         if search_result.get("error"):
             last_error = search_result["error"]
+        used_provider = search_result.get("provider", used_provider)
         for item in search_result.get("items", []):
             vid = item.get("video_id", "")
             if vid and vid not in seen_ids:
@@ -474,7 +605,7 @@ def search_and_enrich(
         return {"items": [], "error": last_error}
 
     # Step 2: Fetch captions for top N
-    captions = fetch_captions(items, token, depth)
+    captions = fetch_captions(items, token, depth) if used_provider == "scrapecreators" else {}
 
     # Step 3: Attach captions to items
     for item in items:
@@ -483,7 +614,7 @@ def search_and_enrich(
         if caption:
             item["caption_snippet"] = caption
 
-    return {"items": items, "error": last_error}
+    return {"items": items, "error": last_error, "provider": used_provider}
 
 
 def parse_tiktok_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -195,12 +195,14 @@ Some examples of what you can do:
 - "last30 watch AI video tools monthly"
 - "last30 what have you found about AI video?"
 
+TikTok, Instagram, Threads, and Pinterest can use ScrapeCreators as the primary path, with Apify configured as a fallback path when needed.
+
 Just start with "last30" and talk to me like normal.
 """
 
 # Shorter promo for single missing key
 PROMO_SINGLE_KEY = {
-    "reddit": "\n💡 Unlock TikTok and Instagram with SCRAPECREATORS_API_KEY - 100 free credits, no CC - scrapecreators.com\n",
+    "reddit": "\n💡 Unlock TikTok, Instagram, Threads, and Pinterest with SCRAPECREATORS_API_KEY as the primary path. Apify can be configured as a fallback path.\n",
     "x": "\n💡 Unlock X: log into x.com in Firefox or Safari, then re-run. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n",
     "web": "\n💡 You can unlock native grounded web search with BRAVE_API_KEY or SERPER_API_KEY.\n",
 }
@@ -500,6 +502,7 @@ def show_diagnostic_banner(diag: dict):
     has_youtube = "youtube" in available_sources
     has_web = "grounding" in available_sources
     has_xiaohongshu = "xiaohongshu" in available_sources
+    social_provider_status = diag.get("social_provider_status") or {}
     x_backend = diag.get("x_backend")
     native_web_backend = diag.get("native_web_backend")
 
@@ -546,6 +549,10 @@ def show_diagnostic_banner(diag: dict):
         if has_xiaohongshu:
             lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.GREEN}✅ Xiaohongshu{Colors.RESET} — API connected + logged in         {Colors.DIM}│{Colors.RESET}")
 
+        pinterest_status = social_provider_status.get("pinterest") if isinstance(social_provider_status, dict) else None
+        if isinstance(pinterest_status, dict) and pinterest_status.get("enabled_but_opt_in"):
+            lines.append(f"{Colors.DIM}│{Colors.RESET}  {Colors.BLUE}ℹ Pinterest{Colors.RESET} — provider ready, opt-in source        {Colors.DIM}│{Colors.RESET}")
+
         # Web
         if has_web:
             backend = native_web_backend or "native"
@@ -587,6 +594,10 @@ def show_diagnostic_banner(diag: dict):
 
         if has_xiaohongshu:
             lines.append("│  ✅ Xiaohongshu — API connected + logged in         │")
+
+        pinterest_status = social_provider_status.get("pinterest") if isinstance(social_provider_status, dict) else None
+        if isinstance(pinterest_status, dict) and pinterest_status.get("enabled_but_opt_in"):
+            lines.append("│  ℹ Pinterest — provider ready, opt-in source       │")
 
         if has_web:
             backend = native_web_backend or "native"

--- a/skills/last30days/scripts/smoke_provider_paths.py
+++ b/skills/last30days/scripts/smoke_provider_paths.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Smoke-test provider paths for last30days social sources."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from lib import env, instagram, pinterest, tiktok, threads  # noqa: E402
+
+
+DATE_RANGE = ("2026-05-11", "2026-06-10")
+DIRECT_CASES = [
+    ("tiktok", "Trump Iran", tiktok.search_tiktok),
+    ("instagram", "iran", instagram.search_instagram),
+    ("threads", "Trump Iran", threads.search_threads),
+    ("pinterest", "Trump Iran", pinterest.search_pinterest),
+]
+FULL_CASES = [
+    ("tiktok", "Trump Iran"),
+    ("instagram", "iran"),
+    ("threads", "Trump Iran"),
+    ("pinterest", "Trump Iran"),
+]
+
+
+def _ok(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run_direct_cases(config: dict[str, object]) -> list[str]:
+    apify_tokens = env.get_apify_tokens(config)
+    _ok(bool(apify_tokens), "No Apify tokens configured for direct fallback smoke test")
+    passed: list[str] = []
+    for source, topic, func in DIRECT_CASES:
+        result = func(
+            topic,
+            DATE_RANGE[0],
+            DATE_RANGE[1],
+            depth="quick",
+            token="",
+            apify_tokens=apify_tokens,
+        )
+        items = result.get("items") or []
+        _ok(result.get("provider") == "apify", f"{source}: expected provider=apify, got {result.get('provider')}")
+        _ok(len(items) > 0, f"{source}: expected >0 items in direct adapter smoke")
+        passed.append(source)
+    return passed
+
+
+def run_full_cases() -> list[str]:
+    passed: list[str] = []
+    cli = SCRIPT_DIR / "last30days.py"
+    for source, topic in FULL_CASES:
+        command = [
+            sys.executable,
+            str(cli),
+            "--search",
+            source,
+            "--topic",
+            topic,
+            "--quick",
+            "--emit=json",
+        ]
+        completed = subprocess.run(command, capture_output=True, text=True, check=True)
+        payload = json.loads(completed.stdout)
+        items = (payload.get("items_by_source") or {}).get(source) or []
+        errors = payload.get("errors_by_source") or {}
+        trace = (payload.get("source_provider_runtime") or {}).get(source) or {}
+        _ok(source not in errors, f"{source}: errors_by_source present: {errors.get(source)}")
+        _ok(len(items) > 0, f"{source}: expected >0 items in full pipeline smoke")
+        _ok(bool(trace.get("actual_provider_used")), f"{source}: missing actual_provider_used in source_provider_runtime")
+        passed.append(source)
+    return passed
+
+
+def main() -> int:
+    config = env.get_config()
+    try:
+        direct_passed = run_direct_cases(config)
+        full_passed = run_full_cases()
+    except Exception as exc:
+        sys.stderr.write(f"FAIL: {type(exc).__name__}: {exc}\n")
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "PASS",
+                "direct_adapter_sources": direct_passed,
+                "full_pipeline_sources": full_passed,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add real `ScrapeCreators -> Apify` fallback support for `TikTok`, `Instagram`, `Threads`, and `Pinterest`
- add shared Apify runner utilities plus backup Apify token support
- expose configured vs actual provider runtime status in diagnostics/output
- add a smoke script for provider-path checks and sync the runtime patch into the repo copy

## Why
These social sources previously behaved as if `ScrapeCreators` was the only backend. When credits or provider availability ran out, retrieval stopped. This change keeps `ScrapeCreators` as the primary path, falls back to `Apify` when needed, and makes the active provider path visible for debugging.

## Changed areas
- provider/env helpers: `env.py`, new `apify_runner.py`
- source adapters: `tiktok.py`, `instagram.py`, `threads.py`, `pinterest.py`
- runtime/diagnostics: `pipeline.py`, `schema.py`, `ui.py`, `quality_nudge.py`, `last30days.py`
- verification helper: `smoke_provider_paths.py`

## Validation
- `python3 -m py_compile` on the updated scripts
- live smoke runs returned non-zero items for TikTok, Instagram, Threads, and Pinterest after fallback wiring
- Apify backup-token failover verified by forcing the primary token path to fail

## Out of scope
- Reddit remains on its existing free path and is not moved to Apify here
- deeper enrichment flows such as comments, transcripts, and profile scraping were intentionally left unchanged