### PR TITLE
Fix X search on Windows + Node 24 (UTF-8 decode + tolerate Bird exit-crash)

### DIFF
--- a/scripts/lib/bird_x.py
+++ b/scripts/lib/bird_x.py
@@ -177,6 +177,8 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             preexec_fn=preexec,
             env=_subprocess_env(),
         )
@@ -205,15 +207,27 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
             except Exception:
                 pass
 
-        if proc.returncode != 0:
-            error = stderr.strip() if stderr else "Bird search failed"
-            return {"error": error, "items": []}
-
         output = stdout.strip() if stdout else ""
+
+        # Windows/Node 24: the vendored Bird CLI uses native fetch (undici), and
+        # calling process.exit() while keep-alive sockets are still closing trips a
+        # libuv assertion (UV_HANDLE_CLOSING, src/win/async.c) -> non-zero exit code
+        # AFTER it has already written a complete, valid JSON result to stdout.
+        # So: if stdout has parseable JSON, trust it regardless of the exit code;
+        # only treat a non-zero exit as a real failure when stdout is empty/garbage.
         if not output:
+            if proc.returncode != 0:
+                error = stderr.strip() if stderr else "Bird search failed"
+                return {"error": error, "items": []}
             return {"items": []}
 
-        parsed = json.loads(output)
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            if proc.returncode != 0:
+                error = stderr.strip() if stderr else "Bird search failed"
+                return {"error": error, "items": []}
+            raise
         if isinstance(parsed, list):
             return {"items": parsed}
         return parsed


### PR DESCRIPTION
## Problem

On **Windows 11 / Node v24.14.0 / Python 3.12**, the bundled Bird X backend returned **0 results** even with valid `AUTH_TOKEN`/`CT0` cookies (auth check passed). Two separate Windows-specific bugs:

**1. UTF-8 decode crash.** `_run_bird_search` spawns the Node CLI with `subprocess.Popen(text=True)` and no `encoding=`, so on Windows the child stdout is decoded as **cp1252**. Any tweet with emoji or non-Latin text (CJK / Arabic / etc.) raises `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81` in the reader thread → search returns 0 results.

**2. Valid results discarded on a benign exit-crash.** The vendored `bird-search.mjs` uses native `fetch` (undici). On Windows + Node 24, calling `process.exit()` while undici keep-alive sockets are still closing trips a libuv assertion:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

The process exits **non-zero AFTER** it has already written a **complete, valid JSON result** to stdout. The wrapper treated any non-zero exit as failure and discarded the good output.

## Fix (`scripts/lib/bird_x.py`, search path only)

- Pin `encoding="utf-8", errors="replace"` on the `Popen` call so non-ASCII tweet text never crashes the reader thread.
- Trust parseable stdout regardless of exit code; only treat a non-zero exit as a real failure when stdout is **empty or not valid JSON**. This tolerates the benign Windows/Node 24 exit-crash without masking genuine failures.

No behavior change on Linux/macOS (python emits LF / exits 0 there).

## Verification

Windows 11 / Node v24.14.0 — a `Claude Code` search now returns live tweets including CJK/Arabic text (previously 0 results). Auth check was already passing; this fixes the search path only.