### PR TITLE
Add Codex plugin manifest

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "last30days",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "url",
+        "url": "https://github.com/mvanhorn/last30days-skill.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,49 @@
+{
+  "name": "last30days",
+  "version": "3.8.1",
+  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and the web.",
+  "author": {
+    "name": "Matt Van Horn",
+    "email": "mvanhorn@gmail.com",
+    "url": "https://github.com/mvanhorn"
+  },
+  "homepage": "https://github.com/mvanhorn/last30days-skill",
+  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "reddit",
+    "twitter",
+    "youtube",
+    "tiktok",
+    "instagram",
+    "trends",
+    "prompts",
+    "polymarket",
+    "github",
+    "perplexity",
+    "threads",
+    "pinterest",
+    "eli5",
+    "hacker-news"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "last30days",
+    "shortDescription": "Research what people are saying about a topic now.",
+    "longDescription": "last30days adds a Codex skill for researching recent discussion and engagement signals across social, video, developer, prediction-market, and web sources.",
+    "developerName": "Matt Van Horn",
+    "category": "Research",
+    "capabilities": [
+      "Research",
+      "Web"
+    ],
+    "websiteURL": "https://github.com/mvanhorn/last30days-skill",
+    "defaultPrompt": [
+      "/last30days OpenAI Codex",
+      "/last30days AI video tools",
+      "/last30days react user complaints"
+    ],
+    "brandColor": "#6F42C1"
+  }
+}

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -372,9 +372,10 @@ The skill is built to flex around different client environments. Four patterns t
 
 **Codex note:** the repository includes `.codex-plugin/plugin.json` so Codex can treat the existing
 `skills/last30days/SKILL.md` tree as plugin metadata without maintaining a separate Codex copy.
-The supported Codex install path remains the Agent Skills install command documented in the README;
-native Codex plugin marketplace installation should only be documented once root-repository plugin
-sources are supported by the released Codex CLI.
+The Codex marketplace catalog points at the repository root URL, matching the root-native plugin
+layout used by Compound Engineering: Codex clones the repo, reads the root `.codex-plugin/plugin.json`,
+and loads skills from `./skills/`. The Agent Skills install command documented in the README remains
+the broadest cross-host path.
 
 ### 1. Trusted per-client `.claude/last30days.env`
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -372,10 +372,9 @@ The skill is built to flex around different client environments. Four patterns t
 
 **Codex note:** the repository includes `.codex-plugin/plugin.json` so Codex can treat the existing
 `skills/last30days/SKILL.md` tree as plugin metadata without maintaining a separate Codex copy.
-The Codex marketplace catalog points at the repository root URL, matching the root-native plugin
-layout used by Compound Engineering: Codex clones the repo, reads the root `.codex-plugin/plugin.json`,
-and loads skills from `./skills/`. The Agent Skills install command documented in the README remains
-the broadest cross-host path.
+The Codex marketplace catalog points at the repository root URL: Codex clones the repo, reads the
+root `.codex-plugin/plugin.json`, and loads skills from `./skills/`. The Agent Skills install
+command documented in the README remains the broadest cross-host path.
 
 ### 1. Trusted per-client `.claude/last30days.env`
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -370,6 +370,12 @@ The schedule field stored on each topic is metadata - the actual cron / Task Sch
 
 The skill is built to flex around different client environments. Four patterns that compose well:
 
+**Codex note:** the repository includes `.codex-plugin/plugin.json` so Codex can treat the existing
+`skills/last30days/SKILL.md` tree as plugin metadata without maintaining a separate Codex copy.
+The supported Codex install path remains the Agent Skills install command documented in the README;
+native Codex plugin marketplace installation should only be documented once root-repository plugin
+sources are supported by the released Codex CLI.
+
 ### 1. Trusted per-client `.claude/last30days.env`
 
 When each client has its own working directory, drop a `.claude/last30days.env` into the client folder and opt in with `LAST30DAYS_TRUST_PROJECT_CONFIG=1` from your shell or global `~/.config/last30days/.env`. The skill loads the project file only after that trust signal. Typical contents:

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -36,7 +36,13 @@ class TestPluginContract(unittest.TestCase):
         self.assertEqual("last30days-skill", marketplace["name"])
         self.assertIn("last30days", plugin_by_name)
         plugin = plugin_by_name["last30days"]
-        self.assertEqual("./", plugin["source"]["path"])
+        self.assertEqual(
+            {
+                "source": "url",
+                "url": "https://github.com/mvanhorn/last30days-skill.git",
+            },
+            plugin["source"],
+        )
 
     def test_versions_match_across_manifests(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -31,11 +31,12 @@ class TestPluginContract(unittest.TestCase):
     def test_codex_marketplace_points_at_repo_root_plugin(self) -> None:
         marketplace = _json(ROOT / ".agents" / "plugins" / "marketplace.json")
         plugins = marketplace.get("plugins") or []
+        plugin_by_name = {plugin["name"]: plugin for plugin in plugins}
 
         self.assertEqual("last30days-skill", marketplace["name"])
-        self.assertEqual(1, len(plugins))
-        self.assertEqual("last30days", plugins[0]["name"])
-        self.assertEqual("./", plugins[0]["source"]["path"])
+        self.assertIn("last30days", plugin_by_name)
+        plugin = plugin_by_name["last30days"]
+        self.assertEqual("./", plugin["source"]["path"])
 
     def test_versions_match_across_manifests(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -21,11 +21,21 @@ def _skill_version() -> str:
 
 
 class TestPluginContract(unittest.TestCase):
-    def test_codex_plugin_scaffold_stays_removed(self) -> None:
-        # .codex-plugin/ was removed in the resolver-collapse refactor; Codex users
-        # install via `npx skills add` or `~/.codex/skills/`. A reintroduction would
-        # silently fork the install surface.
-        self.assertFalse((ROOT / ".codex-plugin").exists())
+    def test_codex_plugin_manifest_uses_repo_skill_root(self) -> None:
+        manifest = _json(ROOT / ".codex-plugin" / "plugin.json")
+
+        self.assertEqual("last30days", manifest["name"])
+        self.assertEqual("./skills/", manifest["skills"])
+        self.assertEqual("last30days", manifest["interface"]["displayName"])
+
+    def test_codex_marketplace_points_at_repo_root_plugin(self) -> None:
+        marketplace = _json(ROOT / ".agents" / "plugins" / "marketplace.json")
+        plugins = marketplace.get("plugins") or []
+
+        self.assertEqual("last30days-skill", marketplace["name"])
+        self.assertEqual(1, len(plugins))
+        self.assertEqual("last30days", plugins[0]["name"])
+        self.assertEqual("./", plugins[0]["source"]["path"])
 
     def test_versions_match_across_manifests(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -33,6 +43,7 @@ class TestPluginContract(unittest.TestCase):
 
         self.assertEqual(version, _skill_version())
         self.assertEqual(version, _json(ROOT / ".claude-plugin" / "plugin.json")["version"])
+        self.assertEqual(version, _json(ROOT / ".codex-plugin" / "plugin.json")["version"])
         self.assertEqual(version, _json(ROOT / "gemini-extension.json")["version"])
 
         marketplace = _json(ROOT / ".claude-plugin" / "marketplace.json")


### PR DESCRIPTION
## Summary

Adds native Codex plugin metadata for the existing `/last30days` skill without copying or moving the runtime skill tree.

This intentionally reintroduces `.codex-plugin/` as metadata only; it does not create a separate Codex skill tree, so Codex and Agent Skills continue to use the same `skills/last30days/SKILL.md`.

## Changes

- Add `.codex-plugin/plugin.json` at the repository root, pointing Codex at the existing `./skills/` directory.
- Update `.agents/plugins/marketplace.json` to use the public Git repository URL as the plugin source, so Codex can clone the repo root and load the root `.codex-plugin/plugin.json` for non-local installs.
- Replace the old "Codex plugin scaffold stays removed" guard with contract checks that keep the Codex manifest tied to the repo-root skill and current package version.
- Add a contract check that the Codex marketplace entry remains a repo URL source instead of a local-checkout-only path.
- Add a `CONFIGURATION.md` note explaining the root-plugin flow while keeping the README's Agent Skills install path as the broadest cross-host path.

## Testing

- [x] Ran `PYTHONPATH=/Users/rfoust/Documents/Codex/2026-06-24/inst/work/pydeps python3 /Users/rfoust/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/rfoust/Documents/Codex/2026-06-24/inst/work/last30days-skill`
- [x] Ran `PYTHONPATH=skills/last30days/scripts python3 -m unittest tests.test_plugin_contract`
- [x] Ran `uv run pytest tests/test_plugin_contract.py`
- [x] Ran `jq . .agents/plugins/marketplace.json .codex-plugin/plugin.json`
- [x] Ran `git diff --check`
- [x] GitHub Actions checks passed on the pushed branch

Note: I could not rerun the system `validate_plugin.py` script in this local checkout because that script's Python runtime is missing `yaml`; the focused contract test, JSON validation, diff check, and GitHub Actions are green.

## Related Issues

- Relates to native Codex plugin compatibility.
