### PR TITLE
Honor plan's explicit sources at quick depth

### DIFF
--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -345,7 +345,7 @@ def _trim_subqueries_for_depth(
     limits = SOURCE_LIMITS.get(depth)
     if not limits:
         return subqueries
-    priority_table = QUICK_SOURCE_PRIORITY if depth == "quick" else SOURCE_PRIORITY
+    priority_table = QUICK_SOURCE_PRIORITY
     priority = priority_table.get(intent, priority_table["breaking_news"])
     limit = limits.get(intent, 3)
     ranked_sources = [source for source in priority if source in available_sources]
@@ -353,42 +353,28 @@ def _trim_subqueries_for_depth(
         ranked_sources = list(available_sources)
     trimmed = []
     for subquery in subqueries:
-        if depth in {"quick", "default"}:
-            # Honor the plan's explicit per-subquery sources (ranked by
-            # priority) so an external plan asking for tiktok/instagram/reddit
-            # is not silently trimmed away in favor of priority defaults like
-            # jobs/youtube. Only fall back to the priority top-N when the plan
-            # lists no usable source for this subquery.
-            # Choose from the plan's OWN sources (priority-ranked, then any
-            # plan sources absent from the priority table like instagram), then
-            # apply the depth limit. This keeps quick fast (still capped) while
-            # honoring an external plan that asked for tiktok/instagram instead
-            # of silently substituting priority defaults like jobs/youtube.
-            preferred_sources = [s for s in ranked_sources if s in subquery.sources]
-            for source in subquery.sources:
-                if source in available_sources and source not in preferred_sources:
+        # Quick depth only reaches this block. Honor the plan's explicit
+        # per-subquery sources: prefer priority-ranked plan sources first, then
+        # append any plan sources absent from the priority table (e.g.
+        # instagram), and cap the planner-selected set to the quick-depth
+        # limit. Fall back to the priority top-N only when the subquery lists
+        # no usable source.
+        preferred_sources = [s for s in ranked_sources if s in subquery.sources]
+        for source in subquery.sources:
+            if source not in preferred_sources:
+                preferred_sources.append(source)
+        preferred_sources = preferred_sources[:limit]
+        if not preferred_sources:
+            preferred_sources = ranked_sources[:limit]
+        if requested_sources:
+            requested = [
+                source
+                for source in requested_sources
+                if source in available_sources and source in subquery.sources
+            ]
+            for source in requested:
+                if source not in preferred_sources:
                     preferred_sources.append(source)
-            preferred_sources = preferred_sources[:limit]
-            if not preferred_sources:
-                preferred_sources = ranked_sources[:limit]
-            if requested_sources:
-                requested = [
-                    source
-                    for source in requested_sources
-                    if source in available_sources and source in subquery.sources
-                ]
-                for source in requested:
-                    if source not in preferred_sources:
-                        preferred_sources.append(source)
-        else:
-            preferred_sources = [source for source in ranked_sources if source in subquery.sources][:limit]
-            if len(preferred_sources) < limit:
-                for source in ranked_sources:
-                    if source in preferred_sources:
-                        continue
-                    preferred_sources.append(source)
-                    if len(preferred_sources) >= limit:
-                        break
         trimmed.append(
             schema.SubQuery(
                 label=subquery.label,

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -354,7 +354,23 @@ def _trim_subqueries_for_depth(
     trimmed = []
     for subquery in subqueries:
         if depth in {"quick", "default"}:
-            preferred_sources = ranked_sources[:limit]
+            # Honor the plan's explicit per-subquery sources (ranked by
+            # priority) so an external plan asking for tiktok/instagram/reddit
+            # is not silently trimmed away in favor of priority defaults like
+            # jobs/youtube. Only fall back to the priority top-N when the plan
+            # lists no usable source for this subquery.
+            # Choose from the plan's OWN sources (priority-ranked, then any
+            # plan sources absent from the priority table like instagram), then
+            # apply the depth limit. This keeps quick fast (still capped) while
+            # honoring an external plan that asked for tiktok/instagram instead
+            # of silently substituting priority defaults like jobs/youtube.
+            preferred_sources = [s for s in ranked_sources if s in subquery.sources]
+            for source in subquery.sources:
+                if source in available_sources and source not in preferred_sources:
+                    preferred_sources.append(source)
+            preferred_sources = preferred_sources[:limit]
+            if not preferred_sources:
+                preferred_sources = ranked_sources[:limit]
             if requested_sources:
                 requested = [
                     source

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -356,25 +356,31 @@ def _trim_subqueries_for_depth(
         # Quick depth only reaches this block. Honor the plan's explicit
         # per-subquery sources: prefer priority-ranked plan sources first, then
         # append any plan sources absent from the priority table (e.g.
-        # instagram), and cap the planner-selected set to the quick-depth
-        # limit. Fall back to the priority top-N only when the subquery lists
-        # no usable source.
-        preferred_sources = [s for s in ranked_sources if s in subquery.sources]
+        # instagram). Explicit --search sources are user overrides, so they get
+        # first claim on the quick slots when present. The final list remains
+        # capped to the quick-depth limit.
+        plan_sources = [s for s in ranked_sources if s in subquery.sources]
         for source in subquery.sources:
+            if source not in plan_sources:
+                plan_sources.append(source)
+        if not plan_sources:
+            plan_sources = ranked_sources[:limit]
+        preferred_sources: list[str] = []
+        if requested_sources:
+            for source in requested_sources:
+                if (
+                    source in available_sources
+                    and source in subquery.sources
+                    and source not in preferred_sources
+                ):
+                    preferred_sources.append(source)
+                    if len(preferred_sources) >= limit:
+                        break
+        for source in plan_sources:
+            if len(preferred_sources) >= limit:
+                break
             if source not in preferred_sources:
                 preferred_sources.append(source)
-        preferred_sources = preferred_sources[:limit]
-        if not preferred_sources:
-            preferred_sources = ranked_sources[:limit]
-        if requested_sources:
-            requested = [
-                source
-                for source in requested_sources
-                if source in available_sources and source in subquery.sources
-            ]
-            for source in requested:
-                if source not in preferred_sources:
-                    preferred_sources.append(source)
         trimmed.append(
             schema.SubQuery(
                 label=subquery.label,

--- a/tests/test_planner_v3.py
+++ b/tests/test_planner_v3.py
@@ -92,7 +92,7 @@ class PlannerV3Tests(unittest.TestCase):
         self.assertEqual(1, len(plan.subqueries))
         self.assertEqual(["reddit", "x"], plan.subqueries[0].sources)
 
-    def test_quick_mode_preserves_explicit_requested_sources(self):
+    def test_quick_mode_prioritizes_explicit_requested_sources_within_cap(self):
         raw = {
             "intent": "product",
             "freshness_mode": "balanced_recent",
@@ -111,10 +111,11 @@ class PlannerV3Tests(unittest.TestCase):
             raw,
             "AI coding agents",
             ["reddit", "youtube", "grounding", "digg"],
-            ["reddit", "youtube", "grounding", "digg"],
+            ["digg", "reddit", "youtube", "grounding"],
             "quick",
         )
         self.assertIn("digg", plan.subqueries[0].sources)
+        self.assertLessEqual(len(plan.subqueries[0].sources), 2)
 
     def test_quick_mode_preserves_explicit_requested_sources_in_fallback_plan(self):
         plan = planner.plan_query(


### PR DESCRIPTION
## Problem

With a valid `SCRAPECREATORS_API_KEY` and an explicit `--plan` listing `tiktok`/`instagram`/`reddit` in a subquery's `sources`, those sources returned 0 items at `--quick`. The quick-depth trimmer substituted global priority defaults (`jobs`, `youtube`) for the plan's explicit sources.

Root cause: the quick-depth branch built `preferred_sources = ranked_sources[:limit]` from the global priority table and ignored `subquery.sources`. The `requested_sources` rescue only fires for the `--search` flag, not for plan sources. So an external quick plan asking for `tiktok` could end up with `['jobs', 'youtube']`.

## Fix

The quick-depth trimmer now selects from the plan's own sources: priority-ranked plan sources first, then plan sources absent from the priority table like `instagram`, then applies the quick-depth limit to that planner-selected set. It falls back to the priority top-N only when the subquery lists no usable source.

The follow-up cleanup also removes unreachable default-depth/dead-else code from this block. Explicit `--search` sources are prioritized as user overrides within the quick-depth cap; they no longer append past the cap.

## Verification

- `_sanitize_plan(..., "quick")` on a plan with `[reddit, tiktok, instagram, youtube]` now keeps plan-selected sources instead of returning `[jobs, youtube]`.
- Requested sources are prioritized inside quick slots and remain capped by the quick-depth limit.
- `uv run pytest tests/test_planner_v3.py tests/test_internals_v3.py -k 'planner or TrimSubqueries or quick_mode or default'`
- `python3 -m py_compile skills/last30days/scripts/lib/planner.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013b95ARRnJMYQjmJbUKQN75
