### PR TITLE
chore: align plugin marketplace metadata and branding

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "last30days-skill",
   "interface": {
-    "displayName": "Last 30 Days"
+    "displayName": "last30days"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/mvanhorn"
   },
   "metadata": {
-    "description": "Marketplace hosting the Last 30 Days research plugin."
+    "description": "Marketplace hosting the last30days research plugin."
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,21 @@
   "homepage": "https://github.com/mvanhorn/last30days-skill",
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
-  "keywords": ["research", "reddit", "twitter", "youtube", "tiktok", "instagram", "trends", "prompts", "polymarket", "github", "perplexity", "threads", "pinterest", "eli5", "hacker-news"]
+  "keywords": [
+    "competitor research",
+    "research",
+    "reddit",
+    "twitter",
+    "youtube",
+    "tiktok",
+    "instagram",
+    "trends",
+    "prompts",
+    "polymarket",
+    "github",
+    "perplexity",
+    "threads",
+    "pinterest",
+    "hacker-news"
+  ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -11,6 +11,7 @@
   "repository": "https://github.com/mvanhorn/last30days-skill",
   "license": "MIT",
   "keywords": [
+    "competitor research",
     "research",
     "reddit",
     "twitter",
@@ -24,25 +25,25 @@
     "perplexity",
     "threads",
     "pinterest",
-    "eli5",
     "hacker-news"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "last30days",
     "shortDescription": "Research what people are saying about a topic now.",
-    "longDescription": "last30days adds a Codex skill for researching recent discussion and engagement signals across social, video, developer, prediction-market, and web sources.",
+    "longDescription": "last30days adds a Codex skill for researching any topic based on recent discussion and engagement signals across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and the web.",
     "developerName": "Matt Van Horn",
     "category": "Research",
     "capabilities": [
-      "Research",
-      "Web"
+      "Interactive",
+      "Read",
+      "Write"
     ],
     "websiteURL": "https://github.com/mvanhorn/last30days-skill",
     "defaultPrompt": [
-      "/last30days OpenAI Codex",
-      "/last30days AI video tools",
-      "/last30days react user complaints"
+      "TikTok shop trends",
+      "Codex vs Cursor",
+      "best travel credit cards"
     ],
     "brandColor": "#6F42C1"
   }


### PR DESCRIPTION
## Summary

Marketplace listings now present the plugin consistently as **last30days** instead of mixing in the title-case "Last 30 Days", and the Codex listing reflects what the skill actually does today rather than a generic earlier blurb.

- **Consistent name** across the `.agents` and `.claude-plugin` marketplace manifests (display name and marketplace description).
- **Keywords**: added `competitor research` (a common real use), dropped the stale `eli5` keyword that no longer maps to a feature.
- **Codex listing refresh**: the long description now names the concrete sources (Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, web), capabilities are corrected to `Interactive`/`Read`/`Write`, and the example prompts show realistic topics.

Manifest-only metadata change — no runtime behavior is affected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
