### PR TITLE
chore: sync mcp/manifest.json version to 3.6.0

### DIFF
--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "last30days-pp-mcp",
   "display_name": "Last30Days",
-  "version": "3.0.0",
+  "version": "3.6.0",
   "description": "Research any topic across Reddit, X, YouTube, Hacker News, Polymarket, GitHub, and the web - last 30 days, scored by upvotes, likes, and real-money prediction-market odds.",
   "author": {
     "name": "Matt Van Horn",


### PR DESCRIPTION
## Summary

The 3.4.0 version bump (#605) updated `pyproject.toml` but left two other version-carrying files stale. This syncs both so the release ships consistent metadata.

@mvanhorn / @tmchow — flagging before you cut the 3.4.0 release.

Update: this PR was opened against the 3.4.0 bump because #605 left `uv.lock` and `mcp/manifest.json` stale. Since then, #612 bumped to 3.5.0 and #615 bumped to 3.6.0, but no corresponding `v*` tag was pushed and the GitHub Release workflow did not run.

After merging current `main`, `uv.lock` is already 3.6.0. The remaining fix is `mcp/manifest.json` from 3.0.0 to 3.6.0 so future MCPB metadata matches the current repo version.

Related release-process note: Claude Code/git-based installs follow repo/plugin metadata, while GitHub release assets are still at v3.3.0 until a tag is pushed. This PR only fixes the stale manifest constant.

## Changes

~- Bump root-package `version` in `uv.lock` to `3.4.0`, matching `pyproject.toml`.~
- Bump `version` in `mcp/manifest.json` to `3.6.0` — it was introduced at `3.0.0` and never bumped since, so the MCPB bundle version shown to users in Claude Desktop is four minors behind.

## Testing

- [x] `UV_NO_CONFIG=1 uv lock --check` resolves cleanly (lockfile consistent with `pyproject.toml`)

## Related Issues

Relates to #605, #612, #615 

---

**Follow-up (process gap):** `pyproject.toml`, `uv.lock`, and `mcp/manifest.json` each carry the version independently with nothing keeping them in sync — hence this drift. Worth a release checklist entry or a small bump script so it can't recur. Happy to do that in a follow-up if you'd like.
