### PR TITLE
Clarify degraded YouTube quality nudges

### DIFF
--- a/skills/last30days/scripts/lib/quality_nudge.py
+++ b/skills/last30days/scripts/lib/quality_nudge.py
@@ -40,13 +40,25 @@ def _has_x_credentials(config: dict) -> bool:
     )
 
 
-def _is_youtube_active(config: dict, research_results: dict) -> bool:
-    """Check if YouTube source is active (yt-dlp installed)."""
+def _has_ytdlp() -> bool:
+    """Return True when the local/free YouTube lane is available."""
     try:
         from . import youtube_yt
-        has_ytdlp = youtube_yt.is_ytdlp_installed()
+        return bool(youtube_yt.is_ytdlp_installed())
     except Exception:
-        has_ytdlp = False
+        return False
+
+
+def _youtube_returned_data(research_results: dict) -> bool:
+    """Return True when YouTube produced usable items through any provider."""
+    videos = int(research_results.get("youtube_videos_count") or 0)
+    transcripts = int(research_results.get("youtube_transcripts_count") or 0)
+    return videos > 0 or transcripts > 0
+
+
+def _is_youtube_active(config: dict, research_results: dict) -> bool:
+    """Check if YouTube source is active (yt-dlp installed)."""
+    has_ytdlp = _has_ytdlp()
     if not has_ytdlp:
         return False
     if research_results.get("youtube_error"):
@@ -139,7 +151,8 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
         research_results: Dict with keys like x_error, youtube_error,
             reddit_error reflecting what happened this run. Optional keys
             ``youtube_videos_count`` and ``youtube_transcripts_count`` enable
-            degraded-YouTube detection (transcript-fetch ratio below threshold).
+            degraded-YouTube detection (transcript-fetch ratio below threshold,
+            or fallback/provider data returned without local yt-dlp).
             Optional key ``instagram_items_count`` enables silent-failure
             detection for the bonus Instagram source.
 
@@ -176,6 +189,8 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
 
     # YouTube
     yt_active = _is_youtube_active(config, research_results)
+    has_ytdlp = _has_ytdlp()
+    youtube_returned_data = _youtube_returned_data(research_results)
     if yt_active:
         core_active.append("youtube")
         # Active means yt-dlp is installed and search did not error at the top
@@ -185,14 +200,17 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
         threshold = float(config.get("DEGRADED_TRANSCRIPT_THRESHOLD") or DEFAULT_DEGRADED_TRANSCRIPT_THRESHOLD)
         if _is_youtube_degraded(research_results, threshold):
             core_degraded.append("youtube")
+    elif youtube_returned_data and not research_results.get("youtube_error"):
+        # YouTube produced data through a fallback/provider lane even though the
+        # local free yt-dlp lane is unavailable. Count the source as present,
+        # but surface it as degraded so users do not see the contradictory
+        # "Missing: YouTube" ending after a report with YouTube evidence.
+        core_active.append("youtube")
+        if not has_ytdlp:
+            core_degraded.append("youtube")
     else:
         core_missing.append("youtube")
         # Check if configured but errored (yt-dlp installed but failed this run)
-        try:
-            from . import youtube_yt
-            has_ytdlp = youtube_yt.is_ytdlp_installed()
-        except Exception:
-            has_ytdlp = False
         if has_ytdlp and research_results.get("youtube_error"):
             core_errored.append("youtube")
 
@@ -298,20 +316,29 @@ def _build_nudge_text(
         videos = int(research_results.get("youtube_videos_count") or 0)
         transcripts = int(research_results.get("youtube_transcripts_count") or 0)
         captions_disabled = int(research_results.get("youtube_captions_disabled_count") or 0)
-        captions_note = ""
-        if captions_disabled > 0:
-            captions_note = (
-                f" ({captions_disabled} of those had captions disabled by the "
-                "uploader, which is a separate cause and not fixable on your end)"
+        if not _has_ytdlp() and _youtube_returned_data(research_results):
+            free_suggestions.append(
+                f"YouTube returned {videos} videos and {transcripts} transcripts "
+                "through a fallback/provider path, but local yt-dlp is not "
+                "installed. Install yt-dlp to enable the free local YouTube lane "
+                "and reduce reliance on fallback providers: brew install yt-dlp "
+                "(macOS), scoop install yt-dlp (Windows), or pip install -U yt-dlp."
             )
-        free_suggestions.append(
-            f"YouTube returned {videos} videos but only {transcripts} transcripts "
-            f"captured{captions_note}. The most common remaining cause is a stale "
-            "yt-dlp binary - YouTube's caption format changes frequently and old "
-            "binaries silently fail every transcript. Update via your package "
-            "manager: scoop update yt-dlp (Windows), brew upgrade yt-dlp (macOS), "
-            "or pip install -U yt-dlp."
-        )
+        else:
+            captions_note = ""
+            if captions_disabled > 0:
+                captions_note = (
+                    f" ({captions_disabled} of those had captions disabled by the "
+                    "uploader, which is a separate cause and not fixable on your end)"
+                )
+            free_suggestions.append(
+                f"YouTube returned {videos} videos but only {transcripts} transcripts "
+                f"captured{captions_note}. The most common remaining cause is a stale "
+                "yt-dlp binary - YouTube's caption format changes frequently and old "
+                "binaries silently fail every transcript. Update via your package "
+                "manager: scoop update yt-dlp (Windows), brew upgrade yt-dlp (macOS), "
+                "or pip install -U yt-dlp."
+            )
 
     if "instagram" in bonus_errored:
         free_suggestions.append(

--- a/skills/last30days/scripts/lib/quality_nudge.py
+++ b/skills/last30days/scripts/lib/quality_nudge.py
@@ -56,9 +56,8 @@ def _youtube_returned_data(research_results: dict) -> bool:
     return videos > 0 or transcripts > 0
 
 
-def _is_youtube_active(config: dict, research_results: dict) -> bool:
+def _is_youtube_active(config: dict, research_results: dict, *, has_ytdlp: bool) -> bool:
     """Check if YouTube source is active (yt-dlp installed)."""
-    has_ytdlp = _has_ytdlp()
     if not has_ytdlp:
         return False
     if research_results.get("youtube_error"):
@@ -188,8 +187,8 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
             core_errored.append("x")
 
     # YouTube
-    yt_active = _is_youtube_active(config, research_results)
     has_ytdlp = _has_ytdlp()
+    yt_active = _is_youtube_active(config, research_results, has_ytdlp=has_ytdlp)
     youtube_returned_data = _youtube_returned_data(research_results)
     if yt_active:
         core_active.append("youtube")
@@ -205,9 +204,10 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
         # local free yt-dlp lane is unavailable. Count the source as present,
         # but surface it as degraded so users do not see the contradictory
         # "Missing: YouTube" ending after a report with YouTube evidence.
+        # has_ytdlp is provably False here: yt_active is False and youtube_error
+        # is excluded by this guard, leaving unavailable yt-dlp as the cause.
         core_active.append("youtube")
-        if not has_ytdlp:
-            core_degraded.append("youtube")
+        core_degraded.append("youtube")
     else:
         core_missing.append("youtube")
         # Check if configured but errored (yt-dlp installed but failed this run)
@@ -231,6 +231,7 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
         has_sc=has_sc,
         active_sources=active_sources,
         bonus_errored=bonus_errored,
+        has_ytdlp=has_ytdlp,
     ) if (core_missing or core_degraded or bonus_errored) else None
 
     return {
@@ -252,6 +253,7 @@ def _build_nudge_text(
     has_sc: bool = False,
     active_sources: list = None,
     bonus_errored: List[str] = None,
+    has_ytdlp: bool = False,
 ) -> str:
     """Build human-readable nudge text describing what was missed or degraded.
 
@@ -316,7 +318,7 @@ def _build_nudge_text(
         videos = int(research_results.get("youtube_videos_count") or 0)
         transcripts = int(research_results.get("youtube_transcripts_count") or 0)
         captions_disabled = int(research_results.get("youtube_captions_disabled_count") or 0)
-        if not _has_ytdlp() and _youtube_returned_data(research_results):
+        if not has_ytdlp and _youtube_returned_data(research_results):
             free_suggestions.append(
                 f"YouTube returned {videos} videos and {transcripts} transcripts "
                 "through a fallback/provider path, but local yt-dlp is not "

--- a/tests/test_quality_nudge.py
+++ b/tests/test_quality_nudge.py
@@ -184,6 +184,47 @@ class TestSCDoesNotAffectCoreScore:
         assert "XQUIK_API_KEY" in q["nudge_text"]
 
 
+class TestYouTubeFallbackProvider:
+    """YouTube data from fallback/provider paths is degraded, not missing."""
+
+    def test_fallback_youtube_data_without_ytdlp_counts_active_not_missing(self):
+        q = _compute(
+            config_overrides={
+                "AUTH_TOKEN": "tok123",
+                "SCRAPECREATORS_API_KEY": "sc_key",
+            },
+            ytdlp_installed=False,
+            result_overrides={
+                "youtube_videos_count": 5,
+                "youtube_transcripts_count": 4,
+            },
+        )
+        assert q["score_pct"] == 100
+        assert "youtube" in q["core_active"]
+        assert "youtube" not in q["core_missing"]
+        assert "youtube" in q["core_degraded"]
+        assert q["nudge_text"] is not None
+        assert "Missing: YouTube" not in q["nudge_text"]
+        assert "Degraded: YouTube" in q["nudge_text"]
+        assert "fallback/provider" in q["nudge_text"]
+        assert "local yt-dlp is not installed" in q["nudge_text"]
+        assert "stale yt-dlp" not in q["nudge_text"].lower()
+
+    def test_no_fallback_data_without_ytdlp_still_missing(self):
+        q = _compute(
+            config_overrides={"SCRAPECREATORS_API_KEY": "sc_key"},
+            ytdlp_installed=False,
+            result_overrides={
+                "youtube_videos_count": 0,
+                "youtube_transcripts_count": 0,
+            },
+        )
+        assert "youtube" in q["core_missing"]
+        assert "youtube" not in q["core_active"]
+        assert "youtube" not in q["core_degraded"]
+        assert "Missing: X/Twitter, YouTube" in q["nudge_text"]
+
+
 class TestDisclaimerAlwaysPresent:
     """Nudge always includes no-affiliate disclaimer when present."""
 

--- a/tests/test_quality_nudge.py
+++ b/tests/test_quality_nudge.py
@@ -210,6 +210,21 @@ class TestYouTubeFallbackProvider:
         assert "local yt-dlp is not installed" in q["nudge_text"]
         assert "stale yt-dlp" not in q["nudge_text"].lower()
 
+    def test_ytdlp_install_check_runs_once_per_score(self):
+        from lib.quality_nudge import compute_quality_score
+        from lib import youtube_yt
+
+        with patch.object(youtube_yt, "is_ytdlp_installed", return_value=False) as ytdlp_check:
+            compute_quality_score(
+                _base_config(AUTH_TOKEN="tok123"),
+                _base_results(
+                    youtube_videos_count=5,
+                    youtube_transcripts_count=4,
+                ),
+            )
+
+        ytdlp_check.assert_called_once()
+
     def test_no_fallback_data_without_ytdlp_still_missing(self):
         q = _compute(
             config_overrides={"SCRAPECREATORS_API_KEY": "sc_key"},


### PR DESCRIPTION
## Summary
- count YouTube as active when fallback/provider data is present without local yt-dlp
- mark that case as degraded instead of missing, with provider-specific fix text
- add regression tests for fallback YouTube data vs true no-data missing state

## Tests
- uv run pytest tests/test_quality_nudge.py tests/test_check_config_ytdlp_detection.py tests/test_youtube_backfill.py

## Boundary
This PR is intentionally limited to source-quality nudge accuracy. It does not change HTML artifact handoff, host invocation instructions, comparison saves, cache reuse, or hosted publishing.