### PR TITLE
fix: register FUN_LEVEL in env.py so .env config is not silently ignored

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -502,6 +502,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('INCLUDE_SOURCES', ''),
         ('EXCLUDE_SOURCES', ''),
         ('LAST30DAYS_DEFAULT_SEARCH', ''),
+        ('FUN_LEVEL', 'medium'),
         ('LAST30DAYS_YOUTUBE_SSH_HOST', None),
         ('LAST30DAYS_TRANSCRIPT_TIMEOUT', None),
         (KEYCHAIN_ALIASES_ENV, None),


### PR DESCRIPTION
Fixes #707.

`FUN_LEVEL` was missing from the config keys tuple in `env.py`, so `get_config()` would never load it from the `.env` file. Users setting `FUN_LEVEL=high` in `.env` always silently got `"medium"` behavior.

The `--fun-level` CLI flag and process env var `FUN_LEVEL` were unaffected (both bypass `env.py`).