### PR TITLE
Improve HTML brief handoff

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1853,7 +1853,7 @@ Close with `I have all the links to the {N} {source list} I pulled from. Just as
 
 - Read `references/save-html-brief.md` BEFORE proceeding to WAIT FOR USER'S RESPONSE
 - Follow that file's instructions exactly - it is the canonical source for the save flow
-- Append the confirmation line (`📎 Shareable brief saved to <path>`) to your already-emitted chat response
+- End with the artifact handoff defined there: saved HTML path, local open/view affordance when available, and a concise confirmation for explicit `--emit=html` / `--html` requests
 
 **You MUST NOT:**
 
@@ -1862,6 +1862,7 @@ Close with `I have all the links to the {N} {source list} I pulled from. Just as
 - Save to a different path than the reference specifies
 - Add data quality warnings, debug headers, or safety notes to the saved HTML
 - Re-research the topic for the HTML render - the engine cache covers the second invocation
+- Upload or publish the HTML anywhere public in this flow
 
 **Why the directive is forceful:** the reference file is the only source of truth for the save flow. Skipping it produces broken artifacts - wrong path conventions, missing synthesis content, leaked engine debug output, or warnings that don't belong in shareable docs.
 

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1842,10 +1842,10 @@ Close with `I have all the links to the {N} {source list} I pulled from. Just as
 
 ## SHAREABLE HTML BRIEF (when the user asked for one)
 
-**This section fires if EITHER trigger is true:**
+**This section fires if EITHER prompt-level trigger is true:**
 
-- `$ARGUMENTS` contains `--emit=html`, `--emit:html`, or `--html` as a flag
-- The user's natural-language request asks for an HTML brief, shareable doc, or file for sharing (Slack, email, Notion, "export as HTML", etc). Use your judgment for phrasing variants.
+- The user included an HTML-looking argument such as `--emit=html`, `--emit:html`, or `--html` in the skill prompt. Treat this as a strong user intent signal for HTML; do not confuse it with the complete Python CLI contract.
+- The user's natural-language request asks for an HTML brief, shareable doc, or file for sharing (Slack, email, Notion, "give it to me in HTML", "export as HTML", etc). Use your judgment for phrasing variants; a literal flag is not required.
 
 **If neither trigger fires, skip this entire section and proceed to WAIT FOR USER'S RESPONSE.** No HTML save flow, no reference read needed.
 
@@ -1853,7 +1853,7 @@ Close with `I have all the links to the {N} {source list} I pulled from. Just as
 
 - Read `references/save-html-brief.md` BEFORE proceeding to WAIT FOR USER'S RESPONSE
 - Follow that file's instructions exactly - it is the canonical source for the save flow
-- End with the artifact handoff defined there: saved HTML path, local open/view affordance when available, and a concise confirmation for explicit `--emit=html` / `--html` requests
+- End with the artifact handoff defined there: saved HTML path, open the local file when the host can do so, and a concise confirmation for requests where HTML is the requested deliverable
 
 **You MUST NOT:**
 

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -19,12 +19,15 @@ The contract has two modes:
 ```bash
 # 1. Write your synthesis prose VERBATIM to a temp file. The synthesis is the
 #    "What I learned:" prose label, the bold-lead-in paragraphs with their
-#    inline citations as you wrote them in chat, and the "KEY PATTERNS from
-#    the research:" numbered list. Do NOT include the badge or the engine
-#    footer in the temp file - the engine adds those when it renders the HTML.
-#    Use the EXACT text you just wrote in chat. Do not paraphrase, do not
-#    summarize, do not reorder. The HTML must read identically to the chat
-#    response in voice and citations.
+#    inline citations, and the "KEY PATTERNS from the research:" numbered list.
+#    Do NOT include the badge or the engine footer in the temp file - the engine
+#    adds those when it renders the HTML.
+#    - HTML-as-deliverable mode: use the exact synthesis draft you prepared for
+#      the artifact. Do not paste it to chat first.
+#    - Normal-report-plus-HTML mode: use the exact synthesis text you already
+#      wrote in chat.
+#    In both modes, do not paraphrase, summarize, or reorder. The HTML must read
+#    identically to the intended report in voice and citations.
 SYNTHESIS_FILE="/tmp/last30days-synthesis-${CLAUDE_SESSION_ID}.md"
 # >| not >: fixed path may already exist on a same-session re-run; a plain >
 # is refused under `set -o noclobber`.

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -2,11 +2,15 @@
 
 This reference file is loaded by the main `SKILL.md` when the user asked for an HTML brief (either explicitly via `--emit=html` / `--emit:html` / `--html`, or in natural language - "give me a shareable HTML brief", "for Slack", "for Notion", "export as HTML", etc.). The detection happens in `SKILL.md` so that the common no-HTML path stays short; the implementation lives here.
 
-The contract: the synthesis still appears in chat as the primary output. The HTML is an additional artifact saved to disk for sharing. Both happen in the same turn.
+The contract has two modes:
+
+- **Explicit HTML export** (`--emit=html`, `--emit:html`, or `--html`): the HTML artifact is the primary output. Write the synthesis to the temp file, render the HTML, then give a concise artifact handoff in chat instead of pasting the full Markdown report again.
+- **Normal report plus HTML copy** (the user asks in prose for an HTML brief while also expecting the report in chat): the synthesis still appears in chat as the primary output. The HTML is an additional artifact saved to disk for sharing. Both happen in the same turn.
 
 ## When to fire this flow
 
-- After you have already emitted the full chat response: badge, "What I learned:" (or comparison title), bold-lead-in paragraphs with citations, KEY PATTERNS list, engine footer pass-through, invitation block.
+- For normal-report-plus-HTML mode: after you have already emitted the full chat response: badge, "What I learned:" (or comparison title), bold-lead-in paragraphs with citations, KEY PATTERNS list, engine footer pass-through, invitation block.
+- For explicit-HTML-export mode: after you have drafted the synthesis that will go into the HTML, before emitting the final chat response.
 - BEFORE the WAIT FOR USER'S RESPONSE pause.
 - ONLY if the user asked. Do NOT save HTML when the user didn't ask for it.
 
@@ -66,11 +70,49 @@ fi
 #    For a scoped --hiring-signals brief, --hiring-signals MUST be here too so
 #    the footer reflects the jobs-scoped board, not a generic crawl.
 
-# 3. Append ONE line to your already-emitted chat response, after the
-#    invitation block. Use a paperclip emoji as a visible signal that an
-#    artifact was produced:
-echo "📎 Shareable brief saved to $HTML_PATH"
+# 3. Finish with the artifact handoff described below.
+printf '📎 Shareable brief saved to %s\n' "$HTML_PATH"
 ```
+
+## Chat handoff after saving
+
+Use the mode that matches the request.
+
+### Explicit HTML export
+
+When the user explicitly supplied `--emit=html`, `--emit:html`, or `--html`, do **not** paste the full Markdown report back into chat after saving the artifact. The user asked for a file; repeating the Markdown makes the run feel like a normal report with an attachment bolted on.
+
+Respond with a concise handoff:
+
+```text
+🌐 last30days v{VERSION} · synced {YYYY-MM-DD}
+
+📎 Shareable brief saved to <absolute HTML path>
+
+Open it locally:
+- macOS: `open "<absolute HTML path>"`
+- Linux: `xdg-open "<absolute HTML path>"`
+- Windows: `start "" "<absolute HTML path>"`
+
+I saved the full HTML brief locally. It is not uploaded or published anywhere.
+```
+
+If the host can safely open local files for the user and doing so matches the user's request, run the local open command after the file is written, leave the saved-path line in chat, and add `Opened locally.` If the command fails or the host is headless, do not treat that as a failed report; show the path and manual open command.
+
+### Normal report plus HTML copy
+
+When the user asked for a normal `/last30days` report and also asked for an HTML copy, keep the full chat synthesis and append this artifact block after the invitation:
+
+```text
+📎 Shareable brief saved to <absolute HTML path>
+
+Open it locally:
+- macOS: `open "<absolute HTML path>"`
+- Linux: `xdg-open "<absolute HTML path>"`
+- Windows: `start "" "<absolute HTML path>"`
+```
+
+Do not offer public publishing or upload in this flow. Hosted sharing is a separate opt-in capability and must not happen automatically.
 
 ## What ends up in the HTML file
 
@@ -91,7 +133,7 @@ Same flow when the topic is `X vs Y` (or `X vs Y vs Z`). The engine routes throu
 
 ## Follow-up turn
 
-If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, and THEN says "save that as HTML" or "give me a shareable version" in a follow-up turn, do the same save flow on the synthesis you wrote in the previous turn. Do not re-research; the synthesis is already in the conversation history. Just write it to the temp file and call the engine with `--emit=html --synthesis-file`.
+If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, and THEN says "save that as HTML" or "give me a shareable version" in a follow-up turn, do the same save flow on the synthesis you wrote in the previous turn. Do not re-research; the synthesis is already in the conversation history. Just write it to the temp file and call the engine with `--emit=html --synthesis-file`, then use the normal-report-plus-HTML artifact block.
 
 ## What NOT to do
 
@@ -99,8 +141,8 @@ If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, an
 - Do NOT add content to the temp file beyond your synthesis prose. The badge / footer / colophon come from the engine.
 - Do NOT change the file path convention. `${LAST30DAYS_MEMORY_DIR}/${SLUG}-brief.html` is the canonical location.
 - Do NOT silently overwrite an existing file. The `--emit=html` output is written via a shell redirect (`>| "$HTML_PATH"`), which OVERWRITES the collision-guarded path — use `>|` not `>` because `set -o noclobber` refuses plain `>` when the file already exists. The collision guard in step 2 handles same-topic re-runs: if `{slug}-brief.html` already exists it date-suffixes to `{slug}-brief-YYYY-MM-DD.html`. Always print whichever path the redirect actually used.
-
 - Do NOT include the data quality warning text in the temp file or in your final chat line. Warnings are an engine-stderr concern, not an artifact concern.
+- Do NOT publish, upload, or send the HTML to a third-party service. This reference only saves and opens local files.
 
 ## Edge cases
 

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -1,16 +1,16 @@
 # Save shareable HTML brief
 
-This reference file is loaded by the main `SKILL.md` when the user asked for an HTML brief (either explicitly via `--emit=html` / `--emit:html` / `--html`, or in natural language - "give me a shareable HTML brief", "for Slack", "for Notion", "export as HTML", etc.). The detection happens in `SKILL.md` so that the common no-HTML path stays short; the implementation lives here.
+This reference file is loaded by the main `SKILL.md` when the user asked for an HTML brief (either through an HTML-looking prompt argument like `--emit=html` / `--emit:html` / `--html`, or in natural language - "give me a shareable HTML brief", "give it to me in HTML", "for Slack", "for Notion", "export as HTML", etc.). The detection happens in `SKILL.md` so that the common no-HTML path stays short; the implementation lives here. Those prompt arguments are user intent signals for the skill; they are not the full Python CLI contract.
 
 The contract has two modes:
 
-- **Explicit HTML export** (`--emit=html`, `--emit:html`, or `--html`): the HTML artifact is the primary output. Write the synthesis to the temp file, render the HTML, then give a concise artifact handoff in chat instead of pasting the full Markdown report again.
-- **Normal report plus HTML copy** (the user asks in prose for an HTML brief while also expecting the report in chat): the synthesis still appears in chat as the primary output. The HTML is an additional artifact saved to disk for sharing. Both happen in the same turn.
+- **HTML as the requested deliverable** (`--emit=html`, `--emit:html`, `--html`, or prose like "give it to me in HTML"): the HTML artifact is the primary output. Write the synthesis to the temp file, render the HTML, then give a concise artifact handoff in chat instead of pasting the full Markdown report again.
+- **Normal report plus HTML copy** (the user asks for the normal report and also wants an HTML copy): the synthesis still appears in chat as the primary output. The HTML is an additional artifact saved to disk for sharing. Both happen in the same turn.
 
 ## When to fire this flow
 
 - For normal-report-plus-HTML mode: after you have already emitted the full chat response: badge, "What I learned:" (or comparison title), bold-lead-in paragraphs with citations, KEY PATTERNS list, engine footer pass-through, invitation block.
-- For explicit-HTML-export mode: after you have drafted the synthesis that will go into the HTML, before emitting the final chat response.
+- For HTML-as-deliverable mode: after you have drafted the synthesis that will go into the HTML, before emitting the final chat response.
 - BEFORE the WAIT FOR USER'S RESPONSE pause.
 - ONLY if the user asked. Do NOT save HTML when the user didn't ask for it.
 
@@ -78,9 +78,9 @@ printf '📎 Shareable brief saved to %s\n' "$HTML_PATH"
 
 Use the mode that matches the request.
 
-### Explicit HTML export
+### HTML as the requested deliverable
 
-When the user explicitly supplied `--emit=html`, `--emit:html`, or `--html`, do **not** paste the full Markdown report back into chat after saving the artifact. The user asked for a file; repeating the Markdown makes the run feel like a normal report with an attachment bolted on.
+When HTML is the requested deliverable - whether by `--emit=html`, `--emit:html`, `--html`, or natural-language phrasing - do **not** paste the full Markdown report back into chat after saving the artifact. The user asked for an HTML deliverable; repeating the Markdown makes the run feel like a normal report with an attachment bolted on.
 
 Respond with a concise handoff:
 
@@ -89,15 +89,10 @@ Respond with a concise handoff:
 
 📎 Shareable brief saved to <absolute HTML path>
 
-Open it locally:
-- macOS: `open "<absolute HTML path>"`
-- Linux: `xdg-open "<absolute HTML path>"`
-- Windows: `start "" "<absolute HTML path>"`
-
 I saved the full HTML brief locally. It is not uploaded or published anywhere.
 ```
 
-If the host can safely open local files for the user and doing so matches the user's request, run the local open command after the file is written, leave the saved-path line in chat, and add `Opened locally.` If the command fails or the host is headless, do not treat that as a failed report; show the path and manual open command.
+If the host can safely open local files for the user and doing so matches the user's request, open the HTML file after it is written, leave the saved-path line in chat, and add `Opened locally.` Let the host choose the correct OS-specific mechanism; do not print a menu of shell commands. If opening fails or the host is headless, do not treat that as a failed report; show the path and say the file is ready to open in a browser.
 
 ### Normal report plus HTML copy
 
@@ -105,14 +100,9 @@ When the user asked for a normal `/last30days` report and also asked for an HTML
 
 ```text
 📎 Shareable brief saved to <absolute HTML path>
-
-Open it locally:
-- macOS: `open "<absolute HTML path>"`
-- Linux: `xdg-open "<absolute HTML path>"`
-- Windows: `start "" "<absolute HTML path>"`
 ```
 
-Do not offer public publishing or upload in this flow. Hosted sharing is a separate opt-in capability and must not happen automatically.
+If the host can safely open local files, open it for the user when that matches the request; otherwise the saved-path line is enough. Do not offer public publishing or upload in this flow. Hosted sharing is a separate opt-in capability and must not happen automatically.
 
 ## What ends up in the HTML file
 

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -73,8 +73,9 @@ fi
 #    For a scoped --hiring-signals brief, --hiring-signals MUST be here too so
 #    the footer reflects the jobs-scoped board, not a generic crawl.
 
-# 3. Finish with the artifact handoff described below.
-printf '📎 Shareable brief saved to %s\n' "$HTML_PATH"
+# 3. Finish with the artifact handoff described below. Do not print the saved
+#    path from the shell block; the chat handoff is the single user-visible
+#    completion message.
 ```
 
 ## Chat handoff after saving

--- a/skills/last30days/references/save-html-brief.md
+++ b/skills/last30days/references/save-html-brief.md
@@ -127,14 +127,16 @@ Same flow when the topic is `X vs Y` (or `X vs Y vs Z`). The engine routes throu
 
 ## Follow-up turn
 
-If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, and THEN says "save that as HTML" or "give me a shareable version" in a follow-up turn, do the same save flow on the synthesis you wrote in the previous turn. Do not re-research; the synthesis is already in the conversation history. Just write it to the temp file and call the engine with `--emit=html --synthesis-file`, then use the normal-report-plus-HTML artifact block.
+If the user runs `/last30days OpenClaw` normally, sees the synthesis in chat, and THEN explicitly refers back to that visible synthesis ("save that as HTML", "make this shareable", "turn the above into HTML"), do the same save flow on the synthesis you wrote in the previous turn. Do not re-research; the synthesis is already in the conversation history. Just write it to the temp file and call the engine with `--emit=html --synthesis-file`, then use the normal-report-plus-HTML artifact block.
+
+If the follow-up instead asks for a new HTML deliverable ("give it to me in HTML", `--emit=html`, `--html`) rather than referring back to an already-visible report, treat it as HTML-as-deliverable mode.
 
 ## What NOT to do
 
 - Do NOT save HTML if the user didn't ask. The sparse mode (no synthesis) produces a thin file; not useful as a shareable.
 - Do NOT add content to the temp file beyond your synthesis prose. The badge / footer / colophon come from the engine.
 - Do NOT change the file path convention. `${LAST30DAYS_MEMORY_DIR}/${SLUG}-brief.html` is the canonical location.
-- Do NOT silently overwrite an existing file. The `--emit=html` output is written via a shell redirect (`>| "$HTML_PATH"`), which OVERWRITES the collision-guarded path — use `>|` not `>` because `set -o noclobber` refuses plain `>` when the file already exists. The collision guard in step 2 handles same-topic re-runs: if `{slug}-brief.html` already exists it date-suffixes to `{slug}-brief-YYYY-MM-DD.html`. Always print whichever path the redirect actually used.
+- Do NOT silently overwrite an existing file. The `--emit=html` output is written via a shell redirect (`>| "$HTML_PATH"`), which OVERWRITES the collision-guarded path — use `>|` not `>` because `set -o noclobber` refuses plain `>` when the file already exists. The collision guard in step 2 handles same-topic re-runs: if `{slug}-brief.html` already exists it date-suffixes to `{slug}-brief-YYYY-MM-DD.html`. Always report whichever path the redirect actually used in the chat handoff.
 - Do NOT include the data quality warning text in the temp file or in your final chat line. Warnings are an engine-stderr concern, not an artifact concern.
 - Do NOT publish, upload, or send the HTML to a third-party service. This reference only saves and opens local files.
 

--- a/tests/test_html_save_contract.py
+++ b/tests/test_html_save_contract.py
@@ -27,6 +27,8 @@ def test_html_deliverable_is_artifact_first_not_full_markdown_repeat():
     assert "**HTML as the requested deliverable**" in text
     assert 'prose like "give it to me in HTML"' in text
     assert "the HTML artifact is the primary output" in text
+    assert "use the exact synthesis draft you prepared for" in text
+    assert "Do not paste it to chat first" in text
     assert "do **not** paste the full Markdown report back into chat" in text
     assert "The user asked for an HTML deliverable" in text
 

--- a/tests/test_html_save_contract.py
+++ b/tests/test_html_save_contract.py
@@ -15,28 +15,29 @@ def test_skill_routes_html_to_reference_and_artifact_handoff():
 
     assert "Read `references/save-html-brief.md`" in section
     assert "artifact handoff" in section
-    assert "local open/view affordance" in section
+    assert "open the local file when the host can do so" in section
     assert "Upload or publish" in section
     assert "Append the confirmation line" not in section
+    assert "a literal flag is not required" in section
+    assert "do not confuse it with the complete Python CLI contract" in section
 
 
-def test_explicit_html_export_is_artifact_first_not_full_markdown_repeat():
+def test_html_deliverable_is_artifact_first_not_full_markdown_repeat():
     text = SAVE_HTML.read_text(encoding="utf-8")
-    assert "**Explicit HTML export**" in text
+    assert "**HTML as the requested deliverable**" in text
+    assert 'prose like "give it to me in HTML"' in text
     assert "the HTML artifact is the primary output" in text
     assert "do **not** paste the full Markdown report back into chat" in text
-    assert "The user asked for a file" in text
+    assert "The user asked for an HTML deliverable" in text
 
 
-def test_html_handoff_includes_local_open_commands_without_requiring_success():
+def test_html_handoff_opens_locally_without_os_command_menu():
     text = SAVE_HTML.read_text(encoding="utf-8")
-    for snippet in [
-        'open "<absolute HTML path>"',
-        'xdg-open "<absolute HTML path>"',
-        'start "" "<absolute HTML path>"',
-        "If the command fails or the host is headless",
-    ]:
-        assert snippet in text
+    assert "Let the host choose the correct OS-specific mechanism" in text
+    assert "do not print a menu of shell commands" in text
+    assert "If opening fails or the host is headless" in text
+    assert 'xdg-open "<absolute HTML path>"' not in text
+    assert 'start "" "<absolute HTML path>"' not in text
 
 
 def test_html_save_flow_does_not_publish_or_upload():

--- a/tests/test_html_save_contract.py
+++ b/tests/test_html_save_contract.py
@@ -1,0 +1,45 @@
+"""Contract tests for the /last30days HTML save handoff."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = ROOT / "skills" / "last30days" / "SKILL.md"
+SAVE_HTML = ROOT / "skills" / "last30days" / "references" / "save-html-brief.md"
+
+
+def test_skill_routes_html_to_reference_and_artifact_handoff():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    start = text.index("## SHAREABLE HTML BRIEF")
+    end = text.index("## WAIT FOR USER'S RESPONSE", start)
+    section = text[start:end]
+
+    assert "Read `references/save-html-brief.md`" in section
+    assert "artifact handoff" in section
+    assert "local open/view affordance" in section
+    assert "Upload or publish" in section
+    assert "Append the confirmation line" not in section
+
+
+def test_explicit_html_export_is_artifact_first_not_full_markdown_repeat():
+    text = SAVE_HTML.read_text(encoding="utf-8")
+    assert "**Explicit HTML export**" in text
+    assert "the HTML artifact is the primary output" in text
+    assert "do **not** paste the full Markdown report back into chat" in text
+    assert "The user asked for a file" in text
+
+
+def test_html_handoff_includes_local_open_commands_without_requiring_success():
+    text = SAVE_HTML.read_text(encoding="utf-8")
+    for snippet in [
+        'open "<absolute HTML path>"',
+        'xdg-open "<absolute HTML path>"',
+        'start "" "<absolute HTML path>"',
+        "If the command fails or the host is headless",
+    ]:
+        assert snippet in text
+
+
+def test_html_save_flow_does_not_publish_or_upload():
+    text = SAVE_HTML.read_text(encoding="utf-8")
+    assert "Do not offer public publishing or upload in this flow" in text
+    assert "Do NOT publish, upload, or send the HTML to a third-party service" in text

--- a/tests/test_html_save_contract.py
+++ b/tests/test_html_save_contract.py
@@ -29,6 +29,8 @@ def test_html_deliverable_is_artifact_first_not_full_markdown_repeat():
     assert "the HTML artifact is the primary output" in text
     assert "use the exact synthesis draft you prepared for" in text
     assert "Do not paste it to chat first" in text
+    assert "the chat handoff is the single user-visible" in text
+    assert "printf '📎 Shareable brief saved to %s\\n'" not in text
     assert "do **not** paste the full Markdown report back into chat" in text
     assert "The user asked for an HTML deliverable" in text
 

--- a/tests/test_html_save_contract.py
+++ b/tests/test_html_save_contract.py
@@ -31,6 +31,7 @@ def test_html_deliverable_is_artifact_first_not_full_markdown_repeat():
     assert "Do not paste it to chat first" in text
     assert "the chat handoff is the single user-visible" in text
     assert "printf '📎 Shareable brief saved to %s\\n'" not in text
+    assert 'echo "📎 Shareable brief saved to $HTML_PATH"' not in text
     assert "do **not** paste the full Markdown report back into chat" in text
     assert "The user asked for an HTML deliverable" in text
 
@@ -48,3 +49,10 @@ def test_html_save_flow_does_not_publish_or_upload():
     text = SAVE_HTML.read_text(encoding="utf-8")
     assert "Do not offer public publishing or upload in this flow" in text
     assert "Do NOT publish, upload, or send the HTML to a third-party service" in text
+
+
+def test_follow_up_turn_preserves_html_deliverable_mode():
+    text = SAVE_HTML.read_text(encoding="utf-8")
+    assert "explicitly refers back to that visible synthesis" in text
+    assert "treat it as HTML-as-deliverable mode" in text
+    assert "Always report whichever path the redirect actually used in the chat handoff" in text


### PR DESCRIPTION
## Summary
- distinguish explicit HTML export from normal report plus HTML copy
- add local open/view handoff instructions for saved HTML briefs
- lock the HTML save contract with focused tests

## PR boundary
PR1 only: local HTML completion UX. No publishing, cache architecture, host invocation, source-quality, or comparison artifact changes.

## Tests
- uv run pytest tests/test_html_save_contract.py tests/test_doc_flag_contract.py tests/test_onboarding_contract.py