### PR TITLE
Fix Hacker News points filtering

### DIFF
--- a/skills/last30days/scripts/lib/hackernews.py
+++ b/skills/last30days/scripts/lib/hackernews.py
@@ -99,7 +99,7 @@ def search_hackernews(
     params = {
         "query": core_flat,
         "tags": "story",
-        "numericFilters": f"created_at_i>{from_ts},created_at_i<{to_ts},points>2",
+        "numericFilters": f"created_at_i>{from_ts},created_at_i<{to_ts}",
         "hitsPerPage": str(count),
     }
     # Algolia defaults to AND across query tokens, so a 4-5 word theme query
@@ -122,9 +122,14 @@ def search_hackernews(
         return {"hits": [], "error": str(e)}
 
     hits = response.get("hits", [])
+
+    # points is not a filterable Algolia attribute; filter client-side
+    hits = [h for h in hits if (h.get("points") or 0) > 2]
+
+    response["hits"] = hits
+
     _log(f"Found {len(hits)} stories")
     return response
-
 
 _WORD_BOUNDARY_RE_CACHE: Dict[str, "re.Pattern[str]"] = {}
 

--- a/tests/test_hackernews.py
+++ b/tests/test_hackernews.py
@@ -267,17 +267,16 @@ def test_search_hackernews_http_error_handling(mock_request):
 
 
 def test_search_hackernews_engagement_filter(mock_request):
-    """Test that low-engagement stories are filtered."""
+    """Test that engagement filtering is done client-side."""
     mock_request.return_value = {"hits": [], "nbHits": 0}
-    
+
     hackernews.search_hackernews("test", "2026-01-01", "2026-01-31")
-    
+
     call_args = mock_request.call_args[0]
     url = call_args[1]
-    
-    # Should filter for points > 2 (URL-encoded)
-    assert "points" in url and "%3E2" in url
 
+    # points should NOT be sent as an Algolia numeric filter
+    assert "points" not in url
 # === Tests for parse_hackernews_response() ===
 
 


### PR DESCRIPTION
## Summary

This PR fixes the Hacker News Algolia search by removing the unsupported `points>2` numeric filter from the request and applying the engagement filter client-side after the response.

## Changes

* Remove `points>2` from `numericFilters`.
* Filter stories with `points <= 2` after receiving the response.
* Update the corresponding test to reflect the new client-side filtering behavior.

## Testing

* `python -m py_compile skills/last30days/scripts/lib/hackernews.py`
* `python -m pytest tests/test_hackernews.py`

All 32 Hacker News tests pass successfully.

Fixes #655.
