### PR TITLE
Clarify host-native search setup

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -251,7 +251,7 @@ When you invoke `/last30days` from Claude Code, Codex, or Gemini, the host model
 
 The search-source preference ladder, strict best-to-floor:
 
-1. **Host-native search** - Claude Code's `WebSearch`, and the equivalents on Codex / Gemini. Best results; used automatically on hosts that have it. Signalled to the engine via `LAST30DAYS_NATIVE_SEARCH=1` (the skill sets this for you when your host has a native search tool) so the engine does not run a worse search underneath it.
+1. **Host-native search** - Claude Code's deferred `WebSearch` after `ToolSearch select:WebSearch`, or the native equivalents already exposed on Codex / Gemini. Best results; used automatically on hosts that have it. A failed schema lookup is not fatal on hosts such as Codex when another native search tool is already available. Signalled to the engine via `LAST30DAYS_NATIVE_SEARCH=1` (the skill sets this for you when your host has a native search tool) so the engine does not run a worse search underneath it.
 2. **Paid engine backend** - one of `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`, auto-detected in that order. Override per-run with `--web-backend=<name>`.
 3. **Keyless engine floor** - zero-key web search (DuckDuckGo, plus an optional SearXNG instance) and zero-key page fetch (Jina Reader). Runs only when the host has **no** native search **and** no paid key is set, so headless/cron and hosts without a built-in search tool still get general-web coverage. Force it explicitly with `--web-backend=keyless`.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -251,15 +251,15 @@ When you invoke `/last30days` from Claude Code, Codex, or Gemini, the host model
 
 The search-source preference ladder, strict best-to-floor:
 
-1. **Host-native search** - Claude Code's deferred `WebSearch` after `ToolSearch select:WebSearch`, or the native equivalents already exposed on Codex / Gemini. Best results; used automatically on hosts that have it. A failed schema lookup is not fatal on hosts such as Codex when another native search tool is already available. Signalled to the engine via `LAST30DAYS_NATIVE_SEARCH=1` (the skill sets this for you when your host has a native search tool) so the engine does not run a worse search underneath it.
+1. **Host web search** - whatever web-search capability the agent session already has: built-in search, a deferred web-search tool that must be loaded first, or an installed connector such as Brave, Firecrawl, Exa, Serper, or another provider. Best results; used automatically on hosts that have it. A failed lookup for one specific tool name is not fatal when another web-search capability is available. Signalled to the engine via `LAST30DAYS_NATIVE_SEARCH=1` (the skill sets this for you when your agent session has web search) so the engine does not run a worse search underneath it.
 2. **Paid engine backend** - one of `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`, auto-detected in that order. Override per-run with `--web-backend=<name>`.
-3. **Keyless engine floor** - zero-key web search (DuckDuckGo, plus an optional SearXNG instance) and zero-key page fetch (Jina Reader). Runs only when the host has **no** native search **and** no paid key is set, so headless/cron and hosts without a built-in search tool still get general-web coverage. Force it explicitly with `--web-backend=keyless`.
+3. **Keyless engine floor** - zero-key web search (DuckDuckGo, plus an optional SearXNG instance) and zero-key page fetch (Jina Reader). Runs only when the agent session has **no** host web search **and** no paid key is set, so headless/cron and hosts without a search tool still get general-web coverage. Force it explicitly with `--web-backend=keyless`.
 
 Relevant env vars:
 
 | Var | Effect |
 | --- | --- |
-| `LAST30DAYS_NATIVE_SEARCH=1` | Tells the engine your host has native search; suppresses the keyless floor. Set automatically by the skill on capable hosts. Leave unset on hosts without a native search tool so the floor runs. |
+| `LAST30DAYS_NATIVE_SEARCH=1` | Tells the engine your agent session has host-side web search; suppresses the keyless floor. Set automatically by the skill when web search is available. Leave unset when the agent has no web-search tool so the floor runs. |
 | `LAST30DAYS_SEARXNG_URL=<base-url>` | Optional. A SearXNG instance used as the keyless-search fallback rung when DuckDuckGo returns nothing. |
 
 Privacy note: the keyless floor sends the query (to DuckDuckGo / your SearXNG instance) and any fetched URL (to Jina Reader) to those third parties. It is intended for public-research use; results may be cached snapshots. It never runs when native search or a paid backend is in play.

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -222,17 +222,29 @@ End of OUTPUT CONTRACT. The laws above are the contract; everything below is imp
 
 # HOW TO INVOKE THIS SKILL (READ FIRST, FOLLOW EVERY TIME)
 
-**STEP 0 - LOAD WEBSEARCH FIRST.** Your literal first tool call on every `/last30days` invocation MUST be:
+**STEP 0 - RESOLVE HOST-NATIVE SEARCH FIRST.** Your first action on every `/last30days` invocation is to determine whether this host has a native web-search tool and load it when the host requires a schema-selection step.
 
-```
-ToolSearch select:WebSearch
-```
+Use this capability matrix:
 
-WebSearch is a **deferred tool** in Claude Code v2.1.114. The frontmatter of this file authorizes it (`allowed-tools: ... WebSearch`) but the runtime lists it as "schemas are NOT loaded." Calling WebSearch without `ToolSearch select:WebSearch` first will fail or do nothing. That friction is the documented cause of the second-most-common failure mode of this skill: the model sees "WebSearch is there but deferred," takes the low-friction path, skips Step 0.5 and 0.55, and runs the engine bare with only keyword search. The output looks fine but misses founder X timelines, GitHub repo activity, and subreddit-specific threads.
+- **Claude Code with deferred WebSearch:** your literal first tool call MUST be:
 
-Load WebSearch first. No exceptions. Then run the first-run gate below before anything else.
+  ```text
+  ToolSearch select:WebSearch
+  ```
 
-**FIRST-RUN GATE — run this Bash command immediately after loading WebSearch, before reading the topic or doing any research:**
+  WebSearch is a deferred tool in Claude Code v2.1.114. The frontmatter authorizes it (`allowed-tools: ... WebSearch`) but the runtime can list schemas as "not loaded." Calling WebSearch without selecting it first may fail or do nothing.
+
+- **Codex / Gemini / hosts with a native web-search tool already exposed:** use that native web-search tool for Step 0.5 / 0.55 pre-research and Step 2 supplements. Do **not** treat a failed or empty `ToolSearch select:WebSearch` lookup as fatal when a native search tool is already available in the host. On Codex, for example, `tool_search` may not return a `WebSearch` schema even though the session has native web search.
+
+- **Hosts with no native web-search tool:** skip Step 0.55 and Step 0.75, and add `--auto-resolve` to the engine command. The engine will use configured web backends (`BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`) or the keyless floor when available.
+
+When native search is available, export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell as the engine invocation so the engine does not also run the lower-quality keyless web floor. Leave it unset on hosts without native search.
+
+Resolving this correctly prevents the second-most-common failure mode of this skill: the model skips Step 0.5 / 0.55 and runs the engine bare with only keyword search. The output looks fine but misses founder X timelines, GitHub repo activity, subreddit-specific threads, and current first-party positioning.
+
+After resolving host-native search, run the first-run gate below before anything else.
+
+**FIRST-RUN GATE — run this Bash command immediately after resolving host-native search, before reading the topic or doing any research:**
 
 ```bash
 grep -q "SETUP_COMPLETE=true" ~/.config/last30days/.env 2>/dev/null && echo "1" || echo "FIRST_RUN_DETECTED"

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -222,29 +222,21 @@ End of OUTPUT CONTRACT. The laws above are the contract; everything below is imp
 
 # HOW TO INVOKE THIS SKILL (READ FIRST, FOLLOW EVERY TIME)
 
-**STEP 0 - RESOLVE HOST-NATIVE SEARCH FIRST.** Your first action on every `/last30days` invocation is to determine whether this host has a native web-search tool and load it when the host requires a schema-selection step.
+**STEP 0 - RESOLVE HOST WEB SEARCH FIRST.** Your first action on every `/last30days` invocation is to determine whether this agent session has a usable web-search tool. Most agent harnesses do: it may be built in, exposed as a deferred tool, or provided by an installed connector such as Brave, Firecrawl, Exa, Serper, or another search provider.
 
-Use this capability matrix:
+Use this capability rule:
 
-- **Claude Code with deferred WebSearch:** your literal first tool call MUST be:
+- **If a web-search tool is available:** use it for Step 0.5 / 0.55 pre-research and Step 2 supplements. If your host requires loading, selecting, or enabling the web-search tool before use, do that using the host's mechanism. Do not fail the skill just because one particular schema lookup or tool name is unavailable; use the web-search capability you actually have.
 
-  ```text
-  ToolSearch select:WebSearch
-  ```
+- **If no web-search tool is available in the agent session:** skip Step 0.55 and Step 0.75, and add `--auto-resolve` to the engine command. The engine will use configured web backends (`BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`) or the keyless floor when available.
 
-  WebSearch is a deferred tool in Claude Code v2.1.114. The frontmatter authorizes it (`allowed-tools: ... WebSearch`) but the runtime can list schemas as "not loaded." Calling WebSearch without selecting it first may fail or do nothing.
-
-- **Codex / Gemini / hosts with a native web-search tool already exposed:** use that native web-search tool for Step 0.5 / 0.55 pre-research and Step 2 supplements. Do **not** treat a failed or empty `ToolSearch select:WebSearch` lookup as fatal when a native search tool is already available in the host. On Codex, for example, `tool_search` may not return a `WebSearch` schema even though the session has native web search.
-
-- **Hosts with no native web-search tool:** skip Step 0.55 and Step 0.75, and add `--auto-resolve` to the engine command. The engine will use configured web backends (`BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY`) or the keyless floor when available.
-
-When native search is available, export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell as the engine invocation so the engine does not also run the lower-quality keyless web floor. Leave it unset on hosts without native search.
+When host web search is available, export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell as the engine invocation so the engine does not also run the lower-quality keyless web floor. Leave it unset when the agent session has no web-search tool.
 
 Resolving this correctly prevents the second-most-common failure mode of this skill: the model skips Step 0.5 / 0.55 and runs the engine bare with only keyword search. The output looks fine but misses founder X timelines, GitHub repo activity, subreddit-specific threads, and current first-party positioning.
 
-After resolving host-native search, run the first-run gate below before anything else.
+After resolving host web search, run the first-run gate below before anything else.
 
-**FIRST-RUN GATE — run this Bash command immediately after resolving host-native search, before reading the topic or doing any research:**
+**FIRST-RUN GATE — run this Bash command immediately after resolving host web search, before reading the topic or doing any research:**
 
 ```bash
 grep -q "SETUP_COMPLETE=true" ~/.config/last30days/.env 2>/dev/null && echo "1" || echo "FIRST_RUN_DETECTED"
@@ -362,13 +354,13 @@ If the preflight script emits `ERROR: last30days v3 requires Python 3.12+` (or `
 
 WebSearch-only synthesis is not equivalent to running the engine — it misses Reddit community data, X/Twitter timelines, YouTube transcripts, TikTok, and Polymarket. Presenting it without disclosure misleads the user about what was actually searched. This is the same category of failure as a WebSearch-only run with no engine footer.
 
-**Native-search signal (web coverage).** If you (the hosting model) have your own web-search tool available — e.g. Claude Code's `WebSearch`, which STEP 0 loads — export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell before invoking the engine:
+**Native-search signal (web coverage).** If you (the hosting model) have your own web-search tool available, export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell before invoking the engine:
 
 ```bash
 export LAST30DAYS_NATIVE_SEARCH=1   # ONLY when you have a native web-search tool
 ```
 
-Your native search is better than the engine's keyless web fallback, so this tells the engine to skip that fallback and leave general web to you (you already run WebSearch supplements in Step 2). If you have NO native web-search tool (some non-Claude hosts and headless/cron paths), do **not** set this: the engine's keyless web floor supplies general-web coverage automatically. The rule is capability-based, not host-name-based — set it only when you genuinely have a better search, never to suppress the floor on a host that has nothing else.
+Your host search is better than the engine's keyless web fallback, so this tells the engine to skip that fallback and leave general web to you (you already run web-search supplements in Step 2). If you have NO web-search tool in the agent session, do **not** set this: the engine's keyless web floor supplies general-web coverage automatically. The rule is capability-based, not host-name-based — set it only when you genuinely have a better search, never to suppress the floor on a host that has nothing else.
 
 ## Configuration
 

--- a/tests/test_codex_host_contract.py
+++ b/tests/test_codex_host_contract.py
@@ -39,3 +39,31 @@ def test_non_modal_completion_mentions_safe_diagnose_and_project_trust():
     assert "safe `--diagnose`" in prose
     assert "LAST30DAYS_TRUST_PROJECT_CONFIG=1" in prose
     assert "Codex desktop" in prose
+
+
+def _step0_search_contract() -> str:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    start_marker = "**STEP 0 - RESOLVE HOST-NATIVE SEARCH FIRST.**"
+    end_marker = "**FIRST-RUN GATE"
+    start = text.find(start_marker)
+    assert start != -1, f"missing section marker: {start_marker}"
+    end = text.find(end_marker, start)
+    assert end != -1, f"missing section marker: {end_marker}"
+    return text[start:end]
+
+
+def test_codex_native_search_does_not_require_deferred_websearch_schema():
+    step0 = _step0_search_contract()
+    assert "Claude Code with deferred WebSearch" in step0
+    assert "ToolSearch select:WebSearch" in step0
+    assert "Codex / Gemini / hosts with a native web-search tool already exposed" in step0
+    assert "Do **not** treat a failed or empty `ToolSearch select:WebSearch` lookup as fatal" in step0
+    assert "Codex" in step0 and "native web search" in step0
+
+
+def test_no_native_search_hosts_use_auto_resolve_and_leave_native_signal_unset():
+    step0 = _step0_search_contract()
+    assert "Hosts with no native web-search tool" in step0
+    assert "--auto-resolve" in step0
+    assert "LAST30DAYS_NATIVE_SEARCH=1" in step0
+    assert "Leave it unset on hosts without native search" in step0

--- a/tests/test_codex_host_contract.py
+++ b/tests/test_codex_host_contract.py
@@ -43,7 +43,7 @@ def test_non_modal_completion_mentions_safe_diagnose_and_project_trust():
 
 def _step0_search_contract() -> str:
     text = SKILL_MD.read_text(encoding="utf-8")
-    start_marker = "**STEP 0 - RESOLVE HOST-NATIVE SEARCH FIRST.**"
+    start_marker = "**STEP 0 - RESOLVE HOST WEB SEARCH FIRST.**"
     end_marker = "**FIRST-RUN GATE"
     start = text.find(start_marker)
     assert start != -1, f"missing section marker: {start_marker}"
@@ -52,18 +52,18 @@ def _step0_search_contract() -> str:
     return text[start:end]
 
 
-def test_codex_native_search_does_not_require_deferred_websearch_schema():
+def test_host_web_search_uses_available_capability_not_specific_tool_name():
     step0 = _step0_search_contract()
-    assert "Claude Code with deferred WebSearch" in step0
-    assert "ToolSearch select:WebSearch" in step0
-    assert "Codex / Gemini / hosts with a native web-search tool already exposed" in step0
-    assert "Do **not** treat a failed or empty `ToolSearch select:WebSearch` lookup as fatal" in step0
-    assert "Codex" in step0 and "native web search" in step0
+    assert "usable web-search tool" in step0
+    assert "built in, exposed as a deferred tool, or provided by an installed connector" in step0
+    assert "Brave, Firecrawl, Exa, Serper" in step0
+    assert "If your host requires loading, selecting, or enabling the web-search tool" in step0
+    assert "Do not fail the skill just because one particular schema lookup or tool name is unavailable" in step0
 
 
-def test_no_native_search_hosts_use_auto_resolve_and_leave_native_signal_unset():
+def test_no_host_search_uses_auto_resolve_and_leaves_native_signal_unset():
     step0 = _step0_search_contract()
-    assert "Hosts with no native web-search tool" in step0
+    assert "If no web-search tool is available in the agent session" in step0
     assert "--auto-resolve" in step0
     assert "LAST30DAYS_NATIVE_SEARCH=1" in step0
-    assert "Leave it unset on hosts without native search" in step0
+    assert "Leave it unset when the agent session has no web-search tool" in step0


### PR DESCRIPTION
## Summary
- replace the Claude-only WebSearch setup with a capability matrix
- document Codex/Gemini native search behavior and no-native-search --auto-resolve fallback
- update configuration docs and host contract tests

## PR boundary
PR2 only: host-aware invocation contract. No HTML behavior, source-quality fixes, engine cache changes, or comparison artifact changes.

## Tests
- uv run pytest tests/test_codex_host_contract.py tests/test_runtime_preflight_contract.py tests/test_onboarding_contract.py