### PR TITLE
fix(x): anchor strongest-token fallback to stop bare-generic X pollution

### DIFF
--- a/docs/investigations/2026-06-17-x-search-and-funny/LEARNINGS.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/LEARNINGS.md
@@ -1,0 +1,107 @@
+# last30days — X search + funny + laziness: consolidated bug inventory
+
+**Date:** 2026-06-17
+**Engine version under test:** 3.4.0 (current `main`, commit fce934b)
+**Source evidence:** five live `/last30days` debug sessions, captured per-session in `sessions/`.
+**Every line/behavior claim below was re-verified against current `main`, not taken on faith from the transcripts.**
+
+This is the grounding document for the fix plan. It examines each problem separately,
+states the verified root cause with file/line, and rates fleet impact (the fixes ship to
+100k+ users — most of whom do NOT have working browser-cookie X auth, so keyless paths and
+honesty matter most at scale).
+
+---
+
+## A. X search bugs
+
+### A1 — `from:{handle}` AND-bug (the headline X bug)  ·  fleet impact: HIGH (every person/entity topic with X auth)
+**Symptom:** Passing `--x-handle=mvanhorn` (or xuezhao, steipete, …) returns ~0 of the person's own tweets. The "X" column fills with unrelated keyword collisions instead.
+**Verified root cause:** `bird_x.search_handles._search_one_handle` builds
+`from:{handle} {core_topic} since:{from_date}` whenever `core_topic` is truthy
+(`bird_x.py` ~373). X search is literal AND — so it only matches the person's tweets that *also contain the topic words* (usually their own name), which they never tweet. The unfiltered `from:{handle} since:` branch only fires when `topic is None`, and the caller (`pipeline.py:861`) always passes a truthy `topic`. So the real-timeline path is effectively unreachable.
+**Proven fix exists in-code:** running `from:{handle} since:` (no AND) returned 40 real tweets in-session.
+**User requirement (2026-06-17):** X must surface tweets **FROM** the person (engagement-weighted) — this is the `from:` lane, fixed to drop the topic-AND for person/handle topics.
+
+### A2 — No mention/“about” lane at all  ·  fleet impact: HIGH
+**Symptom:** Tweets *mentioning* the person (`@handle`) or *to* them never get collected as a category.
+**Verified root cause:** the pipeline only runs `from:` (author) searches and keyword subqueries. There is no `@handle` / `to:handle` mention query anywhere (`bird_x.search_handles` does `from:` only; no other call site builds a mention query).
+**User requirement (2026-06-17):** X must ALSO surface tweets **TO/ABOUT** the person (engagement-weighted) — a new mention lane, weighted by likes/reposts, deduped against the `from:` lane.
+
+### A3 — Handle search is silent on success  ·  fleet impact: MED (observability; caused 3 wrong diagnoses in-session)
+**Verified root cause:** `_search_one_handle` only `_log()`s on timeout / OSError / non-zero / invalid-JSON. A successful OR empty handle search emits zero log lines (`bird_x.py` ~382-405). The only `[Bird] Searching:` lines in task logs are the Phase-1 keyword subqueries, so the `from:` search looks like it never ran.
+**Fix:** log the query + result count on success, like the keyword path.
+
+### A4 — `--diagnose` false-green for X  ·  fleet impact: HIGH (fleet-wide trust bug)
+**Symptom:** `--diagnose` reports `bird_authenticated: true` / `bird_username: "env AUTH_TOKEN"` even when X is effectively returning nothing, and labels the source `env AUTH_TOKEN` when the real lane is live browser-cookie extraction (`_AUTH_TOKEN_SOURCE: browser`).
+**Verified root cause:** `pipeline.diagnose` reads `env.get_x_source_status` → `bird_status["authenticated"]` (`env.py:864`), a static credential-presence check, not a runtime probe.
+**Fix:** diagnose should do a real 1-tweet probe and report the true auth lane (browser vs env vs keychain). At scale most users have NO working X auth; the footer/coverage must say "X: 0 — no working auth" honestly instead of showing green.
+
+### A5 — Off-topic X pollution  ·  **CORRECTED at execution (2026-06-17)**
+**Symptom:** "compound interest / compound nevus" junk filled the X column in the Matt-vs-Trevin run even though bird was failing the whole run.
+**Original (transcript) hypothesis — DISPROVEN against current code:** the debug session blamed Digg's X-post enrichment side channel. False: Digg-enriched X posts live in `metadata["posts"]` and render ONLY as Digg-cluster quotes via `render._digg_posts_for` (returns `[]` for non-digg sources). Nothing adds them to `items_by_source["x"]`. Digg does NOT pollute the X column — a red herring.
+**Actual verified root cause:** the X-column "compound" junk came from the A6 strongest-token fallback querying a bare generic token, whose results ARE parsed into X items. **A6 is the real fix; the planned "entity-filter Digg X posts" unit (U1) was dropped as a non-occurring path.**
+**Residual minor note:** Digg-cluster X-post *quotes* could be tangentially off-topic, but they render as Digg quotes (not X items) and come from already-topic-matched clusters — low-severity, defer.
+
+### A6 — Strongest-token fallback collapses to a bare generic token  ·  fleet impact: MED
+**Verified root cause:** the last-chance retry picks `strongest = max(candidates, key=len)` then queries `f"{strongest} since:{from_date}"` (`bird_x.py:339-341`). For "trevin chow ai agents compound" it picks the longest token — `compound` — and dumps generic "compound" results into the shared X pool.
+**Fix:** don't collapse to a single generic token; keep an entity anchor (handle/name) in the retry, or drop the subquery rather than over-broaden.
+
+### A7 — Name-collision / disambiguation gap  ·  fleet impact: MED-HIGH (every mid-profile person)
+**Symptom:** "Kevin Rose" pulled Kevin Warsh (Fed chair), Leon Rose (Knicks), Kevin Durant, Kevin Hart — 55 items, ~zero on-topic. "Lan Xuezhao" pulled Lanzhou noodle + cdrama edits.
+**Root cause:** bare-name keyword subqueries are too collision-prone for mid-profile people; the engine has no disambiguation anchor (handle/domain/context) baked into the subqueries by default.
+**Note:** larger relevance problem than the deterministic A1-A6 bugs. Candidate for a follow-up scope rather than the first PR. **Call out for the plan.**
+
+### NOT bugs — stop re-chasing (verified):
+- **Bird is not broken.** Vendored `scripts/lib/vendor/bird-search/` v0.8.0, MIT, zero deps; works against live cookies. Peter deprecating the public `@steipete/bird` package is irrelevant — it's vendored.
+- **`@steipete/sweet-cookie` is optional**, never a required dep (the "not installed" line is from the optional browser-cookie lane).
+- **The parser is correct.** Metrics nest under `item["engagement"]` and `item["date"]`, not top-level — earlier "metrics = None" was a debug print-key mistake.
+
+---
+
+## B. Funny things not showing up
+
+### B1 — Best Takes renders empty in normal use (the structural root cause)  ·  fleet impact: HIGH
+**Symptom:** Across the Kanye and Steinberger runs, no `## Best Takes` section appeared; the funniest lines ("Is anyone surprised? It's called TurkiYe", "I bet one of his kids will be a bully") never reached the synthesis.
+**Verified root cause (two compounding):**
+1. `rerank.score_fun` LLM-scores only when a reasoning `provider` exists in the **engine subprocess** (`pipeline.py:534`, `provider=reasoning_provider`). In normal `/last30days` usage the engine subprocess has NO paid reasoning provider (the hosting model is the planner but can't be called back into the subprocess), so fun scores come from the heuristic fallback (~38). `_render_best_takes` requires `fun_score >= _BEST_TAKE_FUNNY_FLOOR (40)` AND effective ≥ threshold (70 at medium) — so Best Takes returns `[]`. The vote-weighting shipped in #592 is moot without LLM fun scoring.
+2. `_render_candidate` (the compact EVIDENCE block) renders top comments ONLY for the representative items of the top-`cluster_limit` (8) clusters (`render.py:166-171, 1208`). Funny comments on lower-ranked or non-representative items are never in the synthesis block at all.
+
+### B2 — The fun judgment is in the wrong place  ·  design finding
+The hosting model (Claude) is an excellent fun judge and *does* have an API. The engine subprocess is the one that can't LLM-score. So the fix direction is to **move fun SELECTION to the hosting model**: have the engine surface a comment-rich, vote-scored "Best Takes candidates" / "Top Community Comments" block (across more than the top-8 representative items) inside the EVIDENCE envelope, and have SKILL.md make weaving 2-3 of the funniest a hard gate. Vote scores (the #592 signal) become the ranking input the model selects from. **Soft vs hard fork — call out for the plan:** engine-surfaces-candidates + model-selects (structural) vs. just lowering the Best Takes heuristic floor (weak).
+
+---
+
+## C. The AI is lazy / not reading what it finds
+
+### C1 — Compact stdout treated as the whole dataset  ·  fleet impact: HIGH (every run)
+**Symptom:** The model synthesized a news-shaped report off the compact EVIDENCE block and never opened the saved raw `.md` until prodded — missing comments, the subject's own quotes, a BULLY DELUXE release two days out, a Dutch court win, an allegation.
+**Root cause (behavioral + structural):** the compact EVIDENCE block is a lossy index (top-8 clusters, representative items, truncated). The richer per-source comment/quote layer lives deeper in the saved raw file, which the model treats as optional. SKILL.md's "weave the funniest takes" / PRE-PRESENT SELF-CHECK exist but are skipped as formalities.
+**Fix direction:** (a) structural — get the high-value layer (top comments with votes, the subject's own posts) INTO the synthesis-facing block so the model can't miss it; (b) behavioral — turn the self-check into an enforced gate (e.g. require ≥2 verbatim attributed quotes, lead with most-recent dated/upcoming event, test the thesis against highest-engagement items).
+
+### C2 — Fabricated / reconstructed citation URL  ·  fleet impact: HIGH (correctness; a wrong link looks authoritative)
+**Symptom:** In the Steinberger run the model linked @OtsileKole to a status ID that belonged to a different account — reconstructed from memory instead of copied from the raw file (a LAW 8 violation).
+**Fix:** every URL in output copied verbatim from the raw data; plain-text fallback if not found; never reconstruct a status ID.
+
+### C3 — Meta-commentary about tooling leaks into the deliverable  ·  fleet impact: MED (output quality)
+**Symptom:** "the social-listening engine struck out … 'Kevin Rose' collided with Kevin Warsh …" — narrating the engine's own failure inside the user-facing report.
+**Fix:** the synthesis presents what's true about the subject and quietly drops junk; engine-health notes belong in the footer/diagnostics, not the prose.
+
+---
+
+## D. Formatting integrity (user constraint #4)
+
+### D1 — Cascading-repeat mangling of the "What I learned" block  ·  fleet impact: unknown
+**Symptom:** In the Kanye run the synthesis block repeated the same paragraphs many times with progressively growing left-indentation — a badly corrupted render.
+**Status:** likely a model-output / terminal-streaming artifact rather than an engine-code bug (it's in the model's emitted prose, not the engine stdout). **Needs reproduction before claiming an engine cause — open question.**
+**Hard constraint on ALL fixes:** changes to the engine's emitted output (especially adding a comments/Best-Takes-candidates block to the EVIDENCE envelope) must NOT break the envelope markers, the PASS-THROUGH FOOTER, the badge, or the `What I learned:` contract. Format is already fragile; every output-touching unit must preserve it and be diffed against a real run.
+
+---
+
+## Priority for the fleet (100k+ users, most without working X auth)
+
+1. **A5 Digg X-pollution** + **A6 fallback drift** — hits everyone, no X auth needed.
+2. **B1/B2 funny (Best Takes dark) + C1 laziness** — the product's headline value ("funniest comments on the whole internet"), every run, keyless.
+3. **A4 diagnose false-green** — fleet-wide honesty.
+4. **A1 from:-AND-bug + A2 mention lane** — the explicit FROM+ABOUT-with-weight requirement; deterministic, high correctness win for the X-auth subset.
+5. **A3 silent logging** — cheap observability, do alongside.
+6. **A7 disambiguation** + **D1 formatting cascade** — likely follow-up scope (bigger/uncertain).

--- a/docs/investigations/2026-06-17-x-search-and-funny/sessions/01-matt-vs-trevin.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/sessions/01-matt-vs-trevin.md
@@ -1,0 +1,19 @@
+# Session 01 — `/last30days Matt Van Horn vs Trevin Chow`
+
+**What this session proved:** the X handle search runs but is poisoned by the topic-AND, fails silently, and the X column is actually Digg-side-channel pollution.
+
+## Key evidence (verbatim engine/log lines)
+- Engine fired keyword X searches only in the visible log: `[Bird] Searching: matt van horn printing press since:2026-05-19`. No `from:mvanhorn` line — because `search_handles` logs nothing on success (→ A3).
+- GitHub person-mode worked (`[GitHub] Person-mode search for @mvanhorn`), so per-entity targeting was wired; X was the broken lane.
+- The 13 "X posts" were `@imAbhishek9596`, `@lebojoycechauke`, etc. — none authored by @mvanhorn.
+- Final verified mechanism: handle search built `from:mvanhorn matt van horn since:...` (topic AND'd onto the timeline → ~0). The clean `from:mvanhorn since:...` returned 40 real tweets.
+- The off-topic "compound interest / compound nevus" X items came in through Digg's X-enrichment side channel (`[Digg] post-dedupe enriched ... clusters with X posts`), NOT bird — bird was failing the whole run under the 2-entity parallel fanout (`Bird search failed`).
+- Strongest-token fallback collapsed `trevin chow ai agents compound` → bare token `compound`.
+
+## Red herrings burned (NOT bugs)
+- "sweet-cookie missing = broken" — optional browser-cookie helper, never required.
+- "auth dead" — standalone test failed only because `get_config()` + `set_credentials()` weren't called to inject cookies.
+- "metrics = None parser bug" — print read wrong keys; parser nests under `engagement`/`date`.
+
+## Bugs surfaced → inventory IDs
+A1 (from-AND), A3 (silent log), A4 (diagnose false-green), A5 (Digg pollution), A6 (fallback drift), A2 (no mention lane).

--- a/docs/investigations/2026-06-17-x-search-and-funny/sessions/02-kanye-west.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/sessions/02-kanye-west.md
@@ -1,0 +1,15 @@
+# Session 02 — `/last30days Kanye West`
+
+**What this session proved:** the funniest, highest-engagement comments never reach the synthesis; the model synthesizes a news report off the lossy compact block; and the output formatting can corrupt.
+
+## Key evidence
+- The best line of the month — `"Is anyone surprised? It's called TurkiYe"` (u/Drekkful, 764 upvotes), under a 3,895-upvote r/hiphopheads thread — was never mentioned. The model only read the compact "Ranked Evidence Clusters" (title + one snippet/item); the comment lived deeper in the saved raw file's per-source section.
+- Also missed: `"I bet one of his kids will be a bully"` (BULLY album callback), `"anyone interested in my kidney? i need tickets"`, plus a 21,707-like TikTok comment.
+- Missed real NEWS too (not just jokes): BULLY DELUXE dropping in 2 days, a Dutch court win clearing Arnhem shows (contradicted the "Europe is collapsing" thesis), an Italy ban, a serious allegation.
+- Model's own root cause: *"I treated the compact stdout as the dataset. It is a lossy index … the actual comment text, full post bodies, and top-comment upvote counts only live in the raw file's All Items by Source section."*
+
+## Formatting corruption (constraint #4)
+- The emitted `What I learned:` block repeated the same paragraphs many times with progressively growing left-indentation — a badly cascaded render (→ D1). Likely a model/terminal artifact; needs reproduction.
+
+## Bugs surfaced → inventory IDs
+B1 (Best Takes empty / comments not in synthesis block), C1 (compact-as-dataset laziness), D1 (formatting cascade), plus contradiction-pass and recency-pass gaps in synthesis behavior.

--- a/docs/investigations/2026-06-17-x-search-and-funny/sessions/03-kevin-rose.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/sessions/03-kevin-rose.md
@@ -1,0 +1,11 @@
+# Session 03 — `/last30days Kevin Rose`
+
+**What this session proved:** mid-profile names are swamped by collisions, and the model leaks tooling-failure meta-commentary into the deliverable.
+
+## Key evidence
+- "Kevin Rose" pulled Kevin Warsh (new Fed chair), Leon Rose (Knicks), Kevin Durant, Kevin Hart — 55 engine items, ~zero genuinely about the Digg founder. The 123K-upvote r/technology haul was all other people.
+- The synthesis opened with a paragraph narrating the engine's own miss: *"the social-listening engine struck out on Kevin Rose … 'Kevin Rose' collided with much louder newsmakers…"* — clutter the user must read past (→ C3).
+- A disambiguated re-run (every subquery locked to "Digg founder" context) killed the Warsh/Durant noise and surfaced real signal — proving disambiguation is the lever, not a synthesis band-aid (→ A7).
+
+## Bugs surfaced → inventory IDs
+A7 (name-collision / disambiguation), C3 (meta-commentary in output).

--- a/docs/investigations/2026-06-17-x-search-and-funny/sessions/04-peter-steinberger.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/sessions/04-peter-steinberger.md
@@ -1,0 +1,12 @@
+# Session 04 — `/last30days Peter Steinberger`
+
+**What this session proved:** funny/community texture missed again (same root cause as Kanye), PLUS a fabricated citation URL and a pattern anchored on the weakest source.
+
+## Key evidence
+- Genuinely funny skeptic comments existed and made ZERO of the report: `@theoldschooldk` (310 likes) *"Don't talk to me about the SPEND. Tell me what he BUILT"*, `u/alemorg` *"one of the most inefficient workflows on earth"*. Model: *"the compact emit didn't hand me a pre-built Best Takes section, so I didn't go dig for them."*
+- **Fabricated URL (LAW 8):** linked `@OtsileKole` to a status ID that actually belonged to `@sabir_huss50540` — reconstructed from memory instead of copied from the raw file (→ C2).
+- Dropped the subject's own first-person quote (`@OmarShahine` fireside: *"you cannot really automate taste or thoughtful design"*) — the highest-value citation tier.
+- Anchored "build loops, not prompts" on a 210-view YouTube video while the raw file showed a rich multi-voice cluster (Boris Cherny coined it). Weak-source anchoring; ignored that all YouTube transcripts 429-failed (0/6).
+
+## Bugs surfaced → inventory IDs
+B1 (Best Takes empty / funny missed), C1 (compact-as-dataset), C2 (fabricated URL), plus weak-source-anchoring + source-health-weighting gaps.

--- a/docs/investigations/2026-06-17-x-search-and-funny/sessions/05-lan-xuezhao.md
+++ b/docs/investigations/2026-06-17-x-search-and-funny/sessions/05-lan-xuezhao.md
@@ -1,0 +1,14 @@
+# Session 05 — `/last30days Lan Xuezhao`
+
+**What this session proved (cleanest):** the from:-AND-bug AND the total absence of a mention lane — directly motivating the "FROM + TO/ABOUT, with weight" requirement.
+
+## Key evidence
+- Engine X column = finance/VC keyword collisions (`@TheValueist`, `@arnaudmercier`, `@pierskicks`) + one `@hardmaru` "Thanks, Lan!" reply. None authored by @xuezhao.
+- Verified mechanism: `--x-handle=xuezhao` → `from:xuezhao lan xuezhao since:...` (topic AND) → ~0. The unfiltered `from:xuezhao since:` branch is unreachable because topic is always truthy (→ A1).
+- Structural gap: *"the engine only runs from: (authored-by) and keyword searches. There is no @xuezhao / to:xuezhao mention query anywhere in the pipeline"* (→ A2).
+- Manual unfiltered `from:xuezhao` pulled 12 real posts (DeepSeek take, "new AI stack is global, sovereign and embedded", SpaceX grind) — genuinely interesting, all missed by the engine.
+- Mentions were rich too (practitioners asking about her transcription/Hermes-dashboard rig) — exactly the "TO/ABOUT the person, with weight" lane the user now wants.
+- Engagement counts came back 0 on the manual cookie-search field — note for weighting the mention/from lanes (resolve metrics per-tweet).
+
+## Bugs surfaced → inventory IDs
+A1 (from-AND), A2 (no mention lane), A3 (silent log), plus the FROM+ABOUT-with-weight requirement.

--- a/skills/last30days/scripts/lib/bird_x.py
+++ b/skills/last30days/scripts/lib/bird_x.py
@@ -336,9 +336,17 @@ def search_x(
         }
         candidates = [w for w in core_words if w not in low_signal]
         if candidates:
+            # Keep an entity anchor (the first distinctive topic token) in the
+            # retry so it can't collapse to a bare generic token like "compound"
+            # and flood the X pool with off-topic noise. Add the strongest
+            # (longest) distinctive token when it differs from the anchor;
+            # otherwise query the anchor alone. Better to return 0 than to
+            # over-broaden to an unanchored generic term.
+            anchor = candidates[0]
             strongest = max(candidates, key=len)
-            _log(f"0 results for '{core_topic}', retrying with strongest token '{strongest}'")
-            query = f"{strongest} since:{from_date}"
+            retry_terms = anchor if strongest == anchor else f"{anchor} {strongest}"
+            _log(f"0 results for '{core_topic}', retrying anchored on '{retry_terms}'")
+            query = f"{retry_terms} since:{from_date}"
             response = _run_bird_search(query, count, timeout)
 
     return response

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -302,3 +302,49 @@ class TestRunBirdSearchJsonDecodeRetry(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStrongestTokenRetryAnchored(unittest.TestCase):
+    """The last-chance retry must keep an entity anchor, not collapse to a bare
+    generic token (e.g. 'compound') that floods the X pool with off-topic noise.
+    """
+
+    def test_last_chance_retry_keeps_entity_anchor(self):
+        from unittest import mock
+        from lib import bird_x
+
+        queries = []
+
+        def fake_run(query, count, timeout):
+            queries.append(query)
+            return {"items": []}  # always 0 → forces every retry tier
+
+        # extract_compound_terms may run; let it. Force all bird calls empty.
+        with mock.patch.object(bird_x, "_run_bird_search", side_effect=fake_run):
+            bird_x.search_x("trevin chow ai agents compound", "2026-05-19", "2026-06-18")
+
+        self.assertTrue(queries, "expected at least one bird query")
+        last = queries[-1]
+        # The final (last-chance) query keeps the entity anchor ...
+        self.assertIn("trevin", last)
+        # ... and is NOT a bare generic token query.
+        self.assertFalse(last.startswith("compound "), f"bare generic retry: {last!r}")
+        self.assertNotEqual(last, "compound since:2026-05-19")
+
+    def test_retry_with_single_distinctive_token_no_crash(self):
+        from unittest import mock
+        from lib import bird_x
+
+        queries = []
+
+        def fake_run(query, count, timeout):
+            queries.append(query)
+            return {"items": []}
+
+        with mock.patch.object(bird_x, "_run_bird_search", side_effect=fake_run):
+            # 'trending tools' is all low-signal except nothing distinctive ->
+            # whatever survives, the retry must not crash and stays anchored.
+            bird_x.search_x("agentcookie", "2026-05-19", "2026-06-18")
+
+        self.assertTrue(queries)
+        self.assertIn("agentcookie", queries[-1])


### PR DESCRIPTION
## Why

PR1 of the X-search + funny-surfacing plan (`docs/plans/2026-06-17-004-...`). Targets the X-column pollution that hits every collision-prone topic, keyless.

In the "Matt Van Horn vs Trevin Chow" run the X column filled with "compound interest / compound nevus" junk. **Verified root cause:** the last-chance X keyword retry picked `strongest = max(candidates, key=len)` and queried it bare — `from "trevin chow ai agents compound"` → `compound since:...` → generic compound posts parsed straight into the X pool.

## What changed

- `bird_x.search_x` last-chance retry now keeps an **entity anchor** (the first distinctive topic token) in the query, optionally plus the strongest distinctive token (`trevin compound`, not bare `compound`). Better to return 0 than over-broaden to an unanchored generic term.

## Execution-time correction (don't re-chase)

The original debug session blamed Digg's X-enrichment side channel for the pollution. **Disproven against current code:** Digg-enriched X posts live in `metadata["posts"]` and render only as Digg-cluster quotes (`render._digg_posts_for` returns `[]` for non-digg sources) — they never enter `items_by_source["x"]`. So the planned "entity-filter Digg X posts" unit was dropped as a non-occurring path; the bare-token fallback above is the real fix. Full write-up in `docs/investigations/2026-06-17-x-search-and-funny/`.

## Testing

- `tests/test_bird_x.py::TestStrongestTokenRetryAnchored` — the `compound` case stays anchored on `trevin` and never queries a bare generic token; single-distinctive-token topic doesn't crash. Full `test_bird_x.py` + `test_pipeline_v3.py` + `test_digg.py` green.

Plan: `docs/plans/2026-06-17-004-fix-x-search-and-funny-surfacing-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)