### PR TITLE
fix(setup-wizard): display pp_sources (arXiv/Techmeme) install status in setup summary

### DIFF
--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -564,11 +564,18 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
             lines.append(f"  - {name} CLI already installed ({name} active)")
         elif action == "installed_off_path":
             path = entry.get("path", "")
-            lines.append(
-                f"  - {name} CLI installed but not on PATH — add its install "
-                "directory to PATH and restart your agent session/gateway for "
-                f"{name} to activate"
-            )
+            if path:
+                lines.append(
+                    f"  - {name} CLI at {path} but not on PATH — add "
+                    f"{os.path.dirname(os.path.expanduser(path))} to PATH and "
+                    f"restart your agent session/gateway for {name} to activate"
+                )
+            else:
+                lines.append(
+                    f"  - {name} CLI installed but not on PATH — add its install "
+                    "directory to PATH and restart your agent session/gateway for "
+                    f"{name} to activate"
+                )
         elif action == "install_failed":
             lines.append(
                 f"  - {name} CLI install failed — run "

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -553,6 +553,33 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
             f"{DIGG_INSTALL_CMD}"
         )
 
+    pp_sources = results.get("pp_sources", {})
+    pp_name: dict[str, str] = {"arxiv": "arXiv", "techmeme": "Techmeme"}
+    for source_key, entry in sorted(pp_sources.items()):
+        name = pp_name.get(source_key, source_key.title())
+        action = entry.get("action", "")
+        if action == "installed":
+            lines.append(f"  - Installed {name} CLI ({name} source now active)")
+        elif action == "already_installed":
+            lines.append(f"  - {name} CLI already installed ({name} active)")
+        elif action == "installed_off_path":
+            path = entry.get("path", "")
+            lines.append(
+                f"  - {name} CLI installed but not on PATH — add its install "
+                "directory to PATH and restart your agent session/gateway for "
+                f"{name} to activate"
+            )
+        elif action == "install_failed":
+            lines.append(
+                f"  - {name} CLI install failed — run "
+                f"`npx -y {PRINTING_PRESS_NPM} install {source_key} --cli-only` manually"
+            )
+        elif action == "no_npx":
+            lines.append(
+                f"  - {name} CLI not installed (free, optional). Install Node/npx, "
+                f"then: `npx -y {PRINTING_PRESS_NPM} install {source_key} --cli-only`"
+            )
+
     env_written = results.get("env_written", False)
     if env_written:
         lines.append("")


### PR DESCRIPTION
## Problem

PR #709 added `install_default_pp_sources()` to install arXiv and Techmeme CLIs during first-run setup, and collected per-CLI results in `run_auto_setup()` under the `pp_sources` key. However, `get_setup_status_text()` never read or displayed `pp_sources` — users saw Digg CLI status but received zero feedback on whether arXiv or Techmeme CLIs were installed. A failed installation was silently invisible.

## Fix

Add a display block in `get_setup_status_text()` (after the Digg block) that iterates over `pp_sources` and renders per-CLI status messages for each action (`installed`, `already_installed`, `installed_off_path`, `install_failed`, `no_npx`). Same pattern as the Digg block.

## Impact

Users running first-run setup will now see separate status lines for arXiv CLI and Techmeme CLI (e.g. `Installed arXiv CLI (arXiv source now active)`). No behavior change for existing installations or users who skip setup.