### PR TITLE
fix(setup): stop first-run wizard from triggering Chrome Keychain prompt

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -588,13 +588,15 @@ def main() -> int:
             return 0
         sys.stderr.write("Running auto-setup...\n")
         results = setup_wizard.run_auto_setup(config)
-        # Persist only the browser that actually yielded cookies. When none did,
-        # leave FROM_BROWSER unset so the safe default (Firefox/Safari, no
-        # Keychain prompt) applies instead of pinning "auto", which would make
-        # every subsequent run probe Chrome and re-trigger the prompt.
-        from_browser = None
-        if results.get("cookies_found"):
-            from_browser = next(iter(results["cookies_found"].values()))
+        # Persist FROM_BROWSER only when every service's cookies came from the
+        # SAME single browser — then we can fast-path future runs to it. If
+        # different services matched different browsers, or none matched, leave
+        # FROM_BROWSER unset: the safe default (Firefox/Safari) then covers all
+        # of them with no Keychain prompt. We deliberately do NOT pin "auto"
+        # here (it would re-probe Chrome and re-trigger the prompt) nor a single
+        # browser (it would silently skip the service that used the other one).
+        found_browsers = set(results.get("cookies_found", {}).values())
+        from_browser = found_browsers.pop() if len(found_browsers) == 1 else None
         setup_wizard.write_setup_config(env.CONFIG_FILE, from_browser=from_browser)
         results["env_written"] = True
         sys.stderr.write(setup_wizard.get_setup_status_text(results) + "\n")

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -588,10 +588,13 @@ def main() -> int:
             return 0
         sys.stderr.write("Running auto-setup...\n")
         results = setup_wizard.run_auto_setup(config)
-        from_browser = "auto"
+        # Persist only the browser that actually yielded cookies. When none did,
+        # leave FROM_BROWSER unset so the safe default (Firefox/Safari, no
+        # Keychain prompt) applies instead of pinning "auto", which would make
+        # every subsequent run probe Chrome and re-trigger the prompt.
+        from_browser = None
         if results.get("cookies_found"):
-            first_browser = next(iter(results["cookies_found"].values()))
-            from_browser = first_browser
+            from_browser = next(iter(results["cookies_found"].values()))
         setup_wizard.write_setup_config(env.CONFIG_FILE, from_browser=from_browser)
         results["env_written"] = True
         sys.stderr.write(setup_wizard.get_setup_status_text(results) + "\n")

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -400,32 +400,47 @@ COOKIE_DOMAINS: dict[str, dict[str, Any]] = {
 }
 
 
-def extract_browser_credentials(config: dict[str, Any]) -> dict[str, str]:
-    """Extract auth cookies from local browsers.
+def cookie_extraction_browsers(config: dict[str, Any]) -> list[str]:
+    """Browsers to try for cookie extraction, honoring FROM_BROWSER.
 
-    Default behavior (FROM_BROWSER unset): tries Firefox and Safari only.
-    These read local files silently with no system dialogs.  Chrome is
-    skipped because ``security find-generic-password`` triggers a macOS
-    Keychain prompt that cannot be reliably suppressed.
+    Default (FROM_BROWSER unset): Firefox and Safari only. These read local
+    files silently with no system dialogs. Chrome/Brave are skipped because
+    reading their cookies on macOS requires the "Chrome Safe Storage" Keychain
+    key, which triggers a system password prompt that cannot be reliably
+    suppressed.
 
-    Set ``FROM_BROWSER=auto`` to also try Chrome (accepts the dialog),
-    or ``FROM_BROWSER=off`` to disable extraction entirely.
+    - ``FROM_BROWSER=firefox|chrome|safari`` - that single browser.
+    - ``FROM_BROWSER=auto`` - also try Chrome (the user has accepted the dialog).
+    - ``FROM_BROWSER=off`` - returns [] (extraction disabled).
+
+    Returning the browser list from one place keeps the setup wizard and the
+    steady-state path on the same policy, so neither surprises the user with an
+    unrequested Keychain prompt.
     """
     from_browser = (config.get("FROM_BROWSER") or "").strip().lower()
     if from_browser == "off":
+        return []
+    if from_browser in ("firefox", "chrome", "safari"):
+        return [from_browser]
+    if from_browser == "auto":
+        return ["firefox", "safari", "chrome"]
+    return ["firefox", "safari"]
+
+
+def extract_browser_credentials(config: dict[str, Any]) -> dict[str, str]:
+    """Extract auth cookies from local browsers.
+
+    Browser selection (and the Chrome-prompt caveat) is handled by
+    ``cookie_extraction_browsers``; this function just runs the extraction for
+    each configured cookie domain.
+    """
+    browsers = cookie_extraction_browsers(config)
+    if not browsers:
         return {}
     try:
         from . import cookie_extract
     except ImportError:
         return {}
-    # Determine which browsers to try
-    if from_browser in ("firefox", "chrome", "safari"):
-        browsers = [from_browser]
-    elif from_browser == "auto":
-        browsers = ["firefox", "safari", "chrome"]
-    else:
-        # Default: silent browsers only (no Keychain dialog)
-        browsers = ["firefox", "safari"]
     extracted: dict[str, str] = {}
     for _service, spec in COOKIE_DOMAINS.items():
         if all(config.get(env_key) for env_key in spec["mapping"].values()):

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -30,7 +30,9 @@ def is_first_run(config: Dict[str, Any]) -> bool:
 def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
     """Perform the auto-setup actions.
 
-    - Runs cookie extraction in auto mode for all registered domains
+    - Runs cookie extraction for all registered domains, trying the browsers
+      from ``env.cookie_extraction_browsers()`` (honors ``FROM_BROWSER``;
+      defaults to Firefox/Safari, so no Chrome Keychain prompt)
     - Checks if yt-dlp is installed
 
     Returns:

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -40,23 +40,30 @@ def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
           env_written: bool (always False here — caller writes config separately)
     """
     from . import cookie_extract
-    from .env import COOKIE_DOMAINS
+    from .env import COOKIE_DOMAINS, cookie_extraction_browsers
 
     cookies_found: Dict[str, str] = {}
+
+    # Honor FROM_BROWSER and default to the silent browsers (Firefox/Safari).
+    # Using "auto" here used to probe Chrome unconditionally, triggering a
+    # "Chrome Safe Storage" Keychain prompt on first run that the steady-state
+    # path deliberately avoids. Chrome is now opt-in via FROM_BROWSER=chrome|auto.
+    # An empty list (FROM_BROWSER=off) makes the inner loop a no-op.
+    browsers = cookie_extraction_browsers(config)
 
     for source_name, spec in COOKIE_DOMAINS.items():
         domain = spec["domain"]
         cookie_names = spec["cookies"]
 
-        try:
-            result = cookie_extract.extract_cookies_with_source("auto", domain, cookie_names)
-        except Exception as exc:
-            logger.debug("Cookie extraction failed for %s: %s", source_name, exc)
-            continue
-
-        if result is not None:
-            _cookies, browser_name = result
-            cookies_found[source_name] = browser_name
+        for browser in browsers:
+            try:
+                result = cookie_extract.extract_cookies_with_source(browser, domain, cookie_names)
+            except Exception as exc:
+                logger.debug("Cookie extraction failed for %s via %s: %s", source_name, browser, exc)
+                continue
+            if result is not None and result[0]:
+                cookies_found[source_name] = result[1]
+                break  # Found cookies for this service, stop trying browsers
 
     # Check yt-dlp availability and install via Homebrew if missing
     ytdlp_action: str
@@ -98,7 +105,7 @@ def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
     return results
 
 
-def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
+def write_setup_config(env_path: Path, from_browser: str | None = None) -> bool:
     """Write SETUP_COMPLETE and FROM_BROWSER to the .env file.
 
     Creates the file and parent directories if needed.
@@ -106,7 +113,12 @@ def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
 
     Args:
         env_path: Path to the .env file (e.g. ~/.config/last30days/.env)
-        from_browser: Browser extraction mode to write (default: "auto")
+        from_browser: Browser extraction mode to persist. Pass the browser that
+            actually yielded cookies (e.g. "firefox") to fast-path future runs.
+            Pass None (default) to NOT pin FROM_BROWSER — the steady-state
+            default (Firefox/Safari, no Keychain prompt) then applies. We avoid
+            persisting "auto" because it makes every later run probe Chrome and
+            re-trigger the Keychain prompt.
 
     Returns:
         True if config was written successfully, False on error.
@@ -129,7 +141,7 @@ def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
         lines_to_add = []
         if "SETUP_COMPLETE" not in existing_keys:
             lines_to_add.append("SETUP_COMPLETE=true")
-        if "FROM_BROWSER" not in existing_keys:
+        if from_browser and "FROM_BROWSER" not in existing_keys:
             lines_to_add.append(f"FROM_BROWSER={from_browser}")
 
         if not lines_to_add:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -177,7 +177,13 @@ class TestWriteSetupConfig:
     """Tests for write_setup_config()."""
 
     def test_creates_new_env_file(self):
-        """Creates .env file with SETUP_COMPLETE and FROM_BROWSER."""
+        """Creates .env with SETUP_COMPLETE; omits FROM_BROWSER when unspecified.
+
+        With no detected browser we must NOT pin FROM_BROWSER=auto, because
+        that makes every later run probe Chrome and re-trigger the macOS
+        Keychain prompt. Leaving it unset applies the safe Firefox/Safari
+        default instead.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             env_path = Path(tmpdir) / "subdir" / ".env"
 
@@ -187,7 +193,7 @@ class TestWriteSetupConfig:
             assert env_path.exists()
             content = env_path.read_text()
             assert "SETUP_COMPLETE=true" in content
-            assert "FROM_BROWSER=auto" in content
+            assert "FROM_BROWSER" not in content
 
     def test_appends_to_existing_file(self):
         """Appends to existing .env without overwriting keys."""
@@ -202,9 +208,9 @@ class TestWriteSetupConfig:
             # Original keys preserved
             assert "XAI_API_KEY=my-key" in content
             assert "AUTH_TOKEN=tok123" in content
-            # New keys appended
+            # SETUP_COMPLETE appended; FROM_BROWSER omitted (no browser detected)
             assert "SETUP_COMPLETE=true" in content
-            assert "FROM_BROWSER=auto" in content
+            assert "FROM_BROWSER" not in content
 
     def test_does_not_overwrite_existing_keys(self):
         """If SETUP_COMPLETE or FROM_BROWSER already exist, don't duplicate."""
@@ -249,7 +255,7 @@ class TestWriteSetupConfig:
             env_path = Path(tmpdir) / ".env"
             env_path.write_text("EXISTING_KEY=value")  # no trailing newline
 
-            result = setup_wizard.write_setup_config(env_path)
+            result = setup_wizard.write_setup_config(env_path, from_browser="firefox")
 
             assert result is True
             content = env_path.read_text()
@@ -258,6 +264,55 @@ class TestWriteSetupConfig:
             assert len(lines) == 3
             assert lines[0] == "EXISTING_KEY=value"
             assert "SETUP_COMPLETE=true" in lines[1]
+
+
+class TestCookieExtractionBrowsers:
+    """Tests for env.cookie_extraction_browsers() — the shared browser policy."""
+
+    def test_default_excludes_chrome(self):
+        """FROM_BROWSER unset -> Firefox/Safari only, never Chrome (no prompt)."""
+        from lib import env
+        browsers = env.cookie_extraction_browsers({})
+        assert "chrome" not in browsers
+        assert browsers == ["firefox", "safari"]
+
+    def test_off_disables_extraction(self):
+        from lib import env
+        assert env.cookie_extraction_browsers({"FROM_BROWSER": "off"}) == []
+
+    def test_auto_opts_into_chrome(self):
+        from lib import env
+        assert "chrome" in env.cookie_extraction_browsers({"FROM_BROWSER": "auto"})
+
+    def test_specific_browser(self):
+        from lib import env
+        assert env.cookie_extraction_browsers({"FROM_BROWSER": "chrome"}) == ["chrome"]
+
+
+class TestWizardDoesNotProbeChromeByDefault:
+    """Regression: first-run setup must not silently read Chrome cookies."""
+
+    @patch("lib.cookie_extract.extract_cookies_with_source", return_value=None)
+    @patch("shutil.which", return_value=None)
+    def test_default_run_never_requests_chrome(self, _mock_which, mock_extract):
+        setup_wizard.run_auto_setup({})
+        requested_browsers = {call.args[0] for call in mock_extract.call_args_list}
+        assert "chrome" not in requested_browsers
+        assert requested_browsers <= {"firefox", "safari"}
+
+    @patch("lib.cookie_extract.extract_cookies_with_source", return_value=None)
+    @patch("shutil.which", return_value=None)
+    def test_from_browser_auto_does_request_chrome(self, _mock_which, mock_extract):
+        setup_wizard.run_auto_setup({"FROM_BROWSER": "auto"})
+        requested_browsers = {call.args[0] for call in mock_extract.call_args_list}
+        assert "chrome" in requested_browsers
+
+    @patch("lib.cookie_extract.extract_cookies_with_source")
+    @patch("shutil.which", return_value=None)
+    def test_from_browser_off_skips_extraction(self, _mock_which, mock_extract):
+        results = setup_wizard.run_auto_setup({"FROM_BROWSER": "off"})
+        mock_extract.assert_not_called()
+        assert results["cookies_found"] == {}
 
 
 class TestGetSetupStatusText:


### PR DESCRIPTION
## Summary

On macOS, the first-run setup wizard pops a **"Chrome Safe Storage" Keychain password prompt** — the same dialog malware uses to steal browser cookies. The wizard probes browser cookies in `"auto"` mode, which includes Chrome; reading Chrome/Brave cookies on macOS requires the Chrome Safe Storage Keychain key, triggering the prompt.

This directly contradicts the steady-state path (`env.extract_browser_credentials`), which **deliberately** defaults to Firefox/Safari only and documents *why* it skips Chrome:

> Chrome is skipped because `security find-generic-password` triggers a macOS Keychain prompt that cannot be reliably suppressed.

Two code paths, opposite policies on the same sensitive operation. It also compounds on persistence: when no cookies are found (e.g. the user denies the prompt), setup persisted `FROM_BROWSER=auto`, so **every subsequent run re-probed Chrome and re-triggered the prompt**.

## Changes

- Add `env.cookie_extraction_browsers()` as the single source of truth for which browsers to probe, honoring `FROM_BROWSER` (default Firefox/Safari; Chrome opt-in via `chrome`/`auto`; `off` disables). Both the wizard and the steady-state path now use it, so they can't diverge again.
- `run_auto_setup()` honors that policy instead of hardcoding `"auto"`.
- `write_setup_config()` / the `setup` caller no longer persist `FROM_BROWSER=auto` when no browser yielded cookies — it's left unset so the safe default applies and the prompt doesn't recur.
- Behavior is unchanged for users who explicitly opt in with `FROM_BROWSER=auto|chrome`.

## Testing

- [x] `uv run pytest -q` — 1624 passed, 4 skipped
- Added `cookie_extraction_browsers()` unit tests + a regression test that first-run setup never requests Chrome unless `FROM_BROWSER=auto`.
- Updated `write_setup_config` expectations to the new (no-`auto`) default.

**Controlled before/after** (same machine, default config / no `FROM_BROWSER`, Chrome cookie DB present), intercepting at the Keychain-access boundary so no live dialog fires:

| code | browsers the wizard requests | reaches "Chrome Safe Storage" |
|------|------------------------------|-------------------------------|
| before | `['auto', 'auto']` | **yes** → dialog |
| after  | `['firefox', 'safari', ...]` | **no** |

## Related Issues

None filed — found while running the skill on macOS.

---

_Unrelated, noticed in passing (out of scope for this PR):_ `SKILL.md` Step 0 tells the host model to `Read skills/last30days/nux-wizard.md`, but that file isn't in the repo (it was never committed). Worth a look — it means there's no human-readable consent step before the cookie scan.
