### PR TITLE
fix(tests): stale mock target lets the suite hit the real macOS Keychain (Chrome Safe Storage prompt)

### DIFF
--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -253,7 +253,7 @@ class TestUnencryptedCookies:
 
         with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
             # No keychain needed for unencrypted values
-            with mock.patch("lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+            with mock.patch("lib.chrome_cookies._get_chromium_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
 
         assert result == {"auth_token": "plain_token_value", "ct0": "plain_ct0_value"}
@@ -297,7 +297,7 @@ class TestFullExtraction:
         ])
 
         with mock.patch("lib.chrome_cookies.CHROME_COOKIES_DB", Path(db_path)):
-            with mock.patch("lib.chrome_cookies._get_chrome_encryption_key", return_value=None):
+            with mock.patch("lib.chrome_cookies._get_chromium_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
 
         assert result is None


### PR DESCRIPTION
## Summary

Two tests in `tests/test_chrome_cookies.py` mock `lib.chrome_cookies._get_chrome_encryption_key`, but the production path (`extract_chrome_cookies_macos`) calls `_get_chromium_encryption_key` directly. The mock therefore patches an unused wrapper, and the real `security find-generic-password -w -s "Chrome Safe Storage"` runs inside the test suite. On any macOS machine with Chrome installed, every full `pytest` run pops the Keychain password dialog twice. This PR points the two mocks at the function the code actually calls.

## Changes

- `tests/test_chrome_cookies.py`: `test_plain_value_returned` and `test_no_matching_cookies_returns_none` now patch `_get_chromium_encryption_key` (the function `extract_chrome_cookies_macos` calls at the decryption step) instead of the `_get_chrome_encryption_key` wrapper. The wrapper itself stays, since it is legitimately exercised by `test_security_command_fails` / `test_security_command_not_found`, which mock `subprocess.run` correctly.

## How it was confirmed

Ran the suite with a logging shim placed ahead of `security` on `PATH`:

- Before the fix: `tests/test_chrome_cookies.py` produced exactly 2 calls of `find-generic-password -w -s "Chrome Safe Storage"` (one per affected test).
- After the fix: the full suite produces 0 Chrome Safe Storage calls. The remaining `security` calls are env.py's silent `last30days-*` key lookups, which return item-not-found and never prompt.

## Testing

- [x] Ran `uv run pytest` (full suite): `1617 passed, 4 skipped, 2 subtests passed`. `tests/test_chrome_cookies.py` is 22/22.

## Related Issues

None filed. Happy to open an issue first if you prefer issues-before-PRs for test fixes.

---

Authored with Claude Code assistance; reproduced and verified locally on macOS with the PATH-shim method above.
