### PR TITLE
fix(render): keep the synthesis contract reachable when stdout is truncated (#726)

### DIFF
--- a/changelog.d/727.fixed.md
+++ b/changelog.d/727.fixed.md
@@ -1,0 +1,1 @@
+Synthesis contract is echoed at the top of the evidence envelope so hosts that truncate stdout still see the "synthesize, don't dump" directive.

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -731,6 +731,8 @@ def render_compact(
     # block below) vs "synthesize from" (this block).
     lines.append("<!-- EVIDENCE FOR SYNTHESIS: read this, do not emit verbatim. Transform into `What I learned:` prose per LAW 2. -->")
     lines.append("")
+    # Echo the synthesis contract early so it survives tail truncation (#726).
+    lines.extend(_render_synthesis_directive())
     visible_clusters = evidence_report.clusters[:cluster_limit]
     solid_clusters = _clusters_clearing_relevance_floor(
         evidence_report,
@@ -1031,6 +1033,36 @@ def _append_html_footer(lines: list[str], report: schema.Report, save_path: str 
     lines.append("<!-- END PASS-THROUGH FOOTER -->")
 
 
+def _render_synthesis_directive() -> list[str]:
+    """Echo the synthesis contract at the TOP of the evidence envelope.
+
+    Added 2026-06-30 for issue #726 (Grok Build v0.2.67 emitted only logs and
+    raw evidence clusters instead of the canonical synthesis). Root cause: the
+    strong directive only lived in `_render_canonical_boundary` — the very END
+    of stdout, AFTER the whole evidence block and footer. Hosts that truncate
+    the tail (`engine | head -N`, timeout-backgrounding that captures partial
+    output, scrollback caps) keep the badge and the `### N.` clusters but never
+    reach the instruction that says "synthesize, don't dump", so they fall into
+    the LAW 6 failure mode and emit the raw evidence.
+
+    This block restates the contract in the head region that survives
+    truncation. It lives INSIDE the EVIDENCE FOR SYNTHESIS envelope (a model
+    instruction, not user output), mirroring how the DEGRADED RUN WARNING is
+    positioned early so the pass-through contract still carries it.
+    """
+    return [
+        "> **SYNTHESIS CONTRACT — read before emitting anything.** Everything below this",
+        "> line, up to where this evidence envelope closes, is raw evidence for you to",
+        "> READ, not text to emit. Transform it into `What I learned:` prose paragraphs",
+        "> per LAW 2. Do NOT pass the `### N.` evidence clusters or the stats and",
+        "> source-coverage blocks through verbatim. The ONLY block you emit verbatim is",
+        "> the PASS-THROUGH FOOTER (the emoji tree) lower down. The full contract repeats",
+        "> at the end-of-output boundary near the bottom; if your captured output was",
+        "> truncated and never reached it, this contract still binds.",
+        "",
+    ]
+
+
 def _render_canonical_boundary() -> list[str]:
     """Emit the explicit END-OF-CANONICAL-OUTPUT boundary.
 
@@ -1316,6 +1348,8 @@ def render_comparison_multi(
         "`What I learned:` prose per LAW 2. Each entity has its own evidence subsection. -->"
     )
     lines.append("")
+    # Echo the synthesis contract early so it survives tail truncation (#726).
+    lines.extend(_render_synthesis_directive())
 
     resolved_block = _render_resolved_entities_block(entity_reports)
     if resolved_block:

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -203,7 +203,7 @@ def test_default_register_is_byte_identical_when_omitted(monkeypatch):
 
     assert implicit == explicit
     assert hashlib.sha256(implicit.encode()).hexdigest() == (
-        "0e550d98b09885e868ea4a1fc8eb21b5babe10eefcba7f14be39e0a318e02f40"
+        "8ca92207d49f09bc08ac4aba60c573cc832a23b1c78ad7cf90a5ca24bfbafe50"
     )
 
 

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -531,6 +531,13 @@ class SynthesisDirectiveSurvivesTruncationTests(unittest.TestCase):
         report = sample_report()
         text = render.render_comparison_multi([("Topic A", report), ("Topic B", report)])
         self.assertIn("SYNTHESIS CONTRACT", text)
+        # Survive head-truncation: the directive must precede the FIRST entity
+        # evidence cluster heading (H3 in the comparison path), not merely the
+        # envelope close tag — that is the real point a `| head -N` capture cuts.
+        self.assertLess(
+            text.index("SYNTHESIS CONTRACT"),
+            text.index("### Ranked Evidence Clusters"),
+        )
         self.assertLess(
             text.index("SYNTHESIS CONTRACT"),
             text.index("<!-- END EVIDENCE FOR SYNTHESIS -->"),

--- a/tests/test_render_v3.py
+++ b/tests/test_render_v3.py
@@ -488,6 +488,55 @@ class OutputEnvelopeTests(unittest.TestCase):
         )
 
 
+class SynthesisDirectiveSurvivesTruncationTests(unittest.TestCase):
+    """Issue #726: a host that truncates the engine's stdout (`| head -N`,
+    timeout-backgrounding, scrollback caps) used to lose the synthesis
+    instructions entirely, because the only strong directive lived at the
+    `# END OF last30days CANONICAL OUTPUT` boundary AFTER the whole evidence
+    block. Left holding only raw `### N.` clusters with no directive, the host
+    dumps them — the LAW 6 failure mode. A concise synthesis contract must
+    therefore ALSO appear at the TOP of the evidence, in the region that
+    survives head-truncation.
+    """
+
+    def _head_before_clusters(self, text: str) -> str:
+        # Everything a `engine | head -N` capture keeps when N lands inside the
+        # evidence block: the badge, metadata, and the directive must live here.
+        return text[: text.index("## Ranked Evidence Clusters")]
+
+    def test_synthesis_contract_present_before_evidence_block(self):
+        head = self._head_before_clusters(render.render_compact(sample_report()))
+        self.assertIn("SYNTHESIS CONTRACT", head)
+
+    def test_early_directive_restates_what_i_learned_and_dump_self_check(self):
+        head = self._head_before_clusters(render.render_compact(sample_report()))
+        # LAW 2 target shape...
+        self.assertIn("What I learned:", head)
+        # ...and the concrete "do not emit the cluster headings" self-check, so
+        # the directive is actionable without the tail boundary.
+        self.assertIn("### N.", head)
+        self.assertIn("PASS-THROUGH FOOTER", head)
+
+    def test_early_directive_sits_inside_evidence_envelope(self):
+        # It is a model instruction, not user output, so it belongs in the
+        # read-don't-emit zone (after the open comment, before the close).
+        text = render.render_compact(sample_report())
+        open_idx = text.index("<!-- EVIDENCE FOR SYNTHESIS:")
+        close_idx = text.index("<!-- END EVIDENCE FOR SYNTHESIS -->")
+        marker = text.index("SYNTHESIS CONTRACT")
+        self.assertLess(open_idx, marker)
+        self.assertLess(marker, close_idx)
+
+    def test_comparison_render_also_carries_early_directive(self):
+        report = sample_report()
+        text = render.render_comparison_multi([("Topic A", report), ("Topic B", report)])
+        self.assertIn("SYNTHESIS CONTRACT", text)
+        self.assertLess(
+            text.index("SYNTHESIS CONTRACT"),
+            text.index("<!-- END EVIDENCE FOR SYNTHESIS -->"),
+        )
+
+
 class RenderTopCommentsTests(unittest.TestCase):
     """Tests for the top-3 comments rendering in compact cluster view."""
 


### PR DESCRIPTION
## Summary

The strong "synthesize the evidence, don't dump it" directive only lived in `_render_canonical_boundary` — the very end of `--emit=compact`/`md` stdout, after the whole evidence block and the emoji-tree footer. A host that truncates the tail keeps the badge and the `### N.` clusters but never reaches that directive, so it falls into the LAW 6 failure mode and emits raw evidence. This PR echoes the contract once more at the **top** of the `EVIDENCE FOR SYNTHESIS` envelope, in the head region that survives truncation.

## Changes

- `lib/render.py`: add `_render_synthesis_directive()` and emit it right after the open `<!-- EVIDENCE FOR SYNTHESIS -->` comment in both `render_compact` and `render_comparison_multi`.
  - The directive lives **inside** the evidence envelope (a model instruction, not user output), mirroring how the `DEGRADED RUN WARNING` is positioned early so the pass-through contract still carries it.
  - It restates LAW 2 (`What I learned:` prose), the concrete `### N.` dump self-check, the footer-only pass-through scope, and explicitly covers the truncated-capture case.
  - It deliberately avoids the literal envelope/section anchor strings (`<!-- END EVIDENCE FOR SYNTHESIS -->`, `## Source Coverage`, `<!-- PASS-THROUGH FOOTER: -->`, …) so it can't be mistaken for the real markers or shift the existing index/count assertions.
- `tests/test_render_v3.py`: add `SynthesisDirectiveSurvivesTruncationTests` — directive present before the evidence block, the restated `What I learned:` / `### N.` self-check, envelope containment, and the comparison path.

## Why this is the right layer

This is the failure the reporter hit: when the engine's stdout is cut off (`engine | head -N`, a timeout that backgrounds the run and captures partial output, scrollback caps), the host is left holding only raw clusters with no instruction to synthesize — exactly the LAW 6 dump. The behavior the model must follow is unchanged; the fix just makes the existing instruction reachable when the tail is lost, consistent with the engine's existing defense-in-depth (badge + early degraded-run banner).

## Testing

- [x] Ran `uv run pytest --cov --cov-report=term-missing` (the CI command): **2308 passed, 4 skipped**; total coverage **84%** (gate 60%).
- Confirmed the new tests fail on `main` (the directive is absent from the pre-`## Ranked Evidence Clusters` head) and pass with the change.

## Related Issues

Fixes #726
