### PR TITLE
env: register DEGRADED_TRANSCRIPT_THRESHOLD so .env value is picked up

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -312,6 +312,17 @@ Privacy note: the keyless floor sends the query (to DuckDuckGo / your SearXNG in
 
 Visible quality difference between hosts with vs without native search or a configured backend. If your client setup produces thinner results than yours, this is usually why.
 
+### YouTube degraded-run detection
+
+When yt-dlp is stale it still returns search results but fails to fetch transcripts for every video. The engine detects this and surfaces a `DEGRADED RUN WARNING` in the output. The detection threshold is a ratio (fetched transcripts ÷ videos returned); the default `0.5` means two or more failures in a four-video result triggers the warning. Tune per-environment:
+
+```bash
+DEGRADED_TRANSCRIPT_THRESHOLD=0.3   # more tolerant: allow more misses before warning
+DEGRADED_TRANSCRIPT_THRESHOLD=0.8   # stricter: warn even on a single miss in a small result
+```
+
+Set to `0` to disable the nudge entirely (not recommended — a stale yt-dlp silently produces weak briefs).
+
 ---
 
 ### `--hiring-signals` flag

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -462,6 +462,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('EXCLUDE_SOURCES', ''),
         ('LAST30DAYS_DEFAULT_SEARCH', ''),
         ('LAST30DAYS_YOUTUBE_SSH_HOST', None),
+        ('DEGRADED_TRANSCRIPT_THRESHOLD', None),
         ('LAST30DAYS_TRANSCRIPT_TIMEOUT', None),
         (KEYCHAIN_ALIASES_ENV, None),
         # Whisper transcription provider for caption-free audio/video. Groq's


### PR DESCRIPTION
## Problem

`DEGRADED_TRANSCRIPT_THRESHOLD` was missing from the env.py keys tuple. Users who set this value in their `.env` file found it silently ignored:

- `_is_youtube_degraded()` in `quality_nudge.py:199` reads via `config.get('DEGRADED_TRANSCRIPT_THRESHOLD')`
- `config.get()` always returned `None` because the key was never loaded from `.env` into the config dict
- The default of 0.5 was used regardless of the user's `.env` setting

This is the same bug pattern as FUN_LEVEL (#707), GITHUB_TOKEN (#724), and LAST30DAYS_REPORT_CACHE_TTL_SECONDS (#732).

## Fix

Register `('DEGRADED_TRANSCRIPT_THRESHOLD', None)` in the env.py keys tuple (one line). Same pattern as every other env var in the list.

## Impact

Users who explicitly configure `DEGRADED_TRANSCRIPT_THRESHOLD` in `.env` will now have it picked up correctly. No behavior change for users relying on the default.