### PR TITLE
test: tighten Hermes skillignore regression coverage

### DIFF
--- a/tests/test_hermes_skillignore.py
+++ b/tests/test_hermes_skillignore.py
@@ -28,11 +28,15 @@ def test_hermes_skillignore_excludes_non_runtime_scan_surface() -> None:
     }
 
     assert expected <= entries
+    for entry in sorted(expected):
+        assert (SKILL_ROOT / entry.rstrip("/")).exists()
 
 
 def test_hermes_skillignore_keeps_runtime_contract_scannable() -> None:
     entries = _skillignore_entries()
 
     assert "SKILL.md" not in entries
+    assert "references/" not in entries
+    assert "references/save-html-brief.md" not in entries
     assert "scripts/last30days.py" not in entries
     assert "scripts/lib/" not in entries

--- a/tests/test_hermes_skillignore.py
+++ b/tests/test_hermes_skillignore.py
@@ -35,8 +35,15 @@ def test_hermes_skillignore_excludes_non_runtime_scan_surface() -> None:
 def test_hermes_skillignore_keeps_runtime_contract_scannable() -> None:
     entries = _skillignore_entries()
 
-    assert "SKILL.md" not in entries
-    assert "references/" not in entries
-    assert "references/save-html-brief.md" not in entries
-    assert "scripts/last30days.py" not in entries
-    assert "scripts/lib/" not in entries
+    expected_scannable = {
+        "SKILL.md",
+        "references",
+        "references/",
+        "references/save-html-brief.md",
+        "scripts/last30days.py",
+        "scripts/lib/",
+    }
+
+    for entry in sorted(expected_scannable):
+        assert entry not in entries
+        assert (SKILL_ROOT / entry.rstrip("/")).exists()


### PR DESCRIPTION
## Summary

- Tighten the Hermes `.skillignore` regression test so every expected ignored entry must still exist on disk.
- Add coverage that runtime reference instructions stay scannable, including `references/save-html-brief.md`, which `SKILL.md` requires for HTML deliverables.

## Changes

- `tests/test_hermes_skillignore.py` now checks that expected ignored paths exist under `skills/last30days/`.
- The runtime scannability test now also guards `references/` and `references/save-html-brief.md`.

## Testing

- [x] `uv run pytest tests/test_hermes_skillignore.py tests/test_html_save_contract.py tests/test_version_consistency.py -q`
  - Result: `13 passed`
- [x] `git diff --check`
  - Result: passed
- [ ] Ran `uv run python -m pytest -q --tb=short`
  - Result: failed in `tests/test_footer_nudge_suppression.py::FooterNudgeSuppressionTests::test_bare_run_emits_web_promo`.
  - Caveat: this reproduces in this checkout when the footer nudge test file is run alone and is outside the touched test file/code path.

## Scope / Non-goals

- Scope: test coverage in `tests/test_hermes_skillignore.py`.
- Non-goals: no runtime behavior change, no `.skillignore` behavior change, no `SKILL.md` contract change, no env or credential handling change, no vendor changes, and no security workflow changes.

## Caveats

- This does not claim to eliminate all scanner warnings. Runtime env/API-key reads and a large runtime skill prompt can still be flagged by broad scanners.
- An initial idea to ignore all of `references/` was intentionally not included after review because `SKILL.md` reads `references/save-html-brief.md` as runtime guidance for HTML output.

## Related Issues

Relates to #735, #565, and #513.

Follow-up context: #526 added the Hermes `.skillignore`; #656 added further dev-artifact exclusions. This PR only tightens regression coverage around that ignore list.
