### PR TITLE
fix(html_render): escape META marker text to close stored-XSS path

### DIFF
--- a/skills/last30days/scripts/lib/html_render.py
+++ b/skills/last30days/scripts/lib/html_render.py
@@ -574,7 +574,15 @@ def _promote_meta_marker(body: str) -> str:
     Both collapse to ``<div class="meta">TEXT</div>``.
     """
     def replace(match: re.Match[str]) -> str:
-        text = match.group(1).strip()
+        # The marker survives the comment-strip pass, and the markdown reaching
+        # this point can include LLM-synthesized content derived from untrusted
+        # web/social bodies. The escaped-form branches below carry text the
+        # markdown pass already entity-escaped, while the raw-form fallbacks do
+        # not — so normalize with unescape, then escape exactly once. A crafted
+        # `<!-- META: <img src=x onerror=...> -->` thus cannot render as live
+        # markup in the saved, shareable HTML artifact, and legitimate
+        # date/source-name markers render unchanged.
+        text = html.escape(html.unescape(match.group(1).strip()))
         return f'<div class="meta">{text}</div>'
 
     # Escaped form (most common after markdown conversion)

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -238,6 +238,41 @@ class HtmlRenderBehaviorTests(unittest.TestCase):
         self.assertNotIn("<a ", rendered)
         self.assertNotIn("href=", rendered)
 
+    def test_meta_marker_escapes_payload_through_pipeline(self):
+        """A META marker carrying markup must not render as live HTML.
+
+        The marker is exempted from the comment-strip pass and promoted into a
+        <div class="meta">. Its text can come from LLM-synthesized content
+        derived from untrusted source bodies, so a crafted
+        `<!-- META: <img src=x onerror=...> -->` must be escaped, not rendered.
+        """
+        md = "intro\n\n<!-- META: <img src=x onerror=alert(1)> -->\n\nmore"
+        body = html_render._markdown_to_html(md)
+        body = html_render._wrap_engine_footer(body)
+        body = html_render._promote_meta_marker(body)
+        self.assertNotIn("<img", body)
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", body)
+
+    def test_meta_marker_escapes_raw_fallback(self):
+        """The raw (unescaped) META fallback path must also escape its payload."""
+        body = html_render._promote_meta_marker(
+            "<!-- META: <img src=x onerror=alert(1)> -->"
+        )
+        self.assertNotIn("<img", body)
+        self.assertEqual(
+            body, '<div class="meta">&lt;img src=x onerror=alert(1)&gt;</div>'
+        )
+
+    def test_meta_marker_preserves_plain_text(self):
+        """Legitimate date/source-name markers render unchanged (no double-escape)."""
+        body = html_render._promote_meta_marker(
+            "<!-- META: 2026-01-01 to 2026-01-31 · reddit, x -->"
+        )
+        self.assertEqual(
+            body,
+            '<div class="meta">2026-01-01 to 2026-01-31 · reddit, x</div>',
+        )
+
     def test_markdown_links_allow_relative_url(self):
         rendered = html_render._markdown_to_html("[home](/path?x=1#section)")
         self.assertIn(


### PR DESCRIPTION
## Before
`_promote_meta_marker` interpolated the captured META text straight into `<div class="meta">{text}</div>` with no escaping. The META comment is exempted from the comment-strip pass on purpose, and the markdown reaching this stage can include model-synthesized content derived from untrusted web and social bodies, the same prompt-injection surface the link-scheme allowlist already guards. A crafted `<!-- META: <img src=x onerror=...> -->` reaching the raw-form fallback would render as live markup in the saved, shareable HTML file.

## After
The replace step normalizes with `html.unescape` then `html.escape`, so both the markdown-escaped form and the raw fallback get escaped once. Legitimate date and source-name markers, which is all the current callers emit, render unchanged.

## Scope rationale
- This path is not reachable through current internal callers; render.py feeds only date ranges and source names. The fix hardens the boundary against a future caller that routes synthesized content through a META marker.

## Test plan
- [x] `uv run pytest tests/test_html_render.py` passes
- [x] Three new tests cover the full-pipeline payload, the raw fallback, and plain-text preservation.
