### PR TITLE
fix: hiring-signal company size inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ htmlcov/
 
 # Internal planning docs (ce:plan output) — keep local, don't publish
 docs/plans/
+docs/brainstorms/
 .context/
 
 /work

--- a/skills/last30days/scripts/lib/hiring_signals.py
+++ b/skills/last30days/scripts/lib/hiring_signals.py
@@ -96,6 +96,14 @@ def analyze(
 
 def infer_company_size(items: list[schema.SourceItem], *, topic: str = "") -> str:
     """Infer a coarse company-size tier from jobs evidence."""
+    topic_lower = topic.lower()
+    firmographic_text = " ".join(
+        " ".join([
+            str(item.metadata.get("company_size") or ""),
+            topic,
+        ])
+        for item in items
+    ).lower()
     text = " ".join(
         " ".join([
             item.title,
@@ -111,9 +119,9 @@ def infer_company_size(items: list[schema.SourceItem], *, topic: str = "") -> st
     # never the job-description body - JDs list enterprise customers (e.g.
     # "trusted by Microsoft, Google"), which would misclassify a startup as
     # mega-cap and suppress its real signals.
-    if re.search(r"\b(apple|uber|google|microsoft|amazon|meta|netflix)\b", topic.lower()):
+    if re.search(r"\b(apple|uber|google|microsoft|amazon|meta|netflix)\b", topic_lower):
         return "mega-cap"
-    if count >= 200 or re.search(r"\b(fortune 500|thousands of employees)\b", text):
+    if count >= 200 or re.search(r"\b(fortune 500|thousands of employees)\b", firmographic_text):
         return "large-enterprise"
     if count >= 35 or re.search(r"\b(series [cd]|public company)\b", text):
         return "growth"

--- a/tests/test_hiring_signals.py
+++ b/tests/test_hiring_signals.py
@@ -39,6 +39,23 @@ class HiringSignalsTests(unittest.TestCase):
         self.assertEqual("mega-cap", summary["company_size_tier"])
         self.assertIn("too diffuse", summary["omitted_reason"])
 
+    def test_fortune_500_customer_boilerplate_does_not_make_startup_large_enterprise(self):
+        items = [
+            job(
+                "Founding Enterprise Solutions Engineer",
+                "Help Fortune 500 customers adopt SSO, SOC 2, and procurement workflows.",
+                "Sales",
+            ),
+            job(
+                "Security Platform Engineer",
+                "Build enterprise security, audit, and admin workflows for Fortune 500 customers.",
+                "Engineering",
+            ),
+        ]
+        summary = hiring_signals.analyze(items, explicit=False, topic="Listen Labs")
+        self.assertEqual("startup", summary["company_size_tier"])
+        self.assertTrue(summary["include"])
+
     def test_explicit_mode_keeps_low_confidence_signal(self):
         items = [job("Customer Success Manager", "support enterprise customers", "Success")]
         summary = hiring_signals.analyze(items, explicit=True, topic="Acme")


### PR DESCRIPTION
## Summary

- Keep internal brainstorming docs out of git by ignoring `docs/brainstorms/` alongside `docs/plans/`.
- Restrict `fortune 500` / `thousands of employees` company-size inference to firmographic metadata and topic context instead of full job-description body text.
- Add a regression test proving Fortune 500 customer boilerplate does not make a startup look like a large enterprise.

## Why

Hiring Signals previously searched full job descriptions when inferring whether a company was large-enterprise. Startup job postings often mention Fortune 500 customers, which could incorrectly classify the company as large-enterprise and suppress otherwise useful startup hiring signals.

## Validation

- `uv run pytest tests/test_hiring_signals.py`
- `git diff --check`
