### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | X / Twitter | Log into x.com in any browser, or set `XQUIK_API_KEY` / `XAI_API_KEY` | Browser cookies are free; keys are provider-specific |
 | YouTube | `brew install yt-dlp` | Free |
 | Bluesky | App password from bsky.app | Free |
-| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 1000 free calls, then PAYG |
+| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 1,000 free calls, then PAYG |
 | Perplexity Sonar / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go |
 | Web search | Brave Search key | 2,000 free queries/month |
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | X / Twitter | Log into x.com in any browser, or set `XQUIK_API_KEY` / `XAI_API_KEY` | Browser cookies are free; keys are provider-specific |
 | YouTube | `brew install yt-dlp` | Free |
 | Bluesky | App password from bsky.app | Free |
-| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 10,000 free calls, then PAYG |
+| TikTok + Instagram + Threads + Pinterest + YouTube comments | ScrapeCreators key | 1000 free calls, then PAYG |
 | Perplexity Sonar / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go |
 | Web search | Brave Search key | 2,000 free queries/month |
 


### PR DESCRIPTION
Changed the Scrapecreator free credits value to '1000' from previous incorrect '10,000'.

## Summary

Fixed the ScrapeCreator's Free credits value listed in the README.md file.

## Changes

- Changed 10,000 to 1000 in README.md for scrapcreator

## Testing

No testing was needed as it was just a textual change. But i verified it on their website: 
<img width="328" height="471" alt="Screenshot 2026-07-01 at 11 43 21 AM" src="https://github.com/user-attachments/assets/2572a528-595d-4e7b-968c-285edcf7e8dd" />


## Related Issues

-None
