### PR TITLE
fix(threads): use 'query' param and cap to 1-2 word queries

### DIFF
--- a/skills/last30days/scripts/lib/threads.py
+++ b/skills/last30days/scripts/lib/threads.py
@@ -29,15 +29,22 @@ def _log(msg: str):
 
 
 def _extract_core_subject(topic: str) -> str:
-    """Extract core subject from verbose query for Threads search."""
+    """Extract core subject from verbose query for Threads search.
+
+    The ScrapeCreators Threads keyword endpoint only returns hits for short
+    (1-2 word) queries; 3+ words or leaked boolean operators (the planner
+    emits "A OR B") return zero. Strip boolean operators and cap to the two
+    most salient words.
+    """
     from .query import extract_core_subject
     _THREADS_NOISE = frozenset({
         'best', 'top', 'good', 'great', 'awesome',
         'latest', 'new', 'news', 'update', 'updates',
         'trending', 'hottest', 'popular', 'viral',
         'practices', 'features', 'recommendations', 'advice',
+        'or', 'and',
     })
-    return extract_core_subject(topic, noise=_THREADS_NOISE)
+    return extract_core_subject(topic, noise=_THREADS_NOISE, max_words=2)
 
 
 def _parse_date(item: Dict[str, Any]) -> Optional[str]:
@@ -154,7 +161,7 @@ def search_threads(
     try:
         data = http.get(
             f"{SCRAPECREATORS_BASE}/search",
-            params={"keyword": core_topic},
+            params={"query": core_topic},
             headers=http.scrapecreators_headers(token),
             timeout=30,
             retries=2,

--- a/skills/last30days/scripts/lib/threads.py
+++ b/skills/last30days/scripts/lib/threads.py
@@ -44,7 +44,8 @@ def _extract_core_subject(topic: str) -> str:
         'practices', 'features', 'recommendations', 'advice',
         'or', 'and',
     })
-    return extract_core_subject(topic, noise=_THREADS_NOISE, max_words=2)
+    core = extract_core_subject(topic, noise=_THREADS_NOISE, max_words=2)
+    return " ".join(core.rstrip("?!.").split()[:2])
 
 
 def _parse_date(item: Dict[str, Any]) -> Optional[str]:

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,25 @@
+"""Tests for Threads source module."""
+
+import unittest
+
+from lib import threads
+
+
+class TestExtractCoreSubject(unittest.TestCase):
+    """Test Threads query preprocessing."""
+
+    def test_caps_verbose_planner_query_to_two_words(self):
+        self.assertEqual(
+            threads._extract_core_subject("AI video tools OR tutorials"),
+            "ai video",
+        )
+
+    def test_caps_all_noise_fallback_to_two_words(self):
+        self.assertEqual(
+            threads._extract_core_subject("best practices and recommendations"),
+            "best practices",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The Threads source has been **dark for all users**. The ScrapeCreators Threads search endpoint changed its contract and now rejects the `keyword` parameter the adapter sends:

```json
{"success":false,"error":"bad_request","message":"You must provide a 'query'"}
```

HTTP 400 on every call. `search_threads` catches it and returns `{"items": [], ...}`, so it fails silently — runs just show `Threads: 0 results`.

## Fix

**1. Correct the param name** — `params={"query": ...}` instead of `{"keyword": ...}`.

**2. Cap query length.** Even with the right param, the endpoint only returns hits for short (1–2 word) queries, and the planner feeds sources verbose boolean strings (e.g. `"skincare routine favorites OR recommendations"`). Empirically against the live API:

| query | posts |
|---|---|
| `skincare routine favorites or` | 0 |
| `skincare routine favorites` (3 words) | 0 |
| `skincare routine` | 19 |
| `skincare` | 20 |
| `AI video generator tutorial` (4 words) | 0 |
| `AI video` | 20 |

So `_extract_core_subject` now strips boolean operators (`or`/`and`) and caps to the two most salient words (`max_words=2`).

## Verification

Tested end-to-end against the live API on v3.3.2. Threads now returns parsed posts with correct dates, engagement, and relevance for both single-word topics and verbose planner queries (e.g. `"AI video tools"` → 4 posts, `"skincare"` → 2 posts).

- `python3 -m py_compile` passes.
- No existing test asserts the `keyword` param (the only `*thread*` test is `test_competitors_plan_threading.py`, unrelated Python threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)