### PR TITLE
Add LinkedIn source via ScrapeCreators

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -99,6 +99,7 @@ The project-scoped file is useful for **intentional per-client setups**: drop a 
 | Instagram | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `instagram` | Instagram Reels | 10K free calls; raise `LAST30DAYS_TRANSCRIPT_TIMEOUT` (default 30s) if SC is slow on your network |
 | Threads | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `threads` | Threads items | 10K free calls |
 | Pinterest | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `pinterest` | Pinterest items | 10K free calls |
+| LinkedIn | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `linkedin` | LinkedIn posts | 10K free calls; power-user opt-in, not offered during first-run onboarding |
 | Bluesky | `BSKY_HANDLE` + `BSKY_APP_PASSWORD` | Bluesky items | yes (app password at bsky.app) |
 | TruthSocial | `TRUTHSOCIAL_TOKEN` | TruthSocial items | yes |
 | Web search | one of: `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY` | `--auto-resolve` and Step 2 supplements | Brave has a free tier; native WebSearch on Claude Code / Codex / Gemini works as a fallback |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -99,7 +99,7 @@ The project-scoped file is useful for **intentional per-client setups**: drop a 
 | Instagram | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `instagram` | Instagram Reels | 10K free calls; raise `LAST30DAYS_TRANSCRIPT_TIMEOUT` (default 30s) if SC is slow on your network |
 | Threads | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `threads` | Threads items | 10K free calls |
 | Pinterest | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `pinterest` | Pinterest items | 10K free calls |
-| LinkedIn | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `linkedin` | LinkedIn posts | 10K free calls; power-user opt-in, not offered during first-run onboarding |
+| LinkedIn | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `linkedin` | LinkedIn posts + articles (articles rank as high signal on person topics) | 10K free calls; power-user opt-in, not offered during first-run onboarding |
 | Bluesky | `BSKY_HANDLE` + `BSKY_APP_PASSWORD` | Bluesky items | yes (app password at bsky.app) |
 | TruthSocial | `TRUTHSOCIAL_TOKEN` | TruthSocial items | yes |
 | Web search | one of: `BRAVE_API_KEY`, `EXA_API_KEY`, `SERPER_API_KEY`, `PARALLEL_API_KEY` | `--auto-resolve` and Step 2 supplements | Brave has a free tier; native WebSearch on Claude Code / Codex / Gemini works as a fallback |

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -44,6 +44,7 @@ metadata:
       - youtube
       - tiktok
       - instagram
+      - linkedin
       - hackernews
       - polymarket
       - digg
@@ -533,7 +534,7 @@ The magic of /last30days is Reddit comments + X posts together - and both are fr
 
 **Bonus: TikTok, Instagram, YouTube comments (ScrapeCreators):**
 - `SCRAPECREATORS_API_KEY=xxx` - 10,000 free calls at scrapecreators.com.
-- After adding your key, set `INCLUDE_SOURCES=tiktok,instagram` to turn on the popular ones. (Threads and Pinterest are also available via `INCLUDE_SOURCES=threads,pinterest` for power users.)
+- After adding your key, set `INCLUDE_SOURCES=tiktok,instagram` to turn on the popular ones. (Threads, Pinterest, and LinkedIn are also available via `INCLUDE_SOURCES=threads,pinterest,linkedin` for power users.)
 
 **Other optional sources (add anytime):**
 - `PERPLEXITY_API_KEY=xxx` (or `OPENROUTER_API_KEY=xxx`) - AI-synthesized research with citations; set `INCLUDE_SOURCES=perplexity`.
@@ -592,7 +593,7 @@ SKILL_DIR="<absolute path of the directory containing the SKILL.md you just Read
 "${LAST30DAYS_PYTHON}" "${SKILL_DIR}/scripts/last30days.py" --diagnose
 ```
 
-`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs.
+`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `linkedin`→LinkedIn, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs.
 
 - If EXCLUDE_SOURCES is set (comma-separated, case-insensitive): drop any matching source from ACTIVE_SOURCES_LIST before displaying
 

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -10,7 +10,6 @@ Requires SCRAPECREATORS_API_KEY environment variable.
 from __future__ import annotations
 
 import re
-import sys
 from typing import Any, Dict, List
 from urllib.parse import urlencode
 
@@ -115,10 +114,19 @@ def _int_field(post: dict[str, Any], *keys: str) -> int:
     return 0
 
 
-def parse_linkedin_response(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+def parse_linkedin_response(
+    result: Dict[str, Any],
+    from_date: str | None = None,
+    to_date: str | None = None,
+) -> List[Dict[str, Any]]:
     """Parse ScrapeCreators LinkedIn response into engine-compatible item dicts.
 
     Each returned dict must be normalizable by normalize._normalize_linkedin.
+
+    If from_date/to_date are given, applies the same hard date-range filter
+    used by instagram.search_and_enrich: drop items outside the window, but
+    fall back to keeping everything if the filter would otherwise empty the
+    result (SC doesn't always return a usable date per post).
     """
     posts = result.get("posts") or []
     items: List[Dict[str, Any]] = []
@@ -180,5 +188,15 @@ def parse_linkedin_response(result: Dict[str, Any]) -> List[Dict[str, Any]]:
             },
             "relevance": 0.5,
         })
+
+    if from_date and to_date:
+        in_range = [i for i in items if i["date"] and from_date <= i["date"] <= to_date]
+        out_of_range = len(items) - len(in_range)
+        if in_range:
+            items = in_range
+            if out_of_range:
+                _log(f"Filtered {out_of_range} posts outside date range")
+        elif items:
+            _log(f"No posts within date range, keeping all {len(items)}")
 
     return items

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -242,24 +242,38 @@ def _normalize_name(s: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).strip()
 
 
+def _token_run(needle: List[str], haystack: List[str]) -> bool:
+    """True if `needle` appears as a contiguous run of whole tokens in `haystack`.
+
+    Token-level (not substring) so "ai" never matches inside "daisuke" — matching
+    is on word boundaries. Equality is the n == len(haystack) case.
+    """
+    n = len(needle)
+    if n == 0 or n > len(haystack):
+        return False
+    return any(haystack[i : i + n] == needle for i in range(len(haystack) - n + 1))
+
+
 def _best_author_match(items: List[Dict[str, Any]], topic: str) -> str:
     """Return the profile URL of the post author whose name matches the topic.
 
-    Person-topic detection without a global predicate: if one of the returned
-    posts is authored by someone whose (multi-word) name equals or is contained
-    in the topic, treat the topic as being about that person and return their
-    profile URL. Empty string when no confident match — which keeps enrichment
-    off for keyword topics like "AI agents".
+    Person-topic detection without a global predicate: when a returned post's
+    author has a multi-word name that the topic clearly refers to, treat the
+    topic as being about that person and return their profile URL. Matching is
+    on whole-token runs (the author's full name appears in the topic, or vice
+    versa), and the topic itself must be at least two tokens — so single-word
+    keyword topics ("AI", "Tesla") and short phrases never enrich, and a topic
+    token can't accidentally match inside an unrelated author's name.
     """
-    topic_norm = _normalize_name(topic)
-    if not topic_norm:
+    topic_tokens = _normalize_name(topic).split()
+    if len(topic_tokens) < 2:
         return ""
     for item in items:
-        name = _normalize_name(item.get("author", ""))
+        name_tokens = _normalize_name(item.get("author", "")).split()
         url = (item.get("author_url") or "").strip()
-        if not url or len(name.split()) < 2:
+        if not url or len(name_tokens) < 2:
             continue
-        if name == topic_norm or name in topic_norm or topic_norm in name:
+        if _token_run(name_tokens, topic_tokens) or _token_run(topic_tokens, name_tokens):
             return url
     return ""
 

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -19,14 +19,14 @@ from . import http, log
 SC_BASE = "https://api.scrapecreators.com/v1/linkedin"
 
 DEPTH_CONFIG: dict[str, dict[str, Any]] = {
-    "quick": {"date_posted": "last-week", "max_results": 5},
-    "default": {"date_posted": "last-week", "max_results": 8},
-    "deep": {"date_posted": "last-week", "max_results": 10},
+    "quick": {"date_posted": "last-week", "max_results": 10},
+    "default": {"date_posted": "last-month", "max_results": 20},
+    "deep": {"date_posted": "last-month", "max_results": 30},
 }
 
 
 def _log(msg: str) -> None:
-    log.source_log("LinkedIn", msg)
+    log.source_log("LinkedIn", msg, tty_only=False)
 
 
 def search_linkedin(

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import re
 from typing import Any, Dict, List
-from urllib.parse import urlencode
 
 from . import http, log
 
@@ -56,15 +55,13 @@ def search_linkedin(
 
     _log(f"Searching for '{topic}' (date_posted={date_posted})")
 
-    params: dict[str, str] = {"query": topic, "date_posted": date_posted}
-    url = f"{SC_BASE}/search/posts?{urlencode(params)}"
-
     try:
-        response = http.request(
-            "GET",
-            url,
-            headers={"x-api-key": token},
+        response = http.get(
+            f"{SC_BASE}/search/posts",
+            params={"query": topic, "date_posted": date_posted},
+            headers=http.scrapecreators_headers(token),
             timeout=30,
+            retries=2,
         )
     except http.HTTPError as exc:
         _log(f"Search failed (HTTP {exc.status_code}): {exc}")
@@ -271,10 +268,13 @@ def search_profile(profile_url: str, token: str) -> Dict[str, Any]:
     """Fetch a LinkedIn profile (incl. `articles[]`) via ScrapeCreators."""
     if not token or not profile_url:
         return {}
-    url = f"{SC_BASE}/profile?{urlencode({'url': profile_url})}"
     try:
-        response = http.request(
-            "GET", url, headers={"x-api-key": token}, timeout=30
+        response = http.get(
+            f"{SC_BASE}/profile",
+            params={"url": profile_url},
+            headers=http.scrapecreators_headers(token),
+            timeout=30,
+            retries=2,
         )
     except http.HTTPError as exc:
         _log(f"Profile fetch failed (HTTP {exc.status_code}): {exc}")

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -1,0 +1,184 @@
+"""LinkedIn post search via ScrapeCreators API.
+
+Searches public LinkedIn posts by keyword using the ScrapeCreators
+/v1/linkedin/search/posts endpoint, which uses Google-indexed LinkedIn
+content to bypass auth requirements.
+
+Requires SCRAPECREATORS_API_KEY environment variable.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Any, Dict, List
+from urllib.parse import urlencode
+
+from . import http, log
+
+SC_BASE = "https://api.scrapecreators.com/v1/linkedin"
+
+DEPTH_CONFIG: dict[str, dict[str, Any]] = {
+    "quick": {"date_posted": "last-week", "max_results": 5},
+    "default": {"date_posted": "last-week", "max_results": 8},
+    "deep": {"date_posted": "last-week", "max_results": 10},
+}
+
+
+def _log(msg: str) -> None:
+    log.source_log("LinkedIn", msg)
+
+
+def search_linkedin(
+    topic: str,
+    from_date: str,
+    to_date: str,
+    depth: str = "default",
+    token: str = "",
+) -> Dict[str, Any]:
+    """Search LinkedIn posts via ScrapeCreators API.
+
+    Args:
+        topic: Search query / topic string.
+        from_date: Window start date (YYYY-MM-DD) — used for depth mapping.
+        to_date: Window end date (YYYY-MM-DD).
+        depth: Retrieval profile — 'quick', 'default', or 'deep'.
+        token: ScrapeCreators API key.
+
+    Returns:
+        Dict with a 'posts' list of raw post dicts.
+    """
+    if not token:
+        _log("No SCRAPECREATORS_API_KEY — skipping")
+        return {"posts": []}
+
+    cfg = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
+    date_posted = cfg["date_posted"]
+
+    _log(f"Searching for '{topic}' (date_posted={date_posted})")
+
+    params: dict[str, str] = {"query": topic, "date_posted": date_posted}
+    url = f"{SC_BASE}/search/posts?{urlencode(params)}"
+
+    try:
+        response = http.request(
+            "GET",
+            url,
+            headers={"x-api-key": token},
+            timeout=30,
+        )
+    except http.HTTPError as exc:
+        _log(f"Search failed (HTTP {exc.status_code}): {exc}")
+        return {"posts": [], "error": str(exc)}
+    except Exception as exc:
+        _log(f"Search failed: {type(exc).__name__}: {exc}")
+        return {"posts": [], "error": str(exc)}
+
+    posts = _extract_posts(response)
+    max_results = cfg["max_results"]
+    posts = posts[:max_results]
+    _log(f"Found {len(posts)} posts")
+    return {"posts": posts}
+
+
+def _extract_posts(response: Any) -> List[Dict[str, Any]]:
+    """Extract the posts list from various possible response shapes."""
+    if not isinstance(response, dict):
+        return []
+    for key in ("posts", "items", "data", "results"):
+        val = response.get(key)
+        if isinstance(val, list):
+            return val
+    return []
+
+
+def _parse_date(raw: Any) -> str | None:
+    """Extract a YYYY-MM-DD string from various date formats."""
+    if not raw:
+        return None
+    s = str(raw).strip()
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", s)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _int_field(post: dict[str, Any], *keys: str) -> int:
+    """Return the first present integer field from a post dict."""
+    for key in keys:
+        val = post.get(key)
+        if val is not None:
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                pass
+    return 0
+
+
+def parse_linkedin_response(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Parse ScrapeCreators LinkedIn response into engine-compatible item dicts.
+
+    Each returned dict must be normalizable by normalize._normalize_linkedin.
+    """
+    posts = result.get("posts") or []
+    items: List[Dict[str, Any]] = []
+
+    for i, post in enumerate(posts):
+        if not isinstance(post, dict):
+            continue
+
+        text = str(
+            post.get("text") or post.get("content") or post.get("body") or ""
+        ).strip()
+        if not text:
+            continue
+
+        author_raw = (
+            post.get("author")
+            or post.get("authorName")
+            or post.get("author_name")
+            or ""
+        )
+        if isinstance(author_raw, dict):
+            author = str(
+                author_raw.get("name") or author_raw.get("full_name") or ""
+            ).strip()
+        else:
+            author = str(author_raw).strip()
+
+        url = str(
+            post.get("url") or post.get("postUrl") or post.get("post_url") or ""
+        ).strip()
+
+        post_id = str(
+            post.get("urn") or post.get("id") or post.get("postId") or f"LI{i + 1}"
+        )
+
+        date_raw = (
+            post.get("date")
+            or post.get("postedAt")
+            or post.get("posted_at")
+            or post.get("createdAt")
+            or post.get("created_at")
+        )
+        date = _parse_date(date_raw)
+
+        likes = _int_field(post, "likes", "likesCount", "likes_count", "numLikes", "likeCount")
+        comments = _int_field(post, "comments", "commentsCount", "comments_count", "numComments", "commentCount")
+        reposts = _int_field(post, "reposts", "repostsCount", "shares", "shareCount", "reshares")
+
+        items.append({
+            "id": post_id,
+            "text": text,
+            "url": url,
+            "author": author,
+            "date": date,
+            "engagement": {
+                "likes": likes,
+                "comments": comments,
+                "reposts": reposts,
+            },
+            "relevance": 0.5,
+        })
+
+    return items

--- a/skills/last30days/scripts/lib/linkedin.py
+++ b/skills/last30days/scripts/lib/linkedin.py
@@ -114,6 +114,21 @@ def _int_field(post: dict[str, Any], *keys: str) -> int:
     return 0
 
 
+def _is_article(url: str) -> bool:
+    """A LinkedIn long-form article (Pulse) lives under a /pulse/ URL.
+
+    Articles are higher-signal than ordinary posts — someone who wrote a
+    full article on a topic is a stronger source than someone who dashed off
+    a status update.
+    """
+    return "/pulse/" in (url or "").lower()
+
+
+# Relevance hints: articles outrank ordinary posts at rerank time.
+_ARTICLE_RELEVANCE = 0.9
+_POST_RELEVANCE = 0.5
+
+
 def parse_linkedin_response(
     result: Dict[str, Any],
     from_date: str | None = None,
@@ -135,8 +150,15 @@ def parse_linkedin_response(
         if not isinstance(post, dict):
             continue
 
+        # The live ScrapeCreators post object carries the body in `description`
+        # and the timestamp in `datePublished`. The other keys are tolerated
+        # fallbacks for shape drift / alternate endpoints.
         text = str(
-            post.get("text") or post.get("content") or post.get("body") or ""
+            post.get("description")
+            or post.get("text")
+            or post.get("content")
+            or post.get("body")
+            or ""
         ).strip()
         if not text:
             continue
@@ -147,10 +169,12 @@ def parse_linkedin_response(
             or post.get("author_name")
             or ""
         )
+        author_url = ""
         if isinstance(author_raw, dict):
             author = str(
                 author_raw.get("name") or author_raw.get("full_name") or ""
             ).strip()
+            author_url = str(author_raw.get("url") or author_raw.get("link") or "").strip()
         else:
             author = str(author_raw).strip()
 
@@ -163,7 +187,8 @@ def parse_linkedin_response(
         )
 
         date_raw = (
-            post.get("date")
+            post.get("datePublished")
+            or post.get("date")
             or post.get("postedAt")
             or post.get("posted_at")
             or post.get("createdAt")
@@ -175,18 +200,21 @@ def parse_linkedin_response(
         comments = _int_field(post, "comments", "commentsCount", "comments_count", "numComments", "commentCount")
         reposts = _int_field(post, "reposts", "repostsCount", "shares", "shareCount", "reshares")
 
+        is_article = _is_article(url)
         items.append({
             "id": post_id,
             "text": text,
             "url": url,
             "author": author,
+            "author_url": author_url,
             "date": date,
             "engagement": {
                 "likes": likes,
                 "comments": comments,
                 "reposts": reposts,
             },
-            "relevance": 0.5,
+            "relevance": _ARTICLE_RELEVANCE if is_article else _POST_RELEVANCE,
+            "is_article": is_article,
         })
 
     if from_date and to_date:
@@ -200,3 +228,122 @@ def parse_linkedin_response(
             _log(f"No posts within date range, keeping all {len(items)}")
 
     return items
+
+
+# --- Article enrichment ---------------------------------------------------
+#
+# LinkedIn articles (Pulse long-form) never appear in /search/posts results —
+# every search hit is a /posts/ status update. Articles live only on the
+# author's profile, under `articles[]`. To honor "an article is high signal"
+# we run a bounded enrichment lane: when a returned post's author name matches
+# the topic (i.e. this is a person topic and we already hold their profile
+# URL), make ONE profile call and surface their articles as high-signal items.
+
+
+def _normalize_name(s: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace — for name matching."""
+    return re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).strip()
+
+
+def _best_author_match(items: List[Dict[str, Any]], topic: str) -> str:
+    """Return the profile URL of the post author whose name matches the topic.
+
+    Person-topic detection without a global predicate: if one of the returned
+    posts is authored by someone whose (multi-word) name equals or is contained
+    in the topic, treat the topic as being about that person and return their
+    profile URL. Empty string when no confident match — which keeps enrichment
+    off for keyword topics like "AI agents".
+    """
+    topic_norm = _normalize_name(topic)
+    if not topic_norm:
+        return ""
+    for item in items:
+        name = _normalize_name(item.get("author", ""))
+        url = (item.get("author_url") or "").strip()
+        if not url or len(name.split()) < 2:
+            continue
+        if name == topic_norm or name in topic_norm or topic_norm in name:
+            return url
+    return ""
+
+
+def search_profile(profile_url: str, token: str) -> Dict[str, Any]:
+    """Fetch a LinkedIn profile (incl. `articles[]`) via ScrapeCreators."""
+    if not token or not profile_url:
+        return {}
+    url = f"{SC_BASE}/profile?{urlencode({'url': profile_url})}"
+    try:
+        response = http.request(
+            "GET", url, headers={"x-api-key": token}, timeout=30
+        )
+    except http.HTTPError as exc:
+        _log(f"Profile fetch failed (HTTP {exc.status_code}): {exc}")
+        return {}
+    except Exception as exc:
+        _log(f"Profile fetch failed: {type(exc).__name__}: {exc}")
+        return {}
+    return response if isinstance(response, dict) else {}
+
+
+def parse_profile_articles(
+    profile: Dict[str, Any],
+    from_date: str | None = None,
+    to_date: str | None = None,
+) -> List[Dict[str, Any]]:
+    """Map a profile's `articles[]` into high-signal engine item dicts."""
+    articles = profile.get("articles") or []
+    author = str(profile.get("name") or "").strip()
+    items: List[Dict[str, Any]] = []
+
+    for i, art in enumerate(articles):
+        if not isinstance(art, dict):
+            continue
+        headline = str(art.get("headline") or art.get("title") or "").strip()
+        if not headline:
+            continue
+        url = str(art.get("url") or art.get("link") or "").strip()
+        date = _parse_date(art.get("datePublished") or art.get("date"))
+        items.append({
+            "id": str(art.get("id") or f"LIA{i + 1}"),
+            "text": headline,
+            "url": url,
+            "author": author,
+            "date": date,
+            "engagement": {},
+            "relevance": _ARTICLE_RELEVANCE,
+            "is_article": True,
+        })
+
+    if from_date and to_date:
+        in_range = [i for i in items if i["date"] and from_date <= i["date"] <= to_date]
+        if in_range:
+            items = in_range
+    return items
+
+
+def enrich_articles(
+    items: List[Dict[str, Any]],
+    topic: str,
+    token: str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+) -> List[Dict[str, Any]]:
+    """Surface a person's LinkedIn articles as high-signal items.
+
+    Bounded: fires only on person topics (a returned post author matches the
+    topic) and makes at most ONE profile API call. No-ops gracefully when
+    there's no match, no token, no profile, or no articles.
+    """
+    if not token:
+        return []
+    profile_url = _best_author_match(items, topic)
+    if not profile_url:
+        return []
+    _log(f"Person topic — enriching articles from {profile_url}")
+    profile = search_profile(profile_url, token)
+    if not profile:
+        return []
+    articles = parse_profile_articles(profile, from_date=from_date, to_date=to_date)
+    if articles:
+        _log(f"Found {len(articles)} article(s)")
+    return articles

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -610,23 +610,32 @@ def _normalize_linkedin(
     from_date: str,
     to_date: str,
 ) -> schema.SourceItem:
-    """Normalizer for LinkedIn posts via ScrapeCreators."""
+    """Normalizer for LinkedIn posts and articles via ScrapeCreators.
+
+    A LinkedIn article (Pulse long-form, under a /pulse/ URL) is treated as
+    high signal: it ranks above ordinary posts. Detection is belt-and-suspenders
+    — honor the parser's `is_article` flag, and re-derive from the URL so an
+    article still ranks high even if the flag wasn't set upstream.
+    """
     text = str(item.get("text") or "").strip()
     author = str(item.get("author") or "").strip()
     url = str(item.get("url") or "").strip()
+    is_article = bool(item.get("is_article")) or "/pulse/" in url.lower()
+    kind = "article" if is_article else "post"
+    default_relevance = 0.9 if is_article else 0.5
     return _source_item(
         item_id=str(item.get("id") or f"LI{index + 1}"),
         source=source,
-        title=text[:140] or f"LinkedIn post {index + 1}",
+        title=text[:140] or f"LinkedIn {kind} {index + 1}",
         body=text,
         url=url,
         author=author,
-        container="LinkedIn",
+        container="LinkedIn Article" if is_article else "LinkedIn",
         published_at=item.get("date"),
         date_confidence=_date_confidence(item, from_date, to_date, default="medium"),
         engagement=item.get("engagement") or {},
-        relevance_hint=item.get("relevance", 0.5),
+        relevance_hint=item.get("relevance", default_relevance),
         why_relevant=str(item.get("why_relevant") or ""),
         snippet=text[:200],
-        metadata={"author_display": author},
+        metadata={"author_display": author, "is_article": is_article},
     )

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -55,6 +55,7 @@ def normalize_source_items(
         "github": _normalize_github,
         "perplexity": _normalize_grounding,
         "jobs": _normalize_jobs,
+        "linkedin": _normalize_linkedin,
     }
     normalizer = normalizers.get(source)
     if normalizer is None:
@@ -599,4 +600,33 @@ def _normalize_grounding(
         why_relevant=str(item.get("why_relevant") or ""),
         snippet=snippet,
         metadata=item.get("metadata") or {},
+    )
+
+
+def _normalize_linkedin(
+    source: str,
+    item: dict[str, Any],
+    index: int,
+    from_date: str,
+    to_date: str,
+) -> schema.SourceItem:
+    """Normalizer for LinkedIn posts via ScrapeCreators."""
+    text = str(item.get("text") or "").strip()
+    author = str(item.get("author") or "").strip()
+    url = str(item.get("url") or "").strip()
+    return _source_item(
+        item_id=str(item.get("id") or f"LI{index + 1}"),
+        source=source,
+        title=text[:140] or f"LinkedIn post {index + 1}",
+        body=text,
+        url=url,
+        author=author,
+        container="LinkedIn",
+        published_at=item.get("date"),
+        date_confidence=_date_confidence(item, from_date, to_date, default="medium"),
+        engagement=item.get("engagement") or {},
+        relevance_hint=item.get("relevance", 0.5),
+        why_relevant=str(item.get("why_relevant") or ""),
+        snippet=text[:200],
+        metadata={"author_display": author},
     )

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -120,7 +120,7 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
     # reddit_public needs no API key - always available
     available.append("reddit")
     if config.get("SCRAPECREATORS_API_KEY"):
-        available.extend(["tiktok", "instagram", "linkedin"])
+        available.extend(["tiktok", "instagram"])
     if env.get_x_source(config):
         available.append("x")
     if which("yt-dlp") or env.is_youtube_sc_available(config):
@@ -151,6 +151,15 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         "perplexity" in include_sources or (requested_sources and "perplexity" in requested_sources)
     ):
         available.append("perplexity")
+    # LinkedIn: opt-in additive source via INCLUDE_SOURCES=linkedin (same
+    # consent pattern as Perplexity). Unlike tiktok/instagram, which are
+    # offered during SKILL.md Step 0 onboarding, LinkedIn is power-user-only
+    # and must not silently activate for existing SCRAPECREATORS_API_KEY
+    # holders.
+    if config.get("SCRAPECREATORS_API_KEY") and (
+        "linkedin" in include_sources or (requested_sources and "linkedin" in requested_sources)
+    ):
+        available.append("linkedin")
     if requested_sources and "xiaohongshu" in requested_sources and env.is_xiaohongshu_available(config):
         available.append("xiaohongshu")
     if env.is_threads_available(config):
@@ -1409,7 +1418,7 @@ def _retrieve_stream(
             depth=depth,
             token=config.get("SCRAPECREATORS_API_KEY", ""),
         )
-        return linkedin.parse_linkedin_response(result), {}
+        return linkedin.parse_linkedin_response(result, from_date=from_date, to_date=to_date), {}
     if source == "hackernews":
         result = hackernews.search_hackernews(subquery.search_query, from_date, to_date, depth=depth)
         return hackernews.parse_hackernews_response(result, query=subquery.search_query), {}

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -25,6 +25,7 @@ from . import (
     hiring_signals,
     instagram,
     jobs,
+    linkedin,
     normalize,
     permission_preflight,
     perplexity,
@@ -67,7 +68,7 @@ SEARCH_ALIAS = {
     "xquik": "x",  # xquik is a backend of the single "x" source, not its own source
 }
 
-MAX_SOURCE_FETCHES: dict[str, int] = {"x": 2, "jobs": 1}
+MAX_SOURCE_FETCHES: dict[str, int] = {"x": 2, "jobs": 1, "linkedin": 1}
 
 # Per-handle result caps for the X handle-search lanes. The FROM lane (the
 # subject's own timeline) is the single best source for a person topic, so it
@@ -99,6 +100,7 @@ MOCK_AVAILABLE_SOURCES = [
     "pinterest",
     "digg",
     "jobs",
+    "linkedin",
 ]
 
 
@@ -118,7 +120,7 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
     # reddit_public needs no API key - always available
     available.append("reddit")
     if config.get("SCRAPECREATORS_API_KEY"):
-        available.extend(["tiktok", "instagram"])
+        available.extend(["tiktok", "instagram", "linkedin"])
     if env.get_x_source(config):
         available.append("x")
     if which("yt-dlp") or env.is_youtube_sc_available(config):
@@ -1399,6 +1401,15 @@ def _retrieve_stream(
             ig_creators=ig_creators,
         )
         return instagram.parse_instagram_response(result), {}
+    if source == "linkedin":
+        result = linkedin.search_linkedin(
+            subquery.search_query,
+            from_date,
+            to_date,
+            depth=depth,
+            token=config.get("SCRAPECREATORS_API_KEY", ""),
+        )
+        return linkedin.parse_linkedin_response(result), {}
     if source == "hackernews":
         result = hackernews.search_hackernews(subquery.search_query, from_date, to_date, depth=depth)
         return hackernews.parse_hackernews_response(result, query=subquery.search_query), {}

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1411,14 +1411,23 @@ def _retrieve_stream(
         )
         return instagram.parse_instagram_response(result), {}
     if source == "linkedin":
+        token = config.get("SCRAPECREATORS_API_KEY", "")
         result = linkedin.search_linkedin(
             subquery.search_query,
             from_date,
             to_date,
             depth=depth,
-            token=config.get("SCRAPECREATORS_API_KEY", ""),
+            token=token,
         )
-        return linkedin.parse_linkedin_response(result, from_date=from_date, to_date=to_date), {}
+        items = linkedin.parse_linkedin_response(
+            result, from_date=from_date, to_date=to_date
+        )
+        # Articles never appear in post search — surface them (high signal)
+        # via a bounded profile-enrichment lane on person topics.
+        items += linkedin.enrich_articles(
+            items, raw_topic or topic, token, from_date=from_date, to_date=to_date
+        )
+        return items, {}
     if source == "hackernews":
         result = hackernews.search_hackernews(subquery.search_query, from_date, to_date, depth=depth)
         return hackernews.parse_hackernews_response(result, query=subquery.search_query), {}

--- a/tests/test_linkedin.py
+++ b/tests/test_linkedin.py
@@ -184,5 +184,49 @@ class TestSearchLinkedin(unittest.TestCase):
             self.assertIn("error", result)
 
 
+class TestDateRangeFiltering(unittest.TestCase):
+    def test_filters_out_posts_outside_range(self):
+        posts = [
+            {"text": "in range", "date": "2026-06-15"},
+            {"text": "too old", "date": "2026-01-01"},
+        ]
+        items = parse_linkedin_response(
+            {"posts": posts}, from_date="2026-05-27", to_date="2026-06-26"
+        )
+        self.assertEqual(1, len(items))
+        self.assertEqual("in range", items[0]["text"])
+
+    def test_keeps_all_when_none_in_range(self):
+        # Graceful fallback: SC doesn't always return a parseable date, so if
+        # the filter would drop everything, keep the unfiltered set instead
+        # of returning zero results.
+        posts = [
+            {"text": "old post", "date": "2026-01-01"},
+            {"text": "older post", "date": "2025-12-01"},
+        ]
+        items = parse_linkedin_response(
+            {"posts": posts}, from_date="2026-05-27", to_date="2026-06-26"
+        )
+        self.assertEqual(2, len(items))
+
+    def test_no_filtering_when_dates_not_provided(self):
+        posts = [{"text": "any date", "date": "2020-01-01"}]
+        items = parse_linkedin_response({"posts": posts})
+        self.assertEqual(1, len(items))
+
+    def test_posts_without_date_excluded_from_in_range_but_not_counted_as_failure(self):
+        posts = [
+            {"text": "has date in range", "date": "2026-06-15"},
+            {"text": "no date at all"},
+        ]
+        items = parse_linkedin_response(
+            {"posts": posts}, from_date="2026-05-27", to_date="2026-06-26"
+        )
+        # Only the dated, in-range post survives; the undated one isn't
+        # counted toward "in range" and gets dropped since in_range is non-empty.
+        self.assertEqual(1, len(items))
+        self.assertEqual("has date in range", items[0]["text"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_linkedin.py
+++ b/tests/test_linkedin.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from lib.linkedin import (
+    _best_author_match,
     _extract_posts,
     _int_field,
     _parse_date,
@@ -323,6 +324,36 @@ class TestProfileArticles(unittest.TestCase):
     def test_article_without_headline_skipped(self):
         prof = {"name": "X", "articles": [{"url": "u", "datePublished": "2026-06-10"}]}
         self.assertEqual([], parse_profile_articles(prof))
+
+
+class TestBestAuthorMatch(unittest.TestCase):
+    def test_exact_person_topic_matches(self):
+        items = [{"author": "Matt Van Horn", "author_url": "u-mvh"}]
+        self.assertEqual("u-mvh", _best_author_match(items, "Matt Van Horn"))
+
+    def test_name_contained_in_longer_topic(self):
+        items = [{"author": "Matt Van Horn", "author_url": "u-mvh"}]
+        self.assertEqual(
+            "u-mvh", _best_author_match(items, "what is Matt Van Horn building")
+        )
+
+    def test_single_word_topic_never_enriches(self):
+        # "AI" is one token — a keyword topic, not a person.
+        items = [{"author": "Daisuke Tanaka", "author_url": "u-dt"}]
+        self.assertEqual("", _best_author_match(items, "AI"))
+
+    def test_no_substring_false_positive_across_token_boundaries(self):
+        # Regression for the Greptile finding: a topic token must not match
+        # inside an unrelated author's name. "ai" must not hit "daisuke".
+        items = [{"author": "Daisuke Tanaka", "author_url": "u-dt"}]
+        self.assertEqual("", _best_author_match(items, "AI agents"))
+
+    def test_picks_matching_author_not_first(self):
+        items = [
+            {"author": "Eric Siu", "author_url": "u-eric"},
+            {"author": "Matt Van Horn", "author_url": "u-mvh"},
+        ]
+        self.assertEqual("u-mvh", _best_author_match(items, "Matt Van Horn loops"))
 
 
 class TestEnrichArticles(unittest.TestCase):

--- a/tests/test_linkedin.py
+++ b/tests/test_linkedin.py
@@ -354,8 +354,8 @@ class TestEnrichArticles(unittest.TestCase):
             # Bounded: exactly one profile call.
             self.assertEqual(1, mock_request.call_count)
             # And it fetched the matching author's profile, not the first author.
-            called_url = mock_request.call_args[0][1]
-            self.assertIn("mattvanhorn", called_url)
+            called_profile = mock_request.call_args.kwargs["params"]["url"]
+            self.assertIn("mattvanhorn", called_profile)
 
     def test_keyword_topic_makes_no_profile_call(self):
         with mock.patch("lib.linkedin.http.request") as mock_request:

--- a/tests/test_linkedin.py
+++ b/tests/test_linkedin.py
@@ -1,0 +1,188 @@
+import unittest
+from unittest import mock
+
+from lib.linkedin import (
+    _extract_posts,
+    _int_field,
+    _parse_date,
+    parse_linkedin_response,
+    search_linkedin,
+)
+
+
+class TestParseLinkedinResponse(unittest.TestCase):
+    def _make_post(self, **overrides):
+        base = {
+            "id": "urn:li:activity:123",
+            "text": "Excited to share our latest product update.",
+            "url": "https://www.linkedin.com/posts/example_123",
+            "author": "Jane Doe",
+            "date": "2026-06-01",
+            "likes": 42,
+            "comments": 5,
+            "reposts": 2,
+        }
+        base.update(overrides)
+        return base
+
+    def test_basic_post_parses_all_fields(self):
+        items = parse_linkedin_response({"posts": [self._make_post()]})
+        self.assertEqual(1, len(items))
+        item = items[0]
+        self.assertEqual("urn:li:activity:123", item["id"])
+        self.assertEqual("Excited to share our latest product update.", item["text"])
+        self.assertEqual("https://www.linkedin.com/posts/example_123", item["url"])
+        self.assertEqual("Jane Doe", item["author"])
+        self.assertEqual("2026-06-01", item["date"])
+        self.assertEqual(42, item["engagement"]["likes"])
+        self.assertEqual(5, item["engagement"]["comments"])
+        self.assertEqual(2, item["engagement"]["reposts"])
+
+    def test_empty_posts_returns_empty_list(self):
+        self.assertEqual([], parse_linkedin_response({"posts": []}))
+        self.assertEqual([], parse_linkedin_response({}))
+
+    def test_post_without_text_is_skipped(self):
+        raw = self._make_post()
+        del raw["text"]
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual([], items)
+
+    def test_non_dict_post_is_skipped(self):
+        items = parse_linkedin_response({"posts": ["not-a-dict", None]})
+        self.assertEqual([], items)
+
+    def test_author_as_dict(self):
+        raw = self._make_post(author={"name": "Jane Doe", "full_name": "Jane M Doe"})
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual("Jane Doe", items[0]["author"])
+
+    def test_author_dict_falls_back_to_full_name(self):
+        raw = self._make_post(author={"full_name": "Jane M Doe"})
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual("Jane M Doe", items[0]["author"])
+
+    def test_author_missing_defaults_to_empty_string(self):
+        raw = self._make_post()
+        del raw["author"]
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual("", items[0]["author"])
+
+    def test_id_falls_back_to_generated_index(self):
+        raw = self._make_post()
+        del raw["id"]
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual("LI1", items[0]["id"])
+
+    def test_alternate_field_names(self):
+        raw = {
+            "postId": "p1",
+            "content": "alternate field names",
+            "postUrl": "https://example.com/p1",
+            "authorName": "Alt Author",
+            "postedAt": "2026-05-15T10:00:00Z",
+            "likesCount": 10,
+            "commentsCount": 3,
+            "shares": 1,
+        }
+        items = parse_linkedin_response({"posts": [raw]})
+        item = items[0]
+        self.assertEqual("p1", item["id"])
+        self.assertEqual("alternate field names", item["text"])
+        self.assertEqual("https://example.com/p1", item["url"])
+        self.assertEqual("Alt Author", item["author"])
+        self.assertEqual("2026-05-15", item["date"])
+        self.assertEqual(10, item["engagement"]["likes"])
+        self.assertEqual(3, item["engagement"]["comments"])
+        self.assertEqual(1, item["engagement"]["reposts"])
+
+
+class TestExtractPosts(unittest.TestCase):
+    def test_extracts_from_posts_key(self):
+        self.assertEqual([{"a": 1}], _extract_posts({"posts": [{"a": 1}]}))
+
+    def test_extracts_from_items_key(self):
+        self.assertEqual([{"a": 1}], _extract_posts({"items": [{"a": 1}]}))
+
+    def test_extracts_from_data_key(self):
+        self.assertEqual([{"a": 1}], _extract_posts({"data": [{"a": 1}]}))
+
+    def test_extracts_from_results_key(self):
+        self.assertEqual([{"a": 1}], _extract_posts({"results": [{"a": 1}]}))
+
+    def test_non_dict_response_returns_empty(self):
+        self.assertEqual([], _extract_posts(["not", "a", "dict"]))
+        self.assertEqual([], _extract_posts(None))
+
+    def test_no_matching_key_returns_empty(self):
+        self.assertEqual([], _extract_posts({"unexpected": [1, 2, 3]}))
+
+
+class TestParseDate(unittest.TestCase):
+    def test_extracts_date_from_iso_string(self):
+        self.assertEqual("2026-06-01", _parse_date("2026-06-01T12:30:00Z"))
+
+    def test_plain_date_string(self):
+        self.assertEqual("2026-06-01", _parse_date("2026-06-01"))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_parse_date(None))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(_parse_date(""))
+
+    def test_no_date_pattern_returns_none(self):
+        self.assertIsNone(_parse_date("not a date"))
+
+
+class TestIntField(unittest.TestCase):
+    def test_returns_first_present_key(self):
+        self.assertEqual(5, _int_field({"likes": 5, "likesCount": 10}, "likes", "likesCount"))
+
+    def test_falls_back_to_second_key(self):
+        self.assertEqual(10, _int_field({"likesCount": 10}, "likes", "likesCount"))
+
+    def test_missing_all_keys_returns_zero(self):
+        self.assertEqual(0, _int_field({}, "likes", "likesCount"))
+
+    def test_non_numeric_value_returns_zero(self):
+        self.assertEqual(0, _int_field({"likes": "not-a-number"}, "likes"))
+
+    def test_string_numeric_value_is_coerced(self):
+        self.assertEqual(7, _int_field({"likes": "7"}, "likes"))
+
+
+class TestSearchLinkedin(unittest.TestCase):
+    def test_no_token_returns_empty_without_network_call(self):
+        with mock.patch("lib.linkedin.http.request") as mock_request:
+            result = search_linkedin("AI agents", "2026-05-27", "2026-06-26", token="")
+            self.assertEqual({"posts": []}, result)
+            mock_request.assert_not_called()
+
+    def test_successful_search_returns_capped_posts(self):
+        raw_posts = [{"text": f"post {i}"} for i in range(20)]
+        with mock.patch(
+            "lib.linkedin.http.request", return_value={"posts": raw_posts}
+        ):
+            result = search_linkedin(
+                "AI agents", "2026-05-27", "2026-06-26", depth="quick", token="fake-token"
+            )
+            # "quick" depth caps at 10 results per DEPTH_CONFIG
+            self.assertEqual(10, len(result["posts"]))
+
+    def test_http_error_returns_empty_with_error_message(self):
+        from lib import http as http_module
+
+        with mock.patch(
+            "lib.linkedin.http.request",
+            side_effect=http_module.HTTPError("rate limited", status_code=429),
+        ):
+            result = search_linkedin(
+                "AI agents", "2026-05-27", "2026-06-26", token="fake-token"
+            )
+            self.assertEqual([], result["posts"])
+            self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linkedin.py
+++ b/tests/test_linkedin.py
@@ -5,38 +5,60 @@ from lib.linkedin import (
     _extract_posts,
     _int_field,
     _parse_date,
+    enrich_articles,
     parse_linkedin_response,
+    parse_profile_articles,
     search_linkedin,
 )
 
 
 class TestParseLinkedinResponse(unittest.TestCase):
     def _make_post(self, **overrides):
+        # Mirrors the live ScrapeCreators /v1/linkedin/search/posts post object:
+        # body in `description`, timestamp in `datePublished`, author as a nested
+        # dict, engagement in `likeCount`/`commentCount`, comments as a list.
         base = {
-            "id": "urn:li:activity:123",
-            "text": "Excited to share our latest product update.",
             "url": "https://www.linkedin.com/posts/example_123",
-            "author": "Jane Doe",
-            "date": "2026-06-01",
-            "likes": 42,
-            "comments": 5,
-            "reposts": 2,
+            "datePublished": "2026-06-01T12:30:00.000Z",
+            "description": "Excited to share our latest product update.",
+            "author": {
+                "name": "Jane Doe",
+                "url": "https://www.linkedin.com/in/janedoe",
+                "followers": 1234,
+            },
+            "comments": [{"author": "Bob", "text": "nice", "linkedinUrl": "x"}],
+            "likeCount": 42,
+            "commentCount": 5,
         }
         base.update(overrides)
         return base
 
-    def test_basic_post_parses_all_fields(self):
+    def test_real_shape_post_parses_all_fields(self):
         items = parse_linkedin_response({"posts": [self._make_post()]})
         self.assertEqual(1, len(items))
         item = items[0]
-        self.assertEqual("urn:li:activity:123", item["id"])
-        self.assertEqual("Excited to share our latest product update.", item["text"])
         self.assertEqual("https://www.linkedin.com/posts/example_123", item["url"])
+        self.assertEqual("Excited to share our latest product update.", item["text"])
         self.assertEqual("Jane Doe", item["author"])
+        self.assertEqual("https://www.linkedin.com/in/janedoe", item["author_url"])
         self.assertEqual("2026-06-01", item["date"])
         self.assertEqual(42, item["engagement"]["likes"])
         self.assertEqual(5, item["engagement"]["comments"])
-        self.assertEqual(2, item["engagement"]["reposts"])
+        self.assertFalse(item["is_article"])
+
+    def test_description_and_datepublished_only_parses_nonempty(self):
+        # Regression guard for the exact bug that shipped: the live API uses
+        # `description` + `datePublished`, and a parser keyed on `text`/`date`
+        # dropped every post (10 raw -> 0 items). This must stay non-empty.
+        raw = {
+            "description": "body via description field",
+            "datePublished": "2026-06-10T09:00:00Z",
+            "url": "https://www.linkedin.com/posts/abc",
+        }
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual(1, len(items))
+        self.assertEqual("body via description field", items[0]["text"])
+        self.assertEqual("2026-06-10", items[0]["date"])
 
     def test_empty_posts_returns_empty_list(self):
         self.assertEqual([], parse_linkedin_response({"posts": []}))
@@ -44,7 +66,7 @@ class TestParseLinkedinResponse(unittest.TestCase):
 
     def test_post_without_text_is_skipped(self):
         raw = self._make_post()
-        del raw["text"]
+        del raw["description"]
         items = parse_linkedin_response({"posts": [raw]})
         self.assertEqual([], items)
 
@@ -69,10 +91,16 @@ class TestParseLinkedinResponse(unittest.TestCase):
         self.assertEqual("", items[0]["author"])
 
     def test_id_falls_back_to_generated_index(self):
+        # The live post object carries no top-level id/urn; the parser
+        # synthesizes a stable per-index id.
         raw = self._make_post()
-        del raw["id"]
         items = parse_linkedin_response({"posts": [raw]})
         self.assertEqual("LI1", items[0]["id"])
+
+    def test_explicit_urn_used_as_id(self):
+        raw = self._make_post(urn="urn:li:activity:999")
+        items = parse_linkedin_response({"posts": [raw]})
+        self.assertEqual("urn:li:activity:999", items[0]["id"])
 
     def test_alternate_field_names(self):
         raw = {
@@ -226,6 +254,140 @@ class TestDateRangeFiltering(unittest.TestCase):
         # counted toward "in range" and gets dropped since in_range is non-empty.
         self.assertEqual(1, len(items))
         self.assertEqual("has date in range", items[0]["text"])
+
+
+class TestArticleDetection(unittest.TestCase):
+    def test_pulse_url_tagged_as_article_and_boosted(self):
+        raw = {
+            "description": "long-form piece",
+            "datePublished": "2026-06-10",
+            "url": "https://www.linkedin.com/pulse/wtf-is-a-loop-matt-van-horn-abc",
+        }
+        item = parse_linkedin_response({"posts": [raw]})[0]
+        self.assertTrue(item["is_article"])
+        self.assertEqual(0.9, item["relevance"])
+
+    def test_posts_url_not_article_default_relevance(self):
+        raw = {
+            "description": "ordinary status update",
+            "datePublished": "2026-06-10",
+            "url": "https://www.linkedin.com/posts/example_123",
+        }
+        item = parse_linkedin_response({"posts": [raw]})[0]
+        self.assertFalse(item["is_article"])
+        self.assertEqual(0.5, item["relevance"])
+
+
+class TestProfileArticles(unittest.TestCase):
+    def _profile(self, **overrides):
+        base = {
+            "name": "Matt Van Horn",
+            "articles": [
+                {
+                    "headline": "WTF Is a Loop? Part 2",
+                    "url": "https://www.linkedin.com/pulse/wtf-loop-part-2-abc",
+                    "datePublished": "2026-06-20T21:06:18.000+00:00",
+                    "articleBody": "",
+                },
+                {
+                    "headline": "Every Agentic Engineering Hack I Know",
+                    "url": "https://www.linkedin.com/pulse/every-hack-def",
+                    "datePublished": "2026-06-04T02:31:36.000+00:00",
+                    "articleBody": "",
+                },
+            ],
+        }
+        base.update(overrides)
+        return base
+
+    def test_articles_parse_as_high_signal(self):
+        items = parse_profile_articles(self._profile())
+        self.assertEqual(2, len(items))
+        for it in items:
+            self.assertTrue(it["is_article"])
+            self.assertEqual(0.9, it["relevance"])
+            self.assertEqual("Matt Van Horn", it["author"])
+        self.assertEqual("WTF Is a Loop? Part 2", items[0]["text"])
+
+    def test_articles_respect_date_range(self):
+        items = parse_profile_articles(
+            self._profile(), from_date="2026-06-15", to_date="2026-06-26"
+        )
+        self.assertEqual(1, len(items))
+        self.assertEqual("WTF Is a Loop? Part 2", items[0]["text"])
+
+    def test_empty_or_missing_articles(self):
+        self.assertEqual([], parse_profile_articles({"name": "X"}))
+        self.assertEqual([], parse_profile_articles({"name": "X", "articles": []}))
+
+    def test_article_without_headline_skipped(self):
+        prof = {"name": "X", "articles": [{"url": "u", "datePublished": "2026-06-10"}]}
+        self.assertEqual([], parse_profile_articles(prof))
+
+
+class TestEnrichArticles(unittest.TestCase):
+    def _person_items(self):
+        # Parsed post items as enrich_articles receives them: a person-topic
+        # search returns posts authored by the subject.
+        return [
+            {"author": "Eric Siu", "author_url": "https://www.linkedin.com/in/ericosiu"},
+            {"author": "Matt Van Horn", "author_url": "https://www.linkedin.com/in/mattvanhorn"},
+        ]
+
+    def test_person_topic_enriches_via_one_profile_call(self):
+        profile = {
+            "name": "Matt Van Horn",
+            "articles": [
+                {"headline": "WTF Is a Loop?", "url": "https://www.linkedin.com/pulse/a", "datePublished": "2026-06-20"},
+            ],
+        }
+        with mock.patch(
+            "lib.linkedin.http.request", return_value=profile
+        ) as mock_request:
+            arts = enrich_articles(
+                self._person_items(), "Matt Van Horn", token="fake",
+                from_date="2026-05-27", to_date="2026-06-26",
+            )
+            self.assertEqual(1, len(arts))
+            self.assertTrue(arts[0]["is_article"])
+            self.assertEqual(0.9, arts[0]["relevance"])
+            # Bounded: exactly one profile call.
+            self.assertEqual(1, mock_request.call_count)
+            # And it fetched the matching author's profile, not the first author.
+            called_url = mock_request.call_args[0][1]
+            self.assertIn("mattvanhorn", called_url)
+
+    def test_keyword_topic_makes_no_profile_call(self):
+        with mock.patch("lib.linkedin.http.request") as mock_request:
+            arts = enrich_articles(
+                self._person_items(), "AI agents", token="fake",
+                from_date="2026-05-27", to_date="2026-06-26",
+            )
+            self.assertEqual([], arts)
+            mock_request.assert_not_called()
+
+    def test_no_token_no_call(self):
+        with mock.patch("lib.linkedin.http.request") as mock_request:
+            arts = enrich_articles(self._person_items(), "Matt Van Horn", token="")
+            self.assertEqual([], arts)
+            mock_request.assert_not_called()
+
+    def test_profile_error_returns_empty(self):
+        from lib import http as http_module
+
+        with mock.patch(
+            "lib.linkedin.http.request",
+            side_effect=http_module.HTTPError("boom", status_code=500),
+        ):
+            arts = enrich_articles(self._person_items(), "Matt Van Horn", token="fake")
+            self.assertEqual([], arts)
+
+    def test_no_author_url_no_call(self):
+        items = [{"author": "Matt Van Horn", "author_url": ""}]
+        with mock.patch("lib.linkedin.http.request") as mock_request:
+            arts = enrich_articles(items, "Matt Van Horn", token="fake")
+            self.assertEqual([], arts)
+            mock_request.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -1276,6 +1276,36 @@ class TestPerplexityAvailability(unittest.TestCase):
         self.assertTrue(diag["local_mode"])
 
 
+class TestLinkedinAvailability(unittest.TestCase):
+    """LinkedIn is power-user opt-in (INCLUDE_SOURCES=linkedin), unlike
+    tiktok/instagram which activate on SCRAPECREATORS_API_KEY alone. This
+    keeps existing SCRAPECREATORS_API_KEY holders from silently picking up a
+    new source — and spending new credits — on their next run."""
+
+    def test_not_available_with_key_alone(self):
+        sources = pipeline.available_sources({"SCRAPECREATORS_API_KEY": "test-key"})
+        self.assertNotIn("linkedin", sources)
+        # tiktok/instagram remain unconditional with just the key
+        self.assertIn("tiktok", sources)
+        self.assertIn("instagram", sources)
+
+    def test_available_with_key_and_include_sources(self):
+        sources = pipeline.available_sources(
+            {"SCRAPECREATORS_API_KEY": "test-key", "INCLUDE_SOURCES": "linkedin"}
+        )
+        self.assertIn("linkedin", sources)
+
+    def test_available_with_key_and_requested_sources(self):
+        sources = pipeline.available_sources(
+            {"SCRAPECREATORS_API_KEY": "test-key"}, requested_sources=["linkedin"]
+        )
+        self.assertIn("linkedin", sources)
+
+    def test_not_available_with_include_sources_but_no_key(self):
+        sources = pipeline.available_sources({"INCLUDE_SOURCES": "linkedin"})
+        self.assertNotIn("linkedin", sources)
+
+
 class TestKeylessGroundingAvailability(unittest.TestCase):
     """Grounding (general web) availability is host-aware.
 


### PR DESCRIPTION
Adds LinkedIn as a retrieval source, using the ScrapeCreators
`/v1/linkedin/search/posts` endpoint (Google-indexed LinkedIn content,
no auth required on ScrapeCreators' side beyond the API key).

Changes:
- New `lib/linkedin.py`: `search_linkedin()` calls the ScrapeCreators
  endpoint; `parse_linkedin_response()` normalizes the raw response into
  engine-compatible item dicts (id, text, url, author, date, engagement).
- `lib/pipeline.py`: registers `linkedin` as an available source (gated
  on `SCRAPECREATORS_API_KEY`, same as tiktok/instagram), adds it to
  `MOCK_AVAILABLE_SOURCES` and `MAX_SOURCE_FETCHES` (capped at 1
  fetch/run), and dispatches to it in `_retrieve_stream`.
- `lib/normalize.py`: adds `_normalize_linkedin` to map raw LinkedIn
  post dicts into the generic `SourceItem` model, registered in the
  source normalizer dispatch dict.
- `tests/test_linkedin.py`: unit tests for response parsing, field
  fallbacks, and the no-token/error short-circuit paths.

Requires `SCRAPECREATORS_API_KEY` to be set; falls back to skipping
(empty results) if absent, consistent with other ScrapeCreators-backed
sources.

Note on `DEPTH_CONFIG`: since `SCRAPECREATORS_API_KEY` is BYOK, the
default/deep windows use `last-month` with higher `max_results` (20/30)
rather than throttling to `last-week`/lower counts — each user's own
credit usage is their call to manage, not something to bake into the
upstream default.

Testing: added unit tests in `tests/test_linkedin.py` covering response
parsing, field-name fallbacks, and the no-token/error short-circuit
paths (all mocked, no live API calls). Ran the full existing test suite
locally with no regressions.