### PR TITLE
fix: wrap pwd import in try/except for Windows compatibility

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -130,11 +130,15 @@ def _load_keychain(keys: list[str]) -> dict[str, str]:
         return {}
 
     import subprocess
-    import pwd
-    # USER can be unset under sudo, in Docker without --env USER, or in some CI
-    # runners; fall back to the OS user record so lookups still match items
-    # stored by setup-keychain.sh (which uses $USER).
-    user = os.environ.get("USER") or pwd.getpwuid(os.getuid()).pw_name
+    try:
+        import pwd as _pwd
+        # USER can be unset under sudo, in Docker without --env USER, or in some CI
+        # runners; fall back to the OS user record so lookups still match items
+        # stored by setup-keychain.sh (which uses $USER).
+        user = os.environ.get("USER") or _pwd.getpwuid(os.getuid()).pw_name
+    except (ImportError, AttributeError):
+        import getpass
+        user = getpass.getuser()
     env: dict[str, str] = {}
     for key in keys:
         try:


### PR DESCRIPTION
## What

`env.py` does a lazy `import pwd` inside `_load_keychain_vars()`. The `pwd` module is Unix-only and raises `ImportError` on Windows. While the function already returns early when no `security` binary is found (the common Windows case), a `security` binary in PATH would trigger the import and crash.

## Fix

Wrap the `import pwd` block in `try/except (ImportError, AttributeError)` with a `getpass.getuser()` fallback — stdlib cross-platform, no new dependencies.

## Scope

Single file, 4-line change. No behavior change on macOS/Linux where `pwd` is always available.