### PR TITLE
Resolve 1Password refs in v3 config

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -121,6 +121,83 @@ def load_env_file(path: Path) -> dict[str, str]:
     return env
 
 
+def _load_op_service_account_token() -> str | None:
+    """Best-effort load of the 1Password service token for non-interactive runs."""
+    token = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN")
+    if token:
+        return token
+
+    zshrc = Path.home() / ".zshrc"
+    if not zshrc.exists():
+        return None
+
+    try:
+        for line in zshrc.read_text(errors="ignore").splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("export OP_SERVICE_ACCOUNT_TOKEN="):
+                continue
+            _, _, value = stripped.partition("=")
+            value = value.strip()
+            if value and value[0] in ('"', "'") and value[-1] == value[0]:
+                value = value[1:-1]
+            return value or None
+    except OSError:
+        return None
+
+    return None
+
+
+def resolve_secret_reference(value: str | None) -> str | None:
+    """Resolve 1Password ``op://...`` references without exposing secret values.
+
+    The installed wrapper normally resolves these with ``op run``. Agents can
+    still invoke the Python engine directly from SKILL.md, so the config loader
+    also resolves references in-process and treats failures as missing keys.
+    """
+    if not isinstance(value, str) or not value.startswith("op://"):
+        return value
+
+    import shutil
+    import subprocess
+
+    op_bin = shutil.which("op") or "/opt/homebrew/bin/op"
+    if not Path(op_bin).exists():
+        return None
+
+    child_env = os.environ.copy()
+    token = _load_op_service_account_token()
+    if token:
+        child_env["OP_SERVICE_ACCOUNT_TOKEN"] = token
+
+    try:
+        result = subprocess.run(
+            [op_bin, "read", value],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=child_env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    resolved = result.stdout.strip()
+    return resolved or None
+
+
+def _resolve_secret_references(values: dict[str, str]) -> dict[str, str]:
+    """Resolve any supported secret references in a config-source map."""
+    resolved: dict[str, str] = {}
+    for key, value in values.items():
+        secret = resolve_secret_reference(value)
+        if secret is not None:
+            resolved[key] = secret
+    return resolved
+
+
 def _load_keychain(keys: list[str]) -> dict[str, str]:
     """Load credentials from macOS Keychain (no-op on other platforms).
 
@@ -288,7 +365,7 @@ def get_codex_access_token() -> tuple[str | None, str]:
 
 def get_openai_auth(file_env: dict[str, str]) -> OpenAIAuth:
     """Resolve OpenAI auth from API key or Codex login."""
-    api_key = os.environ.get('OPENAI_API_KEY') or file_env.get('OPENAI_API_KEY')
+    api_key = resolve_secret_reference(os.environ.get('OPENAI_API_KEY')) or file_env.get('OPENAI_API_KEY')
     if api_key:
         return OpenAIAuth(
             token=api_key,
@@ -338,18 +415,18 @@ def get_config() -> dict[str, Any]:
       4. macOS Keychain items prefixed ``last30days-`` (Darwin only)
     """
     # Load from global config file
-    file_env = load_env_file(CONFIG_FILE) if CONFIG_FILE else {}
+    file_env = _resolve_secret_references(load_env_file(CONFIG_FILE)) if CONFIG_FILE else {}
 
     # Load from per-project config (overrides global)
     project_env_path = _find_project_env()
-    project_env = load_env_file(project_env_path) if project_env_path else {}
+    project_env = _resolve_secret_references(load_env_file(project_env_path)) if project_env_path else {}
 
     # Merge file sources: project > global
     merged_env = {**file_env, **project_env}
 
     # Keychain is the lowest-priority source (Darwin only; no-op elsewhere).
     # Loaded before openai_auth so OPENAI_API_KEY can come from Keychain too.
-    keychain_env = _load_keychain(list(KEYCHAIN_KEYS))
+    keychain_env = _resolve_secret_references(_load_keychain(list(KEYCHAIN_KEYS)))
     merged_env = {**keychain_env, **merged_env}
     # pass(1) store: Linux/Unix analog of Keychain at convention path
     # {prefix}<KEY>. Decrypts transiently so secrets stay encrypted at rest (no
@@ -365,7 +442,7 @@ def get_config() -> dict[str, Any]:
         or DEFAULT_PASS_PATH_PREFIX
     )
     pass_missing = [k for k in KEYCHAIN_KEYS if k not in os.environ and not merged_env.get(k)]
-    pass_env = _load_pass(pass_missing, pass_prefix)
+    pass_env = _resolve_secret_references(_load_pass(pass_missing, pass_prefix))
     merged_env = {**pass_env, **merged_env}
 
     openai_auth = get_openai_auth(merged_env)
@@ -443,7 +520,7 @@ def get_config() -> dict[str, Any]:
     ]
 
     for key, default in keys:
-        config[key] = os.environ.get(key) or merged_env.get(key, default)
+        config[key] = resolve_secret_reference(os.environ.get(key)) or merged_env.get(key, default)
 
     # Backward-compat: ScrapeCreators' own examples and tutorials use the
     # SCRAPE_CREATORS_API_KEY spelling (with underscore between SCRAPE and
@@ -451,7 +528,10 @@ def get_config() -> dict[str, Any]:
     # don't silently end up with has_scrapecreators=False. Canonical name
     # wins when both are set.
     if not config.get('SCRAPECREATORS_API_KEY'):
-        legacy = os.environ.get('SCRAPE_CREATORS_API_KEY') or merged_env.get('SCRAPE_CREATORS_API_KEY')
+        legacy = (
+            resolve_secret_reference(os.environ.get('SCRAPE_CREATORS_API_KEY'))
+            or merged_env.get('SCRAPE_CREATORS_API_KEY')
+        )
         if legacy:
             config['SCRAPECREATORS_API_KEY'] = legacy
 

--- a/tests/test_env_op.py
+++ b/tests/test_env_op.py
@@ -1,0 +1,82 @@
+"""Tests for 1Password op:// config references."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from lib import env
+
+
+def _run_result(returncode: int, stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Hide real host config so op:// tests are deterministic."""
+    for var in [
+        "OPENAI_API_KEY", "XAI_API_KEY", "BRAVE_API_KEY", "AUTH_TOKEN", "CT0",
+        "SCRAPECREATORS_API_KEY", "SCRAPE_CREATORS_API_KEY", "APIFY_API_TOKEN",
+        "BSKY_HANDLE", "BSKY_APP_PASSWORD", "TRUTHSOCIAL_TOKEN", "EXA_API_KEY",
+        "SERPER_API_KEY", "OPENROUTER_API_KEY", "PERPLEXITY_API_KEY",
+        "PARALLEL_API_KEY", "XQUIK_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
+        "GOOGLE_GENAI_API_KEY", "INCLUDE_SOURCES", "FROM_BROWSER",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(env, "CONFIG_FILE", tmp_path / "does-not-exist.env")
+    monkeypatch.setattr(env, "_load_pass", lambda *a, **k: {})
+    monkeypatch.chdir(tmp_path)
+
+
+def test_resolve_secret_reference_passes_through_plain_values():
+    assert env.resolve_secret_reference("plain-token") == "plain-token"
+    assert env.resolve_secret_reference(None) is None
+
+
+def test_resolve_secret_reference_reads_op_value(monkeypatch):
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "service-token")
+
+    with mock.patch("shutil.which", return_value="/opt/homebrew/bin/op"), \
+         mock.patch("pathlib.Path.exists", return_value=True), \
+         mock.patch("subprocess.run", return_value=_run_result(0, "resolved-token\n")) as run:
+        assert env.resolve_secret_reference("op://Vault/Item/credential") == "resolved-token"
+
+    run.assert_called_once()
+    assert run.call_args.args[0][:2] == ["/opt/homebrew/bin/op", "read"]
+    assert run.call_args.kwargs["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "service-token"
+
+
+def test_resolve_secret_reference_fails_closed():
+    with mock.patch("shutil.which", return_value="/opt/homebrew/bin/op"), \
+         mock.patch("pathlib.Path.exists", return_value=True), \
+         mock.patch("subprocess.run", return_value=_run_result(1, "")):
+        assert env.resolve_secret_reference("op://Vault/Item/credential") is None
+
+
+def test_get_config_resolves_op_value_from_config_file(clean_env, tmp_path, monkeypatch):
+    cfg_file = tmp_path / "global.env"
+    cfg_file.write_text("XAI_API_KEY=op://Vault/XAI/credential\n", encoding="utf-8")
+    monkeypatch.setattr(env, "CONFIG_FILE", cfg_file)
+
+    with mock.patch.object(env, "_load_keychain", return_value={}), \
+         mock.patch.object(env, "resolve_secret_reference", side_effect=lambda value: {
+             "op://Vault/XAI/credential": "xai-resolved",
+         }.get(value, value)):
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] == "xai-resolved"
+
+
+def test_get_config_resolves_op_value_from_process_env(clean_env, monkeypatch):
+    monkeypatch.setenv("SCRAPECREATORS_API_KEY", "op://Vault/ScrapeCreators/credential")
+
+    with mock.patch.object(env, "_load_keychain", return_value={}), \
+         mock.patch.object(env, "resolve_secret_reference", side_effect=lambda value: {
+             "op://Vault/ScrapeCreators/credential": "sc-resolved",
+         }.get(value, value)):
+        cfg = env.get_config()
+
+    assert cfg["SCRAPECREATORS_API_KEY"] == "sc-resolved"


### PR DESCRIPTION
## Summary
- Resolve 1Password op:// references in the v3 config loader so direct Python invocations behave like the secure wrapper
- Apply resolution across global/project env files, process env, Keychain, pass(1), and legacy SCRAPE_CREATORS_API_KEY
- Add focused tests for op:// pass-through, resolution, fail-closed behavior, and get_config integration

## Verification
- uv run pytest tests/test_env_op.py tests/test_env_keychain.py tests/test_env_pass.py tests/test_env_v3.py
- python3 skills/last30days/scripts/last30days.py --diagnose
- /Users/m04/.local/bin/last30days --diagnose