### PR TITLE
fix: guard os.killpg on Windows with AttributeError catch (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `bird_x.py` / `subproc.py` — `os.killpg(os.getpgid(...))` timeout handler on Windows now falls through safely to `proc.kill()` instead of crashing with `AttributeError` ([#91](https://github.com/mvanhorn/last30days-skill/issues/91))
+
 ## [3.3.2] - 2026-06-06
 
 ### Fixed

--- a/skills/last30days/scripts/lib/subproc.py
+++ b/skills/last30days/scripts/lib/subproc.py
@@ -82,7 +82,7 @@ def run_with_timeout(
     except subprocess.TimeoutExpired:
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        except (ProcessLookupError, PermissionError, OSError):
+        except (ProcessLookupError, PermissionError, OSError, AttributeError):
             proc.kill()
         proc.wait(timeout=5)
         raise SubprocTimeout(f"Command {cmd[0]} timed out after {timeout}s")


### PR DESCRIPTION
On Windows, `os.killpg` and `os.getpgid` do not exist. When a subprocess times out, the timeout handler raises an unhandled `AttributeError` instead of falling through to `proc.kill()`.

**Changes**
- `subproc.py`: add `AttributeError` to the except clause guarding the `os.killpg(os.getpgid(...))` call.

Closes #91.