### PR TITLE
feat: keyless web coverage and honest source degradation

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -158,15 +158,22 @@ When you invoke `/last30days` from Claude Code, Codex, or Gemini, the host model
 
 ## Web search backend priority
 
-Used by `--auto-resolve` (when WebSearch isn't available from the host) and Step 2 supplements. Auto-detect priority (override per-run with `--web-backend=<name>`):
+The search-source preference ladder, strict best-to-floor:
 
-1. **Brave** - `BRAVE_API_KEY`
-2. **Exa** - `EXA_API_KEY`
-3. **Serper** - `SERPER_API_KEY`
-4. **Parallel** - `PARALLEL_API_KEY`
-5. **Host's native WebSearch** - Claude Code, Codex, Gemini all have one built in
+1. **Host-native search** - Claude Code's `WebSearch`, and the equivalents on Codex / Gemini. Best results; used automatically on hosts that have it. Signalled to the engine via `LAST30DAYS_NATIVE_SEARCH=1` (the skill sets this for you when your host has a native search tool) so the engine does not run a worse search underneath it.
+2. **Paid engine backend** - one of `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`, auto-detected in that order. Override per-run with `--web-backend=<name>`.
+3. **Keyless engine floor** - zero-key web search (DuckDuckGo, plus an optional SearXNG instance) and zero-key page fetch (Jina Reader). Runs only when the host has **no** native search **and** no paid key is set, so headless/cron and hosts without a built-in search tool still get general-web coverage. Force it explicitly with `--web-backend=keyless`.
 
-Visible quality difference between hosts with vs without a configured backend. If your client setup produces thinner results than yours, this is usually why.
+Relevant env vars:
+
+| Var | Effect |
+| --- | --- |
+| `LAST30DAYS_NATIVE_SEARCH=1` | Tells the engine your host has native search; suppresses the keyless floor. Set automatically by the skill on capable hosts. Leave unset on hosts without a native search tool so the floor runs. |
+| `LAST30DAYS_SEARXNG_URL=<base-url>` | Optional. A SearXNG instance used as the keyless-search fallback rung when DuckDuckGo returns nothing. |
+
+Privacy note: the keyless floor sends the query (to DuckDuckGo / your SearXNG instance) and any fetched URL (to Jina Reader) to those third parties. It is intended for public-research use; results may be cached snapshots. It never runs when native search or a paid backend is in play.
+
+Visible quality difference between hosts with vs without native search or a configured backend. If your client setup produces thinner results than yours, this is usually why.
 
 ---
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,7 +65,7 @@ The project-scoped file is the cleanest pattern for **per-client setups**: drop 
 | TruthSocial | `TRUTHSOCIAL_TOKEN` | TruthSocial items | yes |
 | Web search | one of: `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY` | `--auto-resolve` and Step 2 supplements | Brave has a free tier; native WebSearch on Claude Code / Codex / Gemini works as a fallback |
 | Perplexity Deep Research | `OPENROUTER_API_KEY` | `--deep-research` flag (~$0.90/query) | no |
-| Caption-free transcription | `GROQ_API_KEY` (free tier, preferred) or `OPENAI_API_KEY` (paid backstop); requires `ffmpeg` | Whisper transcription for audio/video without captions | Groq free tier is generous; needs ffmpeg installed |
+| Caption-free transcription | `GROQ_API_KEY` (free tier, preferred) or `OPENAI_API_KEY` (paid backstop); requires `ffmpeg` | Whisper transcription for audio/video without captions (groundwork: module shipped, not yet auto-invoked by the engine) | Groq free tier is generous; needs ffmpeg installed |
 | Jobs / careers pages | none for public ATS pages; web backend improves fallback discovery | `--hiring-signals` and strong Hiring Signals in standard company reports | yes |
 | Apify (alternate scraper) | `APIFY_API_TOKEN` | fallback for Reddit/TikTok/Instagram when ScrapeCreators is exhausted | yes (limited) |
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,6 +65,7 @@ The project-scoped file is the cleanest pattern for **per-client setups**: drop 
 | TruthSocial | `TRUTHSOCIAL_TOKEN` | TruthSocial items | yes |
 | Web search | one of: `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY` | `--auto-resolve` and Step 2 supplements | Brave has a free tier; native WebSearch on Claude Code / Codex / Gemini works as a fallback |
 | Perplexity Deep Research | `OPENROUTER_API_KEY` | `--deep-research` flag (~$0.90/query) | no |
+| Caption-free transcription | `GROQ_API_KEY` (free tier, preferred) or `OPENAI_API_KEY` (paid backstop); requires `ffmpeg` | Whisper transcription for audio/video without captions | Groq free tier is generous; needs ffmpeg installed |
 | Jobs / careers pages | none for public ATS pages; web backend improves fallback discovery | `--hiring-signals` and strong Hiring Signals in standard company reports | yes |
 | Apify (alternate scraper) | `APIFY_API_TOKEN` | fallback for Reddit/TikTok/Instagram when ScrapeCreators is exhausted | yes (limited) |
 

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -270,6 +270,14 @@ fi
 LAST30DAYS_MEMORY_DIR="${LAST30DAYS_MEMORY_DIR:-$HOME/Documents/Last30Days}"
 ```
 
+**Native-search signal (web coverage).** If you (the hosting model) have your own web-search tool available — e.g. Claude Code's `WebSearch`, which STEP 0 loads — export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell before invoking the engine:
+
+```bash
+export LAST30DAYS_NATIVE_SEARCH=1   # ONLY when you have a native web-search tool
+```
+
+Your native search is better than the engine's keyless web fallback, so this tells the engine to skip that fallback and leave general web to you (you already run WebSearch supplements in Step 2). If you have NO native web-search tool (some non-Claude hosts and headless/cron paths), do **not** set this: the engine's keyless web floor supplies general-web coverage automatically. The rule is capability-based, not host-name-based — set it only when you genuinely have a better search, never to suppress the floor on a host that has nothing else.
+
 ## Configuration
 
 Set `LAST30DAYS_MEMORY_DIR` before invoking the skill to choose where raw research files are saved. If it is not set, the skill defaults to `~/Documents/Last30Days`.

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -509,7 +509,12 @@ def _missing_sources_for_promo(diag: dict[str, object]) -> str | None:
         missing.append("reddit")
     if "x" not in available:
         missing.append("x")
-    if "grounding" not in available:
+    # The web promo nudges toward a paid backend for higher-quality web search.
+    # Grounding is now available keyless on non-native hosts, so key the promo on
+    # the absence of a *paid* backend, not on grounding availability. Suppress it
+    # entirely on native-search hosts, where the model's own search is better and
+    # setting a paid engine key would be the wrong advice.
+    if not diag.get("native_web_backend") and not diag.get("native_search"):
         missing.append("web")
     if not missing:
         return None

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -395,6 +395,12 @@ def get_config() -> dict[str, Any]:
         ('OPENROUTER_API_KEY', None),
         ('PARALLEL_API_KEY', None),
         ('XQUIK_API_KEY', None),
+        # Host-native search signal: set by the SKILL.md agent-host path when the
+        # invoking runtime has its own (better) web-search tool, so the engine's
+        # keyless search floor stays off there. Defaults unset -> floor allowed.
+        ('LAST30DAYS_NATIVE_SEARCH', None),
+        # Optional SearXNG instance for the keyless-search fallback rung.
+        ('LAST30DAYS_SEARXNG_URL', None),
         ('FROM_BROWSER', None),
         ('SETUP_COMPLETE', None),
         ('INCLUDE_SOURCES', ''),
@@ -631,6 +637,32 @@ def is_hackernews_available() -> bool:
     Always returns True - HN uses free Algolia API, no key needed.
     """
     return True
+
+
+def is_native_search(config: dict[str, Any]) -> bool:
+    """Whether the invoking host has its own (better) native web search.
+
+    Defined by capability, not host identity: the SKILL.md agent-host path sets
+    ``LAST30DAYS_NATIVE_SEARCH`` when the runtime actually has a native web-search
+    tool (e.g. Claude Code's WebSearch). When true, the engine's keyless search
+    floor is suppressed so a worse free search never preempts the model's own.
+    Defaults False (unset), so headless/cron and hosts without native search fall
+    to the keyless floor.
+    """
+    raw = config.get('LAST30DAYS_NATIVE_SEARCH')
+    if raw is None:
+        return False
+    return str(raw).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def keyless_web_allowed(config: dict[str, Any]) -> bool:
+    """Whether the engine may use its keyless web-search floor for this run.
+
+    Allowed only when the host does NOT have native search. Independent of
+    whether a paid key is set (the grounding dispatcher prefers paid first and
+    falls to keyless on empty/error for non-native runs).
+    """
+    return not is_native_search(config)
 
 
 def is_bluesky_available(config: dict[str, Any]) -> bool:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -407,6 +407,10 @@ def get_config() -> dict[str, Any]:
         ('EXCLUDE_SOURCES', ''),
         ('LAST30DAYS_YOUTUBE_SSH_HOST', None),
         ('LAST30DAYS_TRANSCRIPT_TIMEOUT', None),
+        # Whisper transcription provider for caption-free audio/video. Groq's
+        # free tier is preferred; OPENAI_API_KEY is the paid backstop (already
+        # resolved above via openai_auth).
+        ('GROQ_API_KEY', None),
     ]
 
     for key, default in keys:
@@ -663,6 +667,20 @@ def keyless_web_allowed(config: dict[str, Any]) -> bool:
     falls to keyless on empty/error for non-native runs).
     """
     return not is_native_search(config)
+
+
+def transcription_providers(config: dict[str, Any]) -> list[tuple[str, str]]:
+    """Ordered (name, api_key) Whisper providers for caption-free transcription.
+
+    Groq (free tier) first, OpenAI (paid) as the backstop. Empty when neither
+    key is set, in which case transcription degrades rather than runs.
+    """
+    providers: list[tuple[str, str]] = []
+    if config.get('GROQ_API_KEY'):
+        providers.append(('groq', config['GROQ_API_KEY']))
+    if config.get('OPENAI_API_KEY'):
+        providers.append(('openai', config['OPENAI_API_KEY']))
+    return providers
 
 
 def is_bluesky_available(config: dict[str, Any]) -> bool:

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -202,11 +202,12 @@ def search_github(
         envelope = {"items": [], "context": {"core": core, "from_date": from_date,
                                              "to_date": to_date, "count": count}}
         if not authed:
-            # Most likely the anon rate limit (403). Surface it so the pipeline
-            # records a degraded/failed reason instead of silently showing zero.
+            # Could be the anon rate limit (403) or an unprocessable query (422)
+            # -- _fetch_json maps both to None. Don't over-claim which; suggest a
+            # token since that fixes the common (rate-limit) case.
             envelope["error"] = (
-                "GitHub unauthenticated request failed (likely anon rate limit; "
-                "set GITHUB_TOKEN or run gh auth login for higher limits)"
+                "GitHub unauthenticated request returned no data (anon rate limit "
+                "or unprocessable query; set GITHUB_TOKEN or run gh auth login)"
             )
         return envelope
 

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -35,6 +35,10 @@ ENRICH_LIMITS = {
     "deep": 8,
 }
 
+# Unauthenticated GitHub search allows ~10 requests/min, so cap result volume
+# conservatively when running without a token to stay within the anon tier.
+UNAUTH_COUNT_CAP = 10
+
 USER_AGENT = "last30days/3.0 (research tool)"
 
 
@@ -175,18 +179,12 @@ def search_github(
     count = DEPTH_LIMITS.get(depth, DEPTH_LIMITS["default"])
     core = extract_core_subject(topic)
     resolved_token = _resolve_token(token)
-    if not resolved_token:
-        _log("No GitHub token available (set GITHUB_TOKEN or install gh CLI)")
-        return {
-            "items": [],
-            "error": "no token",
-            "context": {
-                "core": core,
-                "from_date": from_date,
-                "to_date": to_date,
-                "count": count,
-            },
-        }
+    authed = bool(resolved_token)
+    if not authed:
+        # Fall back to the unauthenticated REST tier instead of returning nothing.
+        # It is rate-limited, so cap the request volume.
+        count = min(count, UNAUTH_COUNT_CAP)
+        _log("No GitHub token; using the unauthenticated REST tier (low rate limit)")
     _log(f"Searching for '{core}' (raw: '{topic}', since {from_date}, count={count})")
 
     # Build search query with date filter
@@ -201,8 +199,16 @@ def search_github(
 
     data = _fetch_json(url, token=resolved_token, timeout=30)
     if not data:
-        return {"items": [], "context": {"core": core, "from_date": from_date,
-                                          "to_date": to_date, "count": count}}
+        envelope = {"items": [], "context": {"core": core, "from_date": from_date,
+                                             "to_date": to_date, "count": count}}
+        if not authed:
+            # Most likely the anon rate limit (403). Surface it so the pipeline
+            # records a degraded/failed reason instead of silently showing zero.
+            envelope["error"] = (
+                "GitHub unauthenticated request failed (likely anon rate limit; "
+                "set GITHUB_TOKEN or run gh auth login for higher limits)"
+            )
+        return envelope
 
     raw_items = data.get("items", [])
     _log(f"Found {len(raw_items)} issues/PRs")

--- a/skills/last30days/scripts/lib/grounding.py
+++ b/skills/last30days/scripts/lib/grounding.py
@@ -1,4 +1,4 @@
-"""Web search retrieval via Brave Search, Exa, and Serper."""
+"""Web search retrieval via Brave Search, Exa, Serper, Parallel, or a keyless floor."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import urllib.parse
 from datetime import datetime
 from urllib.parse import urlparse
 
-from . import dates, http
+from . import dates, env, http, web_search_keyless
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +207,11 @@ def web_search(
             backend = "serper"
         elif config.get("PARALLEL_API_KEY"):
             backend = "parallel"
+        elif env.keyless_web_allowed(config):
+            # No paid key and the host has no native search -> use the keyless
+            # floor. On a native-search host this branch is skipped (the model
+            # supplies web results itself), so the engine returns nothing here.
+            backend = "keyless"
         else:
             return [], {}
     items: list[dict] = []
@@ -231,6 +236,8 @@ def web_search(
         if not key:
             raise RuntimeError("PARALLEL_API_KEY is required when web_backend='parallel'")
         items, artifact = parallel_search(query, date_range, key)
+    elif backend == "keyless":
+        items, artifact = web_search_keyless.keyless_search(query, date_range, config)
     elif backend != "none":
         raise ValueError(f"Unsupported web backend: {backend!r}")
     else:

--- a/skills/last30days/scripts/lib/health.py
+++ b/skills/last30days/scripts/lib/health.py
@@ -1,0 +1,92 @@
+"""Typed source health: classify a source/tool outcome honestly.
+
+The pipeline historically collapsed every failure into "returned nothing" or a
+flat ``errors_by_source`` entry, which hides the difference between a tool that
+is *absent*, one that is *present but broken* (the classic stale-venv-shim after
+a Python upgrade), one that *timed out*, and one that merely *degraded* (fewer
+results than expected). This module gives callers a small typed vocabulary so
+warnings can say what actually happened and prescribe the right fix.
+
+It complements ``preflight.py`` (which gates doomed *queries*); this gates
+doomed *sources/tools*.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+# Health states, best to worst.
+OK = "ok"
+DEGRADED = "degraded"        # ran, but returned less than expected
+MISSING = "missing"          # tool/binary/credential absent
+BROKEN = "broken"            # present but won't execute (stale shim, bad perms)
+TIMEOUT = "timeout"          # exceeded the probe deadline
+ERROR = "error"              # ran and failed for another reason
+
+
+@dataclass
+class SourceHealth:
+    """Typed outcome for a source or the tool backing it.
+
+    ``state`` is one of the module-level constants. ``reason`` is a short,
+    human-readable explanation suitable for a run warning.
+    """
+
+    name: str
+    state: str
+    reason: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.state == OK
+
+    @property
+    def usable(self) -> bool:
+        """True when the source produced something worth keeping (ok/degraded)."""
+        return self.state in (OK, DEGRADED)
+
+
+def probe_command(
+    command: list[str],
+    timeout: float = 5.0,
+) -> SourceHealth:
+    """Probe an external command, distinguishing missing/broken/timeout/ok.
+
+    Separating these is what lets the caller emit a correct repair prescription
+    instead of a generic "failed":
+      - ``missing``: the executable is not on PATH.
+      - ``broken``: on PATH but won't run — FileNotFoundError/OSError on exec, or
+        shell exit 126/127 (not-executable / not-found-after-resolution), the
+        signature of a stale interpreter shim after an upgrade.
+      - ``timeout``: exceeded ``timeout`` seconds.
+      - ``ok``: exited 0.
+      - ``error``: ran but exited non-zero for another reason.
+
+    The command should be side-effect-free (e.g. ``["gh", "auth", "status"]``);
+    callers pass a status/version subcommand, not a mutating one.
+    """
+    name = command[0] if command else ""
+    if not name or shutil.which(name) is None:
+        return SourceHealth(name=name, state=MISSING, reason=f"{name or 'command'} not found on PATH")
+
+    try:
+        proc = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return SourceHealth(name=name, state=BROKEN, reason=f"{name} present but won't execute: {exc}")
+    except subprocess.TimeoutExpired:
+        return SourceHealth(name=name, state=TIMEOUT, reason=f"{name} timed out after {timeout:g}s")
+
+    if proc.returncode == 0:
+        return SourceHealth(name=name, state=OK)
+    if proc.returncode in (126, 127):
+        return SourceHealth(name=name, state=BROKEN, reason=f"{name} not executable (exit {proc.returncode})")
+    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    first = detail[0] if detail else f"exit {proc.returncode}"
+    return SourceHealth(name=name, state=ERROR, reason=f"{name}: {first}")

--- a/skills/last30days/scripts/lib/http.py
+++ b/skills/last30days/scripts/lib/http.py
@@ -4,6 +4,7 @@ import json
 import re
 import socket
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -268,6 +269,54 @@ def get_text(
     except HTTPError as e:
         log(f"get_text failed ({e}): {url}")
         return None
+
+
+class RateLimiter:
+    """Thread-safe minimum-interval throttle for an endpoint family.
+
+    The keyless source tiers run under the pipeline's ThreadPoolExecutor, so a
+    multi-subquery run can fire many requests at the same host at once. A bare
+    per-request retry budget does not prevent that stampede — it only reacts
+    after a 429. This spaces calls so concurrent futures sharing one limiter
+    cannot burst past ``min_interval`` seconds between requests.
+    """
+
+    def __init__(self, min_interval: float):
+        self.min_interval = min_interval
+        self._last = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        """Block until at least ``min_interval`` has elapsed since the last call."""
+        with self._lock:
+            now = time.monotonic()
+            wait = self.min_interval - (now - self._last)
+            if wait > 0:
+                time.sleep(wait)
+                now = time.monotonic()
+            self._last = now
+
+
+# Shared across all keyless Reddit tiers (RSS, listing, shreddit) so their
+# combined fan-out is throttled as one family, not three independent bursts.
+REDDIT_KEYLESS_LIMITER = RateLimiter(min_interval=0.5)
+
+
+def reddit_keyless_get_text(
+    url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = 2,
+    accept: str = "*/*",
+    headers: Optional[Dict[str, str]] = None,
+) -> Optional[str]:
+    """get_text for the keyless Reddit tiers, throttled by a shared limiter.
+
+    Same contract as :func:`get_text` (returns None on any failure) but spaces
+    requests via :data:`REDDIT_KEYLESS_LIMITER` so a broad multi-query run does
+    not stampede Reddit's keyless endpoints and trip blocks.
+    """
+    REDDIT_KEYLESS_LIMITER.acquire()
+    return get_text(url, timeout=timeout, retries=retries, accept=accept, headers=headers)
 
 
 def scrapecreators_headers(token: str) -> Dict[str, str]:

--- a/skills/last30days/scripts/lib/http.py
+++ b/skills/last30days/scripts/lib/http.py
@@ -272,34 +272,49 @@ def get_text(
 
 
 class RateLimiter:
-    """Thread-safe minimum-interval throttle for an endpoint family.
+    """Thread-safe token-bucket throttle for an endpoint family.
 
     The keyless source tiers run under the pipeline's ThreadPoolExecutor, so a
     multi-subquery run can fire many requests at the same host at once. A bare
     per-request retry budget does not prevent that stampede — it only reacts
-    after a 429. This spaces calls so concurrent futures sharing one limiter
-    cannot burst past ``min_interval`` seconds between requests.
+    after a 429. A token bucket bounds the *sustained* rate while still allowing
+    a short burst, so legitimate parallelism is preserved (unlike a strict
+    min-interval gate that would serialize every concurrent caller and could
+    push later futures past their result timeouts).
+
+    ``rate_per_sec`` tokens refill per second; ``burst`` is the bucket capacity
+    (max simultaneous calls before throttling kicks in). The lock is released
+    while sleeping so waiting threads don't serialize on each other.
     """
 
-    def __init__(self, min_interval: float):
-        self.min_interval = min_interval
-        self._last = 0.0
+    def __init__(self, rate_per_sec: float, burst: int | None = None):
+        self.rate = rate_per_sec
+        self.capacity = burst if burst is not None else max(1, int(rate_per_sec))
+        self._tokens = float(self.capacity)
+        self._last = time.monotonic()
         self._lock = threading.Lock()
 
     def acquire(self) -> None:
-        """Block until at least ``min_interval`` has elapsed since the last call."""
-        with self._lock:
-            now = time.monotonic()
-            wait = self.min_interval - (now - self._last)
-            if wait > 0:
-                time.sleep(wait)
+        """Consume one token, blocking only when the bucket is empty."""
+        while True:
+            with self._lock:
                 now = time.monotonic()
-            self._last = now
+                # Clamp elapsed to >= 0: a backward clock reading must never
+                # drive tokens negative (which would spin this loop forever).
+                elapsed = max(0.0, now - self._last)
+                self._tokens = min(self.capacity, self._tokens + elapsed * self.rate)
+                self._last = now
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / self.rate
+            time.sleep(wait)
 
 
 # Shared across all keyless Reddit tiers (RSS, listing, shreddit) so their
-# combined fan-out is throttled as one family, not three independent bursts.
-REDDIT_KEYLESS_LIMITER = RateLimiter(min_interval=0.5)
+# combined fan-out is throttled as one family. Burst lets the parallel
+# enrichment workers proceed; sustained rate caps the stampede.
+REDDIT_KEYLESS_LIMITER = RateLimiter(rate_per_sec=5.0, burst=5)
 
 
 def reddit_keyless_get_text(

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -120,7 +120,13 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.append("bluesky")
     if env.is_truthsocial_available(config):
         available.append("truthsocial")
-    if config.get("BRAVE_API_KEY") or config.get("EXA_API_KEY") or config.get("SERPER_API_KEY") or config.get("PARALLEL_API_KEY"):
+    # Grounding (general web) is available when a paid backend is configured OR
+    # the keyless floor is permitted (i.e. the host has no native search). On a
+    # native-search host with no paid key, keyless_web_allowed is False and the
+    # engine leaves general web to the model's own search.
+    if (config.get("BRAVE_API_KEY") or config.get("EXA_API_KEY")
+            or config.get("SERPER_API_KEY") or config.get("PARALLEL_API_KEY")
+            or env.keyless_web_allowed(config)):
         available.append("grounding")
     if requested_sources and "jobs" in requested_sources:
         available.append("jobs")
@@ -216,7 +222,7 @@ def run(
             available = [source for source in available if source in requested_sources]
     if web_backend == "none":
         available = [s for s in available if s != "grounding"]
-    elif web_backend in ("brave", "exa", "serper", "parallel") and "grounding" not in available:
+    elif web_backend in ("brave", "exa", "serper", "parallel", "keyless") and "grounding" not in available:
         available.append("grounding")
     if (hiring_signals_mode or _company_topic_likely(topic)) and "jobs" not in available:
         available.append("jobs")

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -484,10 +484,16 @@ def run(
         skip_sources=_github_skip_retry,
     )
 
-    # Clear errors for sources that returned items despite partial failures.
-    # A source that 429'd on one subquery but succeeded on another is not "errored".
+    # Reclassify partial failures as DEGRADED instead of silently dropping them.
+    # A source that 429'd on one subquery but succeeded on another is not a hard
+    # failure, but it is not healthy either: it likely returned fewer results
+    # than it should have. Move it out of errors_by_source (so it isn't reported
+    # as "failed") and into degraded_by_source (so it survives into warnings),
+    # rather than deleting the signal outright as the engine used to.
+    degraded_by_source: dict[str, str] = {}
     for source in list(bundle.errors_by_source):
         if bundle.items_by_source.get(source):
+            degraded_by_source[source] = bundle.errors_by_source[source]
             del bundle.errors_by_source[source]
 
     hiring_summary = _apply_hiring_signal_gate(
@@ -524,7 +530,7 @@ def run(
         )
 
     clusters = cluster_candidates(ranked_candidates, plan)
-    warnings = _warnings(items_by_source, ranked_candidates, bundle.errors_by_source)
+    warnings = _warnings(items_by_source, ranked_candidates, bundle.errors_by_source, degraded_by_source)
 
     return schema.Report(
         topic=topic,
@@ -682,6 +688,7 @@ def _warnings(
     items_by_source: dict[str, list[schema.SourceItem]],
     candidates: list[schema.Candidate],
     errors_by_source: dict[str, str],
+    degraded_by_source: dict[str, str] | None = None,
 ) -> list[str]:
     warnings: list[str] = []
     if not candidates:
@@ -697,6 +704,13 @@ def _warnings(
         warnings.append("Top evidence is highly concentrated in one source.")
     if errors_by_source:
         warnings.append(f"Some sources failed: {', '.join(sorted(errors_by_source))}")
+    if degraded_by_source:
+        # Partial failures: the source returned some items but errored/timed out
+        # on at least one subquery, so its coverage is likely incomplete. Kept
+        # distinct from hard failures so the signal is not silently dropped.
+        warnings.append(
+            f"Some sources returned partial results (degraded): {', '.join(sorted(degraded_by_source))}"
+        )
     if not items_by_source:
         warnings.append("No source returned usable items.")
     return warnings

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1166,10 +1166,10 @@ def _retrieve_stream(
         token = github.resolve_token(config.get("GITHUB_TOKEN"))
         response = github.search_github(subquery.search_query, from_date, to_date, depth=depth, token=token)
         items = github.parse_github_response(response)
-        if not items and response.get("error"):
-            # Surface unauth rate-limit (or other hard failure) so the run
-            # records it as degraded/failed instead of silently showing zero.
-            raise RuntimeError(response["error"])
+        # Note: an unauth rate-limit (response["error"]) is expected on the
+        # tokenless anon tier and returns empty here rather than raising — github
+        # is now always eligible, so raising would spam "github failed" on every
+        # tokenless run. The condition is logged in github.search_github.
         items = github.enrich_with_comments(items, depth=depth, token=token)
         return items, {}
     if source == "pinterest":

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -179,6 +179,7 @@ def diagnose(config: dict[str, Any], requested_sources: list[str] | None = None)
         "bird_authenticated": x_status["bird_authenticated"],
         "bird_username": x_status["bird_username"],
         "native_web_backend": native_web_backend,
+        "native_search": env.is_native_search(config),
         "has_scrapecreators": bool(config.get("SCRAPECREATORS_API_KEY")),
         "has_github": bool(config.get("GITHUB_TOKEN") or which("gh")),
         "available_sources": available_sources(config, requested_sources),

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -112,8 +112,9 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
     if which("yt-dlp") or env.is_youtube_sc_available(config):
         available.append("youtube")
     available.extend(["hackernews", "polymarket"])
-    if config.get("GITHUB_TOKEN") or which("gh"):
-        available.append("github")
+    # GitHub is reachable via the unauthenticated REST tier too, so it is
+    # available even without a token/gh CLI (a token only raises rate limits).
+    available.append("github")
     if which("digg-pp-cli"):
         available.append("digg")
     if env.is_bluesky_available(config):
@@ -1164,6 +1165,10 @@ def _retrieve_stream(
         token = github.resolve_token(config.get("GITHUB_TOKEN"))
         response = github.search_github(subquery.search_query, from_date, to_date, depth=depth, token=token)
         items = github.parse_github_response(response)
+        if not items and response.get("error"):
+            # Surface unauth rate-limit (or other hard failure) so the run
+            # records it as degraded/failed instead of silently showing zero.
+            raise RuntimeError(response["error"])
         items = github.enrich_with_comments(items, depth=depth, token=token)
         return items, {}
     if source == "pinterest":

--- a/skills/last30days/scripts/lib/reddit_listing.py
+++ b/skills/last30days/scripts/lib/reddit_listing.py
@@ -128,8 +128,8 @@ def _listing_url(subreddit: str, sort: str) -> str:
 
 def _fetch_one(subreddit: str, sort: str, query: str) -> List[Dict[str, Any]]:
     try:
-        text = http.get_text(_listing_url(subreddit, sort), timeout=LISTING_TIMEOUT,
-                             accept="text/html")
+        text = http.reddit_keyless_get_text(_listing_url(subreddit, sort), timeout=LISTING_TIMEOUT,
+                                            accept="text/html")
         return parse_cards(text, query) if text else []
     except Exception as e:
         _log(f"listing fetch failed r/{subreddit} {sort}: {e}")

--- a/skills/last30days/scripts/lib/reddit_rss.py
+++ b/skills/last30days/scripts/lib/reddit_rss.py
@@ -173,7 +173,7 @@ def _build_urls(query: str, depth: str, subreddits: Optional[List[str]]) -> List
 def _fetch_feed(url: str, query: str) -> List[Dict[str, Any]]:
     """Fetch and parse one feed. Never raises."""
     try:
-        text = http.get_text(url, timeout=FEED_TIMEOUT, accept="application/atom+xml")
+        text = http.reddit_keyless_get_text(url, timeout=FEED_TIMEOUT, accept="application/atom+xml")
         return _parse_feed(text, query) if text else []
     except Exception as e:  # defensive: a single bad feed must not sink the run
         _log(f"feed fetch failed for {url}: {e}")

--- a/skills/last30days/scripts/lib/reddit_shreddit.py
+++ b/skills/last30days/scripts/lib/reddit_shreddit.py
@@ -162,7 +162,7 @@ def fetch_comments(
         return {"top_comments": [], "comment_insights": [], "num_comments": None}
     sub, post_id = ref
 
-    html_text = http.get_text(_svc_url(sub, post_id), timeout=timeout, accept="text/html")
+    html_text = http.reddit_keyless_get_text(_svc_url(sub, post_id), timeout=timeout, accept="text/html")
     if not html_text:
         return {"top_comments": [], "comment_insights": [], "num_comments": None}
 

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -119,18 +119,24 @@ def _open_secret_append(path: Path):
 def _format_env_value(value: str) -> str:
     """Quote a value so it round-trips through env.load_env_file.
 
-    The loader strips a single layer of matching surrounding quotes, so values
-    containing whitespace or a leading quote are wrapped in double quotes to
-    survive the parse. Plain tokens (the common case) are returned unchanged.
-    Embedded double quotes are backslash-escaped. Newlines are not permitted in
-    a single-line env value and are stripped defensively.
+    env.load_env_file strips a single layer of matching surrounding quotes but
+    does NOT process backslash escapes, so we wrap (never escape):
+      - plain tokens (no whitespace, no leading quote): returned unchanged;
+      - values with whitespace/leading quote and no double-quote: double-quoted;
+      - values containing a double-quote but no single-quote: single-quoted;
+      - values containing both quote types: returned as-is (best effort; no
+        wrapper round-trips through the loader, and tokens never hit this).
+    Newlines are not valid in a single-line env value and are stripped.
     """
     value = value.replace("\r", "").replace("\n", " ")
     needs_quoting = (not value) or value[0] in ("'", '"') or any(c.isspace() for c in value)
     if not needs_quoting:
         return value
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    if '"' not in value:
+        return f'"{value}"'
+    if "'" not in value:
+        return f"'{value}'"
+    return value
 
 
 def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -7,6 +7,7 @@ presents it), but this module provides the detection and setup actions.
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 import time
@@ -98,6 +99,40 @@ def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
     return results
 
 
+def _open_secret_append(path: Path):
+    """Open ``path`` for appending as a 0o600 secret file with no readable window.
+
+    ``os.open`` with ``O_CREAT|O_WRONLY|O_APPEND`` and mode ``0o600`` sets
+    restrictive permissions at creation (umask can only further restrict, never
+    widen, so the file is never world-readable even transiently). An explicit
+    ``chmod`` afterwards also tightens a pre-existing loose file. This matters
+    because the .env stores API keys, cookies, and tokens.
+    """
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return os.fdopen(fd, "a", encoding="utf-8")
+
+
+def _format_env_value(value: str) -> str:
+    """Quote a value so it round-trips through env.load_env_file.
+
+    The loader strips a single layer of matching surrounding quotes, so values
+    containing whitespace or a leading quote are wrapped in double quotes to
+    survive the parse. Plain tokens (the common case) are returned unchanged.
+    Embedded double quotes are backslash-escaped. Newlines are not permitted in
+    a single-line env value and are stripped defensively.
+    """
+    value = value.replace("\r", "").replace("\n", " ")
+    needs_quoting = (not value) or value[0] in ("'", '"') or any(c.isspace() for c in value)
+    if not needs_quoting:
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
     """Write SETUP_COMPLETE and FROM_BROWSER to the .env file.
 
@@ -130,13 +165,14 @@ def write_setup_config(env_path: Path, from_browser: str = "auto") -> bool:
         if "SETUP_COMPLETE" not in existing_keys:
             lines_to_add.append("SETUP_COMPLETE=true")
         if "FROM_BROWSER" not in existing_keys:
-            lines_to_add.append(f"FROM_BROWSER={from_browser}")
+            lines_to_add.append(f"FROM_BROWSER={_format_env_value(from_browser)}")
 
         if not lines_to_add:
             return True  # Nothing to write, already configured
 
-        # Ensure trailing newline before appending
-        with open(env_path, "a", encoding="utf-8") as f:
+        # Create/append as a 0o600 secret file: the .env holds tokens and keys,
+        # so it must never be created world-readable.
+        with _open_secret_append(env_path) as f:
             if existing_content and not existing_content.endswith("\n"):
                 f.write("\n")
             f.write("\n".join(lines_to_add) + "\n")

--- a/skills/last30days/scripts/lib/transcribe.py
+++ b/skills/last30days/scripts/lib/transcribe.py
@@ -20,12 +20,11 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from typing import Optional
 
-from . import env, health
+from . import env, health, subproc
 
 # Whisper's documented upload ceiling. We compress to stay under it and chunk
 # when a single clip still exceeds it.
@@ -224,9 +223,13 @@ def _post_audio(provider: str, path: str, api_key: str, timeout: float) -> Optio
 
 
 def _run(command: list[str], timeout: float = 120.0) -> bool:
-    """Run a subprocess; return True on exit 0, False on any failure. No raise."""
+    """Run a subprocess; return True on exit 0, False on any failure. No raise.
+
+    Uses subproc.run_with_timeout so a timed-out yt-dlp/ffmpeg is killed at the
+    process-group level (os.setsid/killpg) instead of orphaning child trees.
+    """
     try:
-        proc = subprocess.run(command, capture_output=True, timeout=timeout)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        result = subproc.run_with_timeout(command, timeout=int(timeout))
+    except (subproc.SubprocTimeout, FileNotFoundError, OSError):
         return False
-    return proc.returncode == 0
+    return result.returncode == 0

--- a/skills/last30days/scripts/lib/transcribe.py
+++ b/skills/last30days/scripts/lib/transcribe.py
@@ -1,0 +1,232 @@
+"""Caption-free transcription: compress -> chunk -> provider-fallback.
+
+When a video/audio item has no captions, this turns the media into text via a
+Whisper API. Source-agnostic: the input is a media URL or local path, the output
+is transcript text. The pipeline:
+
+  1. Acquire audio (yt-dlp for a URL, or use a local file as-is).
+  2. Re-encode to a low-bitrate mono stream so most clips fit under the provider
+     upload limit.
+  3. If still over the limit, split into bounded-duration chunks.
+  4. Transcribe each chunk through an ordered provider list (Groq free tier
+     first, OpenAI paid backstop), with per-chunk fallback, then join.
+
+Never raises. Returns a typed :class:`TranscriptResult`; missing prerequisites
+(no ffmpeg, no provider key) yield a degraded result with a reason, consumed by
+the source-health layer, rather than a crash.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from typing import Optional
+
+from . import env, health
+
+# Whisper's documented upload ceiling. We compress to stay under it and chunk
+# when a single clip still exceeds it.
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+CHUNK_SECONDS = 600  # 10-minute chunks when splitting is required
+
+_PROVIDER_ENDPOINTS = {
+    "groq": "https://api.groq.com/openai/v1/audio/transcriptions",
+    "openai": "https://api.openai.com/v1/audio/transcriptions",
+}
+_PROVIDER_MODELS = {
+    "groq": "whisper-large-v3",
+    "openai": "whisper-1",
+}
+
+
+@dataclass
+class TranscriptResult:
+    text: str = ""
+    ok: bool = False
+    reason: str = ""
+    provider: str = ""
+    chunks: int = 0
+    health: Optional[health.SourceHealth] = field(default=None)
+
+
+def is_available(config: dict) -> bool:
+    """True when ffmpeg is present AND at least one Whisper provider key is set."""
+    return bool(shutil.which("ffmpeg")) and bool(env.transcription_providers(config))
+
+
+def transcribe_media(
+    source: str,
+    config: dict,
+    timeout: float = 120.0,
+) -> TranscriptResult:
+    """Transcribe a media URL or local path. Never raises.
+
+    Returns a degraded result (ok=False, reason set) when prerequisites are
+    missing or every provider fails, so callers can report the gap honestly.
+    """
+    if not shutil.which("ffmpeg"):
+        return _degraded("ffmpeg not installed", health.MISSING)
+    providers = env.transcription_providers(config)
+    if not providers:
+        return _degraded(
+            "no transcription provider key (set GROQ_API_KEY or OPENAI_API_KEY)",
+            health.MISSING,
+        )
+
+    workdir = tempfile.mkdtemp(prefix="l30d-transcribe-")
+    try:
+        audio_path = _acquire_audio(source, workdir, timeout=timeout)
+        if not audio_path:
+            return _degraded("could not acquire/compress audio", health.ERROR)
+
+        chunk_paths = _chunk_audio(audio_path, workdir)
+        if not chunk_paths:
+            return _degraded("audio chunking produced no segments", health.ERROR)
+
+        texts: list[str] = []
+        used_provider = ""
+        for chunk in chunk_paths:
+            chunk_text, provider = _transcribe_chunk(chunk, providers, timeout=timeout)
+            if chunk_text is None:
+                return _degraded(
+                    f"all providers failed on a chunk ({len(texts)}/{len(chunk_paths)} done)",
+                    health.ERROR,
+                )
+            texts.append(chunk_text)
+            used_provider = provider or used_provider
+
+        joined = "\n".join(t.strip() for t in texts if t.strip())
+        if not joined:
+            return _degraded("transcription produced empty text", health.DEGRADED)
+        return TranscriptResult(
+            text=joined,
+            ok=True,
+            provider=used_provider,
+            chunks=len(chunk_paths),
+            health=health.SourceHealth(name="transcribe", state=health.OK),
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _degraded(reason: str, state: str) -> TranscriptResult:
+    return TranscriptResult(
+        ok=False,
+        reason=reason,
+        health=health.SourceHealth(name="transcribe", state=state, reason=reason),
+    )
+
+
+def _acquire_audio(source: str, workdir: str, timeout: float) -> Optional[str]:
+    """Produce a compressed mono/16kHz/low-bitrate audio file, or None.
+
+    For a URL, extract audio with yt-dlp; for a local path, transcode it. The
+    re-encode keeps most clips under the upload ceiling.
+    """
+    raw = source
+    if source.startswith("http"):
+        raw = os.path.join(workdir, "raw.m4a")
+        if not _run([
+            "yt-dlp", "-f", "bestaudio", "-o", raw, "--no-playlist", source
+        ], timeout=timeout):
+            return None
+        if not os.path.exists(raw):
+            return None
+    elif not os.path.exists(source):
+        return None
+
+    out = os.path.join(workdir, "audio.mp3")
+    # Mono, 16kHz, 32kbps keeps speech intelligible while shrinking the file.
+    if not _run([
+        "ffmpeg", "-y", "-i", raw, "-ac", "1", "-ar", "16000", "-b:a", "32k", out
+    ], timeout=timeout):
+        return None
+    return out if os.path.exists(out) else None
+
+
+def _chunk_audio(audio_path: str, workdir: str) -> list[str]:
+    """Return [audio_path] when small enough, else ffmpeg-segmented chunk paths."""
+    try:
+        size = os.path.getsize(audio_path)
+    except OSError:
+        return []
+    if size <= MAX_UPLOAD_BYTES:
+        return [audio_path]
+
+    pattern = os.path.join(workdir, "chunk_%03d.mp3")
+    if not _run([
+        "ffmpeg", "-y", "-i", audio_path, "-f", "segment",
+        "-segment_time", str(CHUNK_SECONDS), "-c", "copy", pattern
+    ]):
+        # Fall back to the single (oversized) file; the provider may still accept it.
+        return [audio_path]
+    chunks = sorted(
+        os.path.join(workdir, f) for f in os.listdir(workdir) if f.startswith("chunk_")
+    )
+    return chunks or [audio_path]
+
+
+def _transcribe_chunk(
+    path: str,
+    providers: list[tuple[str, str]],
+    timeout: float,
+) -> tuple[Optional[str], str]:
+    """Try each provider in order; return (text, provider) or (None, '')."""
+    for name, key in providers:
+        try:
+            text = _post_audio(name, path, key, timeout=timeout)
+        except Exception:  # noqa: BLE001 - any provider failure -> try the next
+            text = None
+        if text is not None:
+            return text, name
+    return None, ""
+
+
+def _post_audio(provider: str, path: str, api_key: str, timeout: float) -> Optional[str]:
+    """POST one audio file to a Whisper-compatible endpoint; return text or None."""
+    import json
+    import urllib.request
+
+    endpoint = _PROVIDER_ENDPOINTS[provider]
+    model = _PROVIDER_MODELS[provider]
+    boundary = "----l30dTranscribeBoundary"
+    with open(path, "rb") as fh:
+        audio = fh.read()
+
+    parts: list[bytes] = []
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(b'Content-Disposition: form-data; name="model"\r\n\r\n')
+    parts.append(f"{model}\r\n".encode())
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(
+        b'Content-Disposition: form-data; name="file"; filename="audio.mp3"\r\n'
+        b"Content-Type: audio/mpeg\r\n\r\n"
+    )
+    parts.append(audio)
+    parts.append(f"\r\n--{boundary}--\r\n".encode())
+    body = b"".join(parts)
+
+    req = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    return data.get("text")
+
+
+def _run(command: list[str], timeout: float = 120.0) -> bool:
+    """Run a subprocess; return True on exit 0, False on any failure. No raise."""
+    try:
+        proc = subprocess.run(command, capture_output=True, timeout=timeout)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0

--- a/skills/last30days/scripts/lib/web_fetch_keyless.py
+++ b/skills/last30days/scripts/lib/web_fetch_keyless.py
@@ -1,0 +1,105 @@
+"""Keyless URL-to-markdown fetch (floor tier for engine-side page reads).
+
+Turns any URL into clean, JS-rendered markdown via Jina Reader's free hosted
+endpoint (``https://r.jina.ai/{url}``) with no API key. This is a *fallback*
+tier, never the primary firehose:
+
+- On agent hosts with a native fetch tool, prefer that (this module exists for
+  headless/cron and hosts without one).
+- The free tier is rate-limited and returns cached snapshots (staleness), so
+  callers should treat results as best-effort and record when it was used.
+- The target URL is sent to a third party; only use for public-research fetches.
+
+Never raises. Returns a typed :class:`KeylessFetchResult` carrying the failure
+reason on any error, so tiered callers (and the source-health layer) can fall
+through or report degradation instead of seeing a bare empty string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+from . import http
+
+JINA_READER_PREFIX = "https://r.jina.ai/"
+
+# Conservative timeout: Jina renders the page server-side, so it is slower than
+# a plain GET, but we are the floor tier and must not stall the pipeline.
+DEFAULT_FETCH_TIMEOUT = 30
+
+
+@dataclass
+class KeylessFetchResult:
+    """Result of a keyless page fetch.
+
+    ``ok`` is True only when markdown was retrieved. On failure, ``markdown`` is
+    empty and ``reason`` explains why (consumed by the source-health layer).
+    """
+
+    url: str
+    ok: bool
+    markdown: str = ""
+    reason: str = ""
+    cached_snapshot: bool = False
+
+
+def _looks_like_http_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _detect_cached_snapshot(markdown: str) -> bool:
+    """Best-effort detection of Jina's cached-snapshot warning.
+
+    Jina prepends a small metadata/warning header to the text response; when it
+    serves a cached copy it says so. We scan only the leading window to avoid
+    false positives from article bodies that happen to mention caching.
+    """
+    head = markdown[:600].lower()
+    return "cached" in head and "snapshot" in head
+
+
+def fetch_markdown(
+    url: str,
+    timeout: int = DEFAULT_FETCH_TIMEOUT,
+    retries: int = 2,
+) -> KeylessFetchResult:
+    """Fetch ``url`` as clean markdown via the keyless reader endpoint.
+
+    Args:
+        url: The http(s) URL to fetch.
+        timeout: Per-attempt HTTP timeout in seconds.
+        retries: Retry budget (kept low; this is a fail-fast floor tier).
+
+    Returns:
+        A :class:`KeylessFetchResult`. ``ok`` is False with a populated
+        ``reason`` on invalid input, network failure, or empty body.
+    """
+    if not url or not _looks_like_http_url(url):
+        return KeylessFetchResult(url=url or "", ok=False, reason="invalid-url")
+
+    reader_url = f"{JINA_READER_PREFIX}{url}"
+    text = http.get_text(
+        reader_url,
+        timeout=timeout,
+        retries=retries,
+        accept="text/plain",
+    )
+
+    if text is None:
+        return KeylessFetchResult(url=url, ok=False, reason="fetch-failed")
+
+    if not text.strip():
+        return KeylessFetchResult(url=url, ok=False, reason="empty-body")
+
+    return KeylessFetchResult(
+        url=url,
+        ok=True,
+        markdown=text,
+        cached_snapshot=_detect_cached_snapshot(text),
+    )

--- a/skills/last30days/scripts/lib/web_search_keyless.py
+++ b/skills/last30days/scripts/lib/web_search_keyless.py
@@ -1,0 +1,153 @@
+"""Keyless web search (floor tier for engine-side general web).
+
+Returns ranked web results for a query with no API key. This is strictly the
+FLOOR of the search-source ladder:
+
+    host-native search  >  paid engine backend  >  keyless engine search
+
+It must never run on a host that has native search (the model does it better
+there) or preempt a configured paid backend. The pipeline/grounding layer owns
+that gating; this module just performs the search when asked.
+
+Two vendor-neutral rungs, both stdlib-only via :mod:`http`:
+  1. DuckDuckGo HTML endpoint (no key, no instance to maintain).
+  2. A configurable SearXNG instance returning JSON (``LAST30DAYS_SEARXNG_URL``),
+     tried when the primary yields nothing.
+
+Never raises. Returns results in the same dict shape as the paid backends in
+:mod:`grounding` so they flow through normalize/score/dedupe unchanged. On total
+failure returns ``([], artifact)`` with a degraded reason in the artifact, so the
+source-health layer can report it.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from urllib.parse import parse_qs, urlparse
+
+from . import http
+
+KEYLESS_BACKEND = "keyless"
+
+_DDG_HTML_URL = "https://html.duckduckgo.com/html/"
+
+# Floor-tier relevance: below the paid backends' 0.8 so fusion prefers paid/native
+# results when both are present.
+_KEYLESS_RELEVANCE = 0.6
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_RESULT_A_RE = re.compile(
+    r'class="result__a"[^>]*href="(?P<href>[^"]+)"[^>]*>(?P<title>.*?)</a>',
+    re.IGNORECASE | re.DOTALL,
+)
+_SNIPPET_RE = re.compile(
+    r'class="result__snippet"[^>]*>(?P<snippet>.*?)</a>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _domain(url: str) -> str:
+    try:
+        return urlparse(url).netloc
+    except (ValueError, AttributeError):
+        return ""
+
+
+def _strip_html(fragment: str) -> str:
+    return html.unescape(_TAG_RE.sub("", fragment or "")).strip()
+
+
+def _unwrap_ddg_redirect(href: str) -> str:
+    """DuckDuckGo wraps result links as //duckduckgo.com/l/?uddg=<encoded>."""
+    if "uddg=" not in href:
+        return href if href.startswith("http") else f"https:{href}" if href.startswith("//") else href
+    try:
+        query = urlparse(href if href.startswith("http") else f"https:{href}").query
+        target = parse_qs(query).get("uddg", [""])[0]
+        return target or href
+    except (ValueError, AttributeError):
+        return href
+
+
+def keyless_search(
+    query: str,
+    date_range: tuple[str, str],
+    config: dict,
+    count: int = 5,
+) -> tuple[list[dict], dict]:
+    """Run keyless web search; returns (items, artifact). Never raises."""
+    items = _search_ddg(query, count)
+    used = "ddg"
+    if not items:
+        searxng_url = (config.get("LAST30DAYS_SEARXNG_URL") or "").strip()
+        if searxng_url:
+            items = _search_searxng(query, count, searxng_url)
+            used = "searxng"
+    artifact = {
+        "label": "keyless",
+        "webSearchQueries": [query],
+        "resultCount": len(items),
+        "keyless_backend": used,
+    }
+    if not items:
+        artifact["reason"] = "keyless-search-unavailable"
+    return items, artifact
+
+
+def _search_ddg(query: str, count: int) -> list[dict]:
+    from urllib.parse import urlencode
+
+    url = f"{_DDG_HTML_URL}?{urlencode({'q': query})}"
+    text = http.get_text(url, accept="text/html", retries=2)
+    if not text:
+        return []
+    items: list[dict] = []
+    snippets = _SNIPPET_RE.findall(text)
+    for i, match in enumerate(_RESULT_A_RE.finditer(text)):
+        if len(items) >= count:
+            break
+        target = _unwrap_ddg_redirect(match.group("href"))
+        if not target.startswith("http"):
+            continue
+        title = _strip_html(match.group("title"))
+        snippet = _strip_html(snippets[i]) if i < len(snippets) else ""
+        items.append(_to_item(i, title, target, snippet))
+    return items
+
+
+def _search_searxng(query: str, count: int, instance_url: str) -> list[dict]:
+    base = instance_url.rstrip("/")
+    from urllib.parse import urlencode
+
+    url = f"{base}/search?{urlencode({'q': query, 'format': 'json'})}"
+    try:
+        data = http.get(url, headers={"Accept": "application/json"}, timeout=15, retries=2)
+    except http.HTTPError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    items: list[dict] = []
+    for i, r in enumerate(data.get("results", [])):
+        if len(items) >= count:
+            break
+        if not isinstance(r, dict):
+            continue
+        target = r.get("url", "")
+        if not target.startswith("http"):
+            continue
+        items.append(_to_item(i, r.get("title", ""), target, r.get("content", "")))
+    return items
+
+
+def _to_item(index: int, title: str, url: str, snippet: str) -> dict:
+    return {
+        "id": f"WK{index + 1}",
+        "title": title,
+        "url": url,
+        "source_domain": _domain(url),
+        "snippet": (snippet or "")[:500],
+        "date": None,
+        "relevance": _KEYLESS_RELEVANCE,
+        "why_relevant": "Keyless web search",
+    }

--- a/skills/last30days/scripts/lib/web_search_keyless.py
+++ b/skills/last30days/scripts/lib/web_search_keyless.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import html
 import re
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from . import http
 
@@ -48,8 +48,10 @@ _SNIPPET_RE = re.compile(
 
 
 def _domain(url: str) -> str:
+    # Normalize identically to grounding._domain (strip + lowercase) so keyless
+    # and paid results dedupe/group consistently by source_domain.
     try:
-        return urlparse(url).netloc
+        return urlparse(url).netloc.strip().lower()
     except (ValueError, AttributeError):
         return ""
 
@@ -96,30 +98,33 @@ def keyless_search(
 
 
 def _search_ddg(query: str, count: int) -> list[dict]:
-    from urllib.parse import urlencode
-
     url = f"{_DDG_HTML_URL}?{urlencode({'q': query})}"
     text = http.get_text(url, accept="text/html", retries=2)
     if not text:
         return []
     items: list[dict] = []
-    snippets = _SNIPPET_RE.findall(text)
-    for i, match in enumerate(_RESULT_A_RE.finditer(text)):
+    # Associate each result's snippet by position, not by a parallel index:
+    # some result anchors (video/news modules) have no snippet, so a global
+    # zip would shift every later snippet onto the wrong result. Take the first
+    # snippet that falls between this anchor and the next one.
+    matches = list(_RESULT_A_RE.finditer(text))
+    for idx, match in enumerate(matches):
         if len(items) >= count:
             break
         target = _unwrap_ddg_redirect(match.group("href"))
         if not target.startswith("http"):
             continue
+        next_start = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+        window = text[match.end():next_start]
+        snippet_match = _SNIPPET_RE.search(window)
+        snippet = _strip_html(snippet_match.group("snippet")) if snippet_match else ""
         title = _strip_html(match.group("title"))
-        snippet = _strip_html(snippets[i]) if i < len(snippets) else ""
-        items.append(_to_item(i, title, target, snippet))
+        items.append(_to_item(len(items), title, target, snippet))
     return items
 
 
 def _search_searxng(query: str, count: int, instance_url: str) -> list[dict]:
     base = instance_url.rstrip("/")
-    from urllib.parse import urlencode
-
     url = f"{base}/search?{urlencode({'q': query, 'format': 'json'})}"
     try:
         data = http.get(url, headers={"Accept": "application/json"}, timeout=15, retries=2)

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -134,8 +134,18 @@ class CliV3Tests(unittest.TestCase):
             "web",
             cli._missing_sources_for_promo({"available_sources": ["reddit", "x"]}),
         )
+        # The web promo is satisfied by a paid backend (better web search), not
+        # by the keyless grounding floor — keyless web is always available now.
         self.assertIsNone(
-            cli._missing_sources_for_promo({"available_sources": ["reddit", "x", "grounding"]}),
+            cli._missing_sources_for_promo(
+                {"available_sources": ["reddit", "x", "grounding"], "native_web_backend": "brave"}
+            ),
+        )
+        # ...or suppressed entirely on a native-search host.
+        self.assertIsNone(
+            cli._missing_sources_for_promo(
+                {"available_sources": ["reddit", "x", "grounding"], "native_search": True}
+            ),
         )
 
     def test_slugify_and_emit_output_cover_supported_modes(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -73,16 +73,29 @@ class TestParseDate(unittest.TestCase):
 class TestSearchGithub(unittest.TestCase):
     @patch.dict("os.environ", {}, clear=True)
     @patch("subprocess.run", side_effect=FileNotFoundError)
-    def test_no_token_returns_empty_envelope(self, mock_run):
+    @patch("lib.github._fetch_json", return_value=None)
+    def test_no_token_unauth_rate_limited_sets_error(self, mock_fetch, mock_run):
+        # No token -> unauthenticated request; on failure (likely anon rate
+        # limit) the envelope carries a clear error instead of being silent.
         result = github.search_github("react", "2026-03-01", "2026-03-31", token=None)
         self.assertEqual(result.get("items", []), [])
         self.assertIn("error", result)
-        # Envelope shape must match the fetch-failure path: context is
-        # always present so callers (and parse_github_response) can read
-        # diagnostic fields without branching on which failure mode hit.
+        self.assertIn("unauthenticated", result["error"].lower())
         self.assertIn("context", result)
         self.assertEqual(result["context"]["from_date"], "2026-03-01")
-        self.assertEqual(result["context"]["to_date"], "2026-03-31")
+        # Unauth requests are capped to the low-rate tier.
+        self.assertLessEqual(result["context"]["count"], github.UNAUTH_COUNT_CAP)
+        # The request was actually attempted without a token (no early return).
+        mock_fetch.assert_called_once()
+        self.assertIsNone(mock_fetch.call_args.kwargs.get("token"))
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    @patch("lib.github._fetch_json", return_value={"items": [{"id": 1, "title": "x"}]})
+    def test_no_token_unauth_success_returns_items(self, mock_fetch, mock_run):
+        result = github.search_github("react", "2026-03-01", "2026-03-31", token=None)
+        self.assertEqual(len(result["items"]), 1)
+        self.assertNotIn("error", result)
 
     def test_resolve_token_public_alias(self):
         """resolve_token is the public entry point pipeline uses; _resolve_token stays

--- a/tests/test_github_unauth.py
+++ b/tests/test_github_unauth.py
@@ -1,0 +1,31 @@
+"""Tests for unauthenticated GitHub availability + error surfacing (U5)."""
+
+from unittest import mock
+
+from lib import github, pipeline
+
+
+class TestUnauthAvailability:
+    def test_github_available_without_token_or_gh(self):
+        # GitHub is reachable via the anon REST tier, so it is available even
+        # with no token and no gh CLI.
+        with mock.patch.dict("os.environ", {}, clear=True):
+            sources = pipeline.available_sources({})
+        assert "github" in sources
+
+
+class TestUnauthCap:
+    def test_unauth_caps_result_count(self):
+        with mock.patch.object(github, "_resolve_token", return_value=None), \
+             mock.patch.object(github, "_fetch_json", return_value={"items": []}) as fetch:
+            github.search_github("kubernetes", "2026-03-01", "2026-03-31", depth="deep")
+        # deep would be 60 with a token; unauth caps to UNAUTH_COUNT_CAP.
+        called_url = fetch.call_args.args[0]
+        assert f"per_page={github.UNAUTH_COUNT_CAP}" in called_url
+
+    def test_authed_keeps_full_depth(self):
+        with mock.patch.object(github, "_resolve_token", return_value="tok"), \
+             mock.patch.object(github, "_fetch_json", return_value={"items": []}) as fetch:
+            github.search_github("kubernetes", "2026-03-01", "2026-03-31", depth="deep")
+        called_url = fetch.call_args.args[0]
+        assert "per_page=60" in called_url

--- a/tests/test_grounding_v3.py
+++ b/tests/test_grounding_v3.py
@@ -191,10 +191,26 @@ class WebSearchDispatchTests(unittest.TestCase):
             grounding.web_search("test", ("2026-02-25", "2026-03-27"), config, backend="auto")
             mock.assert_called_once()
 
-    def test_auto_returns_empty_when_no_keys(self):
-        items, artifact = grounding.web_search("test", ("2026-02-25", "2026-03-27"), {}, backend="auto")
+    def test_auto_returns_empty_when_no_keys_and_native_search(self):
+        # On a native-search host (signal set) with no paid key, the engine
+        # leaves general web to the model's own search and returns nothing.
+        config = {"LAST30DAYS_NATIVE_SEARCH": "1"}
+        items, artifact = grounding.web_search("test", ("2026-02-25", "2026-03-27"), config, backend="auto")
         self.assertEqual([], items)
         self.assertEqual({}, artifact)
+
+    def test_auto_falls_to_keyless_when_no_keys_and_no_native_search(self):
+        # No paid key and no native search -> keyless floor is used.
+        with patch("lib.grounding.web_search_keyless.keyless_search",
+                   return_value=([], {"label": "keyless"})) as mock_keyless:
+            grounding.web_search("test", ("2026-02-25", "2026-03-27"), {}, backend="auto")
+        mock_keyless.assert_called_once()
+
+    def test_explicit_keyless_backend_invokes_keyless(self):
+        with patch("lib.grounding.web_search_keyless.keyless_search",
+                   return_value=([], {"label": "keyless"})) as mock_keyless:
+            grounding.web_search("test", ("2026-02-25", "2026-03-27"), {}, backend="keyless")
+        mock_keyless.assert_called_once()
 
     def test_none_returns_empty(self):
         config = {"BRAVE_API_KEY": "test-key"}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,75 @@
+"""Tests for scripts/lib/health.py and pipeline degradation preservation."""
+
+import subprocess
+from unittest import mock
+
+from lib import health, pipeline
+
+
+class TestProbeCommand:
+    def test_missing_when_not_on_path(self):
+        result = health.probe_command(["definitely-not-a-real-binary-xyz"])
+        assert result.state == health.MISSING
+        assert not result.usable
+
+    def test_ok_on_exit_zero(self):
+        result = health.probe_command(["true"])
+        assert result.state == health.OK
+        assert result.ok
+
+    def test_error_on_nonzero_exit(self):
+        result = health.probe_command(["false"])
+        assert result.state == health.ERROR
+        assert not result.ok
+
+    def test_timeout(self):
+        result = health.probe_command(["sleep", "5"], timeout=0.1)
+        assert result.state == health.TIMEOUT
+
+    def test_broken_when_exec_raises(self):
+        # On PATH (which returns a path) but exec raises -> broken, not missing.
+        with mock.patch.object(health.shutil, "which", return_value="/usr/bin/x"), \
+             mock.patch.object(health.subprocess, "run", side_effect=OSError("exec format error")):
+            result = health.probe_command(["x"])
+        assert result.state == health.BROKEN
+
+    def test_broken_on_exit_127(self):
+        fake = subprocess.CompletedProcess(args=["x"], returncode=127, stdout="", stderr="not found")
+        with mock.patch.object(health.shutil, "which", return_value="/usr/bin/x"), \
+             mock.patch.object(health.subprocess, "run", return_value=fake):
+            result = health.probe_command(["x"])
+        assert result.state == health.BROKEN
+
+
+class _FakeCandidate:
+    def __init__(self, sources):
+        self.sources = sources
+
+
+def _candidates(n=6):
+    return [_FakeCandidate(["reddit"]) for _ in range(n)]
+
+
+class TestDegradationWarnings:
+    """Partial failures survive as a distinct 'degraded' warning."""
+
+    def test_degraded_surfaced_distinctly_from_failed(self):
+        warnings = pipeline._warnings(
+            items_by_source={"reddit": [object()], "github": [object()]},
+            candidates=_candidates(),
+            errors_by_source={"x": "hard failure"},
+            degraded_by_source={"reddit": "429 on one subquery"},
+        )
+        joined = " | ".join(warnings)
+        assert "Some sources failed: x" in joined
+        assert "degraded" in joined.lower()
+        assert "reddit" in joined
+
+    def test_no_degraded_warning_when_none(self):
+        warnings = pipeline._warnings(
+            items_by_source={"reddit": [object()]},
+            candidates=_candidates(),
+            errors_by_source={},
+            degraded_by_source={},
+        )
+        assert not any("degraded" in w.lower() for w in warnings)

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -1091,6 +1091,28 @@ class TestExcludeSources(unittest.TestCase):
         self.assertIn("reddit", sources)
 
 
+class TestKeylessGroundingAvailability(unittest.TestCase):
+    """Grounding (general web) availability is host-aware.
+
+    Non-native hosts get the keyless floor by default; native-search hosts leave
+    general web to the model's own search unless a paid key is configured.
+    """
+
+    def test_grounding_available_without_key_on_non_native_host(self):
+        sources = pipeline.available_sources({})
+        self.assertIn("grounding", sources)
+
+    def test_grounding_suppressed_without_key_on_native_host(self):
+        config = {"LAST30DAYS_NATIVE_SEARCH": "1"}
+        sources = pipeline.available_sources(config)
+        self.assertNotIn("grounding", sources)
+
+    def test_grounding_available_with_paid_key_even_on_native_host(self):
+        config = {"LAST30DAYS_NATIVE_SEARCH": "1", "BRAVE_API_KEY": "k"}
+        sources = pipeline.available_sources(config)
+        self.assertIn("grounding", sources)
+
+
 class TestExcludeSourcesEndToEnd(unittest.TestCase):
     """Wiring regression: EXCLUDE_SOURCES from the process environment must
     reach available_sources() via env.get_config(). The unit tests above

--- a/tests/test_reddit_keyless_backoff.py
+++ b/tests/test_reddit_keyless_backoff.py
@@ -6,28 +6,32 @@ from lib import http, reddit_rss
 
 
 class TestRateLimiter:
-    def test_first_acquire_does_not_sleep(self):
-        limiter = http.RateLimiter(min_interval=0.5)
+    def test_burst_does_not_sleep(self):
+        # A full bucket lets `burst` calls through immediately.
+        limiter = http.RateLimiter(rate_per_sec=5.0, burst=3)
         with mock.patch.object(http.time, "monotonic", return_value=100.0), \
              mock.patch.object(http.time, "sleep") as slept:
             limiter.acquire()
+            limiter.acquire()
+            limiter.acquire()
         slept.assert_not_called()
 
-    def test_second_acquire_sleeps_to_maintain_interval(self):
-        limiter = http.RateLimiter(min_interval=0.5)
-        # First call at t=100, second call 0.1s later -> must wait ~0.4s.
-        times = iter([100.0, 100.1, 100.5])
+    def test_sleeps_when_bucket_empty(self):
+        # burst=1: first call passes, second (same instant) must wait ~1/rate.
+        limiter = http.RateLimiter(rate_per_sec=2.0, burst=1)
+        times = iter([100.0, 100.0, 100.0, 100.5])
         with mock.patch.object(http.time, "monotonic", side_effect=lambda: next(times)), \
              mock.patch.object(http.time, "sleep") as slept:
-            limiter.acquire()
-            limiter.acquire()
-        slept.assert_called_once()
+            limiter.acquire()  # consumes the one token
+            limiter.acquire()  # bucket empty -> sleep, then refilled token consumed
+        slept.assert_called()
         waited = slept.call_args.args[0]
-        assert abs(waited - 0.4) < 1e-6
+        assert abs(waited - 0.5) < 1e-6  # (1 token deficit) / 2 per sec
 
-    def test_no_sleep_when_interval_already_elapsed(self):
-        limiter = http.RateLimiter(min_interval=0.5)
-        times = iter([100.0, 102.0])  # 2s gap > interval
+    def test_refill_over_time_avoids_sleep(self):
+        limiter = http.RateLimiter(rate_per_sec=2.0, burst=1)
+        # Second call 1s later: bucket refilled (2/s * 1s capped at burst=1) -> no sleep.
+        times = iter([100.0, 101.0])
         with mock.patch.object(http.time, "monotonic", side_effect=lambda: next(times)), \
              mock.patch.object(http.time, "sleep") as slept:
             limiter.acquire()

--- a/tests/test_reddit_keyless_backoff.py
+++ b/tests/test_reddit_keyless_backoff.py
@@ -1,0 +1,51 @@
+"""Tests for the shared keyless-Reddit throttle (U4)."""
+
+from unittest import mock
+
+from lib import http, reddit_rss
+
+
+class TestRateLimiter:
+    def test_first_acquire_does_not_sleep(self):
+        limiter = http.RateLimiter(min_interval=0.5)
+        with mock.patch.object(http.time, "monotonic", return_value=100.0), \
+             mock.patch.object(http.time, "sleep") as slept:
+            limiter.acquire()
+        slept.assert_not_called()
+
+    def test_second_acquire_sleeps_to_maintain_interval(self):
+        limiter = http.RateLimiter(min_interval=0.5)
+        # First call at t=100, second call 0.1s later -> must wait ~0.4s.
+        times = iter([100.0, 100.1, 100.5])
+        with mock.patch.object(http.time, "monotonic", side_effect=lambda: next(times)), \
+             mock.patch.object(http.time, "sleep") as slept:
+            limiter.acquire()
+            limiter.acquire()
+        slept.assert_called_once()
+        waited = slept.call_args.args[0]
+        assert abs(waited - 0.4) < 1e-6
+
+    def test_no_sleep_when_interval_already_elapsed(self):
+        limiter = http.RateLimiter(min_interval=0.5)
+        times = iter([100.0, 102.0])  # 2s gap > interval
+        with mock.patch.object(http.time, "monotonic", side_effect=lambda: next(times)), \
+             mock.patch.object(http.time, "sleep") as slept:
+            limiter.acquire()
+            limiter.acquire()
+        slept.assert_not_called()
+
+
+class TestRedditKeylessGetText:
+    def test_acquires_limiter_then_delegates(self):
+        with mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire") as acq, \
+             mock.patch.object(http, "get_text", return_value="body") as gt:
+            out = http.reddit_keyless_get_text("https://www.reddit.com/x.rss", accept="application/atom+xml")
+        assert out == "body"
+        acq.assert_called_once()
+        gt.assert_called_once()
+
+    def test_reddit_rss_routes_through_throttle(self):
+        # The RSS tier must use the throttled helper, not raw get_text.
+        with mock.patch.object(reddit_rss.http, "reddit_keyless_get_text", return_value=None) as throttled:
+            reddit_rss.search_rss("test query")
+        assert throttled.called

--- a/tests/test_secret_hygiene.py
+++ b/tests/test_secret_hygiene.py
@@ -1,0 +1,52 @@
+"""Tests for secret-file write hygiene (U7)."""
+
+import os
+import stat
+from pathlib import Path
+
+from lib import env, setup_wizard
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+class TestSecureEnvWrite:
+    def test_new_env_file_is_0600(self, tmp_path):
+        env_path = tmp_path / "cfg" / ".env"
+        assert setup_wizard.write_setup_config(env_path, from_browser="auto") is True
+        assert env_path.exists()
+        assert _mode(env_path) == 0o600
+
+    def test_existing_loose_file_tightened_to_0600(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("EXISTING_KEY=value\n", encoding="utf-8")
+        os.chmod(env_path, 0o644)
+        setup_wizard.write_setup_config(env_path, from_browser="auto")
+        assert _mode(env_path) == 0o600
+
+    def test_written_config_is_loadable(self, tmp_path):
+        env_path = tmp_path / ".env"
+        setup_wizard.write_setup_config(env_path, from_browser="auto")
+        loaded = env.load_env_file(env_path)
+        assert loaded.get("SETUP_COMPLETE") == "true"
+        assert loaded.get("FROM_BROWSER") == "auto"
+
+
+class TestFormatEnvValue:
+    def test_plain_token_unchanged(self):
+        assert setup_wizard._format_env_value("abc123-TOKEN_x") == "abc123-TOKEN_x"
+
+    def test_value_with_spaces_roundtrips(self, tmp_path):
+        env_path = tmp_path / ".env"
+        line = f"SOME_KEY={setup_wizard._format_env_value('two words')}\n"
+        # Write 0o600 via the loader-compatible path and confirm the loader
+        # strips the quoting back to the original value.
+        env_path.write_text(line, encoding="utf-8")
+        os.chmod(env_path, 0o600)
+        loaded = env.load_env_file(env_path)
+        assert loaded["SOME_KEY"] == "two words"
+
+    def test_newline_is_stripped(self):
+        out = setup_wizard._format_env_value("line1\nline2")
+        assert "\n" not in out

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/lib/transcribe.py — caption-free transcription fallback (U6)."""
+
+from unittest import mock
+
+from lib import health, transcribe
+
+
+class TestPrerequisites:
+    def test_missing_ffmpeg_degrades(self):
+        with mock.patch.object(transcribe.shutil, "which", return_value=None):
+            result = transcribe.transcribe_media("https://x/v", {"GROQ_API_KEY": "k"})
+        assert result.ok is False
+        assert "ffmpeg" in result.reason
+        assert result.health.state == health.MISSING
+
+    def test_no_provider_key_degrades(self):
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"):
+            result = transcribe.transcribe_media("https://x/v", {})
+        assert result.ok is False
+        assert "provider" in result.reason
+        assert result.health.state == health.MISSING
+
+    def test_is_available(self):
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"):
+            assert transcribe.is_available({"GROQ_API_KEY": "k"}) is True
+            assert transcribe.is_available({}) is False
+
+
+class TestTranscribeFlow:
+    def _patches(self, chunks, post_side_effect):
+        return [
+            mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"),
+            mock.patch.object(transcribe, "_acquire_audio", return_value="/tmp/audio.mp3"),
+            mock.patch.object(transcribe, "_chunk_audio", return_value=chunks),
+            mock.patch.object(transcribe, "_post_audio", side_effect=post_side_effect),
+            mock.patch.object(transcribe.shutil, "rmtree"),
+            mock.patch.object(transcribe.tempfile, "mkdtemp", return_value="/tmp/wd"),
+        ]
+
+    def test_under_limit_single_chunk(self):
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"), \
+             mock.patch.object(transcribe, "_acquire_audio", return_value="/tmp/audio.mp3"), \
+             mock.patch.object(transcribe, "_chunk_audio", return_value=["/tmp/audio.mp3"]), \
+             mock.patch.object(transcribe, "_post_audio", return_value="hello world"), \
+             mock.patch.object(transcribe.shutil, "rmtree"), \
+             mock.patch.object(transcribe.tempfile, "mkdtemp", return_value="/tmp/wd"):
+            result = transcribe.transcribe_media("https://x/v", {"GROQ_API_KEY": "k"})
+        assert result.ok is True
+        assert result.text == "hello world"
+        assert result.chunks == 1
+        assert result.provider == "groq"
+
+    def test_over_limit_chunks_joined_in_order(self):
+        chunks = ["/tmp/wd/chunk_000.mp3", "/tmp/wd/chunk_001.mp3"]
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"), \
+             mock.patch.object(transcribe, "_acquire_audio", return_value="/tmp/audio.mp3"), \
+             mock.patch.object(transcribe, "_chunk_audio", return_value=chunks), \
+             mock.patch.object(transcribe, "_post_audio", side_effect=["part one", "part two"]), \
+             mock.patch.object(transcribe.shutil, "rmtree"), \
+             mock.patch.object(transcribe.tempfile, "mkdtemp", return_value="/tmp/wd"):
+            result = transcribe.transcribe_media("https://x/v", {"GROQ_API_KEY": "k"})
+        assert result.ok is True
+        assert result.text == "part one\npart two"
+        assert result.chunks == 2
+
+    def test_provider_fallback_on_chunk(self):
+        # groq raises, openai succeeds -> fallback used.
+        def post(provider, path, key, timeout):
+            if provider == "groq":
+                raise RuntimeError("groq 500")
+            return "via openai"
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"), \
+             mock.patch.object(transcribe, "_acquire_audio", return_value="/tmp/audio.mp3"), \
+             mock.patch.object(transcribe, "_chunk_audio", return_value=["/tmp/audio.mp3"]), \
+             mock.patch.object(transcribe, "_post_audio", side_effect=post), \
+             mock.patch.object(transcribe.shutil, "rmtree"), \
+             mock.patch.object(transcribe.tempfile, "mkdtemp", return_value="/tmp/wd"):
+            result = transcribe.transcribe_media(
+                "https://x/v", {"GROQ_API_KEY": "k", "OPENAI_API_KEY": "o"})
+        assert result.ok is True
+        assert result.text == "via openai"
+        assert result.provider == "openai"
+
+    def test_all_providers_fail_degrades(self):
+        with mock.patch.object(transcribe.shutil, "which", return_value="/usr/bin/ffmpeg"), \
+             mock.patch.object(transcribe, "_acquire_audio", return_value="/tmp/audio.mp3"), \
+             mock.patch.object(transcribe, "_chunk_audio", return_value=["/tmp/audio.mp3"]), \
+             mock.patch.object(transcribe, "_post_audio", side_effect=RuntimeError("boom")), \
+             mock.patch.object(transcribe.shutil, "rmtree"), \
+             mock.patch.object(transcribe.tempfile, "mkdtemp", return_value="/tmp/wd"):
+            result = transcribe.transcribe_media("https://x/v", {"GROQ_API_KEY": "k"})
+        assert result.ok is False
+        assert "all providers failed" in result.reason

--- a/tests/test_web_fetch_keyless.py
+++ b/tests/test_web_fetch_keyless.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/lib/web_fetch_keyless.py — keyless URL-to-markdown fetch."""
+
+from unittest import mock
+
+from lib import web_fetch_keyless
+
+
+class TestFetchMarkdown:
+    """fetch_markdown turns a URL into clean markdown via the keyless reader."""
+
+    def test_happy_path(self):
+        body = "Title: Example\nURL Source: https://example.com\n\n# Example\n\nReal content."
+        with mock.patch.object(web_fetch_keyless.http, "get_text", return_value=body) as gt:
+            result = web_fetch_keyless.fetch_markdown("https://example.com")
+        assert result.ok is True
+        assert "Real content." in result.markdown
+        assert result.cached_snapshot is False
+        # Requests the reader-prefixed URL with a text accept header.
+        called_url = gt.call_args.args[0]
+        assert called_url == "https://r.jina.ai/https://example.com"
+        assert gt.call_args.kwargs.get("accept") == "text/plain"
+
+    def test_cached_snapshot_flagged(self):
+        body = "Warning: showing a cached snapshot of this page.\n\n# Title\n\nbody"
+        with mock.patch.object(web_fetch_keyless.http, "get_text", return_value=body):
+            result = web_fetch_keyless.fetch_markdown("https://example.com/post")
+        assert result.ok is True
+        assert result.cached_snapshot is True
+
+    def test_fetch_failure_returns_typed_empty(self):
+        with mock.patch.object(web_fetch_keyless.http, "get_text", return_value=None):
+            result = web_fetch_keyless.fetch_markdown("https://example.com")
+        assert result.ok is False
+        assert result.markdown == ""
+        assert result.reason == "fetch-failed"
+
+    def test_empty_body_returns_typed_empty(self):
+        with mock.patch.object(web_fetch_keyless.http, "get_text", return_value="   \n  "):
+            result = web_fetch_keyless.fetch_markdown("https://example.com")
+        assert result.ok is False
+        assert result.reason == "empty-body"
+
+    def test_invalid_url_makes_no_request(self):
+        with mock.patch.object(web_fetch_keyless.http, "get_text") as gt:
+            result = web_fetch_keyless.fetch_markdown("not a url")
+        assert result.ok is False
+        assert result.reason == "invalid-url"
+        gt.assert_not_called()
+
+    def test_empty_url_makes_no_request(self):
+        with mock.patch.object(web_fetch_keyless.http, "get_text") as gt:
+            result = web_fetch_keyless.fetch_markdown("")
+        assert result.ok is False
+        assert result.reason == "invalid-url"
+        gt.assert_not_called()

--- a/tests/test_web_search_keyless.py
+++ b/tests/test_web_search_keyless.py
@@ -1,0 +1,67 @@
+"""Tests for scripts/lib/web_search_keyless.py — keyless web search floor."""
+
+from unittest import mock
+
+from lib import web_search_keyless
+
+_DDG_HTML = """
+<div class="result">
+  <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpost&amp;rut=x">First &amp; Best</a>
+  <a class="result__snippet" href="//x">A snippet about the <b>topic</b>.</a>
+</div>
+<div class="result">
+  <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fnews.example.org%2Fa">Second result</a>
+  <a class="result__snippet" href="//y">Second snippet.</a>
+</div>
+"""
+
+
+class TestKeylessSearch:
+    def test_ddg_parsing_happy_path(self):
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=_DDG_HTML):
+            items, artifact = web_search_keyless.keyless_search(
+                "topic", ("2026-02-25", "2026-03-27"), {})
+        assert len(items) == 2
+        assert items[0]["url"] == "https://example.com/post"
+        assert items[0]["title"] == "First & Best"
+        assert items[0]["source_domain"] == "example.com"
+        assert "snippet about the topic" in items[0]["snippet"]
+        assert artifact["keyless_backend"] == "ddg"
+        # Floor relevance is below the paid backends' 0.8.
+        assert items[0]["relevance"] < 0.8
+
+    def test_item_shape_matches_grounding_backends(self):
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=_DDG_HTML):
+            items, _ = web_search_keyless.keyless_search("topic", ("2026-02-25", "2026-03-27"), {})
+        required = {"id", "title", "url", "source_domain", "snippet", "date", "relevance", "why_relevant"}
+        assert required.issubset(items[0].keys())
+
+    def test_count_cap(self):
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=_DDG_HTML):
+            items, _ = web_search_keyless.keyless_search("topic", ("2026-02-25", "2026-03-27"), {}, count=1)
+        assert len(items) == 1
+
+    def test_ddg_down_no_searxng_returns_degraded(self):
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=None):
+            items, artifact = web_search_keyless.keyless_search("topic", ("2026-02-25", "2026-03-27"), {})
+        assert items == []
+        assert artifact["reason"] == "keyless-search-unavailable"
+
+    def test_searxng_fallback_when_ddg_empty(self):
+        searxng_payload = {"results": [
+            {"url": "https://searxng.example/a", "title": "SX A", "content": "sx snippet"},
+        ]}
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=None), \
+             mock.patch.object(web_search_keyless.http, "get", return_value=searxng_payload):
+            items, artifact = web_search_keyless.keyless_search(
+                "topic", ("2026-02-25", "2026-03-27"),
+                {"LAST30DAYS_SEARXNG_URL": "https://searxng.example"})
+        assert len(items) == 1
+        assert items[0]["url"] == "https://searxng.example/a"
+        assert artifact["keyless_backend"] == "searxng"
+
+    def test_skips_non_http_results(self):
+        html = '<a class="result__a" href="//duckduckgo.com/l/?uddg=javascript%3Avoid(0)">bad</a>'
+        with mock.patch.object(web_search_keyless.http, "get_text", return_value=html):
+            items, _ = web_search_keyless.keyless_search("topic", ("2026-02-25", "2026-03-27"), {})
+        assert items == []


### PR DESCRIPTION
## Why

The engine runs fully keyless except for one capability: general web search. With no paid web key set, the `grounding` source silently disappears and the brief is built from social sources only. Several sources also hide failures, returning empty on error so a source dropping from 20 results to 1 looks healthy.

This closes both gaps and a few adjacent keyless holes, without changing behavior for users who already have keys.

## What changed

- Keyless web tier (host-gated): a free URL-to-markdown fetch (Jina Reader) and a keyless web search floor (DuckDuckGo, optional SearXNG fallback). It is the floor of a strict ladder: host-native search > paid backend > keyless. Capability-gated by `LAST30DAYS_NATIVE_SEARCH` (set by the SKILL.md path only when the runtime has a native search tool), so Claude Code and other native-search hosts never fall to the free tier or preempt a paid backend; OpenClaw-style hosts and headless/cron do.
- Honest degradation: a typed source-health probe (missing / broken / timeout / ok) and a fix so partial failures surface as a distinct "degraded" warning instead of being silently dropped.
- Throttled keyless Reddit tiers (token-bucket) so a broad multi-query run cannot stampede the endpoints under the parallel fan-out.
- Unauthenticated GitHub fallback: GitHub search now works without a token via the anon REST tier (capped to the low-rate limit).
- Caption-free transcription module (compress to chunk to provider-fallback Whisper). Groundwork: shipped and tested, not yet auto-invoked by the engine.
- Secret hygiene: the `.env` is now written 0o600 atomically.

## Config added

- `LAST30DAYS_NATIVE_SEARCH` - host-native-search signal (suppresses the keyless floor).
- `LAST30DAYS_SEARXNG_URL` - optional keyless-search fallback instance.
- `GROQ_API_KEY` - Whisper provider for the transcription module.

## Testing

Full suite green. Each unit ships with its own test file (fetch, search, health, reddit throttle, github unauth, transcription, secret hygiene).

## Notes

- Plan: `docs/plans/2026-06-17-001-feat-keyless-coverage-honest-degradation-plan.md`.
- Per the beta-channel convention this would normally land via `/last30days-beta` first; opening here for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
