### PR TITLE
fix: exclude dev artifacts from Hermes skill scan

### DIFF
--- a/.clawhubignore
+++ b/.clawhubignore
@@ -14,6 +14,8 @@ __pycache__/
 *.jpg
 *.png
 *.gif
+assets/
+skills/last30days/assets/
 .DS_Store
 .coverage
 htmlcov/
@@ -56,6 +58,11 @@ TASKS.md
 skills/last30days/scripts/build-skill.sh
 skills/last30days/scripts/compare.sh
 skills/last30days/scripts/evaluate_search_quality.py
+skills/last30days/scripts/setup-keychain.sh
+skills/last30days/scripts/setup-pass.sh
 skills/last30days/scripts/test_device_auth.py
 skills/last30days/scripts/test-v1-vs-v2.sh
 skills/last30days/scripts/verify_v3.py
+
+# Keep visible: optional runtime watchlist/store/briefing feature scripts
+# (`watchlist.py`, `store.py`, and `briefing.py`).

--- a/.skillignore
+++ b/.skillignore
@@ -1,6 +1,5 @@
-# ClawHub/Hermes packaging exclusions for repository-root scans.
-# Mirrors .skillignore so non-runtime docs/dev artifacts stay out of the
-# public bundle and install-time skill security scan.
+# Hermes install-time scanner/package exclusions for repository-root scans.
+# Keep the public bundle focused on the runtime skill under skills/last30days/.
 
 # VCS, local envs, caches, and generated outputs
 .git/

--- a/.skillignore
+++ b/.skillignore
@@ -13,6 +13,8 @@ __pycache__/
 *.jpg
 *.png
 *.gif
+assets/
+skills/last30days/assets/
 .DS_Store
 .coverage
 htmlcov/
@@ -55,6 +57,11 @@ TASKS.md
 skills/last30days/scripts/build-skill.sh
 skills/last30days/scripts/compare.sh
 skills/last30days/scripts/evaluate_search_quality.py
+skills/last30days/scripts/setup-keychain.sh
+skills/last30days/scripts/setup-pass.sh
 skills/last30days/scripts/test_device_auth.py
 skills/last30days/scripts/test-v1-vs-v2.sh
 skills/last30days/scripts/verify_v3.py
+
+# Keep visible: optional runtime watchlist/store/briefing feature scripts
+# (`watchlist.py`, `store.py`, and `briefing.py`).


### PR DESCRIPTION
## Summary
- Add a repository-root `.skillignore` for Hermes install-time scans.
- Expand `.clawhubignore` to mirror the same scanner/package exclusions.
- Exclude non-runtime dev/publication artifacts: `.git/`, `.venv/`, `.github/`, docs/plans/release notes, README/setup/changelog docs, tests/fixtures, hooks/MCP/host metadata, media/assets, logs, and dev/eval scripts under `skills/last30days/scripts/`.

## Scanner verification
Before this change, scanning the existing local checkout at repo root reported `Verdict: DANGEROUS` with 359 findings, including docs/plans/release notes/dev artifacts and local `.venv`/`.git` noise.

From a clean clone of this branch (`/tmp/last30days-scan.AF7Mf8`, commit `a37ade9`), I ran the requested Hermes scanner command against both the repo root and the skill dir using local Hermes source:

```bash
python3 - <<'PY'
import sys
from pathlib import Path
sys.path.insert(0, '/Users/amosclaw/.hermes/hermes-agent')
from tools.skills_guard import scan_skill, format_scan_report
print(format_scan_report(scan_skill(Path('.'), source='mvanhorn/last30days-skill')))
PY
```

Root scan result after ignore rules:
- `Verdict: DANGEROUS`
- `Decision: BLOCKED — Blocked (community source + dangerous verdict, 59 findings)`
- Remaining findings are in runtime skill files under `skills/last30days/` (`SKILL.md`, `scripts/last30days.py`, `scripts/lib/env.py`, `scripts/lib/bird_x.py`, `scripts/lib/github.py`, `scripts/lib/xquik.py`, and the runtime vendored `bird-search` client), not in docs/plans/release notes/dev artifacts.

Skill-dir scan result after ignore rules:
- `Verdict: DANGEROUS`
- `Decision: BLOCKED — Blocked (community source + dangerous verdict, 59 findings)`
- Same remaining runtime findings as above.

## Caveat
This PR fixes the scanner-safe packaging/ignore-rule issue only. It does not rewrite runtime credential/env handling or the vendored X client; those still require a separate narrow follow-up if the target is `Verdict: SAFE` / `Decision: ALLOWED` for community installs.
