### PR TITLE
fix(youtube): exempt transcript-bearing items from relevance pruning (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YouTube items with successfully extracted transcripts are no longer pruned by title-only relevance scoring; the transcript content proves substantive topical coverage even when the video title has low lexical overlap with the query ([#468](https://github.com/mvanhorn/last30days-skill/issues/468))
 - Entity-grounding rerank demotion now keys on the head token of the primary entity instead of requiring the full multi-word phrase as a contiguous substring. A high-engagement on-entity item (e.g. a 323-pt HN thread titled "Stripe is friendly to 'friendly fraud'") is no longer demoted to score 0 on a `Stripe payments` query just because it lacks the trailing search-hint word. The intended demotion still fires for items that never name the brand at all. The keyless Reddit comment-enrichment slot selection (`_slot_priority`), which mirrors this signal, was updated to the same head-token grounding so the two paths stay consistent.
 
 ## [3.3.2] - 2026-06-06

--- a/skills/last30days/scripts/lib/signals.py
+++ b/skills/last30days/scripts/lib/signals.py
@@ -238,6 +238,11 @@ def prune_low_relevance(
     sources_present = {item.source for item in items}
 
     def passes(item: schema.SourceItem) -> bool:
+        # YouTube items with successfully extracted transcripts should not
+        # be pruned by title-only relevance scoring — the transcript content
+        # already proves substantive topical coverage.
+        if item.source == "youtube" and item.snippet:
+            return True
         rel = item.local_relevance if item.local_relevance is not None else 0.0
         if rel < minimum:
             return False

--- a/tests/test_signals_v3.py
+++ b/tests/test_signals_v3.py
@@ -716,10 +716,20 @@ class SignalsV3Tests(unittest.TestCase):
             snippet="This is a detailed transcript about the topic with substantive discussion...",
             local_relevance=0.05,
         )
-        pruned = signals.prune_low_relevance([has_transcript], minimum=0.15)
+        strong = schema.SourceItem(
+            item_id="yt-strong",
+            source="youtube",
+            title="Strong video",
+            body="Detailed analysis of the topic",
+            url="https://youtube.com/watch?v=strong",
+            snippet="Detailed transcript content about the topic",
+            local_relevance=0.6,
+        )
+        pruned = signals.prune_low_relevance([strong, has_transcript], minimum=0.15)
         ids = [item.item_id for item in pruned]
         self.assertIn("yt-transcript", ids,
                       "YouTube item with transcript should survive pruning")
+        self.assertIn("yt-strong", ids, "Strong item should survive")
 
     def test_youtube_without_transcript_is_pruned_normally(self):
         """A YouTube item with no transcript (empty snippet) and low relevance

--- a/tests/test_signals_v3.py
+++ b/tests/test_signals_v3.py
@@ -702,5 +702,78 @@ class SignalsV3Tests(unittest.TestCase):
         aspire_ids = [item.item_id for item in pruned if item.item_id.startswith("aspire")]
         self.assertEqual(len(aspire_ids), 0, f"All @aspiresnippets items should be pruned, got {aspire_ids}")
 
+    # -- Fix 468: YouTube items with transcripts survive relevance pruning --
+
+    def test_youtube_with_transcript_survives_pruning_even_with_low_relevance(self):
+        """A YouTube item with a non-empty snippet (transcript) should not be
+        pruned even if its title-only relevance is below the threshold."""
+        has_transcript = schema.SourceItem(
+            item_id="yt-transcript",
+            source="youtube",
+            title="Short title",
+            body="Short body",
+            url="https://youtube.com/watch?v=abc",
+            snippet="This is a detailed transcript about the topic with substantive discussion...",
+            local_relevance=0.05,
+        )
+        pruned = signals.prune_low_relevance([has_transcript], minimum=0.15)
+        ids = [item.item_id for item in pruned]
+        self.assertIn("yt-transcript", ids,
+                      "YouTube item with transcript should survive pruning")
+
+    def test_youtube_without_transcript_is_pruned_normally(self):
+        """A YouTube item with no transcript (empty snippet) and low relevance
+        should still be pruned when stronger items exist."""
+        no_transcript = schema.SourceItem(
+            item_id="yt-no-transcript",
+            source="youtube",
+            title="Short title",
+            body="Short body",
+            url="https://youtube.com/watch?v=xyz",
+            snippet="",
+            local_relevance=0.05,
+        )
+        strong = schema.SourceItem(
+            item_id="yt-strong",
+            source="youtube",
+            title="Strong video",
+            body="Detailed analysis of the topic",
+            url="https://youtube.com/watch?v=strong",
+            snippet="Detailed transcript content about the topic",
+            local_relevance=0.6,
+        )
+        pruned = signals.prune_low_relevance([strong, no_transcript], minimum=0.15)
+        ids = [item.item_id for item in pruned]
+        self.assertIn("yt-strong", ids, "Strong item should survive")
+        self.assertNotIn("yt-no-transcript", ids,
+                         "YouTube item without transcript should be pruned normally")
+
+    def test_youtube_transcript_exemption_does_not_affect_other_sources(self):
+        """Non-YouTube items with low relevance are still pruned even if they
+        have a non-empty snippet (the exemption is YouTube-specific)."""
+        reddit_with_snippet = schema.SourceItem(
+            item_id="reddit-snippet",
+            source="reddit",
+            title="Short title",
+            body="Short body",
+            url="https://reddit.com/r/test",
+            snippet="Some snippet content",
+            local_relevance=0.05,
+        )
+        strong = schema.SourceItem(
+            item_id="strong",
+            source="reddit",
+            title="Strong post",
+            body="Detailed analysis of the topic",
+            url="https://reddit.com/r/strong",
+            local_relevance=0.5,
+        )
+        pruned = signals.prune_low_relevance([strong, reddit_with_snippet], minimum=0.15)
+        ids = [item.item_id for item in pruned]
+        self.assertIn("strong", ids, "Strong item should survive")
+        self.assertNotIn("reddit-snippet", ids,
+                         "Non-YouTube items should still be pruned by relevance threshold")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

YouTube items with successfully extracted transcripts were being dropped by `prune_low_relevance()` because relevance is computed from title and description only. For broad or long topics, video titles (5-10 words) have low lexical overlap with the query (10+ words), producing `local_relevance < 0.15` — yet the transcript content proves substantive topical coverage.

## Fix

In `signals.py:prune_low_relevance()`, add an early return that skips the minimum threshold for YouTube items with a non-empty `snippet` (which, at pruning time, contains the transcript). This is the minimal, targeted fix (Approach A from the issue).

## Changes

- **signals.py** — `prune_low_relevance()` exempts YouTube items with transcripts from the relevance threshold
- **tests/test_signals_v3.py** — 3 tests: transcript-bearing YT survives pruning; transcript-less YT is pruned; non-YT with snippet is still pruned
- **CHANGELOG.md** — Entry under Unreleased

Closes #468