### PR TITLE
docs: align host security contracts

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -238,7 +238,7 @@ Accepts the same comma-separated names and aliases as `--search` (`web` → grou
 `/last30days` needs one reasoning model for planning + reranking when you don't pass `--plan` yourself. Auto-detect priority (set `LAST30DAYS_REASONING_PROVIDER=<name>` to pin one):
 
 1. **Gemini** - `GOOGLE_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_GENAI_API_KEY`
-2. **OpenAI** - `OPENAI_API_KEY` (or Codex auth at `~/.codex/auth.json`)
+2. **OpenAI** - `OPENAI_API_KEY` only. Codex ChatGPT auth at `~/.codex/auth.json` is intentionally not used as an OpenAI provider credential.
 3. **xAI** - `XAI_API_KEY`
 4. **OpenRouter** - `OPENROUTER_API_KEY` (Sonar fallback for the Perplexity source / `--deep-research`; also usable as a reasoning provider)
 5. **Local / deterministic** - always available, lowest quality

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | X / Twitter | Log into x.com in any browser, or set `XQUIK_API_KEY` / `XAI_API_KEY` | Browser cookies are free; keys are provider-specific |
 | YouTube | `brew install yt-dlp` | Free |
 | Bluesky | App password from bsky.app | Free |
-| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 100 free credits, then PAYG |
+| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 10,000 free calls, then PAYG |
 | Perplexity Sonar / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go |
 | Web search | Brave Search key | 2,000 free queries/month |
 

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -417,14 +417,14 @@ Options:
 
 **If the user picks Auto setup:**
 
-Get cookie consent first. Check if `BROWSER_CONSENT=true` already exists in `~/.config/last30days/.env`; if so, skip the consent prompt and run setup directly. Otherwise **call AskUserQuestion:**
+Get cookie consent first. Check if `BROWSER_CONSENT=true` already exists in `~/.config/last30days/.env`; if so, skip the consent prompt and run `setup --allow-browser-cookies` directly. Otherwise **call AskUserQuestion:**
 Question: "Auto setup will scan your browser (Firefox/Safari) for x.com cookies to authenticate X search. Cookies are read live, not saved to disk. OK to proceed?"
 Options:
-- "Yes, scan my cookies for X" - run `python3 skills/last30days/scripts/last30days.py setup` (relative to the skill root). Append `BROWSER_CONSENT=true` to `.env` after setup completes.
+- "Yes, scan my cookies for X" - run `python3 skills/last30days/scripts/last30days.py setup --allow-browser-cookies` (relative to the skill root). Append `BROWSER_CONSENT=true` to `.env` after setup completes.
 - "Skip X, just set up YouTube + Digg" - run `FROM_BROWSER=off python3 skills/last30days/scripts/last30days.py setup`. Skips all cookie reads; still installs yt-dlp and Digg.
 - "I have an xAI API key instead" - ask them to paste it, write `XAI_API_KEY` to `.env`, then run `FROM_BROWSER=off python3 skills/last30days/scripts/last30days.py setup` (installs yt-dlp + Digg, no cookie read).
 
-The `setup` run extracts cookies (Firefox/Safari by default - never Chrome, to avoid a macOS Keychain prompt) and best-effort installs yt-dlp (YouTube) and the free, keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; Digg activates only when the binary is on the **agent subprocess PATH**, typically `$HOME/.local/bin`; setup reports honestly if installed off-PATH; recommend-only if `npx` is unavailable). Show the user what was found and installed - including whether Digg landed on PATH (active) or off-PATH (installed but not yet active).
+The consented `setup --allow-browser-cookies` run extracts cookies (Firefox/Safari by default - never Chrome, to avoid a macOS Keychain prompt, unless `FROM_BROWSER=auto` or a named Chromium browser was explicitly configured) and best-effort installs yt-dlp (YouTube) and the free, keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; Digg activates only when the binary is on the **agent subprocess PATH**, typically `$HOME/.local/bin`; setup reports honestly if installed off-PATH; recommend-only if `npx` is unavailable). Show the user what was found and installed - including whether Digg landed on PATH (active) or off-PATH (installed but not yet active).
 
 **macOS Full Disk Access remediation.** After the `setup` run, inspect its stderr. If it contains `Permission denied reading Cookies.binarycookies` and the platform is macOS, the OS blocked the read - surface the fix instead of swallowing it: `macOS blocked the cookie read. To enable X/Twitter: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry of the `setup` command. If the user skips, continue.
 
@@ -475,8 +475,8 @@ For hosts without interactive modal prompts (OpenClaw, Codex, Cursor, Gemini CLI
 
 **1. Welcome.** One short branded line, e.g.: `Welcome to /last30days - let me get you set up (about 30 seconds).`
 
-**2. Cookie consent (ask BEFORE reading anything).** First check if `BROWSER_CONSENT=true` already exists in `~/.config/last30days/.env` (e.g. granted in a prior Claude Code session); if so, skip this prompt and run `setup` directly. Otherwise ask. Example: `I can read your browser cookies (Firefox/Safari) to unlock X/Twitter and other logged-in sources. Want me to? (yes / no)` **Wait for the answer.**
-   - On **yes** → run `python3 skills/last30days/scripts/last30days.py setup` (and append `BROWSER_CONSENT=true` to `.env` after it completes). Extracts cookies (Firefox/Safari, never Chrome) and best-effort installs yt-dlp (YouTube) and the free, keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; activates only when on the agent subprocess PATH, typically `$HOME/.local/bin`; reports honestly if off-PATH; recommend-only if `npx` is unavailable).
+**2. Cookie consent (ask BEFORE reading anything).** First check if `BROWSER_CONSENT=true` already exists in `~/.config/last30days/.env` (e.g. granted in a prior Claude Code session); if so, skip this prompt and run `setup --allow-browser-cookies` directly. Otherwise ask. Example: `I can read your browser cookies (Firefox/Safari) to unlock X/Twitter and other logged-in sources. Want me to? (yes / no)` **Wait for the answer.**
+   - On **yes** → run `python3 skills/last30days/scripts/last30days.py setup --allow-browser-cookies` (and append `BROWSER_CONSENT=true` to `.env` after it completes). Extracts cookies (Firefox/Safari, never Chrome unless `FROM_BROWSER=auto` or a named Chromium browser was explicitly configured) and best-effort installs yt-dlp (YouTube) and the free, keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; activates only when on the agent subprocess PATH, typically `$HOME/.local/bin`; reports honestly if off-PATH; recommend-only if `npx` is unavailable).
    - On **no** → run `FROM_BROWSER=off python3 skills/last30days/scripts/last30days.py setup`. Skips all cookie reads; still installs yt-dlp and Digg, still writes `SETUP_COMPLETE`.
 
 **3. Full Disk Access remediation (macOS only).** After `setup`, inspect stderr. If it contains `Permission denied reading Cookies.binarycookies` on macOS, surface: `macOS blocked the cookie read. To enable X/Twitter: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry. If skipped, continue.
@@ -487,7 +487,7 @@ For hosts without interactive modal prompts (OpenClaw, Codex, Cursor, Gemini CLI
    - On **timeout / denied** → tell the user it didn't complete and offer to retry or skip.
    - On **no** → note they can run it later by asking to set up ScrapeCreators, then continue.
 
-**5. Complete.** Once `SETUP_COMPLETE=true` is written, briefly confirm which sources are now active (read the `setup --github` JSON `persisted` field, or re-run `--diagnose`) and proceed to research.
+**5. Complete.** Once `SETUP_COMPLETE=true` is written, briefly confirm which sources are now active (read the `setup --github` JSON `persisted` field, or re-run safe `--diagnose`) and proceed to research. For Codex desktop, Cursor, Gemini CLI, and raw folder-mode hosts, hidden `.claude/last30days.env` project config is ignored unless `LAST30DAYS_TRUST_PROJECT_CONFIG=1` is set from the process environment or global config; do not tell the user a project file is active unless diagnose reports it as the config source.
 
 ---
 
@@ -1978,7 +1978,7 @@ Want another prompt? Just tell me what you're creating next.
 - Sends search queries to Algolia HN Search API (`hn.algolia.com`) for Hacker News story and comment discovery (free, no auth)
 - Sends search queries to Polymarket Gamma API (`gamma-api.polymarket.com`) for prediction market discovery (free, no auth)
 - Runs `yt-dlp` locally for YouTube search and transcript extraction (no API key, public data)
-- Sends search queries to ScrapeCreators API (`api.scrapecreators.com`) for TikTok and Instagram search, transcript/caption extraction (PAYG after 100 free credits)
+- Sends search queries to ScrapeCreators API (`api.scrapecreators.com`) for TikTok and Instagram search, transcript/caption extraction (10,000 free calls, then PAYG)
 - Optionally sends search queries to Brave Search API, Parallel AI API, Perplexity API (`api.perplexity.ai`), or OpenRouter API for web search / synthesis
 - Fetches public Reddit thread data from `reddit.com` for engagement metrics
 - Stores research findings in local SQLite database (watchlist mode only)
@@ -1991,7 +1991,7 @@ Want another prompt? Just tell me what you're creating next.
 - Does not log, cache, or write API keys to output files
 - Does not send data to any endpoint not listed above
 - Hacker News and Polymarket sources are always available (no API key, no binary dependency)
-- TikTok and Instagram sources require SCRAPECREATORS_API_KEY (100 free credits one-time, then PAYG). Reddit uses ScrapeCreators only as a backup when public Reddit is unavailable.
+- TikTok and Instagram sources require SCRAPECREATORS_API_KEY (10,000 free calls, then PAYG). Reddit uses ScrapeCreators only as a backup when public Reddit is unavailable.
 - Can be invoked autonomously by agents via the Skill tool (runs inline, not forked); pass `--agent` for non-interactive report output
 
 **Bundled scripts:** `scripts/last30days.py` (main research engine), `scripts/lib/` (search, enrichment, rendering modules), `scripts/lib/vendor/bird-search/` (vendored X search client, MIT licensed)

--- a/skills/last30days/scripts/lib/ui.py
+++ b/skills/last30days/scripts/lib/ui.py
@@ -200,7 +200,7 @@ Just start with "last30" and talk to me like normal.
 
 # Shorter promo for single missing key
 PROMO_SINGLE_KEY = {
-    "reddit": "\n💡 Unlock TikTok and Instagram with SCRAPECREATORS_API_KEY - 100 free credits, no CC - scrapecreators.com\n",
+    "reddit": "\n💡 Unlock TikTok and Instagram with SCRAPECREATORS_API_KEY - 10,000 free calls, no CC - scrapecreators.com\n",
     "x": "\n💡 Unlock X: log into x.com in your browser, then re-run. "
          "Firefox works on all platforms. Safari works on macOS (detected automatically). "
          "Chrome, Brave, Edge, Arc, Vivaldi, Opera, or Chromium on macOS require "
@@ -214,7 +214,7 @@ BIRD_AUTH_HELP = f"""
 {Colors.YELLOW}Bird authentication failed.{Colors.RESET}
 
 To fix this:
-1. Add AUTH_TOKEN and CT0 to ~/.config/last30days/.env or .claude/last30days.env
+1. Add AUTH_TOKEN and CT0 to ~/.config/last30days/.env, or to trusted .claude/last30days.env with LAST30DAYS_TRUST_PROJECT_CONFIG=1
 2. Or set XAI_API_KEY for the xAI fallback backend
 """
 
@@ -222,7 +222,7 @@ BIRD_AUTH_HELP_PLAIN = """
 Bird authentication failed.
 
 To fix this:
-1. Add AUTH_TOKEN and CT0 to ~/.config/last30days/.env or .claude/last30days.env
+1. Add AUTH_TOKEN and CT0 to ~/.config/last30days/.env, or to trusted .claude/last30days.env with LAST30DAYS_TRUST_PROJECT_CONFIG=1
 2. Or set XAI_API_KEY for the xAI fallback backend
 """
 

--- a/tests/test_codex_host_contract.py
+++ b/tests/test_codex_host_contract.py
@@ -1,0 +1,37 @@
+"""Host-contract tests for non-modal agent runtimes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
+
+
+def _prose_flow() -> str:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    start = text.index("### Non-Modal Prose Flow")
+    end = text.index("### Manual Setup Guide", start)
+    return text[start:end]
+
+
+def test_non_modal_hosts_are_named():
+    prose = _prose_flow()
+    for host in ("Codex", "Cursor", "Gemini CLI", "raw CLI"):
+        assert host in prose
+
+
+def test_non_modal_cookie_consent_uses_engine_allow_flag():
+    prose = _prose_flow()
+    consent = prose.index("Cookie consent")
+    allow = prose.index("setup --allow-browser-cookies")
+    decline = prose.index("FROM_BROWSER=off")
+    assert consent < allow
+    assert consent < decline
+
+
+def test_non_modal_completion_mentions_safe_diagnose_and_project_trust():
+    prose = _prose_flow()
+    assert "safe `--diagnose`" in prose
+    assert "LAST30DAYS_TRUST_PROJECT_CONFIG=1" in prose
+    assert "Codex desktop" in prose

--- a/tests/test_codex_host_contract.py
+++ b/tests/test_codex_host_contract.py
@@ -10,8 +10,12 @@ SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
 
 def _prose_flow() -> str:
     text = SKILL_MD.read_text(encoding="utf-8")
-    start = text.index("### Non-Modal Prose Flow")
-    end = text.index("### Manual Setup Guide", start)
+    start_marker = "### Non-Modal Prose Flow"
+    end_marker = "### Manual Setup Guide"
+    start = text.find(start_marker)
+    assert start != -1, f"missing section marker: {start_marker}"
+    end = text.find(end_marker, start)
+    assert end != -1, f"missing section marker: {end_marker}"
     return text[start:end]
 
 

--- a/tests/test_doc_security_contract.py
+++ b/tests/test_doc_security_contract.py
@@ -1,0 +1,46 @@
+"""Security-copy contract tests for local reads and credential destinations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION = ROOT / "CONFIGURATION.md"
+SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
+UI_PY = ROOT / "skills" / "last30days" / "scripts" / "lib" / "ui.py"
+
+
+def test_cookie_setup_requires_explicit_allow_flag_in_docs():
+    config = CONFIGURATION.read_text(encoding="utf-8")
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    assert "setup --allow-browser-cookies" in config
+    assert "setup --allow-browser-cookies" in skill
+    assert "Unset = no browser-cookie reads" in config
+
+
+def test_project_config_trust_is_documented():
+    config = CONFIGURATION.read_text(encoding="utf-8")
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    assert "LAST30DAYS_TRUST_PROJECT_CONFIG=1" in config
+    assert "LAST30DAYS_TRUST_PROJECT_CONFIG=1" in skill
+    assert "Folder-mode hosts such as Codex desktop do not trust hidden project config by default" in config
+
+
+def test_codex_auth_not_advertised_as_openai_fallback():
+    config = CONFIGURATION.read_text(encoding="utf-8")
+    assert "Codex ChatGPT auth" in config
+    assert "intentionally not used" in config
+    assert "or Codex auth" not in config
+
+
+def test_scrapecreators_copy_uses_canonical_free_call_count():
+    text = "\n".join(
+        [
+            CONFIGURATION.read_text(encoding="utf-8"),
+            SKILL_MD.read_text(encoding="utf-8"),
+            UI_PY.read_text(encoding="utf-8"),
+        ]
+    )
+    assert "10,000 free calls" in text
+    assert "100 free credits" not in text
+    assert "1,000 free" not in text

--- a/tests/test_doc_security_contract.py
+++ b/tests/test_doc_security_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIGURATION = ROOT / "CONFIGURATION.md"
+README = ROOT / "README.md"
 SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
 UI_PY = ROOT / "skills" / "last30days" / "scripts" / "lib" / "ui.py"
 
@@ -37,6 +38,7 @@ def test_scrapecreators_copy_uses_canonical_free_call_count():
     text = "\n".join(
         [
             CONFIGURATION.read_text(encoding="utf-8"),
+            README.read_text(encoding="utf-8"),
             SKILL_MD.read_text(encoding="utf-8"),
             UI_PY.read_text(encoding="utf-8"),
         ]


### PR DESCRIPTION
## Summary

The runtime contract and user-facing docs now describe the engine safety behavior that shipped in the earlier stack: non-modal hosts use explicit cookie consent, Codex folder mode does not trust hidden project config by default, and stale Codex-auth / ScrapeCreators copy is corrected.

Doc contract tests now pin the host split, the cookie-allowing setup command, project-config trust language, and the canonical ScrapeCreators offer so future copy changes cannot drift back to unsafe or stale claims.

## Validation

- `uv run pytest tests/test_onboarding_contract.py tests/test_codex_host_contract.py tests/test_doc_flag_contract.py tests/test_doc_security_contract.py tests/test_plugin_contract.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
