### PR TITLE
fix: separate GitHub stars/merged_prs from reactions in engagement model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Salvage partial YouTube transcripts on non-zero yt-dlp exit.** With the default `en,es,pt` languages an English video wrote `en.vtt` then 429'd on `es`/`pt`, and the already-written transcript was discarded and retried back into the rate limit. Any VTT on disk is now read before the failure is classified, which fixes the dominant `0/N transcripts` case. (#636)
 - **Windows transcript crash on subprocess timeout.** Guarded the SIGKILL escalation path in `run_with_timeout` against `os.killpg` / `os.getpgid` raising `AttributeError` on Windows (they are POSIX-only), mirroring the primary path's guard. (#638, reported in #588)
 
+### Fixed
+
+- GitHub repo stars are no longer mislabeled as "reactions" in the report footer. Repo cards now use a distinct `stars` engagement key, velocity cards use `merged_prs`, and genuine issue/PR reaction counts keep their own `reactions` key, so the footer displays the correct label per item type ([#642](https://github.com/mvanhorn/last30days-skill/issues/642))
+
 ## [3.6.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub repo stars are no longer mislabeled as "reactions" in the report footer. Repo cards now use a distinct `stars` engagement key, velocity cards use `merged_prs`, and genuine issue/PR reaction counts keep their own `reactions` key, so the footer displays the correct label per item type ([#642](https://github.com/mvanhorn/last30days-skill/issues/642))
+
 ## [3.7.0] - 2026-06-20
 
 ### Added
@@ -28,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Salvage partial YouTube transcripts on non-zero yt-dlp exit.** With the default `en,es,pt` languages an English video wrote `en.vtt` then 429'd on `es`/`pt`, and the already-written transcript was discarded and retried back into the rate limit. Any VTT on disk is now read before the failure is classified, which fixes the dominant `0/N transcripts` case. (#636)
 - **Windows transcript crash on subprocess timeout.** Guarded the SIGKILL escalation path in `run_with_timeout` against `os.killpg` / `os.getpgid` raising `AttributeError` on Windows (they are POSIX-only), mirroring the primary path's guard. (#638, reported in #588)
-
-### Fixed
-
-- GitHub repo stars are no longer mislabeled as "reactions" in the report footer. Repo cards now use a distinct `stars` engagement key, velocity cards use `merged_prs`, and genuine issue/PR reaction counts keep their own `reactions` key, so the footer displays the correct label per item type ([#642](https://github.com/mvanhorn/last30days-skill/issues/642))
 
 ## [3.6.0] - 2026-06-18
 

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -628,7 +628,7 @@ def search_github_person(
         "snippet": velocity_text,
         "relevance": 0.95,
         "why_relevant": f"GitHub profile: @{username} - {merged_count} PRs merged across {num_repos} repos",
-        "engagement": {"reactions": merged_count, "comments": total_prs},
+        "engagement": {"merged_prs": merged_count, "comments": total_prs},
         "metadata": {
             "labels": ["person-profile", "velocity"],
             "state": "open",
@@ -689,7 +689,7 @@ def search_github_person(
                 "snippet": "\n".join(snippet_parts),
                 "relevance": min(0.9, 0.6 + math.log1p(stars) / 30 + min(0.15, pr_count / 20)),
                 "why_relevant": f"GitHub contribution: {pr_count} PRs merged to {repo} ({stars_str} stars)",
-                "engagement": {"reactions": stars, "comments": pr_count},
+                "engagement": {"stars": stars, "comments": pr_count},
                 "metadata": {
                     "labels": ["person-profile", "external-repo"],
                     "state": "open",
@@ -747,7 +747,7 @@ def search_github_person(
                 "snippet": "\n".join(snippet_parts),
                 "relevance": min(0.95, 0.7 + math.log1p(stars) / 25),
                 "why_relevant": f"GitHub own project: {repo_name} ({stars_str} stars)",
-                "engagement": {"reactions": stars, "comments": open_issues},
+                "engagement": {"stars": stars, "comments": open_issues},
                 "metadata": {
                     "labels": ["person-profile", "own-repo"],
                     "state": "open",
@@ -867,7 +867,7 @@ def search_github_project(
                 "snippet": "\n".join(snippet_parts),
                 "relevance": min(0.95, 0.7 + math.log1p(stars) / 25),
                 "why_relevant": f"GitHub project: {repo} ({stars_str} stars, live)",
-                "engagement": {"reactions": stars, "comments": open_issues},
+                "engagement": {"stars": stars, "comments": open_issues},
                 "metadata": {
                     "labels": ["project-mode"],
                     "state": "open",

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -1473,7 +1473,7 @@ _FOOTER_SOURCES: list[tuple[str, str, str, str, list[tuple[str, str]]]] = [
     ("hackernews",  "🟡", "HN",           "story",    [("points", "points"), ("comments", "comments")]),
     ("bluesky",     "🦋", "Bluesky",      "post",     [("likes", "likes"), ("reposts", "reposts")]),
     ("truthsocial", "🇺🇸", "Truth Social", "post",     [("likes", "likes"), ("reposts", "reposts")]),
-    ("github",      "🐙", "GitHub",       "item",     [("reactions", "reactions"), ("comments", "comments")]),
+    ("github",      "🐙", "GitHub",       "item",     [("stars", "stars"), ("merged_prs", "merged"), ("reactions", "reactions"), ("comments", "comments")]),
     ("digg",        "⛏️", "Digg",         "cluster",  [("postCount", "posts"), ("uniqueAuthors", "authors")]),
     # Jobs must appear so a scoped --hiring-signals run (jobs-only) still emits
     # the LAW 5 footer; without it the footer was dropped entirely.
@@ -1740,7 +1740,7 @@ ENGAGEMENT_DISPLAY: dict[str, list[tuple[str, str]]] = {
     "bluesky":      [("likes", "likes"), ("reposts", "rt"), ("replies", "re")],
     "truthsocial":  [("likes", "likes"), ("reposts", "rt"), ("replies", "re")],
     "polymarket":   [],
-    "github":       [("reactions", "react"), ("comments", "cmt")],
+    "github":       [("stars", "stars"), ("merged_prs", "merged"), ("reactions", "react"), ("comments", "cmt")],
     "perplexity":   [("citations", "cite")],
     "digg":         [("postCount", "posts"), ("uniqueAuthors", "auth")],
 }


### PR DESCRIPTION
## Summary

Fixes the mislabeling of GitHub repo stars as "reactions" in the report footer and per-item display. Repo cards now use a distinct `stars` engagement key, the velocity card uses `merged_prs`, and genuine issue/PR reaction counts keep their own `reactions` key.

Closes #642.

## Root cause

`github.py` stored repo star counts, merged-PR counts, and genuine issue/PR reaction counts all under the same `"reactions"` engagement key. `render.py` then labeled everything as "reactions"/"react" in the footer and per-item display, even though repo stars are not reactions.

## Changes

**`github.py`:**
- Repo cards (person-mode external, person-mode own, project-mode): `"engagement": {"reactions": stars, ...}` to `{"stars": stars, ...}`
- Velocity card: `"engagement": {"reactions": merged_count, ...}` to `{"merged_prs": merged_count, ...}`
- Issue/PR items: unchanged (`"reactions": reactions_total`)

**`render.py`:**
- `_FOOTER_SOURCES` github entry: added `("stars", "stars")` and `("merged_prs", "merged")` before `("reactions", "reactions")`
- `ENGAGEMENT_DISPLAY` github entry: added `("stars", "stars")` and `("merged_prs", "merged")` before `("reactions", "react")`

**`CHANGELOG.md`:** Added `### Fixed` entry under `[Unreleased]`.

## Test plan
- `pytest tests/test_github.py` - 27 passed
- `pytest tests/test_render_v3.py` - 55 passed