### PR TITLE
fix(hackernews): drop invalid points>2 numericFilter that 400'd every HN query

### DIFF
--- a/skills/last30days/scripts/lib/hackernews.py
+++ b/skills/last30days/scripts/lib/hackernews.py
@@ -93,13 +93,18 @@ def search_hackernews(
     core_flat = _flatten_query_for_algolia(core)
     _log(f"Searching for '{core_flat}' (raw: '{topic}', since {from_date}, count={count})")
 
-    # Use relevance-sorted search with minimum engagement filter.
+    # Use relevance-sorted search. The HN Algolia index only allows
+    # `created_at_i` in numericFilters; `points` is NOT in its
+    # `numericAttributesForFiltering`, so a `points>N` clause makes the API
+    # return HTTP 400 ("invalid numeric attribute(points)") and zero stories.
+    # Low-engagement stories are demoted by parse-time relevance scoring
+    # (rank + engagement_boost in parse_hackernews_response) instead.
     # NOTE: restrictSearchableAttributes=title omitted intentionally — it would
     # miss Ask HN/Show HN threads where the topic appears in the body.
     params = {
         "query": core_flat,
         "tags": "story",
-        "numericFilters": f"created_at_i>{from_ts},created_at_i<{to_ts},points>2",
+        "numericFilters": f"created_at_i>{from_ts},created_at_i<{to_ts}",
         "hitsPerPage": str(count),
     }
     # Algolia defaults to AND across query tokens, so a 4-5 word theme query

--- a/tests/test_hackernews.py
+++ b/tests/test_hackernews.py
@@ -266,17 +266,26 @@ def test_search_hackernews_http_error_handling(mock_request):
 @patch('lib.hackernews.http.request')
 
 
-def test_search_hackernews_engagement_filter(mock_request):
-    """Test that low-engagement stories are filtered."""
+def test_search_hackernews_no_points_numericfilter(mock_request):
+    """numericFilters must NOT include a `points` clause.
+
+    `points` is not in the HN Algolia index's `numericAttributesForFiltering`,
+    so a `points>2` clause returns HTTP 400 ("invalid numeric attribute(points)")
+    and zero stories. Engagement is reflected in parse-time relevance scoring
+    instead. This guards against the invalid filter being reintroduced.
+
+    (Previously this test asserted `points` + `%3E2` were present in the URL,
+    pinning the very bug that broke every HN query — a bug-encoding test.)
+    """
     mock_request.return_value = {"hits": [], "nbHits": 0}
-    
+
     hackernews.search_hackernews("test", "2026-01-01", "2026-01-31")
-    
-    call_args = mock_request.call_args[0]
-    url = call_args[1]
-    
-    # Should filter for points > 2 (URL-encoded)
-    assert "points" in url and "%3E2" in url
+
+    url = mock_request.call_args[0][1]
+
+    # Date filter stays; the invalid points filter must be gone.
+    assert "created_at_i" in url
+    assert "points" not in url
 
 # === Tests for parse_hackernews_response() ===
 


### PR DESCRIPTION
## Problem

Every Hacker News search returns HTTP 400 and zero stories. The Algolia request builds:

```
numericFilters = created_at_i>{from},created_at_i<{to},points>2
```

But `points` is not in the HN index's `numericAttributesForFiltering` (only `created_at_i` is), so Algolia rejects the request:

```
{"code":400,"message":"invalid numeric attribute(points), attribute not specified in numericAttributesForFiltering setting"}
```

Observed in a real run: HN returned 0 across every subquery while all other sources worked. Looks like index bit-rot — `points` was filterable on an older index revision and isn't anymore.

## Fix

Drop the `points>2` clause from `numericFilters`. Low-engagement stories are already demoted by parse-time relevance scoring (`rank + engagement_boost` in `parse_hackernews_response`), so no server-side floor is needed. If a hard floor is still wanted, happy to add a client-side `MIN_POINTS` drop in a follow-up.

## Verification

- Live: `search_hackernews("claude code", <last 30 days>)` now returns **15 stories** (was 0, HTTP 400).
- `uv run pytest tests/test_hackernews.py` → **32 passed**.

## Test change

`test_search_hackernews_engagement_filter` asserted that `points` + `%3E2` **were present** in the URL — i.e. it pinned the exact invalid filter that broke every query (a bug-encoding test). Renamed to `test_search_hackernews_no_points_numericfilter` and inverted to assert the invalid clause is absent while the date filter remains, as a regression guard.
