### PR TITLE
fix(youtube): backfill transcripts for survivors after relevance selection (#542)

### DIFF
--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -455,7 +455,9 @@ def run(
         if bundle.items_by_source.get(source):
             del bundle.errors_by_source[source]
 
-    items_by_source = _finalize_items_by_source(bundle.items_by_source, topic=topic, config=config)
+    items_by_source = _finalize_items_by_source(
+        bundle.items_by_source, topic=topic, config=config, depth=depth, mock=mock,
+    )
     candidates = weighted_rrf(bundle.items_by_source_and_query, plan, pool_limit=settings["pool_limit"])
     ranked_candidates = rerank.rerank_candidates(
         topic=topic,
@@ -525,11 +527,21 @@ def _finalize_items_by_source(
     items_by_source_raw: dict[str, list[schema.SourceItem]],
     topic: str = "",
     config: dict | None = None,
+    depth: str = "default",
+    mock: bool = False,
 ) -> dict[str, list[schema.SourceItem]]:
     finalized = {}
     for source, items in items_by_source_raw.items():
         items = sorted(items, key=lambda item: item.local_rank_score or 0.0, reverse=True)
         items = dedupe.dedupe_items(items)
+        if source == "youtube" and items and not mock:
+            # Same budget-at-the-survivors principle as the digg branch
+            # below: retrieval-time transcripts go to each search's
+            # top-by-views candidates, while final selection ranks by
+            # relevance. Backfill survivors that arrived without one so the
+            # transcript budget lands on videos the brief actually shows
+            # (#542).
+            youtube_yt.backfill_transcripts(items, topic=topic, depth=depth)
         # Post-merge topic-relevance filter for Polymarket: comparison queries
         # fan out into per-entity subqueries ("Hermes", "OpenClaw") whose topic
         # is too narrow for Gamma API to filter meaningfully. Re-validating the

--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -642,6 +642,65 @@ def fetch_transcripts_parallel(
     return results
 
 
+def backfill_transcripts(items: List[Any], topic: str = "", depth: str = "default") -> None:
+    """Second-pass transcript fetch for finalized items that lack one.
+
+    search_and_transcribe() spends its transcript budget on each search's
+    top-by-views candidates, but the pipeline's final selection ranks by
+    relevance - the two orderings can be fully disjoint, shipping a brief
+    where every surviving video is transcript-less while the fetched
+    transcripts ride videos that never appear (#542). Designed to run from
+    _finalize_items_by_source() so the per-depth budget is spent on the
+    survivors, mirroring the digg post-selection enrichment.
+
+    Mutates SourceItem.metadata in place; safe no-op when the budget is
+    already met, yt-dlp is missing, or every survivor has a transcript.
+    """
+    limit = TRANSCRIPT_LIMITS.get(depth, TRANSCRIPT_LIMITS["default"])
+    if limit <= 0 or not items or not is_ytdlp_installed():
+        return
+    have = sum(
+        1 for it in items
+        if it.metadata.get("transcript_highlights") or it.metadata.get("transcript_snippet")
+    )
+    need = limit - have
+    if need <= 0:
+        return
+    missing = [
+        it for it in items
+        if it.item_id
+        and not it.metadata.get("transcript_highlights")
+        and not it.metadata.get("transcript_snippet")
+        and not it.metadata.get("captions_disabled")
+    ]
+    # Attempt extra candidates because some videos lack captions - the same
+    # 3x heuristic the retrieval-time pass uses.
+    attempts = missing[: need * 3]
+    if not attempts:
+        return
+    _log(f"Backfilling transcripts for {len(attempts)} finalized videos (target: {need})")
+    captions_disabled: Set[str] = set()
+    transcripts = fetch_transcripts_parallel(
+        [it.item_id for it in attempts],
+        out_captions_disabled=captions_disabled,
+    )
+    for it in attempts:
+        if it.item_id in captions_disabled:
+            # Feeds quality_nudge's degraded-ratio denominator, same as the
+            # retrieval-time pass.
+            it.metadata["captions_disabled"] = True
+            continue
+        transcript = transcripts.get(it.item_id)
+        if not transcript:
+            continue
+        it.metadata["transcript_snippet"] = transcript
+        highlights = extract_transcript_highlights(transcript, topic)
+        if highlights:
+            it.metadata["transcript_highlights"] = highlights
+        if not it.snippet:
+            it.snippet = " ".join(transcript.split()[:80])
+
+
 def search_and_transcribe(
     topic: str,
     from_date: str,

--- a/tests/test_youtube_backfill.py
+++ b/tests/test_youtube_backfill.py
@@ -1,0 +1,156 @@
+"""Tests for backfill_transcripts - the post-selection transcript pass (#542).
+
+search_and_transcribe() fetches transcripts for each search's top-by-views
+candidates, but the pipeline's final selection ranks by relevance. When the
+two sets are disjoint, every surviving video ships transcript-less. These
+tests pin the second-pass backfill that runs from _finalize_items_by_source().
+"""
+
+import unittest
+from unittest import mock
+
+from lib import schema, youtube_yt
+
+
+def _item(item_id, **metadata):
+    return schema.SourceItem(
+        item_id=item_id,
+        source="youtube",
+        title=f"Video {item_id}",
+        body=f"Video {item_id}",
+        url=f"https://www.youtube.com/watch?v={item_id}",
+        metadata=dict(metadata),
+    )
+
+
+TRANSCRIPT = (
+    "Claude Code skills are directories containing a SKILL md file. "
+    "This video covers the fastest growing skills on GitHub this month. "
+    "Superpowers enforces test driven development across every phase."
+)
+
+
+class TestBackfillTranscripts(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_backfills_survivors_without_transcripts(self):
+        """The #542 shape: finalized videos disjoint from the fetched set."""
+        items = [_item("vidA"), _item("vidB"), _item("vidC"), _item("vidD")]
+        with mock.patch.object(
+            youtube_yt, "fetch_transcripts_parallel",
+            return_value={"vidA": TRANSCRIPT, "vidB": TRANSCRIPT},
+        ) as fetch:
+            youtube_yt.backfill_transcripts(items, topic="claude code skills", depth="default")
+
+        # default budget is 2, attempts capped at need*3
+        fetched_ids = fetch.call_args.args[0]
+        self.assertEqual(fetched_ids, ["vidA", "vidB", "vidC", "vidD"])
+        self.assertEqual(items[0].metadata["transcript_snippet"], TRANSCRIPT)
+        self.assertEqual(items[1].metadata["transcript_snippet"], TRANSCRIPT)
+        self.assertNotIn("transcript_snippet", items[2].metadata)
+        self.assertTrue(items[0].metadata.get("transcript_highlights"))
+        self.assertTrue(items[0].snippet)
+
+    def test_noop_when_budget_already_met(self):
+        """Survivors that already carry >= limit transcripts trigger no fetch."""
+        items = [
+            _item("vidA", transcript_snippet=TRANSCRIPT),
+            _item("vidB", transcript_highlights=["quote"]),
+            _item("vidC"),
+        ]
+        with mock.patch.object(youtube_yt, "fetch_transcripts_parallel") as fetch:
+            youtube_yt.backfill_transcripts(items, depth="default")
+        fetch.assert_not_called()
+
+    def test_partial_budget_fetches_only_the_gap(self):
+        """One transcript present at default depth (limit 2) -> need is 1."""
+        items = [
+            _item("vidA", transcript_snippet=TRANSCRIPT),
+            _item("vidB"),
+            _item("vidC"),
+            _item("vidD"),
+            _item("vidE"),
+        ]
+        with mock.patch.object(
+            youtube_yt, "fetch_transcripts_parallel", return_value={"vidB": TRANSCRIPT},
+        ) as fetch:
+            youtube_yt.backfill_transcripts(items, depth="default")
+        # need=1, attempts capped at need*3=3
+        self.assertEqual(fetch.call_args.args[0], ["vidB", "vidC", "vidD"])
+
+    def test_noop_at_quick_depth(self):
+        """quick depth has a transcript budget of 0 - never fetch."""
+        items = [_item("vidA")]
+        with mock.patch.object(youtube_yt, "fetch_transcripts_parallel") as fetch:
+            youtube_yt.backfill_transcripts(items, depth="quick")
+        fetch.assert_not_called()
+
+    def test_noop_when_ytdlp_missing(self):
+        items = [_item("vidA")]
+        with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=False):
+            with mock.patch.object(youtube_yt, "fetch_transcripts_parallel") as fetch:
+                youtube_yt.backfill_transcripts(items, depth="default")
+        fetch.assert_not_called()
+
+    def test_skips_captions_disabled_items(self):
+        """Uploader-disabled captions are not retried and stay marked."""
+        items = [_item("vidA", captions_disabled=True), _item("vidB")]
+        with mock.patch.object(
+            youtube_yt, "fetch_transcripts_parallel", return_value={"vidB": TRANSCRIPT},
+        ) as fetch:
+            youtube_yt.backfill_transcripts(items, depth="default")
+        self.assertEqual(fetch.call_args.args[0], ["vidB"])
+
+    def test_marks_newly_discovered_captions_disabled(self):
+        """A backfill attempt that reveals no caption tracks feeds quality_nudge."""
+        def fake_fetch(video_ids, out_captions_disabled=None):
+            if out_captions_disabled is not None:
+                out_captions_disabled.add("vidA")
+            return {"vidA": None, "vidB": TRANSCRIPT}
+
+        items = [_item("vidA"), _item("vidB")]
+        with mock.patch.object(youtube_yt, "fetch_transcripts_parallel", side_effect=fake_fetch):
+            youtube_yt.backfill_transcripts(items, depth="default")
+        self.assertTrue(items[0].metadata.get("captions_disabled"))
+        self.assertNotIn("transcript_snippet", items[0].metadata)
+        self.assertEqual(items[1].metadata["transcript_snippet"], TRANSCRIPT)
+
+    def test_does_not_overwrite_existing_snippet(self):
+        items = [_item("vidA")]
+        items[0].snippet = "ranker-chosen snippet"
+        with mock.patch.object(
+            youtube_yt, "fetch_transcripts_parallel", return_value={"vidA": TRANSCRIPT},
+        ):
+            youtube_yt.backfill_transcripts(items, depth="default")
+        self.assertEqual(items[0].snippet, "ranker-chosen snippet")
+        self.assertEqual(items[0].metadata["transcript_snippet"], TRANSCRIPT)
+
+
+class TestFinalizeWiring(unittest.TestCase):
+    def test_finalize_calls_backfill_for_youtube_survivors(self):
+        from lib import pipeline
+
+        items = [_item("vidA")]
+        with mock.patch.object(youtube_yt, "backfill_transcripts") as backfill:
+            pipeline._finalize_items_by_source(
+                {"youtube": items}, topic="claude code skills", depth="deep",
+            )
+        backfill.assert_called_once()
+        self.assertEqual(backfill.call_args.kwargs.get("depth"), "deep")
+
+    def test_finalize_skips_backfill_in_mock_mode(self):
+        from lib import pipeline
+
+        items = [_item("vidA")]
+        with mock.patch.object(youtube_yt, "backfill_transcripts") as backfill:
+            pipeline._finalize_items_by_source(
+                {"youtube": items}, topic="claude code skills", depth="default", mock=True,
+            )
+        backfill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_youtube_backfill.py
+++ b/tests/test_youtube_backfill.py
@@ -140,6 +140,7 @@ class TestFinalizeWiring(unittest.TestCase):
             )
         backfill.assert_called_once()
         self.assertEqual(backfill.call_args.kwargs.get("depth"), "deep")
+        self.assertEqual(backfill.call_args.kwargs.get("topic"), "claude code skills")
 
     def test_finalize_skips_backfill_in_mock_mode(self):
         from lib import pipeline


### PR DESCRIPTION
## Summary

Fixes the `0/N with transcripts` footer on runs where every transcript fetch actually succeeded. `search_and_transcribe()` spends its transcript budget on each search's top-by-views candidates, but final selection ranks by relevance — when the two sets are disjoint, every surviving video ships transcript-less and the quality nudge misdiagnoses a healthy `yt-dlp` as stale. This adds a second-pass backfill in `_finalize_items_by_source()` that spends the same per-depth budget on the survivors, mirroring the existing digg post-selection enrichment pattern.

## Changes

- `skills/last30days/scripts/lib/youtube_yt.py`: new `backfill_transcripts(items, topic, depth)` — no-op when the per-depth budget is already met, yt-dlp is missing, or depth is `quick` (budget 0). Reuses `fetch_transcripts_parallel`, `extract_transcript_highlights`, `TRANSCRIPT_LIMITS`, and the retrieval pass's `need × 3` attempt heuristic. Marks newly discovered `captions_disabled` so quality_nudge's denominator stays correct. Never overwrites an existing snippet.
- `skills/last30days/scripts/lib/pipeline.py`: youtube branch in `_finalize_items_by_source()` (sibling of the digg branch, same budget-at-the-survivors principle); `depth`/`mock` threaded through the single call site, `mock=True` skips the network pass.
- `tests/test_youtube_backfill.py`: 10 tests — the #542 disjoint-sets shape, budget-met no-op, partial-budget gap fetch, quick-depth no-op, missing-binary no-op, captions-disabled skip and discovery, snippet non-clobbering, and finalize wiring incl. mock-mode skip.

Because `RetrievalBundle.add_items()` appends the same `SourceItem` objects to both `items_by_source` and `items_by_source_and_query`, and finalize runs before `weighted_rrf`, the backfilled metadata reaches the footer, the raw dump, and the ranked evidence — not just the counter.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short` — 1627 passed, 4 skipped (live-gated, same as main)
- [x] Live before/after on the original failing topic (`fastest growing claude code skills on github`, default depth, same machine):

Before (v3.3.2):

```
[YouTube] Got transcripts for 6/6 videos (0 failed)
├─ 🔴 YouTube: 4 videos │ 156,056 views │ 0/4 with transcripts
```

After (this branch) — the mismatch reproduced organically and the backfill caught it:

```
[YouTube] Got transcripts for 6/6 videos (0 failed)
[YouTube] Backfilling transcripts for 4 finalized videos (target: 2)
[YouTube] Got transcripts for 4/4 videos (0 failed)
├─ 🔴 YouTube: 4 videos │ 124,582 views │ 4/4 with transcripts
```

Disclosed tradeoff: when the backfill fires it adds one parallel fetch round between retrieval and rerank (~20s on the run above: 185s vs 162s). It only fires when survivors lack transcripts, capped at `need × 3` attempts; runs whose retrieval candidates survive ranking are untouched.

## Related Issues

Fixes #542
