### PR TITLE
fix: auto-remediate .env secrets permissions instead of warning (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `_check_file_permissions` now auto-fixes the `.env` secrets file permissions (`chmod 600`) instead of only printing a warning, preventing secret exfiltration on shared machines ([#573](https://github.com/mvanhorn/last30days-skill/issues/573))
 - Firefox profile detection on Linux now checks `$XDG_CONFIG_HOME/mozilla/firefox` (or its default `~/.config/mozilla/firefox`) in addition to `~/.mozilla/firefox`, fixing cookie extraction on distros that honour the XDG Base Directory Specification ([#667](https://github.com/mvanhorn/last30days-skill/issues/667))
 
 ## [3.8.1] - 2026-06-22

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -126,9 +126,9 @@ def _check_file_permissions(path: Path) -> None:
         mode = path.stat().st_mode
         # Check if group or other can read (bits 0o044)
         if mode & 0o044:
+            os.chmod(path, 0o600)
             sys.stderr.write(
-                f"[last30days] WARNING: {path} is readable by other users. "
-                f"Run: chmod 600 {path}\n"
+                f"[last30days] Fixed permissions on {path} (chmod 600)\n"
             )
             sys.stderr.flush()
     except OSError as exc:


### PR DESCRIPTION
The `.env` secrets file (`XAI_API_KEY`, `SCRAPECREATORS_API_KEY`, X session cookies) was created with world-readable permissions (0o644) on Linux/macOS. The engine detected this and warned the user to run `chmod 600` manually, but never fixed the permissions itself.

**Changes**
- `_check_file_permissions()` in `env.py` now calls `os.chmod(path, 0o600)` when it detects loose permissions, instead of just printing a warning.

Closes #573.