### PR TITLE
fix: fixing claude code installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This README tracks the current v3 pipeline. The runtime skill spec lives in [ski
 **Claude Code (recommended — auto-updates via marketplace):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
+```
+```
 /plugin install last30days
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), which is the source of truth for the latest command and setup behavior.
 
 **Claude Code (recommended — auto-updates via marketplace):**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-```
-/plugin install last30days
-```
 
 **Codex, Cursor, Copilot, Gemini CLI, or any of 50+ [Agent Skills](https://agentskills.io) hosts:**
 ```


### PR DESCRIPTION
## Summary

claude code must take the two instructions separately to work. Copy paste both lines into it will report an error.

## Changes

- README: fixing Claude Code installation instruction

## Testing

My claude code only successfully installed after I split those two instructions and enter them separately one after the other

## Related Issues

N/A
