### PR TITLE
fix(subproc): guard SIGKILL escalation against killpg AttributeError on Windows

### DIFF
--- a/skills/last30days/scripts/lib/subproc.py
+++ b/skills/last30days/scripts/lib/subproc.py
@@ -91,9 +91,17 @@ def run_with_timeout(
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             # Child ignored SIGTERM (or our killpg lost the race); escalate.
+            # Guard killpg/getpgid the same way the SIGTERM path above does:
+            # they are POSIX-only and raise AttributeError on Windows. The
+            # primary path was hardened in #552; this mirrors that guard on the
+            # escalation path (added later in #433) so the same crash can't
+            # re-surface here (#588).
             try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, OSError):
+                if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                else:
+                    proc.kill()
+            except (ProcessLookupError, PermissionError, OSError, AttributeError):
                 proc.kill()
             proc.wait()
         raise SubprocTimeout(f"Command {cmd[0]} timed out after {timeout}s")

--- a/tests/test_subproc.py
+++ b/tests/test_subproc.py
@@ -155,6 +155,44 @@ class TestRunWithTimeout(unittest.TestCase):
                 timeout=1,
             )
 
+    def test_escalation_path_guards_killpg_attributeerror(self):
+        """The SIGKILL escalation must not crash if killpg is unavailable (Windows).
+
+        Regression for the #588 class of bug on the escalation path added in
+        #433: os.killpg raising AttributeError must be caught and fall back to
+        proc.kill(), so the documented SubprocTimeout surfaces instead of a bare
+        AttributeError. The primary SIGTERM path was already guarded (#552); this
+        mirrors that guard on the escalation path.
+        """
+        TimeoutExpired = subproc.subprocess.TimeoutExpired
+
+        class _FakeProc:
+            def __init__(self):
+                self.pid = 4321
+                self.kill_count = 0
+
+            def communicate(self, timeout=None):
+                raise TimeoutExpired(cmd="x", timeout=timeout)
+
+            def wait(self, timeout=None):
+                # First wait (timeout=5) forces the SIGKILL escalation branch;
+                # the final wait() (no timeout) returns.
+                if timeout is not None:
+                    raise TimeoutExpired(cmd="x", timeout=timeout)
+                return 0
+
+            def kill(self):
+                self.kill_count += 1
+
+        fake = _FakeProc()
+        with patch.object(subproc.subprocess, "Popen", return_value=fake), \
+             patch.object(subproc.os, "getpgid", lambda pid: pid), \
+             patch.object(subproc.os, "killpg", side_effect=AttributeError("no killpg on Windows")):
+            with self.assertRaises(subproc.SubprocTimeout):
+                subproc.run_with_timeout(["x"], timeout=1)
+        # Both the primary and escalation paths must have fallen back to kill().
+        self.assertGreaterEqual(fake.kill_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`os.killpg` / `os.getpgid` are POSIX-only and raise `AttributeError` on Windows. The primary SIGTERM cleanup path in `run_with_timeout` was hardened for this in #552 (guard + fall back to `proc.kill()`). The SIGKILL escalation block added later in #433 reintroduced the same unguarded call, with an `except` that omits `AttributeError`:

```python
try:
    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
except (ProcessLookupError, PermissionError, OSError):  # no AttributeError
    proc.kill()
```

So if a child ignores SIGTERM on Windows, the escalation path can let `AttributeError` escape instead of raising the documented `SubprocTimeout`. This is the residual instance of the bug @eevenstad reported in #588 (the primary path it described is already fixed).

## Fix

Mirror the primary path's guard on the escalation block: `hasattr` check plus `AttributeError` in the caught exceptions, falling back to `proc.kill()`.

## Test

Adds `test_escalation_path_guards_killpg_attributeerror`, which drives the escalation path with `os.killpg` raising `AttributeError` and asserts `SubprocTimeout` surfaces with a `proc.kill()` fallback. Verified it fails (bare `AttributeError`) without the guard and passes with it. Full `test_subproc.py` green.

Closes #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)