### PR TITLE
fix: --diagnose no longer falsely reports X unreachable when browser cookies are configured (#692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<<<<<<< HEAD
 - The query-plan invocation guidance now warns against wrapping the heredoc in `bash -lc '...'` / `zsh -lc '...'`, whose single quotes terminate at the first apostrophe in a ranking string and abort the engine run with `unmatched "` on Codex. The quoted `<<'PLAN_EOF'` heredoc is already apostrophe-safe; the `-lc` wrapper was the hazard.
-=======
 - `--diagnose` / `--preflight` no longer falsely reports X as unreachable when browser cookies are configured but cookie reading is skipped for privacy (`plan_only` mode). The X backend chain now treats bird as potentially available when `FROM_BROWSER` points to Firefox or Safari ([#692](https://github.com/mvanhorn/last30days-skill/issues/692))
->>>>>>> bd5591c (fix: --diagnose no longer falsely reports X unreachable when browser cookies are configured (#692))
 - Firefox profile detection on Linux now checks `$XDG_CONFIG_HOME/mozilla/firefox` (or its default `~/.config/mozilla/firefox`) in addition to `~/.mozilla/firefox`, fixing cookie extraction on distros that honour the XDG Base Directory Specification ([#667](https://github.com/mvanhorn/last30days-skill/issues/667))
 
 ## [3.8.1] - 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `--diagnose` / `--preflight` no longer falsely reports X as unreachable when browser cookies are configured but cookie reading is skipped for privacy (`plan_only` mode). The X backend chain now treats bird as potentially available when `FROM_BROWSER` points to Firefox or Safari ([#692](https://github.com/mvanhorn/last30days-skill/issues/692))
+
 ## [3.8.3] - 2026-06-25
 
 ### Added
@@ -35,7 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - The query-plan invocation guidance now warns against wrapping the heredoc in `bash -lc '...'` / `zsh -lc '...'`, whose single quotes terminate at the first apostrophe in a ranking string and abort the engine run with `unmatched "` on Codex. The quoted `<<'PLAN_EOF'` heredoc is already apostrophe-safe; the `-lc` wrapper was the hazard.
+=======
+- `--diagnose` / `--preflight` no longer falsely reports X as unreachable when browser cookies are configured but cookie reading is skipped for privacy (`plan_only` mode). The X backend chain now treats bird as potentially available when `FROM_BROWSER` points to Firefox or Safari ([#692](https://github.com/mvanhorn/last30days-skill/issues/692))
+>>>>>>> bd5591c (fix: --diagnose no longer falsely reports X unreachable when browser cookies are configured (#692))
 - Firefox profile detection on Linux now checks `$XDG_CONFIG_HOME/mozilla/firefox` (or its default `~/.config/mozilla/firefox`) in addition to `~/.mozilla/firefox`, fixing cookie extraction on distros that honour the XDG Base Directory Specification ([#667](https://github.com/mvanhorn/last30days-skill/issues/667))
 
 ## [3.8.1] - 2026-06-22

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -709,8 +709,11 @@ def x_backend_chain(config: dict[str, Any]) -> list[str]:
         if any(b in ('firefox', 'safari') for b in browsers):
             has_bird_creds = True
 
-    if has_bird_creds:
-        bird_x.set_credentials(config.get('AUTH_TOKEN'), config.get('CT0'))
+    # Only seed credentials when the real values exist; in plan_only mode
+    # has_bird_creds is spoofed for availability reporting, but the cookie
+    # values themselves were never read and would be None.
+    if has_bird_creds and config.get('AUTH_TOKEN') and config.get('CT0'):
+        bird_x.set_credentials(config['AUTH_TOKEN'], config['CT0'])
 
     preferred = (config.get('LAST30DAYS_X_BACKEND') or '').lower()
     if preferred in _X_BACKEND_ORDER:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -699,6 +699,16 @@ def x_backend_chain(config: dict[str, Any]) -> list[str]:
     """
     from . import bird_x
     has_bird_creds = bool(config.get('AUTH_TOKEN') and config.get('CT0'))
+
+    # plan_only mode (--diagnose/--preflight) skips cookie extraction as a
+    # privacy safeguard.  When FROM_BROWSER is set to a browser that can serve
+    # X cookies (firefox, safari), treat bird as potentially available so the
+    # startup hook doesn't falsely report "X unreachable".
+    if not has_bird_creds and config.get('_BROWSER_COOKIE_MODE') == 'plan_only':
+        browsers = config.get('_BROWSER_COOKIE_BROWSERS') or []
+        if any(b in ('firefox', 'safari') for b in browsers):
+            has_bird_creds = True
+
     if has_bird_creds:
         bird_x.set_credentials(config.get('AUTH_TOKEN'), config.get('CT0'))
 


### PR DESCRIPTION
**Problem**

`--diagnose` uses `plan_only` browser-cookie mode as a privacy safeguard — it never reads actual cookie values. This means `AUTH_TOKEN`/`CT0` are never populated in the config, causing `x_backend_chain()` to find no credentials and report X as unavailable, even though X works fine on actual research runs.

**Solution**

In `x_backend_chain()`, when in `plan_only` mode and `FROM_BROWSER` is set to Firefox or Safari (browsers that can provide X cookies), treat bird as potentially available. The runtime mode will re-check with live cookie values.

Closes #692.