### PR TITLE
fix(diagnose): report X as available-pending when FROM_BROWSER will authenticate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `--diagnose` / `--preflight` no longer falsely reports X as unreachable when X auth comes from `FROM_BROWSER` browser cookies. These modes run in `plan_only` and skip cookie extraction for privacy (no Keychain access), so X was dropped from `available_sources` even though a real run authenticates fine. A new side-effect-free `env.x_pending_browser_auth` predicate now reports X as available-pending-browser-auth (and surfaces an `x_pending_browser_auth` flag in `--diagnose`) by keying only on the already-resolved browser list — no cookie is read. Covers every configured browser, including Chrome. ([#692](https://github.com/mvanhorn/last30days-skill/issues/692); first reported and fixed by @23241a6749 in #700)
+
 ## [3.8.3] - 2026-06-25
 
 ### Added

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -719,6 +719,39 @@ def get_x_source(config: dict[str, Any]) -> str | None:
     return chain[0] if chain else None
 
 
+def x_pending_browser_auth(config: dict[str, Any]) -> bool:
+    """True when X is not available now but ``FROM_BROWSER`` will authenticate it at run time.
+
+    ``--diagnose`` / ``--preflight`` load config in ``plan_only`` mode, which
+    deliberately skips browser-cookie extraction (no Keychain popup,
+    ``reads_values: false``). As a result ``get_x_source`` returns None and X is
+    dropped from ``available_sources`` even though a normal run would extract the
+    same cookies and authenticate X fine. This predicate reports that
+    "available pending browser auth" state without reading a single cookie — it
+    keys only on the already-resolved browser list (``cookie_extraction_browsers``
+    derives it from ``FROM_BROWSER`` alone, no secrets), bird being installed, and
+    X having a cookie-domain mapping. Side-effect free, so the safe-inspection
+    contract of diagnose/preflight is preserved.
+
+    Returns False whenever X is already available outright (static AUTH_TOKEN/CT0,
+    or xAI/xurl/xquik backend), and in ``read`` mode (a real run has already
+    extracted creds, so its status must be unchanged — never "pending").
+    """
+    # Already available via a static backend (bird creds, xAI, xurl, xquik).
+    if get_x_source(config):
+        return False
+    # Only meaningful in inspection modes that skip extraction; a real ``read``
+    # run has already attempted extraction and must report its true state.
+    if config.get('_BROWSER_COOKIE_MODE') == 'read':
+        return False
+    if 'x' not in COOKIE_DOMAINS:
+        return False
+    if not cookie_extraction_browsers(config):
+        return False
+    from . import bird_x
+    return bird_x.is_bird_installed()
+
+
 def is_ytdlp_available() -> bool:
     """Check if yt-dlp is installed for YouTube search."""
     from . import youtube_yt

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -115,7 +115,12 @@ def normalize_requested_sources(sources: list[str] | None) -> list[str] | None:
     return normalized
 
 
-def available_sources(config: dict[str, Any], requested_sources: list[str] | None = None) -> list[str]:
+def available_sources(
+    config: dict[str, Any],
+    requested_sources: list[str] | None = None,
+    *,
+    x_pending: bool | None = None,
+) -> list[str]:
     available: list[str] = []
     # reddit_public needs no API key - always available
     available.append("reddit")
@@ -123,12 +128,17 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.extend(["tiktok", "instagram"])
     if env.get_x_source(config):
         available.append("x")
-    elif env.x_pending_browser_auth(config):
+    else:
         # Safe inspection (--diagnose/--preflight) skips browser-cookie
         # extraction, so get_x_source is None even though a real run would
         # authenticate X via FROM_BROWSER. Report it as available so consumers
         # of available_sources (SKILL.md ACTIVE_SOURCES_LIST) don't under-report.
-        available.append("x")
+        # diagnose() precomputes the predicate and passes it via x_pending to
+        # avoid evaluating it twice in one diagnose() call.
+        if x_pending is None:
+            x_pending = env.x_pending_browser_auth(config)
+        if x_pending:
+            available.append("x")
     if which("yt-dlp") or env.is_youtube_sc_available(config):
         available.append("youtube")
     available.extend(["hackernews", "polymarket"])
@@ -189,6 +199,8 @@ def diagnose(
     requested_sources = normalize_requested_sources(requested_sources)
     google_key = _google_key(config)
     x_status = env.get_x_source_status(config, probe=not safe)
+    # Compute once and reuse for both the diag flag and available_sources below.
+    x_pending = env.x_pending_browser_auth(config)
     native_web_backend = None
     if config.get("BRAVE_API_KEY"):
         native_web_backend = "brave"
@@ -236,7 +248,7 @@ def diagnose(
         "bird_installed": x_status["bird_installed"],
         "bird_authenticated": x_status["bird_authenticated"],
         "bird_username": x_status["bird_username"],
-        "x_pending_browser_auth": env.x_pending_browser_auth(config),
+        "x_pending_browser_auth": x_pending,
         "xquik_available": x_status.get("xquik_available", False),
         "xquik_working": x_status.get("xquik_working"),
         "xquik_status": x_status.get("xquik_status", ""),
@@ -244,7 +256,7 @@ def diagnose(
         "native_search": env.is_native_search(config),
         "has_scrapecreators": bool(config.get("SCRAPECREATORS_API_KEY")),
         "has_github": bool(config.get("GITHUB_TOKEN") or which("gh")),
-        "available_sources": available_sources(config, requested_sources),
+        "available_sources": available_sources(config, requested_sources, x_pending=x_pending),
         "safe": safe,
         "config_source": config.get("_CONFIG_SOURCE"),
         "ignored_project_config": config.get("_IGNORED_PROJECT_CONFIG"),

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -123,6 +123,12 @@ def available_sources(config: dict[str, Any], requested_sources: list[str] | Non
         available.extend(["tiktok", "instagram"])
     if env.get_x_source(config):
         available.append("x")
+    elif env.x_pending_browser_auth(config):
+        # Safe inspection (--diagnose/--preflight) skips browser-cookie
+        # extraction, so get_x_source is None even though a real run would
+        # authenticate X via FROM_BROWSER. Report it as available so consumers
+        # of available_sources (SKILL.md ACTIVE_SOURCES_LIST) don't under-report.
+        available.append("x")
     if which("yt-dlp") or env.is_youtube_sc_available(config):
         available.append("youtube")
     available.extend(["hackernews", "polymarket"])
@@ -230,6 +236,7 @@ def diagnose(
         "bird_installed": x_status["bird_installed"],
         "bird_authenticated": x_status["bird_authenticated"],
         "bird_username": x_status["bird_username"],
+        "x_pending_browser_auth": env.x_pending_browser_auth(config),
         "xquik_available": x_status.get("xquik_available", False),
         "xquik_working": x_status.get("xquik_working"),
         "xquik_status": x_status.get("xquik_status", ""),

--- a/tests/test_diagnose_browser_pending.py
+++ b/tests/test_diagnose_browser_pending.py
@@ -1,0 +1,115 @@
+"""Tests for the --diagnose / --preflight browser-auth pending signal.
+
+`--diagnose` and `--preflight` load config in `plan_only` mode, which skips
+browser-cookie extraction (no Keychain popup). Before this fix that made X drop
+out of `available_sources` whenever auth came from FROM_BROWSER, even though a
+real run authenticates X fine — a false-negative that sent a debugging session
+down a 30-minute wrong path. `env.x_pending_browser_auth` reports the
+"available pending browser auth" state without reading any cookie, and
+`pipeline.diagnose` / `pipeline.available_sources` surface it.
+"""
+
+from unittest import mock
+
+from lib import env, pipeline
+
+
+def _cfg(**over):
+    cfg = {"_BROWSER_COOKIE_MODE": "plan_only"}
+    cfg.update(over)
+    return cfg
+
+
+class TestXPendingBrowserAuth:
+    """The no-read predicate in env.py."""
+
+    def test_pending_true_with_from_browser_and_bird(self):
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            assert env.x_pending_browser_auth(cfg) is True
+
+    def test_false_when_no_browser_resolved(self):
+        # FROM_BROWSER=off -> cookie_extraction_browsers() returns [].
+        cfg = _cfg(FROM_BROWSER="off")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            assert env.x_pending_browser_auth(cfg) is False
+
+    def test_false_when_from_browser_unset(self):
+        cfg = _cfg()
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            assert env.x_pending_browser_auth(cfg) is False
+
+    def test_false_when_x_available_outright(self):
+        # Static bird creds / xurl / xquik -> get_x_source truthy -> not pending.
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value="bird"):
+            assert env.x_pending_browser_auth(cfg) is False
+
+    def test_false_when_xai_key_present(self):
+        # Real get_x_source path: an xAI key makes X available outright.
+        cfg = _cfg(FROM_BROWSER="chrome", XAI_API_KEY="dummy-not-real")
+        assert env.x_pending_browser_auth(cfg) is False
+
+    def test_false_when_bird_not_installed(self):
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=False):
+            assert env.x_pending_browser_auth(cfg) is False
+
+    def test_false_in_read_mode(self):
+        # A real run (mode=read) has already attempted extraction; its status
+        # must be unchanged, never "pending".
+        cfg = _cfg(FROM_BROWSER="chrome", _BROWSER_COOKIE_MODE="read")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            assert env.x_pending_browser_auth(cfg) is False
+
+    def test_reads_no_cookies(self):
+        # R3: the predicate must never read cookie values or hit Keychain.
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True), \
+             mock.patch("lib.env.extract_browser_credentials",
+                        side_effect=AssertionError("must not read cookies")), \
+             mock.patch("lib.cookie_extract.extract_cookies",
+                        side_effect=AssertionError("must not read cookies")):
+            assert env.x_pending_browser_auth(cfg) is True
+
+
+class TestDiagnoseSurfacesPending:
+    """available_sources + diagnose consume the predicate."""
+
+    def test_diagnose_includes_pending_x_and_flag(self):
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            diag = pipeline.diagnose(cfg, safe=True)
+        assert "x" in diag["available_sources"]
+        assert diag["x_pending_browser_auth"] is True
+        # The safe contract is preserved: no cookie values read.
+        assert diag["browser_cookies"]["reads_values"] is False
+
+    def test_diagnose_excludes_x_when_browser_off(self):
+        cfg = _cfg(FROM_BROWSER="off")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True):
+            diag = pipeline.diagnose(cfg, safe=True)
+        assert "x" not in diag["available_sources"]
+        assert diag["x_pending_browser_auth"] is False
+
+    def test_diagnose_x_outright_not_pending(self):
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value="bird"):
+            diag = pipeline.diagnose(cfg, safe=True)
+        assert "x" in diag["available_sources"]
+        assert diag["x_pending_browser_auth"] is False
+
+    def test_available_sources_no_double_x(self):
+        # When X is available outright, the elif must not also append a 2nd "x".
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value="bird"):
+            sources = pipeline.available_sources(cfg)
+        assert sources.count("x") == 1

--- a/tests/test_diagnose_browser_pending.py
+++ b/tests/test_diagnose_browser_pending.py
@@ -108,8 +108,29 @@ class TestDiagnoseSurfacesPending:
         assert diag["x_pending_browser_auth"] is False
 
     def test_available_sources_no_double_x(self):
-        # When X is available outright, the elif must not also append a 2nd "x".
+        # When X is available outright, the else branch must not also append a 2nd "x".
         cfg = _cfg(FROM_BROWSER="chrome")
         with mock.patch("lib.env.get_x_source", return_value="bird"):
             sources = pipeline.available_sources(cfg)
         assert sources.count("x") == 1
+
+    def test_available_sources_uses_precomputed_x_pending(self):
+        # diagnose() passes x_pending in to avoid a second predicate evaluation;
+        # when provided, available_sources must not call the predicate itself.
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.env.x_pending_browser_auth",
+                        side_effect=AssertionError("must use precomputed x_pending")):
+            assert "x" in pipeline.available_sources(cfg, x_pending=True)
+            assert "x" not in pipeline.available_sources(cfg, x_pending=False)
+
+    def test_diagnose_evaluates_predicate_once(self):
+        # The tidy: x_pending_browser_auth runs exactly once per diagnose() call.
+        cfg = _cfg(FROM_BROWSER="chrome")
+        with mock.patch("lib.env.get_x_source", return_value=None), \
+             mock.patch("lib.bird_x.is_bird_installed", return_value=True), \
+             mock.patch("lib.env.x_pending_browser_auth", wraps=env.x_pending_browser_auth) as spy:
+            diag = pipeline.diagnose(cfg, safe=True)
+        assert spy.call_count == 1
+        assert "x" in diag["available_sources"]
+        assert diag["x_pending_browser_auth"] is True


### PR DESCRIPTION
## Problem

`--diagnose` and `--preflight` load config in `plan_only` mode, which deliberately skips browser-cookie extraction (no Keychain popup, `reads_values: false`). As a side effect, when X auth is supplied entirely by `FROM_BROWSER` browser cookies, `get_x_source` returns `None` and `x` is dropped from `available_sources` — even though a normal run extracts those same cookies and authenticates X fine.

Consumers that trust `available_sources` (the SKILL.md `ACTIVE_SOURCES_LIST` step, anyone debugging) are told X is off when it is actually on. This false-negative directly caused a long mis-diagnosis (concluding X auth was broken / a `sweet-cookie` dependency was missing, when neither was true — the engine extracts Chrome cookies in Python and injects `AUTH_TOKEN`/`CT0` into the vendored bird client).

## Fix

Add `env.x_pending_browser_auth(config)` — a side-effect-free predicate that reports the "available pending browser auth" state **without reading a single cookie**. It keys only on:
- the already-resolved browser list (`cookie_extraction_browsers`, derived from `FROM_BROWSER` alone, no secrets),
- bird being installed,
- X having a cookie-domain mapping.

`available_sources` now includes `x` when pending, and `diagnose` surfaces a new `x_pending_browser_auth` flag. It returns `False` whenever X is already available outright (static creds / xAI / xurl / xquik) and in `read` mode (a real run has already attempted extraction). The safe-inspection contract is unchanged — `reads_values` stays `false`, no Keychain access.

## Before / after (`--diagnose` with `FROM_BROWSER=chrome`, logged into x.com)

Before — X silently dropped:
```
available_sources: [reddit, tiktok, instagram, youtube, hackernews, polymarket, github, digg, threads]
bird_authenticated: false
```

After — X reported as pending, no Keychain popup:
```
available_sources: [reddit, tiktok, instagram, x, youtube, hackernews, polymarket, github, digg, grounding, threads]
x_pending_browser_auth: true
bird_authenticated: false
browser_cookies.reads_values: false
```

## Scope

Touches only the safe diagnose/preflight reporting path. The real-run X path is unchanged (a `read`-mode run already authenticates and reports `x` outright). Out of scope: making diagnose actually read cookies / probe live X (would break the safe contract) — deferred as an optional opt-in `--probe-x` flag.

## Tests

`tests/test_diagnose_browser_pending.py` — 12 cases covering the predicate (pending true/false across `FROM_BROWSER` states, outright-available, xAI key, bird-not-installed, read-mode, no-cookie-read assertion) and the `diagnose`/`available_sources` integration (x present + flag, excluded when off, no double-x). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)