### PR TITLE
Add a pi package bridge for last30days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Build .skill artifact
         run: |
           bash skills/last30days/scripts/build-skill.sh
           test -f dist/last30days.skill
 
+      - name: Verify and pack pi package
+        run: |
+          npm run verify:pi
+          npm pack
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/last30days.skill
+          files: |
+            dist/last30days.skill
+            last30days-pi-*.tgz
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,5 +22,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify pi package
+        run: npm run verify:pi
+
       - name: Run test suite
         run: uv run pytest

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.git
+.github
+.venv
+.pytest_cache
+__pycache__
+*.pyc
+.pytest_cache/
+.DS_Store
+dist/
+fixtures/
+tests/
+media/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pi package bridge (`package.json`, `extensions/index.ts`, `pi-skills/last30days/SKILL.md`, `docs/pi.md`) exposing the engine as pi tools, slash commands, and a concise pi-native skill.
+- `last30days_research` and `last30days_diagnose` tools for natural-language pi use.
+- Pi commands: `/last30days`, `/last30days-doctor`, `/last30days-config`, `/last30days-open`, and `/last30days-skill`.
+- `npm run verify:pi` packaging smoke check for pi release hygiene.
+
 ## [3.3.2] - 2026-06-06
 
 ### Fixed

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -185,7 +185,7 @@ The schedule field stored on each topic is metadata - the actual cron / Task Sch
 
 ## Per-client patterns
 
-The skill is built to flex around different client environments. Four patterns that compose well:
+The skill is built to flex around different client environments. Five patterns that compose well:
 
 ### 1. Per-client `.claude/last30days.env` (preferred when you cd into client folders)
 
@@ -226,13 +226,27 @@ l30d-client() {
 # Usage: l30d-client acme "british airways middle east"
 ```
 
-### 3. Custom category-peer subreddits
+### 3. Pi package bridge
+
+Pi users can install this repo as a native pi package rather than via the generic Agent Skills installer:
+
+```bash
+pi install /absolute/path/to/last30days-skill
+# or a fork / git URL
+pi install https://github.com/<you>/last30days-skill
+```
+
+The pi package loads `extensions/index.ts` and `pi-skills/last30days/SKILL.md`, exposing typed tools (`last30days_research`, `last30days_diagnose`) plus `/last30days`, `/last30days-doctor`, `/last30days-config`, and `/last30days-open`. See [docs/pi.md](docs/pi.md).
+
+For project-scoped client work, install from the project with `pi install -l /absolute/path/to/last30days-skill`; teammates who trust the project will get the same package entry from `.pi/settings.json`.
+
+### 4. Custom category-peer subreddits
 
 [`scripts/lib/categories.py`](skills/last30days/scripts/lib/categories.py) holds a table of `(category_id, trigger_keywords, peer_subreddits)`. If a client lives in a vertical that isn't covered (legal-tech, real-estate-tech, B2B HR SaaS), add a row. Pure data, no logic.
 
 Section 2a of `SKILL.md` documents the merging rule the skill applies when your topic matches a category.
 
-### 4. Pre-built `--competitors-plan` JSON
+### 5. Pre-built `--competitors-plan` JSON
 
 For competitor-vs-comparisons that recur, a pre-written JSON skeleton per client industry saves real time:
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Say "eli5 on" after any research run. The synthesis rewrites in plain language. 
 | **Codex, Cursor, Copilot, Gemini CLI, GitHub Copilot, or any of 50+ [Agent Skills](https://agentskills.io) hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
 | **claude.ai** (web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) and upload via Settings > Capabilities > Skills > + | Re-download and re-upload |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+| **pi** | `pi install https://github.com/<you>/last30days-skill` or `pi install /path/to/checkout` | `pi update https://github.com/<you>/last30days-skill` or pull local checkout + `/reload` |
 
 ### Claude Code (recommended)
 
@@ -237,6 +238,29 @@ Enable "Code execution and file creation" under Capabilities first — skills wo
 ```bash
 clawhub install last30days-official
 ```
+
+### pi
+
+This repo ships a pi-native package bridge with typed tools and concise pi commands:
+
+```bash
+pi install /absolute/path/to/last30days-skill
+# or install a fork
+pi install https://github.com/<you>/last30days-skill
+```
+
+Then in pi:
+
+```text
+/reload
+/last30days OpenAI --quick
+/last30days "Claude Code vs OpenClaw" --deep --days 14
+/last30days Cursor IDE --emit html
+/last30days-doctor
+/last30days-config
+```
+
+The package exposes `last30days_research` and `last30days_diagnose` tools for natural-language use inside pi. More details: [docs/pi.md](docs/pi.md).
 
 ### Manual (developer)
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -1,0 +1,122 @@
+# Pi package
+
+This repo includes a pi-native bridge around the upstream `last30days` Python research engine.
+
+## What it adds
+
+- pi tool: `last30days_research`
+- pi tool: `last30days_diagnose`
+- command: `/last30days <topic> [--quick|--balanced|--deep] [--days N] [--emit html]`
+- command: `/last30days-doctor`
+- command: `/last30days-config`
+- command: `/last30days-open`
+- pi skill: `/skill:last30days`
+
+The pi integration does **not** ask the model to follow the Claude-specific 1400-line runtime contract in `skills/last30days/SKILL.md`. It keeps the useful part for pi: call the local Python engine through typed tools and concise slash commands.
+
+## Install in pi
+
+From a local checkout:
+
+```bash
+pi install /absolute/path/to/last30days-skill
+```
+
+Or from a git repo/fork:
+
+```bash
+pi install https://github.com/<you>/last30days-skill
+```
+
+Then reload pi:
+
+```text
+/reload
+```
+
+## Typical usage
+
+```text
+/last30days OpenAI --quick
+/last30days "Claude Code vs OpenClaw" --deep --days 14
+/last30days Cursor IDE --emit html
+/last30days OpenAI --competitors 2
+/last30days-doctor
+/last30days-config
+/last30days-open
+/skill:last30days cursor vs windsurf
+```
+
+Supported command flags:
+
+- `--quick`, `--balanced`, `--deep`
+- `--depth quick|balanced|deep`
+- `--days N` / `--days=N`
+- `--lookback N` / `--lookback=N`
+- `--emit compact|json|md|html`
+- `--search reddit,youtube,github`
+- `--web-backend auto|brave|exa|serper|parallel|none`
+- `--competitors` / `--competitors N`
+- `--no-auto-resolve` for literal searches
+
+## X / Twitter setup
+
+Fastest path:
+
+1. Log into `x.com` in a local browser.
+2. Open `~/.config/last30days/.env` with `/last30days-config`.
+3. Add:
+
+```env
+FROM_BROWSER=auto
+SETUP_COMPLETE=true
+```
+
+On macOS, Chrome may ask for Keychain permission the first time cookies are read.
+
+Alternative auth methods:
+
+```env
+XAI_API_KEY=...
+# or
+AUTH_TOKEN=...
+CT0=...
+```
+
+## Optional source unlocks
+
+```env
+# TikTok, Instagram, Threads, Pinterest, YouTube/TikTok comments
+SCRAPECREATORS_API_KEY=...
+INCLUDE_SOURCES=tiktok,instagram,threads
+
+# Web backends
+BRAVE_API_KEY=...
+EXA_API_KEY=...
+SERPER_API_KEY=...
+PARALLEL_API_KEY=...
+
+# Perplexity / Deep Research through OpenRouter
+OPENROUTER_API_KEY=...
+
+# Bluesky
+BSKY_HANDLE=you.bsky.social
+BSKY_APP_PASSWORD=...
+```
+
+Digg AI-1000 clusters unlock when `digg-pp-cli` is on `PATH`.
+
+## Developer checks
+
+```bash
+npm run verify:pi
+pi -e ./extensions/index.ts --skill ./pi-skills/last30days --mode json '/last30days-doctor'
+uv run pytest -q
+```
+
+## Notes
+
+- Python 3.12+ is required. If no `python3.12+` binary is found, the pi extension falls back to `uv run --project <repo> python`.
+- Reports are saved to `~/Documents/Last30Days/` by default.
+- Tool output is capped to pi's default tool-output budget; full report files remain in the save directory.
+- If coverage is sparse, run `/last30days-doctor` and configure more sources.

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,0 +1,602 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+const extensionDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(extensionDir);
+const scriptPath = join(repoRoot, "skills", "last30days", "scripts", "last30days.py");
+const configDir = join(homedir(), ".config", "last30days");
+const configPath = join(configDir, ".env");
+const saveDir = join(homedir(), "Documents", "Last30Days");
+
+type ResearchDepth = "quick" | "balanced" | "deep";
+type ResearchEmit = "compact" | "json" | "md" | "html";
+type WebBackend = "auto" | "brave" | "exa" | "serper" | "parallel" | "none";
+
+type PythonCommand = {
+  command: string;
+  prefixArgs: string[];
+  label: string;
+};
+
+const depthSchema = StringEnum(["quick", "balanced", "deep"] as const);
+const emitSchema = StringEnum(["compact", "json", "md", "html"] as const);
+const webBackendSchema = StringEnum(["auto", "brave", "exa", "serper", "parallel", "none"] as const);
+
+const configTemplate = `# /last30days configuration for pi
+# Add only the sources you want. Leave blank to keep zero-config sources.
+
+# X / Twitter (pick one):
+# FROM_BROWSER=auto
+# XAI_API_KEY=
+# AUTH_TOKEN=
+# CT0=
+
+# TikTok, Instagram, Threads, Pinterest, YouTube/TikTok comments:
+# SCRAPECREATORS_API_KEY=
+# INCLUDE_SOURCES=tiktok,instagram,threads
+# EXCLUDE_SOURCES=
+
+# Bluesky:
+# BSKY_HANDLE=you.bsky.social
+# BSKY_APP_PASSWORD=
+
+# Web and Perplexity / Deep Research:
+# BRAVE_API_KEY=
+# EXA_API_KEY=
+# SERPER_API_KEY=
+# PARALLEL_API_KEY=
+# OPENROUTER_API_KEY=
+
+# Optional local save location override:
+# LAST30DAYS_MEMORY_DIR=${saveDir}
+
+SETUP_COMPLETE=true
+`;
+
+async function findPython(pi: ExtensionAPI, signal?: AbortSignal): Promise<PythonCommand> {
+  const candidates = ["python3.14", "python3.13", "python3.12", "python3"];
+
+  for (const candidate of candidates) {
+    try {
+      const result = await pi.exec(
+        candidate,
+        ["-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)"],
+        { signal, timeout: 10_000 },
+      );
+      if (result.code === 0) return { command: candidate, prefixArgs: [], label: candidate };
+    } catch {
+      // keep trying
+    }
+  }
+
+  try {
+    const result = await pi.exec(
+      "uv",
+      ["run", "--project", repoRoot, "python", "-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)"],
+      { signal, timeout: 60_000 },
+    );
+    if (result.code === 0) return { command: "uv", prefixArgs: ["run", "--project", repoRoot, "python"], label: "uv run python" };
+  } catch {
+    // fall through
+  }
+
+  throw new Error("last30days needs Python 3.12+ or uv. I checked python3.14, python3.13, python3.12, python3, and uv run python.");
+}
+
+async function ensureConfigFile(): Promise<void> {
+  await mkdir(configDir, { recursive: true });
+  try {
+    await access(configPath, constants.F_OK);
+  } catch {
+    await writeFile(configPath, configTemplate, { encoding: "utf8", mode: 0o600 });
+  }
+}
+
+async function openPath(pi: ExtensionAPI, path: string): Promise<void> {
+  if (process.platform === "darwin") {
+    await pi.exec("open", [path], { timeout: 10_000 });
+    return;
+  }
+  if (process.platform === "win32") {
+    await pi.exec("cmd", ["/c", "start", "", path], { timeout: 10_000 });
+    return;
+  }
+  await pi.exec("xdg-open", [path], { timeout: 10_000 });
+}
+
+function depthToFlags(depth: ResearchDepth): string[] {
+  if (depth === "quick") return ["--quick"];
+  if (depth === "deep") return ["--deep"];
+  return [];
+}
+
+function tokenizeCommandArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaping = false;
+
+  for (const char of input.trim()) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === undefined) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (/\s/.test(char) && quote === undefined) {
+      if (current) tokens.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function parseDepth(value: string): ResearchDepth | undefined {
+  if (value === "quick" || value === "balanced" || value === "deep") return value;
+  return undefined;
+}
+
+function parseEmit(value: string): ResearchEmit | undefined {
+  if (value === "compact" || value === "json" || value === "md" || value === "html") return value;
+  return undefined;
+}
+
+function parseWebBackend(value: string): WebBackend | undefined {
+  if (value === "auto" || value === "brave" || value === "exa" || value === "serper" || value === "parallel" || value === "none") return value;
+  return undefined;
+}
+
+function parseDays(value: string | undefined): number | undefined {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 365) return parsed;
+  return undefined;
+}
+
+function parseCompetitorCount(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") return 2;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 6) return parsed;
+  return undefined;
+}
+
+type ParsedCommandArgs = {
+  topic: string;
+  depth: ResearchDepth;
+  days?: number;
+  autoResolve: boolean;
+  emit: ResearchEmit;
+  search?: string;
+  webBackend?: WebBackend;
+  competitors?: number;
+};
+
+function parseCommandArgs(input: string): ParsedCommandArgs {
+  const parts = tokenizeCommandArgs(input);
+  const topicParts: string[] = [];
+  let depth: ResearchDepth = "balanced";
+  let days: number | undefined;
+  let autoResolve = true;
+  let emit: ResearchEmit = "compact";
+  let search: string | undefined;
+  let webBackend: WebBackend | undefined;
+  let competitors: number | undefined;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "--quick" || part === "--balanced" || part === "--deep") {
+      depth = parseDepth(part.slice(2)) ?? depth;
+      continue;
+    }
+    if (part === "--depth" && i + 1 < parts.length) {
+      depth = parseDepth(parts[i + 1]) ?? depth;
+      i += 1;
+      continue;
+    }
+    if (part.startsWith("--depth=")) {
+      depth = parseDepth(part.slice("--depth=".length)) ?? depth;
+      continue;
+    }
+    if ((part === "--days" || part === "--lookback" || part === "--lookback-days") && i + 1 < parts.length) {
+      days = parseDays(parts[i + 1]) ?? days;
+      i += 1;
+      continue;
+    }
+    if (part.startsWith("--days=")) {
+      days = parseDays(part.slice("--days=".length)) ?? days;
+      continue;
+    }
+    if (part.startsWith("--lookback=")) {
+      days = parseDays(part.slice("--lookback=".length)) ?? days;
+      continue;
+    }
+    if (part.startsWith("--lookback-days=")) {
+      days = parseDays(part.slice("--lookback-days=".length)) ?? days;
+      continue;
+    }
+    if (part === "--emit" && i + 1 < parts.length) {
+      emit = parseEmit(parts[i + 1]) ?? emit;
+      i += 1;
+      continue;
+    }
+    if (part.startsWith("--emit=")) {
+      emit = parseEmit(part.slice("--emit=".length)) ?? emit;
+      continue;
+    }
+    if (part === "--search" && i + 1 < parts.length) {
+      search = parts[i + 1];
+      i += 1;
+      continue;
+    }
+    if (part.startsWith("--search=")) {
+      search = part.slice("--search=".length);
+      continue;
+    }
+    if (part === "--web-backend" && i + 1 < parts.length) {
+      webBackend = parseWebBackend(parts[i + 1]) ?? webBackend;
+      i += 1;
+      continue;
+    }
+    if (part.startsWith("--web-backend=")) {
+      webBackend = parseWebBackend(part.slice("--web-backend=".length)) ?? webBackend;
+      continue;
+    }
+    if (part === "--auto-resolve") {
+      autoResolve = true;
+      continue;
+    }
+    if (part === "--no-auto-resolve") {
+      autoResolve = false;
+      continue;
+    }
+    if (part === "--competitors") {
+      competitors = parseCompetitorCount(parts[i + 1]?.startsWith("--") ? undefined : parts[i + 1]) ?? competitors;
+      if (parts[i + 1] && !parts[i + 1].startsWith("--")) i += 1;
+      continue;
+    }
+    if (part.startsWith("--competitors=")) {
+      competitors = parseCompetitorCount(part.slice("--competitors=".length)) ?? competitors;
+      continue;
+    }
+    topicParts.push(part);
+  }
+
+  return { topic: topicParts.join(" ").trim(), depth, days, autoResolve, emit, search, webBackend, competitors };
+}
+
+function summarizeDiagnosis(data: any): string {
+  const available = Array.isArray(data?.available_sources) && data.available_sources.length > 0
+    ? data.available_sources.join(", ")
+    : "none";
+
+  const hints: string[] = [];
+  if (!Array.isArray(data?.available_sources) || !data.available_sources.includes("x")) {
+    hints.push("Unlock X/Twitter by logging into x.com or adding XAI_API_KEY or AUTH_TOKEN + CT0.");
+  }
+  if (!Array.isArray(data?.available_sources) || !data.available_sources.includes("digg")) {
+    hints.push("Install digg-pp-cli to add Digg AI-1000 story clusters without X auth.");
+  }
+  if (!Array.isArray(data?.available_sources) || !data.available_sources.includes("youtube")) {
+    hints.push("Install yt-dlp to enable YouTube search and transcripts.");
+  }
+  if (!data?.has_scrapecreators) {
+    hints.push("Add SCRAPECREATORS_API_KEY for TikTok, Instagram, Threads, Pinterest, and comment sources.");
+  }
+  if (!data?.native_web_backend) {
+    hints.push("Add BRAVE_API_KEY, EXA_API_KEY, SERPER_API_KEY, or PARALLEL_API_KEY for stronger auto-resolve / web coverage.");
+  }
+
+  const lines = [
+    `Available sources: ${available}`,
+    `GitHub: ${data?.has_github ? "yes" : "no"}`,
+    `X authenticated: ${data?.bird_authenticated ? "yes" : "no"}`,
+    `ScrapeCreators: ${data?.has_scrapecreators ? "yes" : "no"}`,
+    `Web backend: ${data?.native_web_backend ?? "none"}`,
+    `Config file: ${configPath}`,
+  ];
+
+  if (hints.length > 0) {
+    lines.push("", "Next unlocks:");
+    for (const hint of hints) lines.push(`- ${hint}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatToolText(text: string) {
+  const truncation = truncateHead(text, {
+    maxBytes: DEFAULT_MAX_BYTES,
+    maxLines: DEFAULT_MAX_LINES,
+  });
+
+  if (!truncation.truncated) {
+    return { text, truncation: undefined };
+  }
+
+  const notice = truncation.truncatedBy === "lines"
+    ? `[last30days output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines. Full report files are saved under ${saveDir}.]`
+    : `[last30days output truncated: showing ${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)} (${formatSize(DEFAULT_MAX_BYTES)} tool-output limit). Full report files are saved under ${saveDir}.]`;
+
+  return {
+    text: `${truncation.content.trimEnd()}\n\n${notice}`,
+    truncation,
+  };
+}
+
+type ResearchOptions = {
+  topic: string;
+  depth?: ResearchDepth;
+  days?: number;
+  autoResolve?: boolean;
+  emit?: ResearchEmit;
+  search?: string;
+  webBackend?: WebBackend;
+  competitors?: number;
+};
+
+function buildResearchArgs(options: ResearchOptions): string[] {
+  const depth = options.depth ?? "balanced";
+  const emit = options.emit ?? "compact";
+  const args = [
+    scriptPath,
+    options.topic,
+    "--emit",
+    emit,
+    "--save-dir",
+    saveDir,
+    "--save-suffix",
+    "pi",
+    ...depthToFlags(depth),
+  ];
+
+  if (options.days) args.push("--days", String(options.days));
+  if (options.search) args.push("--search", options.search);
+  if (options.webBackend) args.push("--web-backend", options.webBackend);
+  if (options.autoResolve ?? true) args.push("--auto-resolve");
+  if (options.competitors) args.push("--competitors", String(options.competitors));
+  return args;
+}
+
+async function runResearch(pi: ExtensionAPI, options: ResearchOptions, signal?: AbortSignal) {
+  const python = await findPython(pi, signal);
+  await mkdir(saveDir, { recursive: true });
+
+  const result = await pi.exec(python.command, [...python.prefixArgs, ...buildResearchArgs(options)], {
+    signal,
+    timeout: options.depth === "deep" || options.competitors ? 900_000 : 420_000,
+  });
+
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+  if (result.code !== 0) {
+    throw new Error(stderr || stdout || "last30days failed");
+  }
+
+  return {
+    text: stderr ? `${stderr}\n\n${stdout}` : stdout,
+    details: {
+      topic: options.topic,
+      depth: options.depth ?? "balanced",
+      days: options.days ?? 30,
+      emit: options.emit ?? "compact",
+      search: options.search,
+      webBackend: options.webBackend,
+      autoResolve: options.autoResolve ?? true,
+      competitors: options.competitors,
+      python: python.label,
+      scriptPath,
+      saveDir,
+      configPath,
+    },
+  };
+}
+
+async function runDiagnose(pi: ExtensionAPI, signal?: AbortSignal) {
+  const python = await findPython(pi, signal);
+  const result = await pi.exec(python.command, [...python.prefixArgs, scriptPath, "--diagnose"], {
+    signal,
+    timeout: 60_000,
+  });
+
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+  if (result.code !== 0) {
+    throw new Error(stderr || stdout || "last30days diagnose failed");
+  }
+
+  const data = JSON.parse(stdout);
+  return {
+    text: summarizeDiagnosis(data),
+    details: { ...data, configPath, saveDir, python: python.label },
+  };
+}
+
+export default function last30daysPiBridge(pi: ExtensionAPI) {
+  pi.registerMessageRenderer("last30days-report", (message, _options, theme) => {
+    const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+    const header = theme.fg("accent", theme.bold("last30days"));
+    box.addChild(new Text(`${header}\n\n${message.content}`, 0, 0));
+    return box;
+  });
+
+  pi.registerMessageRenderer("last30days-doctor", (message, _options, theme) => {
+    const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+    const header = theme.fg("warning", theme.bold("last30days doctor"));
+    box.addChild(new Text(`${header}\n\n${message.content}`, 0, 0));
+    return box;
+  });
+
+  pi.registerTool({
+    name: "last30days_research",
+    label: "Last30Days Research",
+    description:
+      "Run the local last30days engine to research what people have been saying about a topic in the last 30 days across Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, Digg, and optional web/social sources. Output is truncated to pi's default tool-output budget; full reports are saved locally.",
+    promptSnippet:
+      "Research current discourse, recommendations, comparisons, and trend signals across last30days social/news sources.",
+    promptGuidelines: [
+      "Use last30days_research when the user wants current last-30-days discourse, sentiment, recommendations, trend signals, or comparisons.",
+      "Prefer last30days_research depth=quick for a fast pulse check, balanced for normal use, and deep for exhaustive research.",
+      "Use last30days_diagnose when last30days_research results seem sparse or the user asks about setup.",
+    ],
+    parameters: Type.Object({
+      topic: Type.String({ description: "Topic to research" }),
+      depth: Type.Optional(depthSchema),
+      days: Type.Optional(Type.Number({ description: "Lookback window in days", minimum: 1, maximum: 365 })),
+      emit: Type.Optional(emitSchema),
+      search: Type.Optional(Type.String({ description: "Optional comma-separated source list, e.g. reddit,youtube,github" })),
+      webBackend: Type.Optional(webBackendSchema),
+      autoResolve: Type.Optional(Type.Boolean({ description: "Use last30days auto-resolve for platforms without native web search", default: true })),
+      competitors: Type.Optional(Type.Number({ description: "Optional number of competitors to auto-discover for comparison mode, 1..6", minimum: 1, maximum: 6 })),
+    }),
+    async execute(_toolCallId, params, signal, onUpdate) {
+      const depth = (params.depth ?? "balanced") as ResearchDepth;
+      onUpdate?.({ content: [{ type: "text", text: `Running last30days (${depth}) for: ${params.topic}` }] });
+
+      const result = await runResearch(
+        pi,
+        {
+          topic: params.topic,
+          depth,
+          days: params.days,
+          emit: params.emit as ResearchEmit | undefined,
+          search: params.search,
+          webBackend: params.webBackend as WebBackend | undefined,
+          autoResolve: params.autoResolve,
+          competitors: params.competitors,
+        },
+        signal,
+      );
+      const toolText = formatToolText(result.text);
+      return {
+        content: [{ type: "text", text: toolText.text }],
+        details: { ...result.details, truncation: toolText.truncation },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "last30days_diagnose",
+    label: "Last30Days Diagnose",
+    description: "Check which last30days sources are currently available and explain what to configure next.",
+    promptSnippet: "Inspect current last30days setup and source availability.",
+    promptGuidelines: ["Use last30days_diagnose when the user asks about setup, missing sources, or why a last30days result seems sparse."],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, signal) {
+      const result = await runDiagnose(pi, signal);
+      return { content: [{ type: "text", text: result.text }], details: result.details };
+    },
+  });
+
+  pi.registerCommand("last30days", {
+    description: "Research a topic with the local last30days engine",
+    handler: async (args, ctx) => {
+      const parsed = parseCommandArgs(args);
+      if (!parsed.topic) {
+        ctx.ui.notify("Usage: /last30days <topic> [--quick|--balanced|--deep] [--days N] [--emit html]", "warning");
+        return;
+      }
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy. Wait for the current turn to finish.", "warning");
+        return;
+      }
+
+      ctx.ui.notify(`Researching ${parsed.topic}...`, "info");
+      ctx.ui.setStatus("last30days", `researching ${parsed.topic}`);
+      try {
+        const result = await runResearch(pi, parsed);
+        pi.sendMessage({ customType: "last30days-report", content: result.text, display: true, details: result.details });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`last30days failed: ${message}`, "error");
+      } finally {
+        ctx.ui.setStatus("last30days", undefined);
+      }
+    },
+  });
+
+  pi.registerCommand("last30days-doctor", {
+    description: "Explain which last30days sources are available and what to configure next",
+    handler: async (_args, ctx) => {
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy. Wait for the current turn to finish.", "warning");
+        return;
+      }
+
+      ctx.ui.notify("Checking last30days setup...", "info");
+      ctx.ui.setStatus("last30days", "checking setup");
+      try {
+        const result = await runDiagnose(pi);
+        pi.sendMessage({ customType: "last30days-doctor", content: result.text, display: true, details: result.details });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`last30days doctor failed: ${message}`, "error");
+      } finally {
+        ctx.ui.setStatus("last30days", undefined);
+      }
+    },
+  });
+
+  pi.registerCommand("last30days-config", {
+    description: "Open ~/.config/last30days/.env for manual setup",
+    handler: async (_args, ctx) => {
+      try {
+        await ensureConfigFile();
+        await openPath(pi, configPath);
+        ctx.ui.notify(`Opened ${configPath}`, "info");
+      } catch {
+        ctx.ui.notify(`Could not open config automatically. Edit ${configPath}`, "warning");
+      }
+    },
+  });
+
+  pi.registerCommand("last30days-open", {
+    description: "Open the local last30days report directory",
+    handler: async (_args, ctx) => {
+      try {
+        await mkdir(saveDir, { recursive: true });
+        await openPath(pi, saveDir);
+        ctx.ui.notify(`Opened ${saveDir}`, "info");
+      } catch {
+        ctx.ui.notify(`Could not open report directory automatically. Open ${saveDir}`, "warning");
+      }
+    },
+  });
+
+  pi.registerCommand("last30days-skill", {
+    description: "Run the pi last30days skill explicitly",
+    handler: async (args, ctx) => {
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy. Wait for the current turn to finish.", "warning");
+        return;
+      }
+      pi.sendUserMessage(`/skill:last30days ${args.trim()}`.trim());
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "last30days-pi",
+  "version": "0.1.0",
+  "description": "Pi package that exposes the last30days research engine as pi tools, commands, and a skill",
+  "license": "MIT",
+  "homepage": "https://github.com/mvanhorn/last30days-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mvanhorn/last30days-skill.git"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-skill",
+    "research",
+    "last30days"
+  ],
+  "files": [
+    "extensions",
+    "pi-skills",
+    "skills/last30days/SKILL.md",
+    "skills/last30days/agents/**/*",
+    "skills/last30days/references/**/*",
+    "skills/last30days/scripts/**/*.py",
+    "skills/last30days/scripts/**/*.sh",
+    "skills/last30days/scripts/lib/vendor/**/*",
+    "scripts/verify-pi-package.mjs",
+    "README.md",
+    "CONFIGURATION.md",
+    "docs/pi.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "verify:pi": "node scripts/verify-pi-package.mjs",
+    "pack:dry-run": "npm pack --json --dry-run"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./extensions"
+    ],
+    "skills": [
+      "./pi-skills"
+    ]
+  }
+}

--- a/pi-skills/last30days/SKILL.md
+++ b/pi-skills/last30days/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: last30days
+description: Research what people are saying about a topic in the last 30 days using the local last30days engine from pi across Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, Digg, and optional web/social sources.
+---
+
+# last30days for pi
+
+Use this skill when the user wants current discourse, recommendations, comparisons, trend signals, market/social sentiment, or a shareable brief from the last 30 days.
+
+This is the pi wrapper around the upstream `mvanhorn/last30days-skill` Python engine. Prefer the pi tools exposed by the extension instead of trying to follow the Claude-specific root skill contract.
+
+## Parse the request
+
+Support these optional inline flags when the user includes them:
+
+- `--quick` → fast pulse check
+- `--balanced` or `--depth balanced` → normal/default depth
+- `--deep` or `--depth deep` → more exhaustive research
+- `--days N`, `--days=N`, `--lookback N`, `--lookback=N`, `--lookback-days N`, or `--lookback-days=N` → custom lookback window
+- `--emit html|md|json|compact` → output/export format. Use `html` when the user asks for a shareable brief.
+- `--search source1,source2` → source filter when the user explicitly asks for one
+- `--web-backend auto|brave|exa|serper|parallel|none` → web backend preference
+- `--competitors` or `--competitors N` → competitor comparison mode
+- `--no-auto-resolve` → skip entity/community pre-resolution if the user wants a literal search
+
+Treat the remaining text as the topic. Quoted phrases are allowed in `/last30days` commands.
+
+If no topic is provided, ask the user what they want to research.
+
+## Setup / sparse-result help
+
+If the user asks about setup, missing sources, auth, sparse results, or why a source did not appear:
+
+1. Call `last30days_diagnose`.
+2. Explain the currently active sources.
+3. Tell the user `/last30days-config` opens `~/.config/last30days/.env`.
+4. Mention `/last30days-open` opens the saved report directory.
+5. Common unlocks:
+   - X/Twitter: log into x.com or add `XAI_API_KEY` or `AUTH_TOKEN` + `CT0`
+   - Digg: install `digg-pp-cli`
+   - YouTube: install `yt-dlp`
+   - TikTok / Instagram / Threads / Pinterest / comments: add `SCRAPECREATORS_API_KEY`
+   - Web: add `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, or `PARALLEL_API_KEY`
+   - Perplexity / Deep Research: add `OPENROUTER_API_KEY`
+
+## Research flow
+
+1. Parse the topic and optional flags.
+2. Call `last30days_research` with the parsed topic.
+3. Use depth `balanced` by default.
+4. Use `quick` for a simple pulse check.
+5. Use `deep` when the user explicitly asks for an exhaustive pass or a richer comparison.
+6. Use `emit=html` when the user asks for a shareable/slack/email/Notion-ready brief.
+7. Keep `autoResolve` enabled unless the user explicitly asks for literal/no-resolve behavior.
+8. If the user asks to compare a company/product against peers and does not name peers, use `competitors=2` unless they specify a different count.
+
+## Response style
+
+- Summarize the highest-signal findings first.
+- Call out when the report is obviously source-limited.
+- Be concrete about what sources were active if that matters.
+- If the tool output says it was truncated, mention that full reports are saved under `LAST30DAYS_MEMORY_DIR`, which defaults to `~/Documents/Last30Days/`.
+- If an HTML or markdown export was requested, include the saved file path when the engine provides it.
+- End with a useful follow-up suggestion.

--- a/scripts/verify-pi-package.mjs
+++ b/scripts/verify-pi-package.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const requiredPaths = [
+  "package.json",
+  "README.md",
+  "CONFIGURATION.md",
+  "docs/pi.md",
+  "extensions/index.ts",
+  "pi-skills/last30days/SKILL.md",
+  "skills/last30days/SKILL.md",
+  "skills/last30days/scripts/last30days.py",
+  "skills/last30days/scripts/lib/schema.py",
+  "skills/last30days/scripts/lib/render.py",
+  "skills/last30days/scripts/lib/setup_wizard.py",
+  "scripts/verify-pi-package.mjs",
+];
+
+const forbiddenPatterns = [
+  /__pycache__\//,
+  /\.pyc$/,
+  /^\.venv\//,
+  /^\.pytest_cache\//,
+  /^tests\//,
+  /^fixtures\//,
+  /^media\//,
+];
+
+function fail(message) {
+  console.error(`verify-pi-package: ${message}`);
+  process.exit(1);
+}
+
+const raw = execFileSync("npm", ["pack", "--json", "--dry-run"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "inherit"],
+});
+
+const parsed = JSON.parse(raw);
+if (!Array.isArray(parsed) || parsed.length === 0) {
+  fail("npm pack --json --dry-run returned no package metadata");
+}
+
+const pkg = parsed[0];
+const files = Array.isArray(pkg.files) ? pkg.files.map((entry) => entry.path) : [];
+const fileSet = new Set(files);
+
+for (const requiredPath of requiredPaths) {
+  if (!fileSet.has(requiredPath)) {
+    fail(`missing required packaged file: ${requiredPath}`);
+  }
+}
+
+for (const path of files) {
+  for (const pattern of forbiddenPatterns) {
+    if (pattern.test(path)) {
+      fail(`forbidden packaged file matched ${pattern}: ${path}`);
+    }
+  }
+}
+
+if (typeof pkg.entryCount === "number" && pkg.entryCount > 220) {
+  fail(`package contains ${pkg.entryCount} entries; expected a lean pi package`);
+}
+
+console.log(
+  `verify-pi-package: ok (${pkg.filename}, ${pkg.entryCount ?? files.length} entries, ${pkg.unpackedSize} bytes unpacked)`,
+);


### PR DESCRIPTION
## Summary

This PR keeps Matt's original `mvanhorn/last30days-skill` engine and Agent Skill contract intact, and adds a pi-native package surface on top of it for people in the pi ecosystem.

The goal is not to fork the product direction or reimplement the research engine. It is to make the existing last30days engine easier to install, invoke, diagnose, and package from pi.

## What's added for pi users

- `package.json` with `pi` manifest so pi can install the repo directly
- `extensions/index.ts` bridge exposing:
  - `last30days_research`
  - `last30days_diagnose`
  - `/last30days`
  - `/last30days-doctor`
  - `/last30days-config`
  - `/last30days-open`
  - `/last30days-skill`
- `pi-skills/last30days/SKILL.md`, a concise pi-native wrapper that avoids asking pi models to follow the Claude-specific long runtime contract
- `docs/pi.md` with install, setup, source unlocks, and developer checks
- README and CONFIGURATION notes for pi install/workflows
- `npm run verify:pi` to keep the pi tarball lean and complete
- CI/release workflow updates so the pi package gets validated and can be attached to releases as `last30days-pi-*.tgz`

## Why this helps the pi ecosystem

Pi users get a first-class path:

```bash
pi install /absolute/path/to/last30days-skill
# or from a fork/git URL
pi install https://github.com/<you>/last30days-skill
```

Then inside pi:

```text
/last30days OpenAI --quick
/last30days "Claude Code vs OpenClaw" --deep --days 14
/last30days Cursor IDE --emit html
/last30days-doctor
/last30days-config
```

This makes Matt's work available to pi users as native tools and commands, while preserving the upstream engine and normal Agent Skills install paths.

## Validation

- `npm run verify:pi`
- `pi -e /Users/geetkhosla/last30days-skill-latest --offline --no-context-files --no-extensions --no-skills --mode json '/last30days-doctor'`
- `uv run pytest -q`
