### PR TITLE
Fix Chromium cookie extraction to search all profiles, not just Default

### DIFF
--- a/changelog.d/725.fixed.md
+++ b/changelog.d/725.fixed.md
@@ -1,0 +1,1 @@
+Chromium cookie extraction now searches every browser profile for a matching cookie set, and reuses the Keychain/AES key across profiles in one scan.

--- a/skills/last30days/scripts/lib/chrome_cookies.py
+++ b/skills/last30days/scripts/lib/chrome_cookies.py
@@ -204,6 +204,7 @@ def _extract_chromium_cookies_macos(
     keychain_service: str,
     domain: str,
     cookie_names: list[str],
+    key_cache: Optional[dict[str, Optional[bytes]]] = None,
 ) -> Optional[dict[str, str]]:
     """Extract cookies from any Chromium-based browser on macOS.
 
@@ -277,8 +278,13 @@ def _extract_chromium_cookies_macos(
                     # Keychain prompt for browsers that don't hold the requested
                     # cookie, which matters for FROM_BROWSER=auto across several
                     # installed Chromium browsers.
-                    passphrase = _get_chromium_encryption_key(keychain_service)
-                    aes_key = _derive_aes_key(passphrase) if passphrase else None
+                    if key_cache is not None and keychain_service in key_cache:
+                        aes_key = key_cache[keychain_service]
+                    else:
+                        passphrase = _get_chromium_encryption_key(keychain_service)
+                        aes_key = _derive_aes_key(passphrase) if passphrase else None
+                        if key_cache is not None:
+                            key_cache[keychain_service] = aes_key
                     key_fetched = True
                 if aes_key is None:
                     logger.debug("Skipping encrypted cookie %s — no Keychain access", name)
@@ -350,28 +356,12 @@ def _find_chromium_cookies_db(base_dir: Path) -> Optional[Path]:
     recently used one is the likeliest to hold current cookies. Lexicographic
     sort would visit "Profile 10" before "Profile 2", which can return the
     wrong profile, so we sort by mtime.
+
+    Kept for backward compatibility; new code should use
+    _find_all_chromium_cookies_dbs() to search across all profiles.
     """
-    found = _profile_cookie_db(base_dir / "Default")
-    if found:
-        return found
-
-    found = _profile_cookie_db(base_dir)
-    if found:
-        return found
-
-    try:
-        candidates = [
-            child for child in base_dir.iterdir()
-            if child.is_dir() and child.name.startswith("Profile ")
-        ]
-        for child in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
-            found = _profile_cookie_db(child)
-            if found:
-                return found
-    except OSError:
-        pass
-
-    return None
+    dbs = _find_all_chromium_cookies_dbs(base_dir)
+    return dbs[0] if dbs else None
 
 
 def _find_all_chromium_cookies_dbs(base_dir: Path) -> list[Path]:
@@ -421,8 +411,11 @@ def _extract_chromium_cookies_any_profile(
         logger.info("%s cookies database not found under %s", keychain_service, base_dir)
         return None
     best: Optional[dict[str, str]] = None
+    key_cache: dict[str, Optional[bytes]] = {}
     for db_path in db_paths:
-        got = _extract_chromium_cookies_macos(db_path, keychain_service, domain, cookie_names)
+        got = _extract_chromium_cookies_macos(
+            db_path, keychain_service, domain, cookie_names, key_cache=key_cache
+        )
         if got:
             if all(name in got for name in cookie_names):
                 logger.debug("Found complete cookie set for %s in %s", domain, db_path)

--- a/skills/last30days/scripts/lib/chrome_cookies.py
+++ b/skills/last30days/scripts/lib/chrome_cookies.py
@@ -319,12 +319,8 @@ def extract_chrome_cookies_macos(domain: str, cookie_names: list[str]) -> Option
     same modern ``Default/Network/Cookies`` (Chromium >= 96) and legacy
     ``Default/Cookies`` probing as the rest of the Chromium family.
     """
-    db_path = _find_chromium_cookies_db(CHROME_BASE_DIR)
-    if db_path is None:
-        logger.info("Chrome cookies database not found under %s", CHROME_BASE_DIR)
-        return None
-    return _extract_chromium_cookies_macos(
-        db_path, "Chrome Safe Storage", domain, cookie_names
+    return _extract_chromium_cookies_any_profile(
+        CHROME_BASE_DIR, "Chrome Safe Storage", domain, cookie_names
     )
 
 
@@ -378,6 +374,64 @@ def _find_chromium_cookies_db(base_dir: Path) -> Optional[Path]:
     return None
 
 
+def _find_all_chromium_cookies_dbs(base_dir: Path) -> list[Path]:
+    """Return ALL candidate Cookies DBs under base_dir, best-guess order first.
+
+    Order: Default, the base dir itself (Opera's flat layout), then numbered
+    "Profile N" dirs by most-recently-modified. Unlike _find_chromium_cookies_db
+    (which returns the first DB that merely EXISTS), this returns every profile
+    so the caller can pick the one that actually holds the target domain's
+    cookies. Needed because a logged-in session often lives in a non-Default
+    profile while Default still has a (guest-only) cookie DB.
+    """
+    paths: list[Path] = []
+    seen: set[Path] = set()
+
+    def add(p: Optional[Path]) -> None:
+        if p is not None and p not in seen:
+            seen.add(p)
+            paths.append(p)
+
+    add(_profile_cookie_db(base_dir / "Default"))
+    add(_profile_cookie_db(base_dir))
+    try:
+        candidates = [
+            child for child in base_dir.iterdir()
+            if child.is_dir() and child.name.startswith("Profile ")
+        ]
+        for child in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
+            add(_profile_cookie_db(child))
+    except OSError:
+        pass
+    return paths
+
+
+def _extract_chromium_cookies_any_profile(
+    base_dir: Path, keychain_service: str, domain: str, cookie_names: list[str]
+) -> Optional[dict[str, str]]:
+    """Try every profile under base_dir and return the best cookie match.
+
+    Returns the first profile that yields ALL requested cookie_names. If no
+    profile has the complete set, returns the first partial match found, or
+    None if no profile yielded any. This fixes the single-profile limitation
+    where a guest-only Default profile shadowed a logged-in "Profile N".
+    """
+    db_paths = _find_all_chromium_cookies_dbs(base_dir)
+    if not db_paths:
+        logger.info("%s cookies database not found under %s", keychain_service, base_dir)
+        return None
+    best: Optional[dict[str, str]] = None
+    for db_path in db_paths:
+        got = _extract_chromium_cookies_macos(db_path, keychain_service, domain, cookie_names)
+        if got:
+            if all(name in got for name in cookie_names):
+                logger.debug("Found complete cookie set for %s in %s", domain, db_path)
+                return got
+            if best is None:
+                best = got
+    return best
+
+
 def _find_brave_cookies_db() -> Optional[Path]:
     """Find Brave's Cookies database on macOS (Default, then Profile N)."""
     return _find_chromium_cookies_db(BRAVE_BASE_DIR)
@@ -389,11 +443,9 @@ def extract_brave_cookies_macos(domain: str, cookie_names: list[str]) -> Optiona
     Brave uses the same v10 AES-128-CBC encryption as Chrome; only the DB
     path and Keychain service name differ.
     """
-    db_path = _find_brave_cookies_db()
-    if db_path is None:
-        logger.info("Brave cookies database not found under %s", BRAVE_BASE_DIR)
-        return None
-    return _extract_chromium_cookies_macos(db_path, "Brave Safe Storage", domain, cookie_names)
+    return _extract_chromium_cookies_any_profile(
+        BRAVE_BASE_DIR, "Brave Safe Storage", domain, cookie_names
+    )
 
 
 def extract_chromium_browser_cookies_macos(
@@ -410,8 +462,6 @@ def extract_chromium_browser_cookies_macos(
         logger.debug("Unknown Chromium browser: %s", browser)
         return None
     base_dir, keychain_service = spec
-    db_path = _find_chromium_cookies_db(base_dir)
-    if db_path is None:
-        logger.info("%s cookies database not found under %s", keychain_service, base_dir)
-        return None
-    return _extract_chromium_cookies_macos(db_path, keychain_service, domain, cookie_names)
+    return _extract_chromium_cookies_any_profile(
+        base_dir, keychain_service, domain, cookie_names
+    )

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -26,6 +26,7 @@ from lib.chrome_cookies import (
     _remove_pkcs7_padding,
     _extract_chromium_cookies_macos,
     _decrypt_v10_value,
+    _find_chromium_cookies_db,
     extract_chrome_cookies_macos,
 )
 
@@ -207,11 +208,26 @@ class TestDecryption:
 class TestChromeNotInstalled:
     def test_db_not_found(self):
         with mock.patch(
-            "lib.chrome_cookies._find_chromium_cookies_db",
-            return_value=None,
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[],
         ):
             result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
             assert result is None
+
+
+class TestChromiumCookieDbFinder:
+    def test_legacy_single_db_finder_returns_first_all_profile_candidate(self, tmp_path):
+        first = tmp_path / "Default" / "Network" / "Cookies"
+        second = tmp_path / "Profile 1" / "Network" / "Cookies"
+
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[first, second],
+        ) as find_all:
+            result = _find_chromium_cookies_db(tmp_path)
+
+        assert result == first
+        find_all.assert_called_once_with(tmp_path)
 
 # ---------------------------------------------------------------------------
 # Keychain access denied → returns None
@@ -312,7 +328,10 @@ class TestUnencryptedCookies:
             (".x.com", "ct0", "plain_ct0_value", b""),
         ])
 
-        with mock.patch("lib.chrome_cookies._find_chromium_cookies_db", return_value=Path(db_path)):
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[Path(db_path)],
+        ):
             # No keychain needed for unencrypted values
             with mock.patch("lib.chrome_cookies._get_chromium_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
@@ -341,7 +360,10 @@ class TestFullExtraction:
             (".other.com", "other", "", b""),  # unrelated cookie
         ])
 
-        with mock.patch("lib.chrome_cookies._find_chromium_cookies_db", return_value=Path(db_path)):
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[Path(db_path)],
+        ):
             with mock.patch(
                 "lib.chrome_cookies._get_chromium_encryption_key",
                 return_value=KNOWN_PASSPHRASE,
@@ -358,7 +380,10 @@ class TestFullExtraction:
             (".other.com", "session", "val", b""),
         ])
 
-        with mock.patch("lib.chrome_cookies._find_chromium_cookies_db", return_value=Path(db_path)):
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[Path(db_path)],
+        ):
             with mock.patch("lib.chrome_cookies._get_chromium_encryption_key", return_value=None):
                 result = extract_chrome_cookies_macos(".x.com", ["auth_token"])
 
@@ -375,7 +400,10 @@ class TestFullExtraction:
             (".x.com", "auth_token", "", encrypted_auth),
         ], db_version=24)
 
-        with mock.patch("lib.chrome_cookies._find_chromium_cookies_db", return_value=Path(db_path)):
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[Path(db_path)],
+        ):
             with mock.patch(
                 "lib.chrome_cookies._get_chromium_encryption_key",
                 return_value=KNOWN_PASSPHRASE,
@@ -384,6 +412,36 @@ class TestFullExtraction:
 
         assert result is not None
         assert result["auth_token"] == auth_val
+
+    @pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl not installed")
+    def test_multi_profile_extraction_reuses_keychain_key(self, tmp_path):
+        """Profiles for one browser share a Keychain service; fetch it once."""
+        first_db = tmp_path / "Default.sqlite"
+        second_db = tmp_path / "Profile1.sqlite"
+        auth_val = "profile_auth_token"
+        ct0_val = "profile_ct0_value"
+
+        _create_chrome_cookies_db(str(first_db), [
+            (".x.com", "auth_token", "", _encrypt_value_v10(auth_val, KNOWN_AES_KEY)),
+        ])
+        _create_chrome_cookies_db(str(second_db), [
+            (".x.com", "auth_token", "", _encrypt_value_v10(auth_val, KNOWN_AES_KEY)),
+            (".x.com", "ct0", "", _encrypt_value_v10(ct0_val, KNOWN_AES_KEY)),
+        ])
+
+        with mock.patch(
+            "lib.chrome_cookies._find_all_chromium_cookies_dbs",
+            return_value=[first_db, second_db],
+        ):
+            with mock.patch(
+                "lib.chrome_cookies._get_chromium_encryption_key",
+                return_value=KNOWN_PASSPHRASE,
+            ) as get_key:
+                result = extract_chrome_cookies_macos(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["ct0"] == ct0_val
+        get_key.assert_called_once_with("Chrome Safe Storage")
 
 # ---------------------------------------------------------------------------
 # DB version detection


### PR DESCRIPTION
## Problem

`_find_chromium_cookies_db()` returns the first profile whose Cookies DB merely **exists** (Default → base dir → first `Profile N`) and stops there. If a user's logged-in session lives in a **non-Default** profile (e.g. `Profile 1`) while the Default profile still has a guest-only Cookies DB, extraction reads Default, finds no matching cookies, and never tries the other profiles.

Observed on macOS / Chrome: a user logged into x.com only in `Profile 1` got `No browser cookies found for X/Twitter` and `No X backend is available` from `FROM_BROWSER=auto`, despite a valid live session. The failure is silent because the X source's per-browser extraction swallows exceptions, so a guest-only Default profile is indistinguishable from "no cookies anywhere."

## Fix

- Add `_find_all_chromium_cookies_dbs(base_dir)` — returns **every** candidate Cookies DB (Default, base dir, then `Profile N` by most-recently-modified), deduped, instead of the first that exists.
- Add `_extract_chromium_cookies_any_profile(...)` — tries each profile and returns the first that yields the **complete** requested cookie set, falling back to the first partial match, else `None`.
- Point `extract_chrome_cookies_macos`, `extract_brave_cookies_macos`, and `extract_chromium_browser_cookies_macos` at the new any-profile path.

Preferring a *complete* set over the first *partial* hit avoids authenticating with a stale leftover cookie (e.g. an `auth_token` without a current `ct0`) in some other profile.

`_find_chromium_cookies_db()` is left in place for backward compatibility with any external callers.

## Testing

Verified locally on macOS with Chrome where the live x.com session lives in `Profile 1` and Default holds only guest cookies:
- Before: `extract_chrome_cookies_macos('x.com', ['auth_token','ct0'])` -> `None`.
- After: returns both cookies (`complete: True`); `FROM_BROWSER=chrome` then drives the `bird` backend to real results. Single-profile (Default-only) setups are unaffected — Default is still tried first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
