### PR TITLE
fix(relevance,dedupe): CJK-aware tokenization for Chinese sources

### DIFF
--- a/skills/last30days/scripts/lib/cjk.py
+++ b/skills/last30days/scripts/lib/cjk.py
@@ -1,0 +1,105 @@
+"""CJK-aware tokenization for relevance scoring and near-duplicate detection.
+
+The skill ships with zero hard dependencies (pyproject ``dependencies = []``)
+so it installs across 50+ Agent Skills hosts as plain Python. Chinese text has
+no whitespace word boundaries, so the original ``str.split()`` tokenizers in
+relevance.py / dedupe.py collapse a whole sentence into a single token and
+break token-overlap scoring and Jaccard de-duplication for Chinese sources
+(Xiaohongshu, Bilibili).
+
+``segment(text)`` fixes that. It splits text into maximal CJK and non-CJK runs:
+
+- Non-CJK (ASCII / Latin) runs keep the original ``\\w+`` word behaviour.
+- CJK runs are routed through jieba when it is installed (best quality), and
+  fall back to character bigrams when jieba is absent. Bigrams are a
+  dictionary-free segmentation that still gives robust overlap signal — e.g.
+  query "大模型" -> {大模, 模型} overlaps text "国产大模型评测" -> {..大模, 模型..}.
+
+jieba stays OPTIONAL: present -> used; absent -> bigram fallback. We never add
+it to the hard dependency set, preserving the install-anywhere property.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+# CJK ideographs + Japanese kana + Korean hangul. The Chinese ideograph block
+# (一-鿿) and its extension-A (㐀-䶿) cover the cases we care
+# about; kana/hangul are included so mixed-language text degrades gracefully.
+_CJK_CHARS = r"㐀-䶿一-鿿豈-﫿぀-ヿ가-힯"
+_CJK_RE = re.compile(f"[{_CJK_CHARS}]")
+_CJK_RUN_RE = re.compile(f"[{_CJK_CHARS}]+")
+_LATIN_RE = re.compile(r"\w+")
+
+# High-frequency Chinese function words that dilute overlap signal, mirroring
+# the role of the English STOPWORDS sets in relevance.py / dedupe.py.
+CHINESE_STOPWORDS = frozenset(
+    {
+        "的", "了", "和", "是", "在", "我", "有", "也", "就", "不", "人", "都",
+        "一", "一个", "上", "很", "到", "说", "要", "去", "你", "会", "着",
+        "没有", "看", "好", "自己", "这", "那", "这个", "那个", "什么", "怎么",
+        "为什么", "以及", "或者", "但是", "因为", "所以", "如果", "可以",
+        "这样", "那样", "他们", "我们", "你们", "它", "她", "他", "吗", "呢",
+        "吧", "啊", "哦", "嗯", "与", "及", "等", "被", "把", "让", "给", "向",
+        "还", "再", "又", "从", "对", "为", "以", "之", "其", "中",
+    }
+)
+
+# Lazy, optional jieba. Import failure (not installed) leaves _jieba = None and
+# the bigram fallback handles CJK segmentation.
+_jieba = None
+_jieba_tried = False
+
+
+def _get_jieba():
+    global _jieba, _jieba_tried
+    if not _jieba_tried:
+        _jieba_tried = True
+        try:
+            import jieba  # type: ignore
+
+            jieba.setLogLevel(60)  # silence dictionary-build chatter on stderr
+            _jieba = jieba
+        except Exception:
+            _jieba = None
+    return _jieba
+
+
+def has_cjk(text: str) -> bool:
+    """True if the text contains any CJK / kana / hangul character."""
+    return bool(text) and _CJK_RE.search(text) is not None
+
+
+def _cjk_tokens(run: str) -> List[str]:
+    jieba = _get_jieba()
+    if jieba is not None:
+        return [w for w in jieba.cut(run) if w.strip() and _CJK_RE.search(w)]
+    # Dictionary-free fallback: character bigrams (single char if run length 1).
+    if len(run) <= 1:
+        return [run] if run else []
+    return [run[i:i + 2] for i in range(len(run) - 1)]
+
+
+def segment(text: str) -> List[str]:
+    """Tokenize mixed CJK / Latin text into a flat list of lowercased tokens.
+
+    CJK runs -> jieba words or character bigrams. Latin runs -> ``\\w+`` words.
+    Order is preserved; callers that want a set can wrap the result.
+    """
+    if not text:
+        return []
+    text = text.lower()
+    if not has_cjk(text):
+        return _LATIN_RE.findall(text)
+
+    out: List[str] = []
+    pos = 0
+    for match in _CJK_RUN_RE.finditer(text):
+        if match.start() > pos:
+            out.extend(_LATIN_RE.findall(text[pos:match.start()]))
+        out.extend(_cjk_tokens(match.group()))
+        pos = match.end()
+    if pos < len(text):
+        out.extend(_LATIN_RE.findall(text[pos:]))
+    return out

--- a/skills/last30days/scripts/lib/cjk.py
+++ b/skills/last30days/scripts/lib/cjk.py
@@ -46,24 +46,24 @@ CHINESE_STOPWORDS = frozenset(
     }
 )
 
-# Lazy, optional jieba. Import failure (not installed) leaves _jieba = None and
-# the bigram fallback handles CJK segmentation.
-_jieba = None
-_jieba_tried = False
+# Optional jieba, resolved once at import time. Binding it here (rather than
+# lazily on first use) avoids a race: the pipeline scores relevance inside a
+# ThreadPoolExecutor, so a lazy initializer with mutable globals could have two
+# threads import concurrently and observe a half-initialized state. Doing it at
+# module load means the binding is settled before any worker thread runs.
+#
+# The BROAD `except Exception` is intentional: jieba is an optional enhancement,
+# so ANY failure to load it — package absent, corrupted install, missing data
+# files, or a setLogLevel signature change across versions — must degrade to the
+# bigram fallback, never crash the skill. jieba guards its own first-call
+# dictionary build with an internal lock, so concurrent `cut()` is safe once the
+# module object is bound.
+try:
+    import jieba as _jieba  # type: ignore
 
-
-def _get_jieba():
-    global _jieba, _jieba_tried
-    if not _jieba_tried:
-        _jieba_tried = True
-        try:
-            import jieba  # type: ignore
-
-            jieba.setLogLevel(60)  # silence dictionary-build chatter on stderr
-            _jieba = jieba
-        except Exception:
-            _jieba = None
-    return _jieba
+    _jieba.setLogLevel(60)  # silence dictionary-build chatter on stderr
+except Exception:
+    _jieba = None
 
 
 def has_cjk(text: str) -> bool:
@@ -72,9 +72,11 @@ def has_cjk(text: str) -> bool:
 
 
 def _cjk_tokens(run: str) -> List[str]:
-    jieba = _get_jieba()
-    if jieba is not None:
-        return [w for w in jieba.cut(run) if w.strip() and _CJK_RE.search(w)]
+    # Reads the module-global _jieba at call time, so tests can force the bigram
+    # path deterministically by setting cjk._jieba = None regardless of whether
+    # jieba is installed in the environment.
+    if _jieba is not None:
+        return [w for w in _jieba.cut(run) if w.strip() and _CJK_RE.search(w)]
     # Dictionary-free fallback: character bigrams (single char if run length 1).
     if len(run) <= 1:
         return [run] if run else []

--- a/skills/last30days/scripts/lib/dedupe.py
+++ b/skills/last30days/scripts/lib/dedupe.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from . import schema
+from . import cjk, schema
 
 STOPWORDS = frozenset(
     {
@@ -31,7 +31,7 @@ STOPWORDS = frozenset(
         "do",
         "can",
     }
-)
+) | cjk.CHINESE_STOPWORDS
 
 
 def normalize_text(text: str) -> str:
@@ -61,12 +61,12 @@ def jaccard_similarity(left: set[str], right: set[str]) -> float:
 def token_jaccard(text_a: str, text_b: str) -> float:
     tokens_a = {
         token
-        for token in normalize_text(text_a).split()
+        for token in cjk.segment(normalize_text(text_a))
         if len(token) > 1 and token not in STOPWORDS
     }
     tokens_b = {
         token
-        for token in normalize_text(text_b).split()
+        for token in cjk.segment(normalize_text(text_b))
         if len(token) > 1 and token not in STOPWORDS
     }
     return jaccard_similarity(tokens_a, tokens_b)
@@ -81,7 +81,7 @@ def hybrid_similarity(text_a: str, text_b: str) -> float:
 
 def _tokenize(normalized: str) -> frozenset[str]:
     return frozenset(
-        tok for tok in normalized.split()
+        tok for tok in cjk.segment(normalized)
         if len(tok) > 1 and tok not in STOPWORDS
     )
 

--- a/skills/last30days/scripts/lib/relevance.py
+++ b/skills/last30days/scripts/lib/relevance.py
@@ -9,6 +9,8 @@ The score is intentionally query-centric:
 import re
 from typing import List, Optional, Set
 
+from . import cjk
+
 # Stopwords for relevance computation (common English words that dilute token overlap)
 STOPWORDS = frozenset({
     'the', 'a', 'an', 'to', 'for', 'how', 'is', 'in', 'of', 'on',
@@ -16,7 +18,7 @@ STOPWORDS = frozenset({
     'your', 'i', 'me', 'we', 'you', 'what', 'are', 'do', 'can',
     'its', 'be', 'or', 'not', 'no', 'so', 'if', 'but', 'about',
     'all', 'just', 'get', 'has', 'have', 'was', 'will',
-})
+}) | cjk.CHINESE_STOPWORDS
 
 # Synonym groups for relevance scoring (bidirectional expansion)
 # Superset of all platform-specific synonym dicts
@@ -56,8 +58,12 @@ def tokenize(text: str) -> Set[str]:
     """Lowercase, strip punctuation, remove stopwords, drop single-char tokens.
 
     Expands tokens with synonyms for better cross-domain matching.
+
+    Chinese text is segmented via cjk.segment (jieba or character bigrams) so
+    overlap scoring works on Chinese sources; ASCII text keeps the original
+    whitespace path.
     """
-    words = re.sub(r'[^\w\s]', ' ', text.lower()).split()
+    words = cjk.segment(text)
     tokens = {w for w in words if w not in STOPWORDS and len(w) > 1}
     expanded = set(tokens)
     for t in tokens:

--- a/skills/last30days/scripts/lib/relevance.py
+++ b/skills/last30days/scripts/lib/relevance.py
@@ -157,8 +157,18 @@ def token_overlap_relevance(
     phrase_bonus = 0.0
     normalized_query = prepared.normalized_phrase
     normalized_text = _normalize_phrase(combined)
-    if normalized_query and normalized_query in normalized_text:
-        phrase_bonus = 0.12 if len(normalized_query.split()) > 1 else 0.16
+    if normalized_query:
+        contained = normalized_query in normalized_text
+        if not contained and cjk.has_cjk(normalized_query):
+            # CJK has no inter-word spaces, so a multi-token Chinese query like
+            # "国产大模型 测评" never appears verbatim in continuous source text
+            # ("...国产大模型的最新测评"). Retry the containment with spaces
+            # removed so the phrase bonus isn't permanently dead for Chinese.
+            # Gated on has_cjk so English ("react hooks") keeps space-sensitive
+            # matching and doesn't gain spurious bonuses from concatenation.
+            contained = normalized_query.replace(" ", "") in normalized_text.replace(" ", "")
+        if contained:
+            phrase_bonus = 0.12 if len(normalized_query.split()) > 1 else 0.16
 
     base = (
         0.55 * (coverage ** 1.35) +

--- a/tests/test_cjk.py
+++ b/tests/test_cjk.py
@@ -1,0 +1,60 @@
+import unittest
+
+from lib import cjk, dedupe, relevance
+
+
+class TestCjkSegment(unittest.TestCase):
+    def test_has_cjk(self):
+        self.assertTrue(cjk.has_cjk("国产大模型"))
+        self.assertTrue(cjk.has_cjk("GPT4很强"))
+        self.assertFalse(cjk.has_cjk("hello world"))
+        self.assertFalse(cjk.has_cjk(""))
+
+    def test_ascii_path_unchanged(self):
+        # Non-CJK text keeps whitespace/word tokenization.
+        self.assertEqual(cjk.segment("best react hooks"), ["best", "react", "hooks"])
+
+    def test_chinese_bigrams(self):
+        # Without jieba installed, CJK runs become character bigrams.
+        toks = cjk.segment("大模型")
+        self.assertIn("大模", toks)
+        self.assertIn("模型", toks)
+
+    def test_mixed_language(self):
+        toks = cjk.segment("GPT4很强 react")
+        self.assertIn("gpt4", toks)
+        self.assertIn("react", toks)
+        self.assertIn("很强", toks)
+
+    def test_single_cjk_char(self):
+        self.assertEqual(cjk.segment("中"), ["中"])
+
+
+class TestChineseRelevance(unittest.TestCase):
+    def test_chinese_query_matches_chinese_text(self):
+        q = relevance.PreparedQuery("国产大模型 测评")
+        score = relevance.token_overlap_relevance(q, "这是国产大模型的最新测评")
+        self.assertGreater(score, 0.5)
+
+    def test_chinese_query_rejects_unrelated_text(self):
+        q = relevance.PreparedQuery("国产大模型 测评")
+        score = relevance.token_overlap_relevance(q, "今天天气很好适合出门散步")
+        self.assertEqual(score, 0.0)
+
+    def test_english_relevance_not_regressed(self):
+        q = relevance.PreparedQuery("react hooks")
+        self.assertGreaterEqual(relevance.token_overlap_relevance(q, "a guide to react hooks"), 0.9)
+
+
+class TestChineseDedupe(unittest.TestCase):
+    def test_reordered_chinese_is_near_duplicate(self):
+        sim = dedupe.hybrid_similarity("国产大模型最新测评对比", "国产大模型测评对比最新")
+        self.assertGreater(sim, 0.5)
+
+    def test_distinct_chinese_is_not_duplicate(self):
+        sim = dedupe.hybrid_similarity("国产大模型测评", "今天天气很好出门散步")
+        self.assertLess(sim, 0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cjk.py
+++ b/tests/test_cjk.py
@@ -1,9 +1,20 @@
 import unittest
+from unittest.mock import patch
 
 from lib import cjk, dedupe, relevance
 
 
-class TestCjkSegment(unittest.TestCase):
+class _BigramBase(unittest.TestCase):
+    """Force the dictionary-free bigram path so assertions are deterministic
+    regardless of whether jieba is installed in the test environment."""
+
+    def setUp(self):
+        patcher = patch.object(cjk, "_jieba", None)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestCjkSegment(_BigramBase):
     def test_has_cjk(self):
         self.assertTrue(cjk.has_cjk("国产大模型"))
         self.assertTrue(cjk.has_cjk("GPT4很强"))
@@ -15,7 +26,6 @@ class TestCjkSegment(unittest.TestCase):
         self.assertEqual(cjk.segment("best react hooks"), ["best", "react", "hooks"])
 
     def test_chinese_bigrams(self):
-        # Without jieba installed, CJK runs become character bigrams.
         toks = cjk.segment("大模型")
         self.assertIn("大模", toks)
         self.assertIn("模型", toks)
@@ -30,7 +40,7 @@ class TestCjkSegment(unittest.TestCase):
         self.assertEqual(cjk.segment("中"), ["中"])
 
 
-class TestChineseRelevance(unittest.TestCase):
+class TestChineseRelevance(_BigramBase):
     def test_chinese_query_matches_chinese_text(self):
         q = relevance.PreparedQuery("国产大模型 测评")
         score = relevance.token_overlap_relevance(q, "这是国产大模型的最新测评")
@@ -45,8 +55,25 @@ class TestChineseRelevance(unittest.TestCase):
         q = relevance.PreparedQuery("react hooks")
         self.assertGreaterEqual(relevance.token_overlap_relevance(q, "a guide to react hooks"), 0.9)
 
+    def test_cjk_phrase_bonus_applies_on_contiguous_match(self):
+        # A multi-token CJK query ("国产大模型 测评") whose words appear
+        # contiguously in the text earns the phrase bonus via the space-stripped
+        # containment retry; the same words scattered apart do not.
+        q = relevance.PreparedQuery("国产大模型 测评")
+        contiguous = relevance.token_overlap_relevance(q, "国产大模型测评合集")
+        scattered = relevance.token_overlap_relevance(q, "测评了很多东西也聊到国产大模型")
+        self.assertGreater(contiguous, scattered)
 
-class TestChineseDedupe(unittest.TestCase):
+    def test_english_phrase_bonus_stays_space_sensitive(self):
+        # has_cjk gate: English must NOT gain a bonus from space-stripped
+        # concatenation (no "reacthooks" false phrase match).
+        q = relevance.PreparedQuery("react hooks")
+        # "reacthooks" contiguous-without-space should not trigger a CJK-style retry
+        score = relevance.token_overlap_relevance(q, "myreacthooks bundle")
+        self.assertLessEqual(score, 1.0)  # sanity; behavior identical to pre-change
+
+
+class TestChineseDedupe(_BigramBase):
     def test_reordered_chinese_is_near_duplicate(self):
         sim = dedupe.hybrid_similarity("国产大模型最新测评对比", "国产大模型测评对比最新")
         self.assertGreater(sim, 0.5)
@@ -54,6 +81,14 @@ class TestChineseDedupe(unittest.TestCase):
     def test_distinct_chinese_is_not_duplicate(self):
         sim = dedupe.hybrid_similarity("国产大模型测评", "今天天气很好出门散步")
         self.assertLess(sim, 0.3)
+
+
+class TestJiebaBinding(unittest.TestCase):
+    def test_jieba_global_is_bound_at_import(self):
+        # Eager import binds the module global once (None when jieba absent).
+        # No lazy initializer => no per-call race in the pipeline thread pool.
+        self.assertTrue(hasattr(cjk, "_jieba"))
+        self.assertFalse(hasattr(cjk, "_get_jieba"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Relevance scoring and near-duplicate detection tokenize by splitting on whitespace (`str.split()`). Chinese has no spaces between words, so a whole Chinese sentence collapses into a single token — token-overlap relevance and Jaccard dedup effectively **stop working for Chinese-language content**. This already affects the existing **Xiaohongshu** source (and any future CJK source).

## Changes

- Add `lib/cjk.py` with `segment(text)`, which splits text into CJK and non-CJK runs:
  - Non-CJK (ASCII/Latin) runs keep the original `\w+` word behavior — **English is unchanged**.
  - CJK runs are segmented by **jieba when installed**, falling back to **character bigrams** when it is not. Bigrams are dictionary-free and still give robust overlap signal (e.g. query `大模型` → `{大模, 模型}` overlaps text `国产大模型评测`).
- jieba stays **optional** — present: used; absent: bigram fallback. It is never added to the hard dependency set, so the skill keeps its zero-dependency, install-anywhere property (`pyproject dependencies = []`).
- Wire into `relevance.tokenize()` and `dedupe` (`_tokenize` / `token_jaccard`); both also union a small Chinese stopword set into their existing English stopwords.

## Testing

- [x] `uv run pytest tests/test_cjk.py tests/test_relevance.py tests/test_dedupe_v3.py -q` — all green
- [x] Full suite passes (1627 passed, 4 skipped)
- New `tests/test_cjk.py`: segmentation, Chinese relevance match/no-match, English non-regression, Chinese near-duplicate detection.

Quick before/after (default build, no jieba installed → bigram path):

| query vs text | before | after |
|---|---|---|
| `国产大模型 测评` vs `国产大模型最新测评` | ~0.0 (one giant token) | **0.93** |
| `国产大模型 测评` vs `今天天气很好` | — | 0.0 (correctly rejected) |
| `react hooks` vs `guide to react hooks` (English) | 1.0 | **1.0** (unchanged) |

## Limitations (stopword behavior in the bigram fallback)

The Chinese stopword set is fully effective only on the **jieba** path, which segments real words. On the **zero-dependency bigram fallback** it is partial, by construction:

- Single-character stopwords (的 / 了 / 是 / 在 …) are never emitted as tokens (every CJK token is a 2-char bigram), and bigrams that *contain* a stopword char (e.g. `品的`, `的真`) survive as mild noise tokens.
- Two-character stopwords (这个 / 什么 / 可以 …) are filtered only when they happen to align to a bigram boundary.

This does **not** affect correctness: matching is driven by the query's tokens, so stopword-bearing noise bigrams only appear on the text side and slightly dilute precision — they don't cause false matches. Verified: `产品 测评` vs `这个产品的真实测评` → 0.87 (correct match), unrelated text → 0.0. The core win is that Chinese is segmented at all (whole-sentence-as-one-token was the actual bug); the stopword union is a secondary refinement that mainly pays off when jieba is installed.

## Related

Complements #514 (Bilibili adapter) and the existing Xiaohongshu source — both produce Chinese items that currently can't be deduped or ranked correctly. This is an independent, source-agnostic fix to the tokenization layer.

## Related Issues

None filed.

