### PR TITLE
fix: SKILL.md references Python setup wizard instead of missing nux-wizard.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- First-run setup wizard in SKILL.md now references the existing Python setup wizard (`last30days.py setup`) instead of the missing `nux-wizard.md` file, so first-run setup actually runs on new installs. ([#574](https://github.com/mvanhorn/last30days-skill/issues/574))
 - Entity-grounding rerank demotion now keys on the head token of the primary entity instead of requiring the full multi-word phrase as a contiguous substring. A high-engagement on-entity item (e.g. a 323-pt HN thread titled "Stripe is friendly to 'friendly fraud'") is no longer demoted to score 0 on a `Stripe payments` query just because it lacks the trailing search-hint word. The intended demotion still fires for items that never name the brand at all. The keyless Reddit comment-enrichment slot selection (`_slot_priority`), which mirrors this signal, was updated to the same head-token grounding so the two paths stay consistent.
+- `--plan` / `--competitors-plan` file reads now specify `encoding="utf-8"` and catch `UnicodeDecodeError`, preventing crashes on non-ASCII content like accented entity names on Windows (cp1252). `check_perms()` in `check-config.sh` now skips the POSIX 600-permission check on MSYS/MinGW/Cygwin where `stat` runs in noacl mode. `skill_meta.py` `read_skill_version()` now passes `encoding="utf-8"` so SKILL.md emoji doesn't break version detection on Windows. ([#549](https://github.com/mvanhorn/last30days-skill/issues/549))
 
 ## [3.3.2] - 2026-06-06
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,4 +57,4 @@ v3 has durable watchlist with multi-source storage and extended time windows.
 - [@JosephOIbrahim](https://github.com/JosephOIbrahim) - Windows Unicode fix ([#17](https://github.com/mvanhorn/last30days-skill/pull/17))
 - [@levineam](https://github.com/levineam) - Model fallback for unverified orgs ([#16](https://github.com/mvanhorn/last30days-skill/pull/16))
 - [@jonthebeef](https://github.com/jonthebeef) - Early testing and feedback
-- [@23241a6749](https://github.com/23241a6749) - Windows cp1252 fixes: utf-8 plan-file reads, skill_meta version-detection encoding, MSYS noacl permission check skip ([#549](https://github.com/mvanhorn/last30days-skill/pull/549))
+- [@23241a6749](https://github.com/23241a6749) - Windows cp1252 fixes: utf-8 plan-file reads, skill_meta version-detection encoding, MSYS noacl permission check skip ([#549](https://github.com/mvanhorn/last30days-skill/pull/549));  first-run setup wizard fix: SKILL.md references existing Python setup wizard instead of missing nux-wizard.md ([#574](https://github.com/mvanhorn/last30days-skill/pull/574))

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ v3 has durable watchlist with multi-source storage and extended time windows.
 - [@JosephOIbrahim](https://github.com/JosephOIbrahim) - Windows Unicode fix ([#17](https://github.com/mvanhorn/last30days-skill/pull/17))
 - [@levineam](https://github.com/levineam) - Model fallback for unverified orgs ([#16](https://github.com/mvanhorn/last30days-skill/pull/16))
 - [@jonthebeef](https://github.com/jonthebeef) - Early testing and feedback
+- [@23241a6749](https://github.com/23241a6749) - Windows cp1252 fixes: utf-8 plan-file reads, skill_meta version-detection encoding, MSYS noacl permission check skip ([#549](https://github.com/mvanhorn/last30days-skill/pull/549))

--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -11,6 +11,11 @@ GLOBAL_ENV="$HOME/.config/last30days/.env"
 check_perms() {
   local file="$1"
   if [[ ! -f "$file" ]]; then return; fi
+  # Git-for-Windows / MSYS / Cygwin run stat in noacl mode (always 644),
+  # so this POSIX check is a false positive. Windows perms use ACLs.
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) return ;;
+  esac
   local perms
   # Try GNU stat first (Linux), fall back to BSD stat (macOS).
   # On Linux, `stat -f` prints filesystem info (not permissions) and exits 0,

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -283,11 +283,11 @@ Before proceeding to Step 1, handle first-run setup.
 - If the file exists and contains `SETUP_COMPLETE=true`, skip Step 0 entirely and go to Step 1 (CRITICAL: Parse User Intent below). Do NOT announce that setup is complete. The user does not need a status message on every run.
 
 **If this IS a first run:**
-- Use the Read tool to load `skills/last30days/nux-wizard.md` (relative to the skill root).
-- Follow the wizard's instructions end-to-end. The wizard handles platform detection (OpenClaw vs Claude Code), auto vs manual setup, ScrapeCreators opt-in, and the initial topic picker.
+- Run `python3 skills/last30days/scripts/last30days.py setup` (relative to the skill root) to launch the setup wizard.
+- Follow the wizard's prompts end-to-end. The wizard handles platform detection (OpenClaw vs Claude Code), auto vs manual setup, browser cookie extraction, ScrapeCreators opt-in, and the initial topic picker.
 - After the wizard writes `SETUP_COMPLETE=true` to `~/.config/last30days/.env`, proceed to research.
 
-The wizard lives in a separate file so the common-case (already set up) path through this file is short and the voice-contract rules further down stay in context.
+The setup wizard lives as a Python module so it works across all hosts (Claude Code, Codex, Cursor, etc.) and the common-case (already set up) path through this file stays short.
 
 ---
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -327,8 +327,8 @@ def parse_competitors_plan(raw: str | None) -> dict[str, dict]:
     plan_str = raw
     if os.path.isfile(plan_str):
         try:
-            plan_str = open(plan_str).read()
-        except OSError as exc:
+            plan_str = open(plan_str, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError) as exc:
             sys.stderr.write(f"[CompetitorsPlan] Cannot read plan file: {exc}\n")
             raise SystemExit(2)
     try:
@@ -640,7 +640,11 @@ def main() -> int:
             import json as _json
             plan_str = args.plan
             if os.path.isfile(plan_str):
-                plan_str = open(plan_str).read()
+                try:
+                    plan_str = open(plan_str, encoding="utf-8").read()
+                except (OSError, UnicodeDecodeError) as exc:
+                    sys.stderr.write(f"[Planner] Cannot read --plan file: {exc}\n")
+                    raise SystemExit(2)
             try:
                 external_plan = _json.loads(plan_str)
             except _json.JSONDecodeError as exc:

--- a/skills/last30days/scripts/lib/skill_meta.py
+++ b/skills/last30days/scripts/lib/skill_meta.py
@@ -24,7 +24,7 @@ def read_skill_version(skill_md_path: Path) -> str | None:
     or unquoted YAML version scalars.
     """
     try:
-        text = skill_md_path.read_text()
+        text = skill_md_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
     match = _VERSION_RE.search(text)

--- a/tests/test_competitors_plan_threading.py
+++ b/tests/test_competitors_plan_threading.py
@@ -43,6 +43,22 @@ class ParseCompetitorsPlanTests(unittest.TestCase):
         finally:
             Path(path).unlink(missing_ok=True)
 
+    def test_file_with_non_ascii_content(self):
+        """Plan file with non-ASCII characters (e.g. accented names) reads without UnicodeDecodeError."""
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".json", delete=False,
+        ) as f:
+            f.write(
+                b'{"Nestl\xc3\xa9": {"x_handle": "Nestle", "subreddits": ["nestle"]}}'
+            )
+            path = f.name
+        try:
+            out = cli.parse_competitors_plan(path)
+            self.assertIn("nestlé", out)
+            self.assertEqual(out["nestlé"]["x_handle"], "Nestle")
+        finally:
+            Path(path).unlink(missing_ok=True)
+
     def test_case_insensitive_key_normalization(self):
         raw = '{"DRAKE": {"x_handle": "Drake"}}'
         out = cli.parse_competitors_plan(raw)

--- a/tests/test_last_run_state.py
+++ b/tests/test_last_run_state.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LAST30DAYS_SCRIPT = REPO_ROOT / "skills" / "last30days" / "scripts" / "last30days.py"
+SKILL_MD = REPO_ROOT / "skills" / "last30days" / "SKILL.md"
 
 
 def run_last30days(topic: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -78,6 +79,17 @@ class LastRunStateTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn('Last run: "custom hook query"', result.stdout)
+
+
+class TestSkillMdFirstRunReference(unittest.TestCase):
+    """Verifies SKILL.md does not reference files missing from the repo."""
+
+    def test_nux_wizard_not_referenced(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "nux-wizard.md", content,
+            "SKILL.md should not reference the missing nux-wizard.md file",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_last_run_state.py
+++ b/tests/test_last_run_state.py
@@ -82,13 +82,27 @@ class LastRunStateTests(unittest.TestCase):
 
 
 class TestSkillMdFirstRunReference(unittest.TestCase):
-    """Verifies SKILL.md does not reference files missing from the repo."""
+    """Verifies SKILL.md references that exist in the CLI."""
 
     def test_nux_wizard_not_referenced(self):
         content = SKILL_MD.read_text(encoding="utf-8")
         self.assertNotIn(
             "nux-wizard.md", content,
             "SKILL.md should not reference the missing nux-wizard.md file",
+        )
+
+    def test_setup_subcommand_exists(self):
+        """The setup subcommand referenced in SKILL.md must exist."""
+        result = subprocess.run(
+            [sys.executable, str(LAST30DAYS_SCRIPT), "setup", "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "usage:", result.stdout.lower(),
+            "--help should print usage for setup subcommand",
         )
 
 


### PR DESCRIPTION
Closes #574

**Problem:** SKILL.md (line 285) instructs the host model to 'Use the Read tool to load skills/last30days/nux-wizard.md' — but that file does not exist in the repo. First-run setup silently fails; the wizard never runs, SETUP_COMPLETE is never written, and the user gets no setup flow.

**Fix:** Replace the missing-file reference with a 'python3 skills/last30days/scripts/last30days.py setup' command that invokes the existing Python setup_wizard module, which handles platform detection, browser cookie extraction, ScrapeCreators opt-in, and the initial topic picker.

**Changes:**
- skills/last30days/SKILL.md: Replace Read nux-wizard.md -> python3 last30days.py setup
- tests/test_last_run_state.py: Add TestSkillMdFirstRunReference guard
- CHANGELOG.md: Entry under [Unreleased] Fixed
- CONTRIBUTORS.md: @23241a6749 contribution line updated