### PR TITLE
fix(watchlist): validate webhook scheme and match Slack host exactly

### DIFF
--- a/skills/last30days/scripts/watchlist.py
+++ b/skills/last30days/scripts/watchlist.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import sys
 import time
+import urllib.parse
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -28,10 +29,22 @@ def _deliver_findings(topic_name: str, counts: dict) -> None:
     mode = store.get_setting("delivery_mode", "announce")
     message = _format_delivery_message(topic_name, counts, mode)
     
+    # Require https before routing. The old "hooks.slack.com" in channel
+    # substring test ran before any scheme check, so a channel like
+    # http://evil.example/hooks.slack.com was treated as Slack and POSTed in
+    # cleartext to the wrong host. Match Slack on the exact hostname instead.
+    parsed = urllib.parse.urlparse(channel)
+    if parsed.scheme != "https":
+        print(
+            f"Delivery skipped: delivery_channel must be an https:// URL, got {channel!r}",
+            file=sys.stderr,
+        )
+        return
+
     try:
-        if "hooks.slack.com" in channel:
+        if parsed.hostname == "hooks.slack.com":
             _send_slack_webhook(channel, message)
-        elif channel.startswith("https://"):
+        else:
             _send_generic_webhook(channel, message)
     except Exception as e:
         # Don't fail the research run if delivery fails

--- a/skills/last30days/scripts/watchlist.py
+++ b/skills/last30days/scripts/watchlist.py
@@ -249,8 +249,15 @@ def cmd_config(args):
         print(json.dumps({"action": "config", "key": "daily_budget", "value": str(args.value)}))
         return
     if args.key == "delivery":
-        store.set_setting("delivery_channel", str(args.value))
-        print(json.dumps({"action": "config", "key": "delivery_channel", "value": str(args.value)}))
+        value = str(args.value)
+        # Reject a non-https channel at write time so the operator gets
+        # immediate feedback, rather than discovering it via a stderr line
+        # buried in a research run hours later. Matches the delivery-time guard
+        # in _deliver_findings.
+        if value and urllib.parse.urlparse(value).scheme != "https":
+            raise SystemExit(f"delivery_channel must be an https:// URL, got {value!r}")
+        store.set_setting("delivery_channel", value)
+        print(json.dumps({"action": "config", "key": "delivery_channel", "value": value}))
         return
     raise SystemExit(f"Unknown config key: {args.key}")
 

--- a/tests/test_watchlist_commands.py
+++ b/tests/test_watchlist_commands.py
@@ -252,6 +252,18 @@ def test_cmd_config_delivery(temp_db, capsys):
     assert output["key"] == "delivery_channel"
 
 
+def test_cmd_config_delivery_rejects_non_https(temp_db):
+    """A non-https delivery channel is rejected at write time, not stored."""
+    args = Mock()
+    args.key = "delivery"
+    args.value = "http://evil.example/hooks.slack.com"
+
+    with pytest.raises(SystemExit):
+        watchlist.cmd_config(args)
+
+    assert not store.get_setting("delivery_channel")
+
+
 def test_cmd_config_budget(temp_db, capsys):
     """Test configuring daily budget."""
     args = Mock()

--- a/tests/test_watchlist_delivery.py
+++ b/tests/test_watchlist_delivery.py
@@ -225,6 +225,42 @@ def test_deliver_findings_handles_failure_gracefully(mock_post, mock_get_setting
 @patch('watchlist.http.post')
 
 
+def test_deliver_findings_rejects_non_https_slack_substring(mock_post, mock_get_setting, capsys):
+    """A non-https channel that merely contains 'hooks.slack.com' must not be
+    sent. The old substring match POSTed it in cleartext to whatever host the
+    URL actually named."""
+    mock_get_setting.side_effect = lambda key, default="": {
+        "delivery_channel": "http://evil.example/hooks.slack.com",
+        "delivery_mode": "announce",
+    }.get(key, default)
+
+    watchlist._deliver_findings("Test Topic", {"new": 5, "updated": 2})
+
+    assert not mock_post.called
+    assert "https://" in capsys.readouterr().err
+
+@patch('watchlist.store.get_setting')
+@patch('watchlist.http.post')
+
+
+def test_deliver_findings_slack_match_is_exact_host(mock_post, mock_get_setting):
+    """An https URL with 'hooks.slack.com' only in the path routes as generic,
+    not Slack — the match is on the exact hostname, not a substring."""
+    mock_get_setting.side_effect = lambda key, default="": {
+        "delivery_channel": "https://webhook.example.com/hooks.slack.com/x",
+        "delivery_mode": "announce",
+    }.get(key, default)
+
+    watchlist._deliver_findings("Test Topic", {"new": 5, "updated": 2})
+
+    json_data = mock_post.call_args[1]["json_data"]
+    assert "message" in json_data  # generic payload shape
+    assert "text" not in json_data  # not the Slack {"text": ...} shape
+
+@patch('watchlist.store.get_setting')
+@patch('watchlist.http.post')
+
+
 def test_deliver_findings_respects_delivery_mode(mock_post, mock_get_setting):
     """Test that different delivery modes produce different messages."""
     mock_get_setting.side_effect = lambda key, default="": {


### PR DESCRIPTION
## Before
`_deliver_findings` chose the Slack path with `"hooks.slack.com" in channel`, an unanchored substring test that ran before any scheme check, while the generic branch required `https://`. A `delivery_channel` like `http://evil.example/hooks.slack.com` was treated as Slack and POSTed in cleartext to whatever host the URL named, leaking the notification payload while the operator believed Slack was configured.

## After
`_deliver_findings` parses the channel, requires an https scheme, and matches Slack on the exact hostname (`parsed.hostname == "hooks.slack.com"`). A non-https channel is reported on stderr instead of being dropped without a word.

## Test plan
- [x] `uv run pytest tests/test_watchlist_delivery.py` passes (17 tests)
- [x] Two new tests cover the cleartext-bypass URL and a URL carrying the Slack host only in its path. Both confirmed to fail without the fix.
