### PR TITLE
harden(save): sanitize --save-suffix into a path-safe token

### DIFF
--- a/changelog.d/736.security.md
+++ b/changelog.d/736.security.md
@@ -1,0 +1,1 @@
+`--save-suffix` is sanitized to a path-safe token so traversal fragments cannot escape the save directory (including discover-mode saves).

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -185,6 +185,19 @@ def slugify(value: str, max_length: int = 180) -> str:
     return slug or "last30days"
 
 
+def sanitize_suffix(suffix: str) -> str:
+    """Sanitize a user-provided ``--save-suffix`` into a path-safe token.
+
+    The suffix is glued directly into the saved-report filename, so restrict it
+    to the same ``[a-z0-9-]`` class as the topic slug. This neutralizes path
+    separators and parent refs (``/``, ``..``) so a suffix can never escape the
+    save directory, while leaving ordinary values ('v3', 'gemini', a client
+    slug) unchanged. Unlike ``slugify`` there is no fallback token: a suffix
+    that sanitizes to nothing simply drops, yielding no suffix part.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", suffix.lower()).strip("-")
+
+
 def _report_has_private_corpus(report: schema.Report) -> bool:
     items_by_source = getattr(report, "items_by_source", {})
     if isinstance(items_by_source, dict) and items_by_source.get("corpus"):
@@ -231,7 +244,8 @@ def save_output(
     slug = slugify(topic_override or report.topic)
     extension = "json" if emit == "json" else "html" if emit == "html" else "md"
     raw_label = "raw-html" if emit == "html" else "raw"
-    suffix_part = f"-{suffix}" if suffix else ""
+    safe_suffix = sanitize_suffix(suffix)
+    suffix_part = f"-{safe_suffix}" if safe_suffix else ""
     base = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
     date_str = datetime.now().strftime('%Y-%m-%d')
     candidates = [base]
@@ -471,7 +485,8 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
     slug = slugify(topic)
     extension = "json" if emit == "json" else "html" if emit == "html" else "md"
     raw_label = "raw-html" if emit == "html" else "raw"
-    suffix_part = f"-{suffix}" if suffix else ""
+    safe_suffix = sanitize_suffix(suffix)
+    suffix_part = f"-{safe_suffix}" if safe_suffix else ""
     raw = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
     try:
         home = _Path.home().resolve()
@@ -1472,7 +1487,8 @@ def _save_discovery_output(
     directory = Path(save_dir).expanduser().resolve()
     directory.mkdir(parents=True, exist_ok=True)
     extension = "json" if emit == "json" else "md"
-    suffix_part = f"-{suffix}" if suffix else ""
+    safe_suffix = sanitize_suffix(suffix)
+    suffix_part = f"-{safe_suffix}" if safe_suffix else ""
     stem = f"{slugify(domain)}-discover-raw{suffix_part}"
     date_str = datetime.datetime.now().strftime("%Y-%m-%d")
     candidates = [directory / f"{stem}.{extension}", directory / f"{stem}-{date_str}.{extension}"]

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -369,6 +369,35 @@ class HtmlCliIntegrationTests(unittest.TestCase):
         with self.subTest("suffix"):
             path = cli.compute_save_path_display("/tmp", report.topic, "v3", "html")
             self.assertTrue(path.endswith("/ai-agent-frameworks-raw-html-v3.html"))
+        with self.subTest("suffix_traversal_sanitized"):
+            # A suffix carrying path separators / parent refs must be sanitized
+            # to a flat token so it can never escape the save directory.
+            path = cli.compute_save_path_display("/tmp", report.topic, "../../etc", "html")
+            self.assertNotIn("..", path)
+            self.assertTrue(path.endswith("/ai-agent-frameworks-raw-html-etc.html"))
+
+    def test_save_suffix_cannot_escape_save_directory(self):
+        report = _report("AI Agent Frameworks", [])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = cli.save_output(report, "md", tmpdir, suffix="../../ESCAPED")
+            # The written file stays inside the intended directory, and the
+            # traversal fragment never lands in the filename.
+            self.assertEqual(Path(tmpdir).resolve(), out.parent)
+            self.assertNotIn("..", out.name)
+            self.assertTrue(out.name.startswith("ai-agent-frameworks-raw"))
+
+    def test_discover_save_suffix_cannot_escape_save_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = cli._save_discovery_output(
+                "# discovery\n",
+                domain="AI agents",
+                emit="md",
+                save_dir=tmpdir,
+                suffix="../../ESCAPED",
+            )
+            self.assertEqual(Path(tmpdir).resolve(), out.parent)
+            self.assertNotIn("..", out.name)
+            self.assertTrue(out.name.startswith("ai-agents-discover-raw"))
 
     def test_save_output_can_persist_comparison_html(self):
         reports = [


### PR DESCRIPTION
## What

`--save-suffix` is concatenated into the saved-report filename without sanitization (`save_output`, `compute_save_path_display`). This restricts it to the same `[a-z0-9-]` class already used for the topic slug.

## Why

Not exploitable today — the topic goes through `slugify()`, and `--save-suffix` is fixed to `v3` in the SKILL.md flow and only ever templated from a user's own shell variable in the CONFIGURATION.md wrapper examples, never from network/topic input. But the suffix is glued onto the fixed filename prefix (`{slug}-{raw_label}`) with no separator boundary, so a future refactor of how prefix/suffix are joined could turn it into a real path traversal. This closes that latent seam defensively rather than relying on the current prefix shape to neutralize it.

## How

- New `sanitize_suffix()` helper — mirrors `slugify()` but without the `"last30days"` fallback, so a suffix that sanitizes to nothing simply drops (no suffix part).
- Applied at both the real-path (`save_output`) and display-path (`compute_save_path_display`) sites so the footer path and the written path stay consistent.
- Ordinary values (`v3`, `gemini`, a client slug) are unchanged.

## Tests

- Extends `test_save_output_uses_raw_html_extension_and_suffix` with a traversal subcase (`../../etc` → flattened `-etc`, no `..` in the path).
- Adds `test_save_suffix_cannot_escape_save_directory`: `save_output(..., suffix="../../ESCAPED")` writes inside the target dir and the traversal fragment never lands in the filename.
- Full suite green locally (2403 passed, 5 skipped).