### PR TITLE
Salvage partial YouTube transcript on non-zero yt-dlp exit

### DIFF
--- a/skills/last30days/scripts/lib/youtube_yt.py
+++ b/skills/last30days/scripts/lib/youtube_yt.py
@@ -668,6 +668,18 @@ def _fetch_transcript_ytdlp(
             # Genuine no-captions: return quietly (caller may still try direct).
             return None
 
+        # Non-zero exit, but yt-dlp may have written a usable VTT before the
+        # failing language errored. With the default `--sub-lang en,es,pt`, an
+        # English video fetches `en` fine, then `es`/`pt` hit a 429 and yt-dlp
+        # exits non-zero — yet the `en` track is already on disk. A partial
+        # success is still a real transcript, so salvage any VTT before
+        # classifying this as an error (and, worse, retrying straight back into
+        # the same rate limit). This is the root cause of the 0/N transcript
+        # runs reported when every video had captions.
+        partial_vtt = _read_vtt(video_id, temp_dir)
+        if partial_vtt is not None:
+            return partial_vtt
+
         # Non-zero exit == a real error worth classifying & surfacing.
         stderr = (result.stderr or "").strip()
         snippet = (stderr.splitlines()[-1][:200] if stderr

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -174,12 +174,16 @@ class TestYtDlpSubLangs(unittest.TestCase):
                      youtube_yt.subproc,
                      "run_with_timeout",
                      return_value=self._fake_result(returncode=1),
-                 ):
+                 ) as run_mock:
                 vtt = youtube_yt._fetch_transcript_ytdlp("abc123", temp_dir, status)
 
         self.assertIsNotNone(vtt)
         self.assertIn("english transcript", vtt)
         self.assertNotIn("ytdlp_error", status)
+        # Salvage must short-circuit the retry loop: yt-dlp must not be called a
+        # second time when a partial VTT is already on disk (locks in the
+        # no-retry guarantee against a future salvage-after-retry regression).
+        self.assertEqual(run_mock.call_count, 1)
 
     def test_vtt_matching_respects_non_default_priority(self):
         """When multiple tracks exist, the user-requested priority wins

--- a/tests/test_youtube_yt.py
+++ b/tests/test_youtube_yt.py
@@ -154,6 +154,33 @@ class TestYtDlpSubLangs(unittest.TestCase):
         self.assertIsNotNone(vtt)
         self.assertIn("Hola mundo", vtt)
 
+    def test_partial_success_returns_vtt_despite_nonzero_exit(self):
+        """A non-zero yt-dlp exit must not discard a VTT already on disk.
+
+        Regression for the 0/N-transcripts bug: with the default
+        ``--sub-lang en,es,pt``, an English video fetches ``en`` successfully,
+        then ``es``/``pt`` hit a 429 and yt-dlp exits non-zero. The ``en``
+        track is already written and must be returned, not discarded (and not
+        retried back into the same rate limit).
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "abc123.en.vtt").write_text(
+                "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nThis is the english transcript.\n",
+                encoding="utf-8",
+            )
+            status: dict = {}
+            with mock.patch.object(youtube_yt, "is_ytdlp_installed", return_value=True), \
+                 mock.patch.object(
+                     youtube_yt.subproc,
+                     "run_with_timeout",
+                     return_value=self._fake_result(returncode=1),
+                 ):
+                vtt = youtube_yt._fetch_transcript_ytdlp("abc123", temp_dir, status)
+
+        self.assertIsNotNone(vtt)
+        self.assertIn("english transcript", vtt)
+        self.assertNotIn("ytdlp_error", status)
+
     def test_vtt_matching_respects_non_default_priority(self):
         """When multiple tracks exist, the user-requested priority wins
         over alphabetical order (regression for the Greptile review on #486)."""


### PR DESCRIPTION
## Problem

On any run where the searched YouTube videos **do** have captions, `_fetch_transcript_ytdlp` could still return 0/N transcripts.

Root cause is the default `--sub-lang en,es,pt`. For an English video, yt-dlp writes `en.vtt` successfully, then `es`/`pt` hit `HTTP 429: Too Many Requests` and yt-dlp **exits non-zero** — even though the `en` track is already on disk. The code gated the VTT read on `result.returncode == 0`, so the `en` transcript was discarded. Worse, `429` matches `_TRANSIENT_RE`, so the fetch retried (2×), hammering the same rate limit, then returned `None`.

Reproduced locally with the exact engine command on a single video:

```
[info] Writing video subtitles to: .../Gqh_KdHP1Xk.en.vtt        # en succeeds
ERROR: Unable to download video subtitles for 'es': HTTP Error 429: Too Many Requests   # non-zero exit
```

`fetch_transcript` returned 0 chars despite `en.vtt` on disk. Setting `LAST30DAYS_YT_SUB_LANGS=en` worked around it (0 → 13,864 chars), confirming the diagnosis. With the default langs and parallel fetching, this showed up as 0/N transcripts across whole runs.

## Fix

On a non-zero exit, read any VTT already on disk **before** classifying the failure. A partial success (`en` written, `es`/`pt` 429'd) is a real transcript — return it instead of discarding it and retrying back into the rate limit.

- Parallel fetch verified **0/N → 3/3** locally after the change.
- Behavior unchanged when no VTT was written (still classifies / retries / sets `ytdlp_error`).
- Adds `test_partial_success_returns_vtt_despite_nonzero_exit`; full `test_youtube_yt.py` green (59 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
