### PR TITLE
feat: make the OpenRouter base URL overridable (OPENROUTER_BASE_URL)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -868,7 +868,7 @@ def _propagate_config_to_environ(config: dict[str, object]) -> None:
     XAI_BASE_URL overrides are silently ignored. This is a no-op for
     keys that are already set in process env.
     """
-    for key in ("OPENAI_BASE_URL", "XAI_BASE_URL"):
+    for key in ("OPENAI_BASE_URL", "XAI_BASE_URL", "OPENROUTER_BASE_URL"):
         val = config.get(key)
         if val and not os.environ.get(key):
             os.environ[key] = val

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -420,6 +420,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('XAI_MODEL_PIN', None),
         ('OPENAI_BASE_URL', None),
         ('XAI_BASE_URL', None),
+        ('OPENROUTER_BASE_URL', None),
         ('SCRAPECREATORS_API_KEY', None),
         ('APIFY_API_TOKEN', None),
         ('AUTH_TOKEN', None),

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -182,7 +182,7 @@ class OpenRouterClient(ReasoningClient):
             "temperature": 0,
         }
         response = http.post(
-            OPENROUTER_URL,
+            os.environ.get("OPENROUTER_BASE_URL", OPENROUTER_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.api_key}",


### PR DESCRIPTION
## What

PR #582 made `OPENAI_BASE_URL` / `XAI_BASE_URL` overridable so the `openai` and `xai` reasoning clients can target a custom endpoint — but those clients speak the **Responses API**. The **`openrouter`** client uses the standard **Chat Completions** format (`/chat/completions` with `messages`), which is what most OpenAI-compatible providers expose — yet its URL is hardcoded to `openrouter.ai`.

This makes that one URL overridable via **`OPENROUTER_BASE_URL`**, mirroring #582 exactly:

- `providers.py` — `OpenRouterClient` reads `os.environ.get("OPENROUTER_BASE_URL", OPENROUTER_URL)`
- `env.py` — whitelist `OPENROUTER_BASE_URL` in the config
- `last30days.py` — propagate it to `os.environ` alongside the other two

**No behavior change unless the env var is set** (defensive default to the existing URL).

## Why

It lets the planner/rerank run on **any OpenAI Chat-Completions-compatible endpoint** — DeepInfra, Together, Groq, Fireworks, a local vLLM/Ollama, etc. — not just OpenRouter. Same "bring your own endpoint" capability #582 gave the Responses-API clients, now for the chat-completions one. Partially addresses #128.

## Usage

```sh
export LAST30DAYS_REASONING_PROVIDER=openrouter
export OPENROUTER_BASE_URL=https://api.deepinfra.com/v1/openai/chat/completions
export OPENROUTER_API_KEY=<deepinfra key>
export LAST30DAYS_RERANK_MODEL=deepseek-ai/DeepSeek-V4-Pro
export LAST30DAYS_PLANNER_MODEL=deepseek-ai/DeepSeek-V4-Pro
```

Verified against DeepInfra (DeepSeek-V4-Pro) — planner returns `source=llm`.
