### PR TITLE
fix: log _write_last_run failures instead of silent swallow

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -720,8 +720,8 @@ def _write_last_run(
             ],
         }
         (target / "last-report.json").write_text(json.dumps(cache_payload, indent=2))
-    except Exception:
-        pass
+    except Exception as exc:
+        sys.stderr.write(f"[last30days] Failed to write run cache: {exc}\n")
 
 
 def _load_last_report_cache(


### PR DESCRIPTION
## Problem

`_write_last_run()` at `last30days.py:723` silently swallowed all exceptions with `except Exception: pass`. Cache write failures — disk full, permission denied, serialization error, or a `CONFIG_DIR` file-path collision — were completely invisible, with no log, no stderr message, and no return value to the caller.

This made debugging report-cache issues impossible because the caller (`main()` at line 1385) could not distinguish `cache written successfully` from `cache write failed silently`.

## Fix

Replace `except Exception: pass` with `except Exception as exc: sys.stderr.write(...)` that reports the failure to stderr using the same `[last30days]` prefix as other error messages in the file. The exception is not re-raised — cache writes are best-effort and should not interrupt the run.

## Impact

Cache write failures are now visible on stderr. No behavior change on the success path. All existing tests continue to pass (they only exercise the success path).