### PR TITLE
fix: trust project config explicitly

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -69,14 +69,14 @@ Re-run onboarding by deleting `~/.config/last30days/.env`. The mechanical work l
 
 ## API keys (`.env`)
 
-The skill reads keys from a `.env` file. Two locations are supported, in priority order:
+The skill reads keys from a `.env` file. Two locations are supported:
 
-1. **`.claude/last30days.env`** in the current project directory (project-scoped) - takes precedence when present.
-2. **`~/.config/last30days/.env`** at the user level (global default) - the fallback.
+1. **`~/.config/last30days/.env`** at the user level (global default) - loaded by default.
+2. **`.claude/last30days.env`** in the current project directory (project-scoped) - loaded only when trusted by setting `LAST30DAYS_TRUST_PROJECT_CONFIG=1` in the process environment or global config.
 
 Override the global location with `LAST30DAYS_CONFIG_DIR=/path` (or `LAST30DAYS_CONFIG_DIR=""` for no-config mode). File permissions should be `600` on POSIX hosts - the engine warns on every run if they aren't.
 
-The project-scoped file is the cleanest pattern for **per-client setups**: drop a `.claude/last30days.env` into each client folder (`SCRAPECREATORS_API_KEY`, `INCLUDE_SOURCES`, `LAST30DAYS_MEMORY_DIR`, `BSKY_HANDLE`, etc), `cd` into that folder, and the skill picks up that client's configuration automatically. No wrapper scripts needed for the common case.
+The project-scoped file is useful for **intentional per-client setups**: drop a `.claude/last30days.env` into each client folder (`SCRAPECREATORS_API_KEY`, `INCLUDE_SOURCES`, `LAST30DAYS_MEMORY_DIR`, `BSKY_HANDLE`, etc), then opt in with `LAST30DAYS_TRUST_PROJECT_CONFIG=1` from your shell or `~/.config/last30days/.env`. Folder-mode hosts such as Codex desktop do not trust hidden project config by default, and discovery stops at the git root so unrelated parent folders cannot silently influence runs.
 
 **Source-by-source** - what each key unlocks:
 
@@ -144,7 +144,7 @@ BSKY_APP_PASSWORD=<your-app-password>
 
 After editing: `chmod 600 ~/.config/last30days/.env` (or `chmod 600 .claude/last30days.env` if using the project-scoped variant).
 
-**Troubleshooting:** if a source you expected to see isn't appearing in results, run `python3 scripts/last30days.py --diagnose`. It prints a safe preflight report for source availability, config source, browser-cookie plan, external command availability, and write destinations without reading browser cookies or running live provider probes.
+**Troubleshooting:** if a source you expected to see isn't appearing in results, run `python3 scripts/last30days.py --diagnose`. It prints a safe preflight report for source availability, config source, browser-cookie plan, external command availability, write destinations, and ignored untrusted project config without reading browser cookies or running live provider probes.
 
 ### Perplexity source modes
 
@@ -334,9 +334,9 @@ The schedule field stored on each topic is metadata - the actual cron / Task Sch
 
 The skill is built to flex around different client environments. Four patterns that compose well:
 
-### 1. Per-client `.claude/last30days.env` (preferred when you cd into client folders)
+### 1. Trusted per-client `.claude/last30days.env`
 
-The simplest pattern when each client has its own working directory: drop a `.claude/last30days.env` into the client folder. The skill picks it up automatically (see [API keys](#api-keys-env) for the lookup priority). Typical contents:
+When each client has its own working directory, drop a `.claude/last30days.env` into the client folder and opt in with `LAST30DAYS_TRUST_PROJECT_CONFIG=1` from your shell or global `~/.config/last30days/.env`. The skill loads the project file only after that trust signal. Typical contents:
 
 ```bash
 LAST30DAYS_MEMORY_DIR=C:\Users\<you>\Clients\acme\Research\Last30Days
@@ -345,7 +345,7 @@ INCLUDE_SOURCES=tiktok,instagram
 BSKY_HANDLE=<acme-bluesky-handle>.bsky.social
 ```
 
-`cd` into the client folder, run `/last30days <topic>` as normal, no flags or wrappers. Combine with `--save-suffix=<client-slug>` per run if you also need to differentiate filenames within that folder.
+`cd` into the client folder, run `/last30days <topic>` as normal, no wrappers. Combine with `--save-suffix=<client-slug>` per run if you also need to differentiate filenames within that folder.
 
 ### 2. Per-client save dir + suffix wrapper
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -651,7 +651,10 @@ def _config_policy_for_args(args: argparse.Namespace, topic: str, extra_argv: li
         browser_mode = "read" if _setup_allows_browser_cookies(args, extra_argv) else "off"
     else:
         browser_mode = "read"
-    return env.ConfigLoadPolicy(browser_cookies=browser_mode)
+    return env.ConfigLoadPolicy(
+        browser_cookies=browser_mode,
+        inspect_ignored_project_config=args.diagnose,
+    )
 
 
 def main() -> int:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -103,10 +103,10 @@ def _truthy(value: Any) -> bool:
 def _project_config_trusted(policy: ConfigLoadPolicy, file_env: dict[str, Any]) -> bool:
     if policy.allow_project_config:
         return True
-    return _truthy(
-        os.environ.get("LAST30DAYS_TRUST_PROJECT_CONFIG")
-        or file_env.get("LAST30DAYS_TRUST_PROJECT_CONFIG")
-    )
+    process_value = os.environ.get("LAST30DAYS_TRUST_PROJECT_CONFIG")
+    if process_value is not None:
+        return _truthy(process_value)
+    return _truthy(file_env.get("LAST30DAYS_TRUST_PROJECT_CONFIG"))
 
 
 def _check_file_permissions(path: Path) -> None:
@@ -658,9 +658,11 @@ def get_x_source_with_method(config: dict[str, Any]) -> tuple[str | None, str]:
     return None, "none"
 
 
-def config_exists() -> bool:
+def config_exists(policy: ConfigLoadPolicy | None = None) -> bool:
     """Check if any configuration source exists."""
-    if _find_project_env():
+    policy = policy or ConfigLoadPolicy()
+    file_env = load_env_file(CONFIG_FILE) if CONFIG_FILE and CONFIG_FILE.exists() else {}
+    if _project_config_trusted(policy, file_env) and _find_project_env():
         return True
     if CONFIG_FILE:
         return CONFIG_FILE.exists()

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -553,13 +553,30 @@ def cookie_extraction_browsers(config: dict[str, Any]) -> list[str]:
         return []
     if from_browser == "off":
         return []
-    if "," in from_browser:
-        browsers = [b.strip() for b in from_browser.split(",") if b.strip()]
-        return [b for b in browsers if b in known_browsers]
-    if from_browser in known_browsers:
-        return [from_browser]
     if from_browser == "auto":
         return silent_browsers + chromium_browsers
+    if "," in from_browser:
+        requested = [b.strip() for b in from_browser.split(",") if b.strip()]
+        resolved = [b for b in requested if b in known_browsers]
+        unknown = [b for b in requested if b not in known_browsers]
+        if unknown:
+            sys.stderr.write(
+                "[last30days] WARNING: FROM_BROWSER ignored unrecognized browser(s): "
+                f"{', '.join(unknown)} (known: {', '.join(known_browsers)})\n"
+            )
+            sys.stderr.flush()
+        return resolved
+    if from_browser in known_browsers:
+        return [from_browser]
+    # Non-empty, not off/auto, not a known browser, not a list: unrecognized.
+    # Warn rather than fail silently so a typo (FROM_BROWSER=chrme) is visible
+    # instead of looking like "no cookies found".
+    sys.stderr.write(
+        f"[last30days] WARNING: FROM_BROWSER='{from_browser}' is not a recognized "
+        f"browser; no cookies will be read (known: {', '.join(known_browsers)}, "
+        "or 'auto'/'off')\n"
+    )
+    sys.stderr.flush()
     return []
 
 

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -84,11 +84,29 @@ BrowserCookieMode = Literal["off", "read", "plan_only"]
 class ConfigLoadPolicy:
     """Local-read gates for configuration loading.
 
-    Bare library calls use the safe default: no browser-cookie extraction. CLI
-    entry points can opt into narrower behavior after parsing command intent.
+    Bare library calls use the safe default: no browser-cookie extraction and no
+    project-scoped config. CLI entry points can opt into narrower behavior after
+    parsing command intent.
     """
 
     browser_cookies: BrowserCookieMode = "off"
+    allow_project_config: bool = False
+    inspect_ignored_project_config: bool = False
+
+
+def _truthy(value: Any) -> bool:
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _project_config_trusted(policy: ConfigLoadPolicy, file_env: dict[str, Any]) -> bool:
+    if policy.allow_project_config:
+        return True
+    return _truthy(
+        os.environ.get("LAST30DAYS_TRUST_PROJECT_CONFIG")
+        or file_env.get("LAST30DAYS_TRUST_PROJECT_CONFIG")
+    )
 
 
 def _check_file_permissions(path: Path) -> None:
@@ -329,13 +347,15 @@ def _find_project_env() -> Path | None:
     """Find per-project .env by walking up from cwd.
 
     Searches for .claude/last30days.env in each parent directory,
-    stopping at the user's home directory or filesystem root.
+    stopping at the git root, user's home directory, or filesystem root.
     """
     cwd = Path.cwd()
     for parent in [cwd, *cwd.parents]:
         candidate = parent / '.claude' / 'last30days.env'
         if candidate.exists():
             return candidate
+        if (parent / ".git").exists():
+            break
         # Stop at filesystem root or home
         if parent == Path.home() or parent == parent.parent:
             break
@@ -347,7 +367,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
 
     Priority (highest wins):
       1. Environment variables (os.environ)
-      2. .claude/last30days.env (per-project config)
+      2. Trusted .claude/last30days.env (per-project config)
       3. ~/.config/last30days/.env (global config)
       4. macOS Keychain items prefixed ``last30days-`` (Darwin only)
     """
@@ -355,9 +375,18 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
     # Load from global config file
     file_env = load_env_file(CONFIG_FILE) if CONFIG_FILE else {}
 
-    # Load from per-project config (overrides global)
-    project_env_path = _find_project_env()
+    # Load per-project config only when trust comes from process env, global
+    # user config, or an explicit policy. A project file cannot grant trust to
+    # itself because it is not parsed until after this decision.
+    project_config_trusted = _project_config_trusted(policy, file_env)
+    project_env_path = _find_project_env() if project_config_trusted else None
     project_env = load_env_file(project_env_path) if project_env_path else {}
+    ignored_project_env_path = None
+    ignored_project_keys: list[str] = []
+    if not project_config_trusted and policy.inspect_ignored_project_config:
+        ignored_project_env_path = _find_project_env()
+        if ignored_project_env_path:
+            ignored_project_keys = sorted(load_env_file(ignored_project_env_path).keys())
 
     # Merge file sources: project > global
     merged_env = {**file_env, **project_env}
@@ -444,6 +473,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         # Optional SearXNG instance for the keyless-search fallback rung.
         ('LAST30DAYS_SEARXNG_URL', None),
         ('FROM_BROWSER', None),
+        ('LAST30DAYS_TRUST_PROJECT_CONFIG', None),
         ('SETUP_COMPLETE', None),
         ('INCLUDE_SOURCES', ''),
         ('EXCLUDE_SOURCES', ''),
@@ -491,7 +521,9 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         config['_CONFIG_SOURCE'] = 'pass'
     else:
         config['_CONFIG_SOURCE'] = 'env_only'
-
+    if ignored_project_env_path:
+        config['_IGNORED_PROJECT_CONFIG'] = str(ignored_project_env_path)
+        config['_IGNORED_PROJECT_CONFIG_KEYS'] = ignored_project_keys
     config['_BROWSER_COOKIE_MODE'] = policy.browser_cookies
     config['_BROWSER_COOKIE_BROWSERS'] = cookie_extraction_browsers(config)
 

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -204,8 +204,15 @@ def diagnose(
         "reads_values": False if safe else config.get("_BROWSER_COOKIE_MODE") == "read",
     }
     ignored_project_keys = list(config.get("_IGNORED_PROJECT_CONFIG_KEYS") or [])
+    endpoint_override_keys = {
+        "BSKY_SEARCH_HOST",
+        "LAST30DAYS_SEARXNG_URL",
+        "OPENAI_BASE_URL",
+        "XAI_BASE_URL",
+        "XIAOHONGSHU_API_BASE",
+    }
     ignored_endpoint_overrides = [
-        key for key in ignored_project_keys if key in {"OPENAI_BASE_URL", "XAI_BASE_URL"}
+        key for key in ignored_project_keys if key in endpoint_override_keys
     ]
     local_writes: list[dict[str, str]] = []
     if config.get("LAST30DAYS_MEMORY_DIR"):

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -203,6 +203,10 @@ def diagnose(
         "browsers": list(config.get("_BROWSER_COOKIE_BROWSERS") or []),
         "reads_values": False if safe else config.get("_BROWSER_COOKIE_MODE") == "read",
     }
+    ignored_project_keys = list(config.get("_IGNORED_PROJECT_CONFIG_KEYS") or [])
+    ignored_endpoint_overrides = [
+        key for key in ignored_project_keys if key in {"OPENAI_BASE_URL", "XAI_BASE_URL"}
+    ]
     local_writes: list[dict[str, str]] = []
     if config.get("LAST30DAYS_MEMORY_DIR"):
         local_writes.append({"kind": "report", "path": str(config.get("LAST30DAYS_MEMORY_DIR"))})
@@ -224,6 +228,9 @@ def diagnose(
         "available_sources": available_sources(config, requested_sources),
         "safe": safe,
         "config_source": config.get("_CONFIG_SOURCE"),
+        "ignored_project_config": config.get("_IGNORED_PROJECT_CONFIG"),
+        "ignored_project_config_keys": ignored_project_keys,
+        "ignored_endpoint_overrides": ignored_endpoint_overrides,
         "browser_cookies": browser_cookies,
         "external_commands": external_commands,
         "credential_destinations": credential_destinations,

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -207,6 +207,7 @@ def diagnose(
     endpoint_override_keys = {
         "BSKY_SEARCH_HOST",
         "LAST30DAYS_SEARXNG_URL",
+        "LAST30DAYS_YOUTUBE_SSH_HOST",
         "OPENAI_BASE_URL",
         "XAI_BASE_URL",
         "XIAOHONGSHU_API_BASE",

--- a/skills/last30days/scripts/watchlist.py
+++ b/skills/last30days/scripts/watchlist.py
@@ -171,6 +171,11 @@ def _run_topic(topic: dict) -> dict:
                 "--quick",
                 "--lookback-days",
                 "90",
+                # Watchlist is an unattended cron host: never probe browser
+                # cookies (matches the MCP server). Avoids a silent Chromium
+                # read / unattended macOS Keychain prompt when a user has set
+                # FROM_BROWSER=auto for interactive use.
+                "--no-browser-cookies",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_project_config_trust.py
+++ b/tests/test_project_config_trust.py
@@ -49,6 +49,25 @@ def test_project_config_loads_with_global_trust_signal(tmp_path, monkeypatch):
     assert cfg["_CONFIG_SOURCE"].startswith(f"project:{project_env}")
 
 
+def test_empty_process_trust_signal_overrides_global_trust_signal(tmp_path, monkeypatch):
+    global_env = tmp_path / "global.env"
+    global_env.write_text("LAST30DAYS_TRUST_PROJECT_CONFIG=1\n", encoding="utf-8")
+    project_dir = tmp_path / "project"
+    project_env = project_dir / ".claude" / "last30days.env"
+    project_env.parent.mkdir(parents=True)
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(env, "CONFIG_FILE", global_env)
+    monkeypatch.setenv("LAST30DAYS_TRUST_PROJECT_CONFIG", "")
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] is None
+    assert cfg["_CONFIG_SOURCE"].startswith(f"global:{global_env}")
+
+
 def test_project_config_discovery_stops_at_git_root(tmp_path, monkeypatch):
     outside_env = tmp_path / ".claude" / "last30days.env"
     outside_env.parent.mkdir()
@@ -88,11 +107,46 @@ def test_global_config_loads_when_project_config_is_untrusted(tmp_path, monkeypa
     assert cfg["_CONFIG_SOURCE"].startswith(f"global:{global_env}")
 
 
+def test_config_exists_ignores_untrusted_project_config(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    assert env.config_exists() is False
+
+
+def test_config_exists_reports_trusted_project_config(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.setenv("LAST30DAYS_TRUST_PROJECT_CONFIG", "1")
+
+    assert env.config_exists() is True
+
+
+def test_config_exists_reports_global_config(tmp_path, monkeypatch):
+    global_env = tmp_path / "global.env"
+    global_env.write_text("XAI_API_KEY=xai-global\n", encoding="utf-8")
+    monkeypatch.setattr(env, "CONFIG_FILE", global_env)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    assert env.config_exists() is True
+
+
 def test_diagnose_reports_ignored_untrusted_endpoint_override(tmp_path, monkeypatch):
     project_env = tmp_path / ".claude" / "last30days.env"
     project_env.parent.mkdir()
     project_env.write_text(
-        "OPENAI_BASE_URL=https://attacker.example\nOPENAI_API_KEY=sk-not-reported\n",
+        "BSKY_SEARCH_HOST=https://bsky-attacker.example\n"
+        "LAST30DAYS_SEARXNG_URL=https://searxng-attacker.example\n"
+        "OPENAI_BASE_URL=https://attacker.example\n"
+        "OPENAI_API_KEY=sk-not-reported\n"
+        "XIAOHONGSHU_API_BASE=https://xhs-attacker.example\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
@@ -110,5 +164,10 @@ def test_diagnose_reports_ignored_untrusted_endpoint_override(tmp_path, monkeypa
     assert cfg["OPENAI_API_KEY"] == "sk-global"
     assert cfg["OPENAI_BASE_URL"] is None
     assert diag["ignored_project_config"] == str(project_env)
-    assert diag["ignored_endpoint_overrides"] == ["OPENAI_BASE_URL"]
+    assert diag["ignored_endpoint_overrides"] == [
+        "BSKY_SEARCH_HOST",
+        "LAST30DAYS_SEARXNG_URL",
+        "OPENAI_BASE_URL",
+        "XIAOHONGSHU_API_BASE",
+    ]
     assert "sk-not-reported" not in str(diag)

--- a/tests/test_project_config_trust.py
+++ b/tests/test_project_config_trust.py
@@ -1,0 +1,114 @@
+"""Tests for trusted project-scoped configuration."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from lib import env, pipeline
+
+
+def _neutral_secret_sources():
+    return (
+        mock.patch.object(env, "_load_keychain", return_value={}),
+        mock.patch.object(env, "_load_pass", return_value={}),
+    )
+
+
+def test_untrusted_project_config_is_ignored_by_default(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] is None
+    assert cfg["_CONFIG_SOURCE"] == "env_only"
+
+
+def test_project_config_loads_with_global_trust_signal(tmp_path, monkeypatch):
+    global_env = tmp_path / "global.env"
+    global_env.write_text("LAST30DAYS_TRUST_PROJECT_CONFIG=1\n", encoding="utf-8")
+    project_dir = tmp_path / "project"
+    project_env = project_dir / ".claude" / "last30days.env"
+    project_env.parent.mkdir(parents=True)
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(env, "CONFIG_FILE", global_env)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] == "xai-project"
+    assert cfg["_CONFIG_SOURCE"].startswith(f"project:{project_env}")
+
+
+def test_project_config_discovery_stops_at_git_root(tmp_path, monkeypatch):
+    outside_env = tmp_path / ".claude" / "last30days.env"
+    outside_env.parent.mkdir()
+    outside_env.write_text("XAI_API_KEY=outside\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    workdir = repo / "nested"
+    workdir.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    monkeypatch.chdir(workdir)
+    monkeypatch.setenv("LAST30DAYS_TRUST_PROJECT_CONFIG", "1")
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] is None
+    assert cfg["_CONFIG_SOURCE"] == "env_only"
+
+
+def test_global_config_loads_when_project_config_is_untrusted(tmp_path, monkeypatch):
+    global_env = tmp_path / "global.env"
+    global_env.write_text("XAI_API_KEY=global\n", encoding="utf-8")
+    project_dir = tmp_path / "project"
+    project_env = project_dir / ".claude" / "last30days.env"
+    project_env.parent.mkdir(parents=True)
+    project_env.write_text("XAI_API_KEY=project\n", encoding="utf-8")
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(env, "CONFIG_FILE", global_env)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] == "global"
+    assert cfg["_CONFIG_SOURCE"].startswith(f"global:{global_env}")
+
+
+def test_diagnose_reports_ignored_untrusted_endpoint_override(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text(
+        "OPENAI_BASE_URL=https://attacker.example\nOPENAI_API_KEY=sk-not-reported\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-global")
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config(
+            policy=env.ConfigLoadPolicy(inspect_ignored_project_config=True)
+        )
+    diag = pipeline.diagnose(cfg, safe=True)
+
+    assert cfg["OPENAI_API_KEY"] == "sk-global"
+    assert cfg["OPENAI_BASE_URL"] is None
+    assert diag["ignored_project_config"] == str(project_env)
+    assert diag["ignored_endpoint_overrides"] == ["OPENAI_BASE_URL"]
+    assert "sk-not-reported" not in str(diag)

--- a/tests/test_project_config_trust.py
+++ b/tests/test_project_config_trust.py
@@ -68,6 +68,26 @@ def test_empty_process_trust_signal_overrides_global_trust_signal(tmp_path, monk
     assert cfg["_CONFIG_SOURCE"].startswith(f"global:{global_env}")
 
 
+def test_explicit_zero_process_trust_signal_overrides_global_trust_signal(tmp_path, monkeypatch):
+    """An explicit process `=0` is a deny and wins over a global `=1`."""
+    global_env = tmp_path / "global.env"
+    global_env.write_text("LAST30DAYS_TRUST_PROJECT_CONFIG=1\n", encoding="utf-8")
+    project_dir = tmp_path / "project"
+    project_env = project_dir / ".claude" / "last30days.env"
+    project_env.parent.mkdir(parents=True)
+    project_env.write_text("XAI_API_KEY=xai-project\n", encoding="utf-8")
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(env, "CONFIG_FILE", global_env)
+    monkeypatch.setenv("LAST30DAYS_TRUST_PROJECT_CONFIG", "0")
+
+    keychain, pass_store = _neutral_secret_sources()
+    with keychain, pass_store:
+        cfg = env.get_config()
+
+    assert cfg["XAI_API_KEY"] is None
+    assert cfg["_CONFIG_SOURCE"].startswith(f"global:{global_env}")
+
+
 def test_project_config_discovery_stops_at_git_root(tmp_path, monkeypatch):
     outside_env = tmp_path / ".claude" / "last30days.env"
     outside_env.parent.mkdir()
@@ -144,6 +164,7 @@ def test_diagnose_reports_ignored_untrusted_endpoint_override(tmp_path, monkeypa
     project_env.write_text(
         "BSKY_SEARCH_HOST=https://bsky-attacker.example\n"
         "LAST30DAYS_SEARXNG_URL=https://searxng-attacker.example\n"
+        "LAST30DAYS_YOUTUBE_SSH_HOST=attacker-host\n"
         "OPENAI_BASE_URL=https://attacker.example\n"
         "OPENAI_API_KEY=sk-not-reported\n"
         "XIAOHONGSHU_API_BASE=https://xhs-attacker.example\n",
@@ -164,9 +185,10 @@ def test_diagnose_reports_ignored_untrusted_endpoint_override(tmp_path, monkeypa
     assert cfg["OPENAI_API_KEY"] == "sk-global"
     assert cfg["OPENAI_BASE_URL"] is None
     assert diag["ignored_project_config"] == str(project_env)
-    assert diag["ignored_endpoint_overrides"] == [
+    assert sorted(diag["ignored_endpoint_overrides"]) == [
         "BSKY_SEARCH_HOST",
         "LAST30DAYS_SEARXNG_URL",
+        "LAST30DAYS_YOUTUBE_SSH_HOST",
         "OPENAI_BASE_URL",
         "XIAOHONGSHU_API_BASE",
     ]

--- a/tests/test_security_boundaries.py
+++ b/tests/test_security_boundaries.py
@@ -122,3 +122,33 @@ def test_diagnose_overrides_setup_cookie_flag(monkeypatch):
 
     assert seen["policy"].browser_cookies == "plan_only"
     assert setup.call_args.kwargs["allow_browser_cookies"] is False
+
+
+def test_research_run_defaults_to_browser_cookie_read():
+    """A plain research run reads cookies (the path that powers X auth)."""
+    parser = cli.build_parser()
+    args, extra = parser.parse_known_args(["some topic"])
+    policy = cli._config_policy_for_args(args, "some topic", extra)
+    assert policy.browser_cookies == "read"
+
+
+def test_no_browser_cookies_flag_disables_research_run_cookie_read():
+    """--no-browser-cookies flips a research run to the no-read policy."""
+    parser = cli.build_parser()
+    args, extra = parser.parse_known_args(["--no-browser-cookies", "some topic"])
+    policy = cli._config_policy_for_args(args, "some topic", extra)
+    assert policy.browser_cookies == "off"
+
+
+def test_watchlist_subprocess_disables_browser_cookies():
+    """The unattended watchlist cron must never probe browser cookies."""
+    import watchlist
+
+    fake_result = mock.Mock(returncode=1, stdout="", stderr="boom")
+    with mock.patch.object(watchlist, "store") as store, \
+         mock.patch.object(watchlist.subprocess, "run", return_value=fake_result) as run:
+        store.record_run.return_value = 1
+        watchlist._run_topic({"id": 1, "name": "test topic", "search_queries": None})
+
+    argv = run.call_args.args[0]
+    assert "--no-browser-cookies" in argv

--- a/tests/test_security_boundaries.py
+++ b/tests/test_security_boundaries.py
@@ -11,6 +11,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
 
 import last30days as cli
+from lib import env
 
 
 def test_importing_cli_does_not_load_config_or_propagate_endpoints(monkeypatch):
@@ -152,3 +153,40 @@ def test_watchlist_subprocess_disables_browser_cookies():
 
     argv = run.call_args.args[0]
     assert "--no-browser-cookies" in argv
+
+
+def test_project_config_ignored_by_default_and_cannot_self_trust(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text(
+        "LAST30DAYS_TRUST_PROJECT_CONFIG=1\nOPENAI_BASE_URL=https://example.invalid\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.delenv("LAST30DAYS_TRUST_PROJECT_CONFIG", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with mock.patch.object(env, "_load_keychain", return_value={}), \
+         mock.patch.object(env, "_load_pass", return_value={}):
+        cfg = env.get_config()
+
+    assert cfg["OPENAI_BASE_URL"] is None
+    assert cfg["_CONFIG_SOURCE"] == "env_only"
+
+
+def test_project_config_loads_with_process_trust_signal(tmp_path, monkeypatch):
+    project_env = tmp_path / ".claude" / "last30days.env"
+    project_env.parent.mkdir()
+    project_env.write_text("OPENAI_BASE_URL=https://trusted.example\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(env, "CONFIG_FILE", None)
+    monkeypatch.setenv("LAST30DAYS_TRUST_PROJECT_CONFIG", "1")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with mock.patch.object(env, "_load_keychain", return_value={}), \
+         mock.patch.object(env, "_load_pass", return_value={}):
+        cfg = env.get_config()
+
+    assert cfg["OPENAI_BASE_URL"] == "https://trusted.example"
+    assert cfg["_CONFIG_SOURCE"].startswith(f"project:{project_env}")


### PR DESCRIPTION
## Summary

Folder-mode runs no longer inherit hidden `.claude/last30days.env` files from arbitrary directories. Project config now loads only when trust is granted from process env, global config, or explicit engine policy, and discovery stops at the git root so unrelated parent folders cannot redirect credentials.

Safe diagnose can still explain what happened: it reports ignored project config key names and blocked endpoint overrides without exposing secret values.

## Validation

- `uv run pytest tests/test_project_config_trust.py tests/test_security_boundaries.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
