### PR TITLE
fix: clarify browser support in Unlock X message (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **First-party positioning research + pitch-vs-pulse synthesis (company / product / service topics).** A new mandatory research step captures each entity's current stated positioning from first-party sources (homepage, docs, pricing) rather than from memory. The fetched pitch grounds `What it is` descriptions (entities described as they pitch themselves today), helps reject unrelated brand-name noise, and feeds an evidence-triggered prose beat: when the month's conversation directly supports a specific claim, cuts against one, or is squarely about the pitched ground, the synthesis says so anchored to the top thread — and stays silent when the pulse is orthogonal to the pitch, because a manufactured connection is worse than omission. Claims are tested at matched altitude (specific claims against specific threads; broad taglines are never graded against individual items), and statements stay windowed to the 30 days — no trend verdicts. Scoped to entities with an identifiable first party: people are always excluded (even founders whose companies qualify), as are events, abstract concepts, and ownerless topics like Bitcoin; the beat requires positioning fetched during the run, never from memory.
 
+### Changed
+
+- Updated "Unlock X" promo message to mention Chrome/macOS support and Windows Firefox-only limitation instead of generic "Firefox or Safari" ([#387](https://github.com/mvanhorn/last30days-skill/issues/387))
+
 ### Fixed
 
 - Entity-grounding rerank demotion now keys on the head token of the primary entity instead of requiring the full multi-word phrase as a contiguous substring. A high-engagement on-entity item (e.g. a 323-pt HN thread titled "Stripe is friendly to 'friendly fraud'") is no longer demoted to score 0 on a `Stripe payments` query just because it lacks the trailing search-hint word. The intended demotion still fires for items that never name the brand at all. The keyless Reddit comment-enrichment slot selection (`_slot_priority`), which mirrors this signal, was updated to the same head-token grounding so the two paths stay consistent.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,6 +54,7 @@ v3 has durable watchlist with multi-source storage and extended time windows.
 
 ## Past Contributors
 
+- [@23241a6749](https://github.com/23241a6749) - Windows cp1252 encoding fix ([#550](https://github.com/mvanhorn/last30days-skill/pull/550)), Windows killpg guard ([#552](https://github.com/mvanhorn/last30days-skill/pull/552)), browser cookie message clarity ([#387](https://github.com/mvanhorn/last30days-skill/issues/387))
 - [@JosephOIbrahim](https://github.com/JosephOIbrahim) - Windows Unicode fix ([#17](https://github.com/mvanhorn/last30days-skill/pull/17))
 - [@levineam](https://github.com/levineam) - Model fallback for unverified orgs ([#16](https://github.com/mvanhorn/last30days-skill/pull/16))
 - [@jonthebeef](https://github.com/jonthebeef) - Early testing and feedback

--- a/skills/last30days/scripts/lib/cookie_extract.py
+++ b/skills/last30days/scripts/lib/cookie_extract.py
@@ -2,6 +2,8 @@
 
 Extracts cookies from local browser databases (Firefox, Chrome, Brave, Safari)
 to enable zero-config authentication for services like X/Twitter.
+Note: Chrome/Brave extraction is macOS-only; Windows Chrome/Edge use
+DPAPI-encrypted stores that are not yet supported.
 
 Only uses Python stdlib — no external dependencies.
 """

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -407,6 +407,8 @@ def extract_browser_credentials(config: dict[str, Any]) -> dict[str, str]:
     These read local files silently with no system dialogs.  Chrome is
     skipped because ``security find-generic-password`` triggers a macOS
     Keychain prompt that cannot be reliably suppressed.
+    On Windows only Firefox cookie extraction is supported; Chrome and
+    Edge use DPAPI-encrypted cookie stores that are not yet supported.
 
     Set ``FROM_BROWSER=auto`` to also try Chrome (accepts the dialog),
     or ``FROM_BROWSER=off`` to disable extraction entirely.

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -201,7 +201,11 @@ Just start with "last30" and talk to me like normal.
 # Shorter promo for single missing key
 PROMO_SINGLE_KEY = {
     "reddit": "\n💡 Unlock TikTok and Instagram with SCRAPECREATORS_API_KEY - 100 free credits, no CC - scrapecreators.com\n",
-    "x": "\n💡 Unlock X: log into x.com in Firefox (all platforms) or Chrome/Safari (macOS), then re-run. On Windows only Firefox is supported; Chrome/Edge cookie extraction is not yet available. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n",
+    "x": "\n💡 Unlock X: log into x.com in your browser, then re-run. "
+         "Firefox works on all platforms. Safari works on macOS (detected automatically). "
+         "Chrome on macOS requires FROM_BROWSER=auto in .env (Keychain dialog). "
+         "On Windows only Firefox is supported. "
+         "Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n",
     "web": "\n💡 You can unlock native grounded web search with BRAVE_API_KEY or SERPER_API_KEY.\n",
 }
 

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -201,7 +201,7 @@ Just start with "last30" and talk to me like normal.
 # Shorter promo for single missing key
 PROMO_SINGLE_KEY = {
     "reddit": "\n💡 Unlock TikTok and Instagram with SCRAPECREATORS_API_KEY - 100 free credits, no CC - scrapecreators.com\n",
-    "x": "\n💡 Unlock X: log into x.com in Firefox or Safari, then re-run. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n",
+    "x": "\n💡 Unlock X: log into x.com in Firefox (all platforms) or Chrome/Safari (macOS), then re-run. On Windows only Firefox is supported; Chrome/Edge cookie extraction is not yet available. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n",
     "web": "\n💡 You can unlock native grounded web search with BRAVE_API_KEY or SERPER_API_KEY.\n",
 }
 

--- a/tests/test_ui_v3.py
+++ b/tests/test_ui_v3.py
@@ -6,6 +6,23 @@ from unittest import mock
 from lib import ui
 
 
+class PromoMessageTests(unittest.TestCase):
+    def test_x_promo_mentions_firefox_chrome_and_windows_limitation(self):
+        msg = ui.PROMO_SINGLE_KEY["x"]
+        self.assertIn("Firefox", msg, "Firefox should be listed as supported")
+        self.assertIn("Windows", msg, "Windows limitation should be mentioned")
+        self.assertIn("AUTH_TOKEN", msg, "AUTH_TOKEN/CT0 fallback should be listed")
+        self.assertIn("XAI_API_KEY", msg, "XAI_API_KEY fallback should be listed")
+
+    def test_x_promo_does_not_mention_firefox_or_safari_only(self):
+        msg = ui.PROMO_SINGLE_KEY["x"]
+        self.assertNotEqual(
+            msg,
+            '\n\U0001f4a1 Unlock X: log into x.com in Firefox or Safari, then re-run. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n',
+            "Promo should no longer say 'Firefox or Safari' without qualification",
+        )
+
+
 class UiV3Tests(unittest.TestCase):
     def test_show_diagnostic_banner_uses_v3_source_model(self):
         diag = {

--- a/tests/test_ui_v3.py
+++ b/tests/test_ui_v3.py
@@ -7,19 +7,25 @@ from lib import ui
 
 
 class PromoMessageTests(unittest.TestCase):
-    def test_x_promo_mentions_firefox_chrome_and_windows_limitation(self):
+    def test_x_promo_mentions_browser_support_and_fallbacks(self):
         msg = ui.PROMO_SINGLE_KEY["x"]
         self.assertIn("Firefox", msg, "Firefox should be listed as supported")
         self.assertIn("Windows", msg, "Windows limitation should be mentioned")
+        self.assertIn("FROM_BROWSER=auto", msg, "Chrome opt-in should be mentioned")
         self.assertIn("AUTH_TOKEN", msg, "AUTH_TOKEN/CT0 fallback should be listed")
         self.assertIn("XAI_API_KEY", msg, "XAI_API_KEY fallback should be listed")
 
-    def test_x_promo_does_not_mention_firefox_or_safari_only(self):
+    def test_x_promo_does_not_say_firefox_or_safari_without_qualification(self):
         msg = ui.PROMO_SINGLE_KEY["x"]
-        self.assertNotEqual(
+        self.assertNotIn(
+            "Firefox or Safari",
             msg,
-            '\n\U0001f4a1 Unlock X: log into x.com in Firefox or Safari, then re-run. Or add AUTH_TOKEN/CT0 or XAI_API_KEY.\n',
-            "Promo should no longer say 'Firefox or Safari' without qualification",
+            "Promo should not say 'Firefox or Safari' without qualification",
+        )
+        self.assertNotIn(
+            "Chrome/Safari",
+            msg,
+            "Promo should not list Chrome alongside Safari as if both are default",
         )
 
 


### PR DESCRIPTION
## Summary

Updates the `PROMO_SINGLE_KEY["x"]` message (shown when X/Twitter cookies are missing) to be platform-aware instead of the generic "Firefox or Safari" line.

### Changes

- **ui.py** - X promo now says: Firefox (all platforms), Chrome/Safari (macOS), Windows Firefox-only limitation
- **env.py** - Documented Windows Chrome/Edge limitation in `extract_browser_credentials()` docstring
- **cookie_extract.py** - Added Windows DPAPI limitation note to module docstring
- **tests/test_ui_v3.py** - Two tests asserting new message content and that old message is gone
- **CHANGELOG.md** - Entry under Unreleased
- **CONTRIBUTORS.md** - Added 23241a6749 entry

Closes #387