### PR TITLE
fix: restore Reddit search for ChatGPT Codex (codex login) auth

### DIFF
--- a/scripts/lib/models.py
+++ b/scripts/lib/models.py
@@ -21,7 +21,10 @@ OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
 # Ordered by cost-efficiency for web_search + JSON extraction tasks.
 # Mini models first: same structured extraction quality at ~3x lower cost.
 OPENAI_FALLBACK_MODELS = ["gpt-5-mini", "gpt-4.1-mini", "gpt-4.1", "gpt-4o"]
-CODEX_FALLBACK_MODELS = ["gpt-5.1-codex-mini", "gpt-5.2"]
+# The ChatGPT Codex backend (chatgpt.com/backend-api/codex) only accepts a
+# subset of models — it rejects the *-codex and -mini variants with HTTP 400.
+# gpt-5.5 is the working general model for web_search + JSON extraction there.
+CODEX_FALLBACK_MODELS = ["gpt-5.5"]
 
 # xAI API - Agent Tools API requires grok-4 family
 # Non-reasoning: same price, faster, no unnecessary thinking tokens.

--- a/scripts/lib/openai_reddit.py
+++ b/scripts/lib/openai_reddit.py
@@ -98,13 +98,19 @@ def _parse_codex_stream(raw: str) -> Dict[str, Any]:
     """Parse SSE stream from Codex responses into a response-like dict."""
     events = _parse_sse_stream_raw(raw)
 
-    # Prefer explicit completed response payload if present
+    # Prefer explicit completed response payload if present.
+    # The Codex backend can emit a completed response with an EMPTY output
+    # array (text arrives only via delta events) — skip those so the delta
+    # reconstruction fallback below can recover the message text.
     for evt in reversed(events):
         if isinstance(evt, dict):
+            candidate = None
             if evt.get("type") == "response.completed" and isinstance(evt.get("response"), dict):
-                return evt["response"]
-            if isinstance(evt.get("response"), dict):
-                return evt["response"]
+                candidate = evt["response"]
+            elif isinstance(evt.get("response"), dict):
+                candidate = evt["response"]
+            if candidate and candidate.get("output"):
+                return candidate
 
     # Fallback: reconstruct output text from deltas
     output_text = ""
@@ -230,6 +236,9 @@ def _build_payload(model: str, instructions_text: str, input_text: str, auth_sou
             }
         ]
         payload["stream"] = True
+        # Codex GPT-5.x models default to slower reasoning; low effort keeps
+        # search+extract quality while fitting the per-source timeout budget.
+        payload["reasoning"] = {"effort": "low"}
     return payload
 
 
@@ -592,14 +601,21 @@ def parse_reddit_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
         print(f"[REDDIT WARNING] No output text found in OpenAI response. Keys present: {list(response.keys())}", flush=True)
         return items
 
-    # Extract JSON from the response
-    json_match = re.search(r'\{[\s\S]*"items"[\s\S]*\}', output_text)
-    if json_match:
+    # Extract JSON from the response. The model can emit multiple JSON
+    # objects back to back; a greedy regex spanning all of them makes
+    # json.loads fail with "Extra data", so decode objects individually.
+    decoder = json.JSONDecoder()
+    pos = output_text.find("{")
+    while pos != -1 and not items:
         try:
-            data = json.loads(json_match.group())
-            items = data.get("items", [])
+            data, end = decoder.raw_decode(output_text, pos)
         except json.JSONDecodeError:
-            pass
+            pos = output_text.find("{", pos + 1)
+            continue
+        if isinstance(data, dict) and isinstance(data.get("items"), list):
+            items = data["items"]
+            break
+        pos = output_text.find("{", end)
 
     # Validate and clean items
     clean_items = []


### PR DESCRIPTION
## Summary

Reddit search returns **zero results** for users who authenticate with `codex login` (a ChatGPT account) instead of an `OPENAI_API_KEY`. This PR makes four small, targeted fixes to the Codex auth path so Reddit search works again.

**Scope is deliberately narrow:** every change is confined to the `auth_source == codex` branch and the shared Reddit JSON parser. The `OPENAI_API_KEY` path and all other sources are untouched.

## Who this affects

Only users on **Codex / ChatGPT-login** auth. Users with an `OPENAI_API_KEY` see no change in behavior.

## Root cause

Three independent bugs in the Codex path, each individually enough to zero out results:

1. **Stale model list.** `CODEX_FALLBACK_MODELS = ["gpt-5.1-codex-mini", "gpt-5.2"]`. The Codex backend (`chatgpt.com/backend-api/codex`) rejects both with `HTTP 400 — "model is not supported when using Codex with a ChatGPT account"`.
2. **Empty `response.completed`.** `_parse_codex_stream` returned the completed event even when its `output` array was empty (the message text arrives via delta events), so the delta-reconstruction fallback never ran.
3. **Multi-object JSON.** `parse_reddit_response` used a greedy regex (`\{[\s\S]*"items"[\s\S]*\}`) that spanned multiple back-to-back JSON objects; `json.loads` then failed with `Extra data` and the exception was silently swallowed, yielding 0 items.

Plus one reliability tweak: gpt-5.x on the Codex backend defaults to slower reasoning and can exceed the per-source timeout. Setting `reasoning: {effort: "low"}` keeps it within the existing budget without measurable quality loss for search + JSON extraction.

## Changes

| File | Change |
|------|--------|
| `scripts/lib/models.py` | `CODEX_FALLBACK_MODELS` → `["gpt-5.5"]` |
| `scripts/lib/openai_reddit.py` | Skip empty-`output` completed payloads; decode JSON incrementally with `JSONDecoder.raw_decode`; add `reasoning: {effort: "low"}` to the Codex payload |

Net **+30 / −11** across 2 files. No new dependencies, no public API changes, no changes to the API-key path. Commits are split by concern for review.

## Testing

Verified locally on macOS against a ChatGPT Codex login (no `OPENAI_API_KEY` set):

- **Before:** `Reddit: error — API error: HTTP 400`, 0 threads.
- **After:** Reddit returns 14–21 threads on representative queries; `--diagnose` and full multi-source runs pass.

The incremental JSON decoder was also checked against a captured real response that previously parsed to 0 items — it now extracts all 24.

**Honest limitation:** I could not exercise the `OPENAI_API_KEY` path end-to-end (no key available). However, no code in that branch was modified, and the only shared change — the JSON extraction in `parse_reddit_response` — is strictly more robust than the regex it replaces (it accepts everything the old path did, plus the multi-object case).

## Notes for maintainers (upfront)

- **`gpt-5.5` is hardcoded** as the working Codex model as of June 2026. The Codex backend's accepted-model set changes over time, so you may prefer an env-configurable override rather than a pin — happy to rework it that way if you'd like.
- **`reasoning: "low"`** is a pragmatic default for timeout safety. If you'd rather derive it from the existing depth/timeout config, I can wire that in.
- Glad to **squash** the two commits if that fits your workflow better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
