### PR TITLE
feat: support OPENAI_BASE_URL / XAI_BASE_URL for local LLM endpoints

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -574,6 +574,27 @@ def _write_last_run(topic: str, report: "schema.Report") -> None:
         pass
 
 
+def _propagate_config_to_environ() -> None:
+    """Push relevant env keys to os.environ so provider modules can read them.
+
+    The env.get_config() function reads from a .env file, but providers.py
+    reads from os.environ directly. Without this, OPENAI_BASE_URL and
+    XAI_BASE_URL overrides are silently ignored. This is a no-op for
+    keys that are already set in process env.
+    """
+    try:
+        config = env.get_config()
+    except Exception:
+        return
+    for key in ("OPENAI_BASE_URL", "XAI_BASE_URL"):
+        val = config.get(key)
+        if val and not os.environ.get(key):
+            os.environ[key] = val
+
+
+_propagate_config_to_environ()
+
+
 def main() -> int:
     parser = build_parser()
     # Use parse_known_args so setup sub-flags (--device-auth, --github,

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -381,6 +381,8 @@ def get_config() -> dict[str, Any]:
         ('LAST30DAYS_STORE', None),
         ('OPENAI_MODEL_PIN', None),
         ('XAI_MODEL_PIN', None),
+        ('OPENAI_BASE_URL', None),
+        ('XAI_BASE_URL', None),
         ('SCRAPECREATORS_API_KEY', None),
         ('APIFY_API_TOKEN', None),
         ('AUTH_TOKEN', None),

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from typing import Any
@@ -144,7 +145,7 @@ class OpenAIClient(ReasoningClient):
             "temperature": 0,
         }
         response = http.post(
-            OPENAI_RESPONSES_URL,
+            os.environ.get("OPENAI_BASE_URL", OPENAI_RESPONSES_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.token}",
@@ -175,7 +176,7 @@ class XAIClient(ReasoningClient):
             "input": [{"role": "user", "content": prompt}],
         }
         response = http.post(
-            XAI_RESPONSES_URL,
+            os.environ.get("XAI_BASE_URL", XAI_RESPONSES_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.api_key}",


### PR DESCRIPTION
## Feature: Support for local OpenAI-compatible LLM endpoints (OPENAI_BASE_URL / XAI_BASE_URL)

**Why this matters:** The skill hardcodes `https://api.openai.com/v1/responses` and `https://api.x.ai/v1/responses` as the endpoints for the OpenAI and xAI reasoning clients. With a self-hosted LLM (llama.cpp, vLLM, ollama, etc.), this is a blocker — even with a fake API key, the planner/rerank/fun-judge steps fail with HTTP 401 because the real OpenAI rejects the fake key.

A growing number of users in the community run local models for cost and privacy reasons. Adding base URL override support is a 3-line change that unblocks all of them.

## What I tested

- Qwen3.6-27B-Q4_K_M.gguf via llama.cpp on `http://host:9876/v1`
- llama.cpp exposes both `/v1/chat/completions` and `/v1/responses` (the latter is what your `OpenAIClient` uses)
- After the patch: planner successfully generates subqueries, evidence flows through correctly. Rerank/fun-judge still fall back to local scoring on smaller models, but the planner is the high-value step and it works.

## Proposed changes

Three small patches, all defensive (no behavior change unless the env vars are set):

1. `skills/last30days/scripts/lib/providers.py` — read `OPENAI_BASE_URL` / `XAI_BASE_URL` from `os.environ`, fall back to hardcoded URLs
2. `skills/last30days/scripts/lib/env.py` — add the two keys to the config whitelist (currently only specific keys are loaded from `.env`)
3. `skills/last30days/scripts/last30days.py` — propagate config values to `os.environ` at script startup so providers.py can read them

## Diff summary

```diff
# skills/last30days/scripts/lib/providers.py
  from __future__ import annotations

  import json
+ import os
  import re
  ...

  class OpenAIClient(ReasoningClient):
      ...
      response = http.post(
-         OPENAI_RESPONSES_URL,
+         os.environ.get("OPENAI_BASE_URL", OPENAI_RESPONSES_URL),
          payload,
          ...
      )

  class XAIClient(ReasoningClient):
      ...
      response = http.post(
-         XAI_RESPONSES_URL,
+         os.environ.get("XAI_BASE_URL", XAI_RESPONSES_URL),
          payload,
          ...
      )

# skills/last30days/scripts/lib/env.py  (in the keys list)
      ('OPENAI_MODEL_PIN', None),
      ('XAI_MODEL_PIN', None),
+     ('OPENAI_BASE_URL', None),
+     ('XAI_BASE_URL', None),
      ('SCRAPECREATORS_API_KEY', None),

# skills/last30days/scripts/last30days.py
+ def _propagate_config_to_environ():
+     """Push relevant env keys to os.environ so provider modules can read them."""
+     try: config = env.get_config()
+     except Exception: return
+     for key in ("OPENAI_BASE_URL", "XAI_BASE_URL"):
+         val = config.get(key)
+         if val and not os.environ.get(key):
+             os.environ[key] = val
+
+ _propagate_config_to_environ()
```

Total: **26 insertions, 2 deletions across 3 files**.

## Usage

In `~/.config/last30days/.env`:

```bash
OPENAI_API_KEY=any-string  # local server ignores the value
OPENAI_BASE_URL=http://your-llm-host:port/v1/responses  # full endpoint, not just base
LAST30DAYS_REASONING_PROVIDER=openai
LAST30DAYS_PLANNER_MODEL=your-model-name  # exact name as the server advertises
LAST30DAYS_RERANK_MODEL=your-model-name
```

Note: `OPENAI_BASE_URL` should be the **full endpoint** (`/v1/responses`), not just the base. The provider modules use the value as-is.

## Why this approach

- **Non-breaking**: if the env vars are unset, behavior is identical to today
- **Standard pattern**: same override mechanism other tools (openai-cli, litellm, etc.) use
- **Smallest possible diff**: 5 lines in providers.py, 2 lines in env.py, 19 lines in last30days.py (the helper)
- **Documented**: the helper has a docstring explaining the asymmetry between `env.get_config()` (whitelist) and `os.environ` (free-for-all)

Happy to iterate on naming, error messages, or whether to gate the override behind a flag. Let me know what would make this easy to merge.

---

## Self-testing notes (if maintainers want to reproduce)

```bash
git checkout v3.3.0
# apply this branch's diff
# set OPENAI_BASE_URL=http://your-llm:port/v1/responses
python3 last30days.py "test query" --auto-resolve --emit=compact
# expect: planner runs, evidence flows, footer renders
```

🤖 Generated with [MiniMax-M3](https://example.com) via opencode
