### PR TITLE
feat: add scheduled OSV-Scanner workflow for vulnerability drift

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -24,6 +24,7 @@ jobs:
   scan-scheduled:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     permissions:
+      contents: read
       security-events: write
     with:
       # Advisory-first: surface results in code scanning without blocking.

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,30 @@
+name: OSV-Scanner
+
+# Scheduled OSV-Scanner workflow for vulnerability drift detection.
+# Scans the repository lockfiles (uv.lock, mcp/go.sum) on a weekly schedule
+# and uploads results to GitHub code scanning, so newly disclosed CVEs in
+# the dependency tree are visible even between PRs.
+#
+# Advisory-first: fail-on-vuln is false until maintainers confirm a clean
+# baseline, matching the pattern in security.yml.
+#
+# Separate from the pip-audit job in security.yml (which runs on every PR
+# and push) and from the dependency-review gate (which blocks on new
+# vulnerable deps at PR time). This workflow fills the scheduled-drift gap.
+
+on:
+  schedule:
+    # Weekly, Mondays at 12:30 UTC.
+    - cron: "30 12 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan-scheduled:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      security-events: write
+    with:
+      # Advisory-first: surface results in code scanning without blocking.
+      fail-on-vuln: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Scheduled OSV-Scanner vulnerability-drift workflow scans repository lockfiles weekly and uploads SARIF results to GitHub code scanning, catching newly disclosed CVEs in the dependency tree even between PRs ([#571](https://github.com/mvanhorn/last30days-skill/issues/571))
+
 ## [3.8.0] - 2026-06-21
 
 ### Added


### PR DESCRIPTION
## Summary

Adds a scheduled [OSV-Scanner](https://google.github.io/osv-scanner/) workflow that scans the repository's locked dependencies (`uv.lock`, `mcp/go.sum`) on a weekly cadence and uploads results to GitHub code scanning.

Closes #571.

## Why

The repo already has advisory security coverage (`security.yml`) that runs on PR/push/main. But newly disclosed CVEs in the existing dependency tree are invisible until someone opens a PR. A scheduled OSV-Scanner job catches vulnerability drift in quiet periods.

This complements the existing:
- `pip-audit` job in `security.yml` (PR/push, same-day advisory)
- `dependency-review` gate (#551, blocks new vulnerable deps at PR time)

## Design

- Uses the `google/osv-scanner-action` reusable workflow for a full scan (not PR-diff, matching the "scheduled drift" ask).
- Runs weekly (Mondays 12:30 UTC) + `workflow_dispatch`.
- Advisory-first: `fail-on-vuln: false`, matching the pattern in `security.yml`.
- Hash-pinned to `v2.3.8`.

## Test plan

1. YAML syntax is valid.
2. Follows the existing workflow conventions (permissions model, advisory-first, hash pinning).
3. Will trigger on merge to main (schedule) and on manual dispatch.