### PR TITLE
Fix last30days setup detection

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -178,8 +178,12 @@ if [[ -n "$HAS_SCRAPECREATORS" ]]; then
   # whitespace) so the matching mirrors pipeline.py's .strip().lower() parsing.
   SC_ADD=3
   EXCLUDED="${ENV_EXCLUDE_SOURCES:-${EXCLUDE_SOURCES:-}}"
-  EXCLUDED_NORM=$(printf '%s' "$EXCLUDED" | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[[:space:]]*,[[:space:]]*/,/g; s/^[[:space:]]+//; s/[[:space:]]+$//')
+  if [[ -n "$EXCLUDED" ]]; then
+    EXCLUDED_NORM=$(printf '%s' "$EXCLUDED" | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[[:space:]]*,[[:space:]]*/,/g; s/^[[:space:]]+//; s/[[:space:]]+$//')
+  else
+    EXCLUDED_NORM=""
+  fi
   if [[ ",$EXCLUDED_NORM," == *",tiktok,"* ]]; then
     SC_ADD=$((SC_ADD - 1))
   fi

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -221,7 +221,7 @@ End of OUTPUT CONTRACT. The laws above are the contract; everything below is imp
 
 # HOW TO INVOKE THIS SKILL (READ FIRST, FOLLOW EVERY TIME)
 
-**STEP 0 - LOAD WEBSEARCH FIRST.** Your literal first tool call on every `/last30days` invocation MUST be:
+**STEP 0 - LOAD WEBSEARCH FIRST WHEN THE HARNESS EXPOSES IT.** On Claude Code, your literal first tool call on every `/last30days` invocation MUST be:
 
 ```
 ToolSearch select:WebSearch
@@ -229,7 +229,9 @@ ToolSearch select:WebSearch
 
 WebSearch is a **deferred tool** in Claude Code v2.1.114. The frontmatter of this file authorizes it (`allowed-tools: ... WebSearch`) but the runtime lists it as "schemas are NOT loaded." Calling WebSearch without `ToolSearch select:WebSearch` first will fail or do nothing. That friction is the documented cause of the second-most-common failure mode of this skill: the model sees "WebSearch is there but deferred," takes the low-friction path, skips Step 0.5 and 0.55, and runs the engine bare with only keyword search. The output looks fine but misses founder X timelines, GitHub repo activity, and subreddit-specific threads.
 
-Load WebSearch first. No exceptions. Then proceed to the branching rule below.
+If the current harness is Codex and `ToolSearch select:WebSearch` returns no tool, do **not** stop and do **not** pretend WebSearch is available. Treat this as the no-WebSearch platform branch for Step 0.55 / Step 0.75, add `--auto-resolve` to the engine command, and use the platform's ordinary web/search tool only for the post-engine supplement step when available. This is a degraded but valid path; report missing source coverage honestly in the synthesis.
+
+Load WebSearch first when available. Then proceed to the branching rule below.
 
 **STEP 1 - RUN THE ENGINE. You MUST run `scripts/last30days.py` via Bash. Do not produce output from WebSearch alone.**
 

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -72,7 +72,17 @@ def run_auto_setup(config: Dict[str, Any]) -> Dict[str, Any]:
                 logger.debug("Cookie extraction failed for %s via %s: %s", source_name, browser, exc)
                 continue
             if result is not None and result[0]:
-                cookies_found[source_name] = result[1]
+                cookies, browser_name = result
+                if not all(name in cookies and cookies[name] for name in cookie_names):
+                    logger.debug(
+                        "Incomplete cookies for %s via %s: found %s, required %s",
+                        source_name,
+                        browser_name,
+                        sorted(cookies.keys()),
+                        sorted(cookie_names),
+                    )
+                    continue
+                cookies_found[source_name] = browser_name
                 break  # Found cookies for this service, stop trying browsers
 
     # Check yt-dlp availability and install via Homebrew if missing
@@ -346,7 +356,10 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
     cookies_found = results.get("cookies_found", {})
     if cookies_found:
         for source, browser in cookies_found.items():
-            lines.append(f"  - {source.upper()} cookies found in {browser}")
+            lines.append(
+                f"  - {source.upper()} browser cookies found in {browser} "
+                "(best-effort; run `last30days.py --diagnose` to verify the source is active)"
+            )
     else:
         lines.append("  - No browser cookies found for X/Twitter")
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -74,6 +74,18 @@ class TestRunAutoSetup:
 
     @patch("lib.cookie_extract.extract_cookies_with_source")
     @patch("shutil.which")
+    def test_partial_cookie_set_not_reported_as_found(self, mock_which, mock_extract):
+        """A source is found only when every required cookie is present."""
+        mock_extract.return_value = ({"auth_token": "abc"}, "chrome")
+        mock_which.return_value = None
+
+        config = {}
+        results = setup_wizard.run_auto_setup(config)
+
+        assert "x" not in results["cookies_found"]
+
+    @patch("lib.cookie_extract.extract_cookies_with_source")
+    @patch("shutil.which")
     def test_cookie_extraction_exception(self, mock_which, mock_extract):
         """Cookie extraction raising an exception is handled gracefully."""
         mock_extract.side_effect = Exception("DB locked")
@@ -478,7 +490,8 @@ class TestGetSetupStatusText:
             "env_written": True,
         }
         text = setup_wizard.get_setup_status_text(results)
-        assert "X cookies found in chrome" in text
+        assert "X browser cookies found in chrome" in text
+        assert "last30days.py --diagnose" in text
         assert "yt-dlp already installed" in text
         assert "Configuration saved" in text
 


### PR DESCRIPTION
## Summary

Fixes setup and host-detection edge cases in the last30days skill:

- clarify that WebSearch loading is Claude-specific and Codex should fall back to the no-WebSearch engine path when the tool is unavailable
- require every expected cookie for a source before setup reports browser cookies as found
- make setup status text explicit that browser-cookie detection is best-effort and should be verified with `last30days.py --diagnose`
- avoid invoking `tr`/`sed` in the SessionStart hook when `EXCLUDE_SOURCES` is empty, which keeps the minimal-PATH hook test green

## Why

A local Codex invocation hit a stale first-run/setup path and then produced misleading coverage around X browser cookies. The installed skill could find a browser cookie hint, but source availability still depends on the runtime diagnostic path confirming the source is active.

## Validation

- `uv run pytest tests/test_setup_wizard.py`
- `HOME=$(mktemp -d /tmp/last30days-home.XXXXXX) uv run pytest tests/test_check_config_ytdlp_detection.py tests/test_setup_wizard.py`
- `HOME=$(mktemp -d /tmp/last30days-home.XXXXXX) uv run pytest`
  - `2026 passed, 4 skipped, 6 subtests passed`
