### PR TITLE
fix: open .env with explicit utf-8 encoding for Windows compat

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -172,7 +172,7 @@ def load_env_file(path: Path) -> dict[str, str]:
         return env
     _check_file_permissions(path)
 
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8-sig') as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith('#'):


### PR DESCRIPTION
Fixes #714.

`load_env_file()` at `env.py:136` opened `.env` without specifying `encoding='utf-8'`. On Windows with non-UTF-8 system locale, any non-ASCII character in the file would raise `UnicodeDecodeError`. The `setup_wizard.py` writes `.env` with `encoding='utf-8'`, creating a read/write mismatch.