### PR TITLE
ci: add artifact attestation for published .skill release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-release:
@@ -21,6 +23,11 @@ jobs:
         run: |
           bash skills/last30days/scripts/build-skill.sh
           test -f dist/last30days.skill
+
+      - name: Attest .skill artifact provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/last30days.skill
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Adds GitHub artifact attestation for the `dist/last30days.skill` release asset by running `actions/attest-build-provenance` after the artifact is built.

This provides build provenance so consumers can verify the .skill file was produced by the repo's trusted release workflow.

Changes:
- Grants `id-token: write` and `attestations: write` permissions
- Adds attestation step for `dist/last30days.skill` after build, before release

Closes #528