### PR TITLE
Clarify comparison artifact paths

### DIFF
--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -845,8 +845,9 @@ When the user asks "X vs Y" (or "X vs Y vs Z"), the engine fans out N full `pipe
 **MANDATORY per-entity resolution.** For each entity, resolve the full Step 0.55 stack (X handle, subreddits, GitHub user/repos, news context). Then assemble a `--competitors-plan` JSON mapping each entity to its targeting, and invoke the engine ONCE with the vs-topic string.
 
 **Output shape per run:**
-- Main topic saves to `{main-slug}-raw.md`.
-- Each peer saves to `{peer-slug}-raw.md`.
+- For `--emit=compact` / `--emit=md`, there is no separate merged Markdown raw file. The main topic saves to `{main-slug}-raw.md`; each peer saves to `{peer-slug}-raw.md`.
+- For `--emit=html`, the main saved artifact is the merged comparison HTML at `{main-slug}-vs-{peer-slug}-raw-html[...].html`; each peer may also save its own per-entity HTML artifact.
+- The engine logs every written file as `[last30days] Saved output to {path}` and, for comparison runs, follows with `[last30days] Comparison artifact set: main={path}; peers={path, ...}`. Treat that log line as authoritative instead of recomputing paths from slugs.
 - Stdout shows a merged comparison with the `## Head-to-Head` scaffold + per-entity Resolved Entities block.
 
 **Invocation:**
@@ -931,7 +932,7 @@ Topic A (the main topic, first in the vs-string) uses outer `--x-handle`, `--x-r
 
 **Engine-internal auto-resolve (headless fallback):** if the engine detects BRAVE_API_KEY / EXA_API_KEY / SERPER_API_KEY / PARALLEL_API_KEY / PERPLEXITY_API_KEY / OPENROUTER_API_KEY, it runs its own per-entity `resolve.auto_resolve()` before each sub-run. The hosting-model path does NOT need those keys — you are the WebSearch. The engine's auto-resolve is the cron/CI fallback for when no reasoning model is driving.
 
-**Output:** one `{slug}-raw.md` per entity in `--save-dir` plus the merged comparison on stdout. Synthesis contract identical to the vs-mode protocol above.
+**Output:** for Markdown/compact runs, one `{slug}-raw.md` per entity in `--save-dir` plus the merged comparison on stdout. For HTML runs, the main saved artifact is merged comparison HTML and peer artifacts remain per-entity. Always use the `[last30days] Comparison artifact set: main=...; peers=...` log line as the source of truth. Synthesis contract identical to the vs-mode protocol above.
 
 ### Hiring Signals mode (`--hiring-signals`)
 
@@ -1329,7 +1330,9 @@ For ALL query types:
 
 **Instructions:**
 1. Read the saved raw file. Locate it via the engine's `[last30days] Saved output to {path}` log line, not a hardcoded path.
-2. Append a `## WebSearch Supplemental Results` section at the end.
+   - **Single-topic runs:** append to the one Markdown raw file shown by the saved-output log.
+   - **Comparison runs:** locate the `[last30days] Comparison artifact set: main=...; peers=...` line. For compact/Markdown runs, append the same `## WebSearch Supplemental Results` section to every listed per-entity Markdown raw file, because the comparison synthesis draws from all of them and there is no separate merged Markdown raw file. For HTML/JSON-only artifacts, do not append Markdown text to `.html` or `.json`; keep the appendix in the Markdown raw artifacts from the source run.
+2. Append a `## WebSearch Supplemental Results` section at the end of each target Markdown raw file.
 3. For each WebSearch result, include one bullet in the canonical format (see Format example below).
 4. Write the updated file back.
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -1212,6 +1212,7 @@ def main() -> int:
             rendered_content=rendered if is_comparison_html else None,
         )
         sys.stderr.write(f"[last30days] Saved output to {save_path}\n")
+        comparison_peer_paths: list[Path] = []
         # Competitor / vs-mode: also save a per-entity raw file for each peer.
         # Matches historical vs-mode behavior (N passes → N save files).
         if entity_reports and len(entity_reports) > 1:
@@ -1221,7 +1222,13 @@ def main() -> int:
                     suffix=args.save_suffix or "",
                     synthesis_md=synthesis_md,
                 )
+                comparison_peer_paths.append(peer_path)
                 sys.stderr.write(f"[last30days] Saved output to {peer_path}\n")
+            peers_display = ", ".join(str(path) for path in comparison_peer_paths)
+            sys.stderr.write(
+                f"[last30days] Comparison artifact set: main={save_path}; "
+                f"peers={peers_display}\n"
+            )
         sys.stderr.flush()
     print(rendered)
     return 0

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -473,6 +473,10 @@ class CliV3Tests(unittest.TestCase):
             )
             self.assertIn(f"[last30days] Saved output to {output_path.resolve()}", stderr.getvalue())
             self.assertIn(f"[last30days] Saved output to {comparison_saved.resolve()}", stderr.getvalue())
+            self.assertIn(
+                f"[last30days] Comparison artifact set: main={comparison_saved.resolve()};",
+                stderr.getvalue(),
+            )
 
     def test_main_canonicalizes_explicit_github_repo_flags(self):
         report = self.make_report()

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -17,9 +17,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class CliV3Tests(unittest.TestCase):
-    def make_report(self) -> schema.Report:
+    def make_report(self, topic: str = "OpenClaw vs NanoClaw") -> schema.Report:
         return schema.Report(
-            topic="OpenClaw vs NanoClaw",
+            topic=topic,
             range_from="2026-02-14",
             range_to="2026-03-16",
             generated_at="2026-03-16T00:00:00+00:00",
@@ -32,12 +32,12 @@ class CliV3Tests(unittest.TestCase):
                 intent="comparison",
                 freshness_mode="balanced_recent",
                 cluster_mode="debate",
-                raw_topic="OpenClaw vs NanoClaw",
+                raw_topic=topic,
                 subqueries=[
                     schema.SubQuery(
                         label="primary",
-                        search_query="openclaw vs nanoclaw",
-                        ranking_query="How does OpenClaw compare to NanoClaw?",
+                        search_query=topic.lower(),
+                        ranking_query=f"What are people saying about {topic}?",
                         sources=["grounding"],
                     )
                 ],
@@ -421,7 +421,6 @@ class CliV3Tests(unittest.TestCase):
             self.assertIn(f"[last30days] Saved output to {output_path.resolve()}", stderr.getvalue())
 
     def test_main_combines_output_and_save_dir_for_comparison_html(self):
-        report = self.make_report()
         diag = {
             "available_sources": ["grounding"],
             "providers": {"google": True, "openai": False, "xai": False},
@@ -432,12 +431,16 @@ class CliV3Tests(unittest.TestCase):
             "native_web_backend": "brave",
         }
         fake_progress = mock.Mock()
+
+        def run_report(*_args, **kwargs):
+            return self.make_report(topic=kwargs["topic"])
+
         with tempfile.TemporaryDirectory() as tmp:
             output_path = Path(tmp) / "exports" / "comparison.html"
             save_dir = Path(tmp) / "saved"
             with mock.patch.object(cli.env, "get_config", return_value={}), \
                  mock.patch.object(cli.pipeline, "diagnose", return_value=diag), \
-                 mock.patch.object(cli.pipeline, "run", return_value=report), \
+                 mock.patch.object(cli.pipeline, "run", side_effect=run_report), \
                  mock.patch.object(cli.ui, "ProgressDisplay", return_value=fake_progress), \
                  mock.patch.object(
                      cli, "emit_comparison_output", return_value="<html>comparison</html>"
@@ -471,10 +474,14 @@ class CliV3Tests(unittest.TestCase):
                 "<html>comparison</html>",
                 comparison_saved.read_text(encoding="utf-8"),
             )
+            peer_saved = save_dir / "beta-raw-html.html"
+            self.assertEqual("<html>peer</html>", peer_saved.read_text(encoding="utf-8"))
             self.assertIn(f"[last30days] Saved output to {output_path.resolve()}", stderr.getvalue())
             self.assertIn(f"[last30days] Saved output to {comparison_saved.resolve()}", stderr.getvalue())
+            self.assertIn(f"[last30days] Saved output to {peer_saved.resolve()}", stderr.getvalue())
             self.assertIn(
-                f"[last30days] Comparison artifact set: main={comparison_saved.resolve()};",
+                f"[last30days] Comparison artifact set: main={comparison_saved.resolve()}; "
+                f"peers={peer_saved.resolve()}",
                 stderr.getvalue(),
             )
 

--- a/tests/test_doc_flag_contract.py
+++ b/tests/test_doc_flag_contract.py
@@ -41,3 +41,17 @@ def test_agent_is_documented_as_skill_argument_not_python_flag():
     agent_section = text[start:start + 2000]
     assert "If `--agent` appears in ARGUMENTS" in agent_section
     assert "Skill tool" in text
+
+
+def test_comparison_artifact_contract_documents_actual_paths():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    comparison_start = text.index("\n## If QUERY_TYPE = COMPARISON\n")
+    comparison_section = text[comparison_start:comparison_start + 5000]
+    assert "there is no separate merged Markdown raw file" in comparison_section
+    assert "[last30days] Comparison artifact set: main={path}; peers={path, ...}" in comparison_section
+    assert "Treat that log line as authoritative" in comparison_section
+
+    step_start = text.index("## Step 2.5: Append WebSearch Results to Saved Raw File")
+    step_section = text[step_start:step_start + 3500]
+    assert "append the same `## WebSearch Supplemental Results` section to every listed per-entity Markdown raw file" in step_section
+    assert "do not append Markdown text to `.html` or `.json`" in step_section

--- a/tests/test_save_raw_per_entity.py
+++ b/tests/test_save_raw_per_entity.py
@@ -46,6 +46,17 @@ class PerEntitySaveFilesTests(unittest.TestCase):
         self.assertIn("drake-raw.md", names)
         self.assertIn("kendrick-lamar-raw.md", names)
 
+    def test_vs_mode_logs_authoritative_artifact_set(self):
+        result, save_dir = self._run(topic="Kanye West vs Drake")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        expected_main = (save_dir / "kanye-west-raw.md").resolve()
+        expected_peer = (save_dir / "drake-raw.md").resolve()
+        self.assertIn(
+            f"[last30days] Comparison artifact set: main={expected_main}; "
+            f"peers={expected_peer}",
+            result.stderr,
+        )
+
     def test_competitors_list_produces_per_entity_files(self):
         result, save_dir = self._run(
             "--competitors-list", "Anthropic,xAI",


### PR DESCRIPTION
## Summary
- add an authoritative comparison artifact-set stderr line after per-entity saves
- document Markdown vs HTML comparison artifact shapes in SKILL.md
- clarify Step 2.5 so comparison WebSearch appendices target every per-entity Markdown raw file, not guessed paths

## Tests
- uv run pytest tests/test_save_raw_per_entity.py tests/test_render_comparison_multi.py tests/test_competitor_subrun_isolation.py tests/test_html_render.py tests/test_cli_v3.py tests/test_doc_flag_contract.py

## Boundary
This PR is intentionally limited to comparison artifact fidelity. It does not change HTML cache reuse, hosted publishing, host invocation setup, or source-quality wording.