### PR TITLE
fix: reject stale CLI and MCP flags

### DIFF
--- a/mcp/internal/tools/research.go
+++ b/mcp/internal/tools/research.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
@@ -90,7 +91,11 @@ func makeResearchHandler(cfg Config) server.ToolHandlerFunc {
 func researchRunArgs(topic, emit string, save bool) []string {
 	runArgs := []string{topic, "--emit=" + emit, "--no-browser-cookies"}
 	if save {
-		runArgs = append(runArgs, "--save-dir", "~/Documents/Last30Days")
+		saveDir := os.Getenv("LAST30DAYS_MEMORY_DIR")
+		if saveDir == "" {
+			saveDir = "~/Documents/Last30Days"
+		}
+		runArgs = append(runArgs, "--save-dir", saveDir)
 	}
 	return runArgs
 }

--- a/mcp/internal/tools/research.go
+++ b/mcp/internal/tools/research.go
@@ -36,7 +36,7 @@ func Register(s *server.MCPServer, cfg Config) {
 			mcplib.WithString("topic", mcplib.Required(), mcplib.Description("The subject to research (a person, company, product, event, or general topic).")),
 			mcplib.WithString("emit", mcplib.Description("Output shape: 'compact' (default) for inline synthesis or 'html' to save a shareable brief alongside the response.")),
 			mcplib.WithBoolean("save", mcplib.Description("Persist the synthesis as a markdown report under ~/Documents/Last30Days/ (or LAST30DAYS_MEMORY_DIR if set).")),
-			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithReadOnlyHintAnnotation(false),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
@@ -90,7 +90,7 @@ func makeResearchHandler(cfg Config) server.ToolHandlerFunc {
 func researchRunArgs(topic, emit string, save bool) []string {
 	runArgs := []string{topic, "--emit=" + emit, "--no-browser-cookies"}
 	if save {
-		runArgs = append(runArgs, "--save")
+		runArgs = append(runArgs, "--save-dir", "~/Documents/Last30Days")
 	}
 	return runArgs
 }

--- a/mcp/internal/tools/research_test.go
+++ b/mcp/internal/tools/research_test.go
@@ -105,6 +105,18 @@ func TestResearchRunArgsIncludesNoBrowserCookies(t *testing.T) {
 	}
 }
 
+func TestResearchRunArgsSaveUsesSupportedSaveDir(t *testing.T) {
+	args := researchRunArgs("OpenAI", "html", true)
+	got := strings.Join(args, "\x00")
+	if strings.Contains(got, "--save\x00") || strings.HasSuffix(got, "--save") {
+		t.Fatalf("args still include unsupported --save: %#v", args)
+	}
+	want := []string{"OpenAI", "--emit=html", "--no-browser-cookies", "--save-dir", "~/Documents/Last30Days"}
+	if got != strings.Join(want, "\x00") {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
 func TestResearchHandlerValidationErrorsAreToolErrors(t *testing.T) {
 	// Validation failures are returned as MCP tool errors (not Go errors)
 	// so Claude sees a structured failure with a readable message rather

--- a/mcp/internal/tools/research_test.go
+++ b/mcp/internal/tools/research_test.go
@@ -106,6 +106,7 @@ func TestResearchRunArgsIncludesNoBrowserCookies(t *testing.T) {
 }
 
 func TestResearchRunArgsSaveUsesSupportedSaveDir(t *testing.T) {
+	t.Setenv("LAST30DAYS_MEMORY_DIR", "")
 	args := researchRunArgs("OpenAI", "html", true)
 	got := strings.Join(args, "\x00")
 	if strings.Contains(got, "--save\x00") || strings.HasSuffix(got, "--save") {
@@ -113,6 +114,15 @@ func TestResearchRunArgsSaveUsesSupportedSaveDir(t *testing.T) {
 	}
 	want := []string{"OpenAI", "--emit=html", "--no-browser-cookies", "--save-dir", "~/Documents/Last30Days"}
 	if got != strings.Join(want, "\x00") {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
+func TestResearchRunArgsSaveUsesMemoryDirEnvOverride(t *testing.T) {
+	t.Setenv("LAST30DAYS_MEMORY_DIR", "/tmp/last30days-reports")
+	args := researchRunArgs("OpenAI", "html", true)
+	want := []string{"OpenAI", "--emit=html", "--no-browser-cookies", "--save-dir", "/tmp/last30days-reports"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("args = %#v, want %#v", args, want)
 	}
 }

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -642,6 +642,40 @@ def _setup_allows_browser_cookies(args: argparse.Namespace, extra_argv: list[str
     )
 
 
+SETUP_PASSTHROUGH_FLAGS = {
+    "--allow-browser-cookies",
+    "--device-auth",
+    "--github",
+    "--openclaw",
+}
+
+SKILL_ONLY_FLAGS = {
+    "--agent",
+}
+
+
+def _validate_extra_argv(parser: argparse.ArgumentParser, topic: str, extra_argv: list[str]) -> None:
+    if not extra_argv:
+        return
+    if topic.lower() == "setup":
+        unsupported = [arg for arg in extra_argv if arg not in SETUP_PASSTHROUGH_FLAGS]
+        if unsupported:
+            parser.error(
+                "unsupported setup argument(s): "
+                + ", ".join(unsupported)
+                + f"; supported setup passthrough flags are {', '.join(sorted(SETUP_PASSTHROUGH_FLAGS))}"
+            )
+        return
+    skill_only = [arg for arg in extra_argv if arg in SKILL_ONLY_FLAGS]
+    if skill_only:
+        parser.error(
+            "unsupported Python CLI argument(s): "
+            + ", ".join(skill_only)
+            + "; these are skill arguments and must not be forwarded to scripts/last30days.py"
+        )
+    parser.error("unsupported Python CLI argument(s): " + ", ".join(extra_argv))
+
+
 def _config_policy_for_args(args: argparse.Namespace, topic: str, extra_argv: list[str]) -> env.ConfigLoadPolicy:
     if args.no_browser_cookies:
         browser_mode = "off"
@@ -666,6 +700,7 @@ def main() -> int:
         os.environ["LAST30DAYS_DEBUG"] = "1"
 
     topic = " ".join(args.topic).strip()
+    _validate_extra_argv(parser, topic, extra_argv)
     config = env.get_config(policy=_config_policy_for_args(args, topic, extra_argv))
     _propagate_config_to_environ(config)
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -667,12 +667,16 @@ def _validate_extra_argv(parser: argparse.ArgumentParser, topic: str, extra_argv
             )
         return
     skill_only = [arg for arg in extra_argv if arg in SKILL_ONLY_FLAGS]
+    other_unknown = [arg for arg in extra_argv if arg not in SKILL_ONLY_FLAGS]
     if skill_only:
-        parser.error(
+        message = (
             "unsupported Python CLI argument(s): "
             + ", ".join(skill_only)
             + "; these are skill arguments and must not be forwarded to scripts/last30days.py"
         )
+        if other_unknown:
+            message += "; also unsupported: " + ", ".join(other_unknown)
+        parser.error(message)
     parser.error("unsupported Python CLI argument(s): " + ", ".join(extra_argv))
 
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -147,6 +147,46 @@ class CliV3Tests(unittest.TestCase):
         self.assertEqual(["biosecurity"], args.topic)
         self.assertEqual([], extra)
 
+    def test_research_unknown_flag_fails_before_config_load(self):
+        with mock.patch.object(
+            cli.env, "get_config", side_effect=AssertionError("config should not load")
+        ), mock.patch.object(sys, "argv", ["last30days.py", "topic", "--save"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as exc:
+                cli.main()
+        self.assertEqual(2, exc.exception.code)
+        self.assertIn("--save", stderr.getvalue())
+
+    def test_agent_is_skill_argument_not_python_cli_flag(self):
+        with mock.patch.object(
+            cli.env, "get_config", side_effect=AssertionError("config should not load")
+        ), mock.patch.object(sys, "argv", ["last30days.py", "topic", "--agent"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as exc:
+                cli.main()
+        self.assertEqual(2, exc.exception.code)
+        self.assertIn("skill arguments", stderr.getvalue())
+
+    def test_setup_passthrough_flags_remain_scoped_to_setup(self):
+        with mock.patch.object(cli.env, "get_config", return_value={}), \
+             mock.patch("lib.setup_wizard.run_github_auth", return_value={"status": "cancelled"}), \
+             mock.patch.object(sys, "argv", ["last30days.py", "setup", "--github"]):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = cli.main()
+        self.assertEqual(0, rc)
+
+    def test_setup_rejects_unknown_passthrough_flag_before_config_load(self):
+        with mock.patch.object(
+            cli.env, "get_config", side_effect=AssertionError("config should not load")
+        ), mock.patch.object(sys, "argv", ["last30days.py", "setup", "--bad"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as exc:
+                cli.main()
+        self.assertEqual(2, exc.exception.code)
+        self.assertIn("--bad", stderr.getvalue())
+
     def test_ensure_supported_python_rejects_old_interpreter_with_actionable_error(self):
         stderr = io.StringIO()
         with redirect_stderr(stderr):

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -167,6 +167,18 @@ class CliV3Tests(unittest.TestCase):
         self.assertEqual(2, exc.exception.code)
         self.assertIn("skill arguments", stderr.getvalue())
 
+    def test_agent_error_includes_other_unknown_flags(self):
+        with mock.patch.object(
+            cli.env, "get_config", side_effect=AssertionError("config should not load")
+        ), mock.patch.object(sys, "argv", ["last30days.py", "topic", "--agent", "--save"]):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), self.assertRaises(SystemExit) as exc:
+                cli.main()
+        self.assertEqual(2, exc.exception.code)
+        message = stderr.getvalue()
+        self.assertIn("--agent", message)
+        self.assertIn("--save", message)
+
     def test_setup_passthrough_flags_remain_scoped_to_setup(self):
         with mock.patch.object(cli.env, "get_config", return_value={}), \
              mock.patch("lib.setup_wizard.run_github_auth", return_value={"status": "cancelled"}), \

--- a/tests/test_doc_flag_contract.py
+++ b/tests/test_doc_flag_contract.py
@@ -1,0 +1,43 @@
+"""Documentation contract for Python CLI and wrapper-only flags."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import last30days as cli
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION = ROOT / "CONFIGURATION.md"
+SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
+
+
+def _parser_flags() -> set[str]:
+    parser = cli.build_parser()
+    flags: set[str] = set()
+    for action in parser._actions:
+        flags.update(action.option_strings)
+    return flags
+
+
+def test_configuration_documents_new_safety_flags():
+    text = CONFIGURATION.read_text(encoding="utf-8")
+    flags = _parser_flags()
+    assert "--no-browser-cookies" in flags
+    assert "--no-browser-cookies" in text
+    assert "--save-dir" in text
+    assert "--output" in text
+
+
+def test_save_is_not_documented_as_python_cli_flag():
+    text = CONFIGURATION.read_text(encoding="utf-8")
+    assert "--save-dir <path>" in text
+    assert "--save " not in text
+    assert "`--save`" not in text
+
+
+def test_agent_is_documented_as_skill_argument_not_python_flag():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    start = text.index("## Agent Mode (--agent flag)")
+    agent_section = text[start:start + 2000]
+    assert "If `--agent` appears in ARGUMENTS" in agent_section
+    assert "Skill tool" in text


### PR DESCRIPTION
## Summary

Stale wrappers now fail loudly instead of silently becoming no-ops. The Python CLI rejects unsupported research flags before loading config, keeps setup passthrough scoped to setup, and classifies `--agent` as a skill argument rather than a Python script flag.

MCP save behavior now uses supported Python save controls and the tool no longer claims read-only behavior while it may perform network research or writes.

## Validation

- `uv run pytest tests/test_cli_v3.py tests/test_doc_flag_contract.py`
- `go test ./...` from `mcp/`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
