### PR TITLE
feat(pipeline): overridable result caps so high-volume sources aren't truncated (#716)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -378,6 +378,17 @@ def build_parser() -> argparse.ArgumentParser:
             "When set, --days looks back from this date instead of today."
             ),
     )
+    parser.add_argument("--max-results", dest="max_results", type=int,
+                        help="Override the final ranked-pool cap (pool_limit/rerank_limit) from the depth profile. "
+                             "Use for high-volume topics where the default (deep=60) under-covers. See issue #716.")
+    parser.add_argument("--max-per-source", dest="max_per_source", type=int,
+                        help="Override the per-stream cap (per_stream_limit) applied to each (source, subquery) before "
+                             "pooling. Raising it increases unique-item yield when one source has many relevant items. "
+                             "See issue #716.")
+    parser.add_argument("--max-source-fetches", dest="max_source_fetches", type=int,
+                        help="Override the per-source fetch cap (MAX_SOURCE_FETCHES, default x=2) that limits how many "
+                             "subqueries actually fetch a capped source. Raise it so every X subquery in a multi-angle "
+                             "--plan runs instead of just the first two. See issue #716.")
     parser.add_argument("--auto-resolve", action="store_true",
                         help="Use web search to discover subreddits/handles before planning (for platforms without WebSearch)")
     parser.add_argument("--github-user", help="GitHub username for person-mode search (e.g., steipete)")
@@ -1078,6 +1089,15 @@ def main() -> int:
     progress.start_processing()
 
     depth = "deep" if args.deep else "quick" if args.quick else "default"
+    # CLI overrides for the depth profile's result caps (issue #716). Stashed on
+    # config so pipeline.run() can apply them without widening its signature; the
+    # comparison path inherits them via `entity_config = dict(config)`.
+    if args.max_results is not None:
+        config["_max_results"] = args.max_results
+    if args.max_per_source is not None:
+        config["_max_per_source"] = args.max_per_source
+    if args.max_source_fetches is not None:
+        config["_max_source_fetches"] = args.max_source_fetches
     try:
         x_related = [h.strip() for h in args.x_related.split(",") if h.strip()] if args.x_related else None
         subreddits = [s.strip().removeprefix("r/") for s in args.subreddits.split(",") if s.strip()] if args.subreddits else None

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -81,11 +81,13 @@ def _resolve_depth_settings(depth: str, config: dict[str, Any]) -> dict[str, int
     cap (`--max-source-fetches`) is applied separately at the fetch site.
     """
     settings = dict(DEPTH_SETTINGS[depth])
+    # `is not None` (not truthiness) so an explicit 0 is honored as a real lower
+    # bound rather than ignored as "unset" — matches how main() stashes these.
     max_per_source = config.get("_max_per_source")
-    if max_per_source:
+    if max_per_source is not None:
         settings["per_stream_limit"] = int(max_per_source)
     max_results = config.get("_max_results")
-    if max_results:
+    if max_results is not None:
         settings["pool_limit"] = int(max_results)
         settings["rerank_limit"] = int(max_results)
     return settings
@@ -477,7 +479,9 @@ def run(
                 # --plan fetches, instead of only the first two.
                 cap = MAX_SOURCE_FETCHES.get(source)
                 _cap_override = config.get("_max_source_fetches")
-                if cap is not None and _cap_override:
+                if cap is not None and _cap_override is not None:
+                    # `is not None` so --max-source-fetches 0 (disable fetching a
+                    # capped source) is honored instead of falling back to default.
                     cap = int(_cap_override)
                 if cap is not None:
                     current = source_fetch_count.get(source, 0)

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -70,6 +70,26 @@ SEARCH_ALIAS = {
 
 MAX_SOURCE_FETCHES: dict[str, int] = {"x": 2, "jobs": 1, "linkedin": 1}
 
+
+def _resolve_depth_settings(depth: str, config: dict[str, Any]) -> dict[str, int]:
+    """Depth profile with optional CLI cap overrides applied (issue #716).
+
+    Returns a copy so the module-level DEPTH_SETTINGS is never mutated. Overrides
+    are set directly (not max()) so callers can also lower a cap. `--max-results`
+    raises the final ranked pool (pool_limit/rerank_limit); `--max-per-source`
+    raises the per-stream truncation applied before pooling. The per-source fetch
+    cap (`--max-source-fetches`) is applied separately at the fetch site.
+    """
+    settings = dict(DEPTH_SETTINGS[depth])
+    max_per_source = config.get("_max_per_source")
+    if max_per_source:
+        settings["per_stream_limit"] = int(max_per_source)
+    max_results = config.get("_max_results")
+    if max_results:
+        settings["pool_limit"] = int(max_results)
+        settings["rerank_limit"] = int(max_results)
+    return settings
+
 # Per-handle result caps for the X handle-search lanes. The FROM lane (the
 # subject's own timeline) is the single best source for a person topic, so it
 # gets the highest cap; the ABOUT (mention) and related-handle lanes stay
@@ -286,7 +306,7 @@ def run(
     hiring_signals_mode: bool = False,
     internal_subrun: bool = False,
 ) -> schema.Report:
-    settings = DEPTH_SETTINGS[depth]
+    settings = _resolve_depth_settings(depth, config)
     requested_sources = normalize_requested_sources(requested_sources)
     from_date, to_date = dates.get_date_range(lookback_days, as_of_date=as_of_date)
 
@@ -452,8 +472,13 @@ def run(
                 # Skip GitHub keyword search if person-mode already ran
                 if source == "github" and (_github_person_done or _github_custom_done):
                     continue
-                # Enforce per-source fetch cap
+                # Enforce per-source fetch cap. A CLI override (issue #716) raises
+                # the cap for capped sources so every X subquery in a multi-angle
+                # --plan fetches, instead of only the first two.
                 cap = MAX_SOURCE_FETCHES.get(source)
+                _cap_override = config.get("_max_source_fetches")
+                if cap is not None and _cap_override:
+                    cap = int(_cap_override)
                 if cap is not None:
                     current = source_fetch_count.get(source, 0)
                     if current >= cap:

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -169,6 +169,25 @@ class CliV3Tests(unittest.TestCase):
         self.assertEqual(["biosecurity"], args.topic)
         self.assertEqual([], extra)
 
+    def test_build_parser_accepts_result_cap_overrides(self):
+        parser = cli.build_parser()
+        args, extra = parser.parse_known_args(
+            ["--max-results", "200", "--max-per-source", "60",
+             "--max-source-fetches", "8", "figma config 2026"]
+        )
+        self.assertEqual(200, args.max_results)
+        self.assertEqual(60, args.max_per_source)
+        self.assertEqual(8, args.max_source_fetches)
+        self.assertEqual(["figma config 2026"], args.topic)
+        self.assertEqual([], extra)
+
+    def test_result_cap_overrides_default_to_none(self):
+        parser = cli.build_parser()
+        args, _ = parser.parse_known_args(["figma config 2026"])
+        self.assertIsNone(args.max_results)
+        self.assertIsNone(args.max_per_source)
+        self.assertIsNone(args.max_source_fetches)
+
     def test_research_unknown_flag_fails_before_config_load(self):
         with mock.patch.object(
             cli.env, "get_config", side_effect=AssertionError("config should not load")

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -273,6 +273,33 @@ class TestSourceFetchCap(unittest.TestCase):
             f"X should be fetched at most 2 times, got {len(x_calls)}",
         )
 
+    @patch("lib.pipeline._retrieve_stream")
+    def test_zero_source_fetch_override_suppresses_capped_source(self, mock_retrieve):
+        """A 0 override is explicit and should suppress capped-source submissions."""
+        mock_retrieve.side_effect = lambda **kwargs: pipeline._mock_stream_results(
+            kwargs["source"], kwargs["subquery"]
+        )
+        pipeline.run(
+            topic="compare iPhone vs Android vs Pixel vs Samsung",
+            config={
+                "LAST30DAYS_REASONING_PROVIDER": "gemini",
+                "_max_source_fetches": 0,
+            },
+            depth="quick",
+            requested_sources=["reddit", "x"],
+            mock=True,
+        )
+        x_calls = [
+            call for call in mock_retrieve.call_args_list
+            if call.kwargs.get("source") == "x"
+        ]
+        reddit_calls = [
+            call for call in mock_retrieve.call_args_list
+            if call.kwargs.get("source") == "reddit"
+        ]
+        self.assertEqual([], x_calls)
+        self.assertGreater(len(reddit_calls), 0)
+
 
 class TestRateLimitSharing(unittest.TestCase):
     """429 signals should be shared across subqueries."""

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -27,6 +27,15 @@ class DepthSettingsOverrideTests(unittest.TestCase):
         settings = pipeline._resolve_depth_settings("deep", {"_max_results": 10})
         self.assertEqual(10, settings["rerank_limit"])
 
+    def test_zero_override_is_honored_not_swallowed(self):
+        # 0 is a valid explicit value (e.g. disable a source), not "unset".
+        settings = pipeline._resolve_depth_settings(
+            "deep", {"_max_results": 0, "_max_per_source": 0}
+        )
+        self.assertEqual(0, settings["pool_limit"])
+        self.assertEqual(0, settings["rerank_limit"])
+        self.assertEqual(0, settings["per_stream_limit"])
+
 
 class PipelineV3Tests(unittest.TestCase):
     def test_mock_pipeline_report_without_live_credentials(self):

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -7,6 +7,27 @@ from lib import http
 from lib import schema
 
 
+class DepthSettingsOverrideTests(unittest.TestCase):
+    def test_no_overrides_returns_depth_defaults(self):
+        settings = pipeline._resolve_depth_settings("deep", {})
+        self.assertEqual(pipeline.DEPTH_SETTINGS["deep"], settings)
+
+    def test_overrides_raise_caps_and_do_not_mutate_module_defaults(self):
+        before = dict(pipeline.DEPTH_SETTINGS["deep"])
+        settings = pipeline._resolve_depth_settings(
+            "deep", {"_max_per_source": 60, "_max_results": 200}
+        )
+        self.assertEqual(60, settings["per_stream_limit"])
+        self.assertEqual(200, settings["pool_limit"])
+        self.assertEqual(200, settings["rerank_limit"])
+        # Module-level defaults must be untouched (issue #716 regression guard).
+        self.assertEqual(before, pipeline.DEPTH_SETTINGS["deep"])
+
+    def test_overrides_can_also_lower_caps(self):
+        settings = pipeline._resolve_depth_settings("deep", {"_max_results": 10})
+        self.assertEqual(10, settings["rerank_limit"])
+
+
 class PipelineV3Tests(unittest.TestCase):
     def test_mock_pipeline_report_without_live_credentials(self):
         report = pipeline.run(


### PR DESCRIPTION
Fixes #716.

## Problem

On a topic with real X volume, `/last30days` returns only ~20-30 X posts no matter what — `--deep`, a 6-7 subquery `--plan`, and `EXCLUDE_SOURCES` for everything else don't help. A direct multi-query sweep of the vendored `bird-search.mjs` for the same topic returns **245 relevant posts (206 authors)**, so the data exists; the pipeline bottlenecks it.

Three independent, non-configurable caps cause it:

1. **`per_stream_limit`** truncates each `(source, subquery)` stream *before* the RRF pool/dedup, so a subquery that found ~40 distinct posts contributes only 20 (deep).
2. **`pool_limit` / `rerank_limit`** hard-cap the final pool at 60 (deep) with no override.
3. **`MAX_SOURCE_FETCHES["x"] = 2`** means only the first two X subqueries ever fetch — a 7-angle X plan still runs X twice.

## Change

Three opt-in CLI overrides, **all default-off** (no behavior change when unused):

| Flag | Overrides |
|------|-----------|
| `--max-results N` | `pool_limit` + `rerank_limit` |
| `--max-per-source N` | `per_stream_limit` |
| `--max-source-fetches N` | the per-source fetch cap (`MAX_SOURCE_FETCHES`) |

Settings resolution is extracted into `pipeline._resolve_depth_settings(depth, config)`, which:
- returns a **copy** so module-level `DEPTH_SETTINGS` is never mutated (matters for the comparison path that reuses one config), and
- sets caps **directly** (not `max()`) so a value can be raised *or* lowered.

The fetch-cap override is applied at the existing cap site in `run()`.

## Verification

Live breaking-news topic (`Figma Config 2026`, X via `bird_x` cookies), X-only plan with 7 distinct feature subqueries:

| Run | Unique X posts |
|-----|----------------|
| baseline (`--deep`) | 28 |
| `--max-per-source 60 --max-results 200` | 30 |
| `+ --max-source-fetches 8` | **75** |

The fetch-cap was the dominant limiter; the three compose to deliver the full set.

## Tests

- `tests/test_cli_v3.py`: parser accepts the three flags; they default to `None`.
- `tests/test_pipeline_v3.py`: `_resolve_depth_settings` applies overrides, can lower caps, and does not mutate `DEPTH_SETTINGS`.

Full suite green locally: `test_pipeline_v3` + `test_cli_v3` → 116 passed.

## Scope / follow-ups

Deliberately not in this PR (noted in #716): per-source *weighting* (Finding 3) and cursor pagination in `bird-search.mjs` (Finding 4, which caps a single query at one ~40-item timeline page). Happy to take direction on flag naming or to fold these in.
