### PR TITLE
fix(setup): use $HOME-relative PATH hints for off-path Digg CLI

### DIFF
--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -171,7 +171,10 @@ def _digg_off_path_binary() -> Optional[str]:
 
 def _digg_bin_dir_hint(digg_path: str) -> str:
     """Return a copy-pasteable PATH directory for the given binary path."""
-    parent = str(Path(digg_path).expanduser().parent)
+    parent = os.path.dirname(os.path.expanduser(digg_path))
+    if os.name == "nt":
+        # Windows PATH edits use absolute dirs; $HOME is a Unix shell convention.
+        return parent
     home = str(Path.home())
     if parent == home:
         return "$HOME"

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -169,6 +169,19 @@ def _digg_off_path_binary() -> Optional[str]:
     return None
 
 
+def _digg_bin_dir_hint(digg_path: str) -> str:
+    """Return a copy-pasteable PATH directory for the given binary path."""
+    parent = str(Path(digg_path).expanduser().parent)
+    home = str(Path.home())
+    if parent == home:
+        return "$HOME"
+    prefix = home + os.sep
+    if parent.startswith(prefix):
+        rel = parent[len(prefix):].replace(os.sep, "/")
+        return f"$HOME/{rel}" if rel else "$HOME"
+    return parent
+
+
 def _install_digg_cli() -> Tuple[bool, str, str, str]:
     """Best-effort install of the digg-pp-cli binary.
 
@@ -355,16 +368,19 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
         lines.append("  - Digg CLI already installed (AI-news clusters active)")
     elif digg_action == "installed_off_path":
         digg_path = results.get("digg_path", "")
-        # Tell the user to add the dir where the binary was ACTUALLY found
-        # (probed across ~/.local/bin, $GOPATH/bin, ~/go/bin, Windows). Hardcoding
-        # ~/.local/bin would misdirect a user whose binary lives in ~/go/bin.
-        bin_dir = str(Path(digg_path).parent) if digg_path else "$HOME/.local/bin"
-        shown_path = digg_path or "$HOME/.local/bin/digg-pp-cli"
-        lines.append(
-            f"  - Digg CLI found at {shown_path} but not on PATH — add "
-            f"{bin_dir} to PATH and restart your agent session/gateway "
-            "for Digg to activate"
-        )
+        if digg_path:
+            bin_dir = _digg_bin_dir_hint(digg_path)
+            lines.append(
+                f"  - Digg CLI found at {digg_path} but not on PATH — add "
+                f"{bin_dir} to PATH and restart your agent session/gateway "
+                "for Digg to activate"
+            )
+        else:
+            lines.append(
+                "  - Digg CLI is installed but not on PATH — add its install "
+                "directory to PATH and restart your agent session/gateway for "
+                "Digg to activate"
+            )
     elif digg_action == "install_failed":
         lines.append(f"  - Digg CLI install failed — run `{DIGG_INSTALL_CMD}` manually")
     elif digg_action == "no_npx":

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -560,6 +560,29 @@ class TestGetSetupStatusText:
         assert "$HOME/go/bin" in text
         assert ".local/bin" not in text
 
+    def test_status_text_digg_installed_off_path_missing_path(self):
+        results = {"cookies_found": {}, "ytdlp_action": "already_installed",
+                   "digg_action": "installed_off_path",
+                   "env_written": False}
+        text = setup_wizard.get_setup_status_text(results)
+        assert "not on PATH" in text
+        assert "add its install directory to PATH" in text
+
+    def test_status_text_digg_installed_off_path_empty_path(self):
+        results = {"cookies_found": {}, "ytdlp_action": "already_installed",
+                   "digg_action": "installed_off_path",
+                   "digg_path": "",
+                   "env_written": False}
+        text = setup_wizard.get_setup_status_text(results)
+        assert "add its install directory to PATH" in text
+
+    def test_digg_bin_dir_hint_windows_returns_absolute_parent(self):
+        home = Path.home()
+        digg_path = str(home / ".local" / "bin" / "digg-pp-cli")
+        expected = str(home / ".local" / "bin")
+        with patch.object(setup_wizard.os, "name", "nt"):
+            assert setup_wizard._digg_bin_dir_hint(digg_path) == expected
+
     def test_status_text_digg_no_npx(self):
         results = {"cookies_found": {}, "ytdlp_action": "already_installed",
                    "digg_action": "no_npx", "env_written": False}

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -537,25 +537,27 @@ class TestGetSetupStatusText:
         assert "printing-press-library" in text
 
     def test_status_text_digg_installed_off_path(self):
+        home = Path.home()
+        digg_path = str(home / ".local" / "bin" / "digg-pp-cli")
         results = {"cookies_found": {}, "ytdlp_action": "already_installed",
                    "digg_action": "installed_off_path",
-                   "digg_path": "/Users/me/.local/bin/digg-pp-cli",
+                   "digg_path": digg_path,
                    "env_written": False}
         text = setup_wizard.get_setup_status_text(results)
         assert "not on PATH" in text
-        assert ".local/bin" in text
+        assert "$HOME/.local/bin" in text
         assert "now active" not in text.lower()
 
-    def test_status_text_digg_off_path_uses_actual_dir(self):
-        """The PATH instruction names the dir where the binary was ACTUALLY found,
-        not a hardcoded ~/.local/bin (Greptile #590)."""
+    def test_status_text_digg_installed_off_path_legacy_go_bin(self):
+        """PATH hint names the actual install dir as $HOME-relative, not ~/.local/bin."""
+        home = Path.home()
+        digg_path = str(home / "go" / "bin" / "digg-pp-cli")
         results = {"cookies_found": {}, "ytdlp_action": "already_installed",
                    "digg_action": "installed_off_path",
-                   "digg_path": "/Users/me/go/bin/digg-pp-cli",
+                   "digg_path": digg_path,
                    "env_written": False}
         text = setup_wizard.get_setup_status_text(results)
-        assert "/Users/me/go/bin/digg-pp-cli" in text
-        assert "add /Users/me/go/bin to PATH" in text
+        assert "$HOME/go/bin" in text
         assert ".local/bin" not in text
 
     def test_status_text_digg_no_npx(self):


### PR DESCRIPTION
## Summary
- Follow-up to #590: when Digg CLI is installed but not on PATH, setup status now shows copy-pasteable `$HOME/...` directory hints derived from the probed binary path
- Adds `_digg_bin_dir_hint()` and a generic fallback when `digg_path` is missing
- Updates off-path tests to assert `$HOME/.local/bin` and `$HOME/go/bin` instead of machine-specific absolute paths

## Test plan
- [x] `uv run pytest tests/test_setup_wizard.py -q`