### PR TITLE
fix(cookie_extract): close world-readable window on temp cookie copy

### DIFF
--- a/skills/last30days/scripts/lib/cookie_extract.py
+++ b/skills/last30days/scripts/lib/cookie_extract.py
@@ -157,7 +157,12 @@ def _query_cookies_db(
     tmp_path = None
     try:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
-        shutil.copy2(str(db_path), tmp_path)
+        # mkstemp creates the file 0600. copy2 would copy the source's mode
+        # (Firefox cookies.sqlite is commonly 0644, looser on WSL /mnt/c) onto
+        # the temp file, leaving live session secrets world-readable in shared
+        # /tmp until the chmod below runs. copyfile writes content only and
+        # leaves the 0600 perms intact, closing that window.
+        shutil.copyfile(str(db_path), tmp_path)
         _lock_temp_cookie_copy(tmp_path)
 
         conn = sqlite3.connect(tmp_path)

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -124,6 +124,7 @@ class TestExtractFirefoxCookies:
 
         assert result == {"auth_token": "tok_abc123"}
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission model does not apply on Windows; mkstemp is 0o666 there")
     def test_temp_cookie_copy_never_world_readable(self, tmp_path):
         """The temp copy must be private the instant it exists, not only after
         the lock chmod. Regression for the TOCTOU window where copy2 widened the

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from lib import cookie_extract
 from lib.cookie_extract import (
     extract_cookies,
     extract_firefox_cookies,
@@ -122,6 +123,37 @@ class TestExtractFirefoxCookies:
             result = _query_cookies_db(db_path, ".x.com", ["auth_token"])
 
         assert result == {"auth_token": "tok_abc123"}
+
+    def test_temp_cookie_copy_never_world_readable(self, tmp_path):
+        """The temp copy must be private the instant it exists, not only after
+        the lock chmod. Regression for the TOCTOU window where copy2 widened the
+        0600 mkstemp file to the source's 0644 before _lock_temp_cookie_copy ran.
+        """
+        db_path = tmp_path / "cookies.sqlite"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE moz_cookies (name TEXT NOT NULL, value TEXT NOT NULL, host TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO moz_cookies (name, value, host) VALUES (?, ?, ?)",
+            ("auth_token", "tok_abc123", ".x.com"),
+        )
+        conn.commit()
+        conn.close()
+        os.chmod(db_path, 0o644)  # loose source perms, as Firefox ships them
+
+        observed = {}
+        real_lock = cookie_extract._lock_temp_cookie_copy
+
+        def spy(path):
+            # Mode of the copy as it exists right after copyfile, before chmod.
+            observed["mode_after_copy"] = os.stat(path).st_mode & 0o777
+            return real_lock(path)
+
+        with patch.object(cookie_extract, "_lock_temp_cookie_copy", side_effect=spy):
+            _query_cookies_db(db_path, ".x.com", ["auth_token"])
+
+        assert observed["mode_after_copy"] == 0o600
 
     def test_valid_cookies_extracted(self, mock_firefox_env):
         """Cookies for the target domain are returned correctly."""


### PR DESCRIPTION
## Before
`_query_cookies_db` copies the browser cookie database, which holds live X auth_token and ct0 session secrets, into a system temp file, then chmods it 0600. `shutil.copy2` copies the source file's mode onto the destination. Firefox `cookies.sqlite` is commonly 0644, looser on WSL `/mnt/c` mounts, so between the copy and the chmod the decrypted secrets sat world-readable in shared `/tmp`, readable by any other local user who won the race.

## After
The copy uses `shutil.copyfile`, which writes content only and leaves the 0600 perms that `mkstemp` created. The temp file is never readable by others. The existing chmod stays as defense in depth.

## Test plan
- [x] `uv run pytest tests/test_cookie_extract.py` passes
- [x] New `test_temp_cookie_copy_never_world_readable` asserts the copy is 0600 the instant it exists. Confirmed it reports 0644 without the fix.
