### PR TITLE
Keep Chromium cookie temp copies private

### DIFF
--- a/skills/last30days/scripts/lib/chrome_cookies.py
+++ b/skills/last30days/scripts/lib/chrome_cookies.py
@@ -229,7 +229,10 @@ def _extract_chromium_cookies_macos(
     tmp_path = None
     try:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".sqlite")
-        shutil.copy2(str(db_path), tmp_path)
+        # mkstemp creates the file 0600. copy2 would copy the source DB's
+        # permission bits onto the temp file before the chmod below runs,
+        # briefly exposing live cookies when the source DB is looser.
+        shutil.copyfile(str(db_path), tmp_path)
         _lock_temp_cookie_copy(tmp_path)
     except Exception as e:
         logger.info("Failed to copy %s cookies database: %s", keychain_service, e)

--- a/tests/test_chrome_cookies.py
+++ b/tests/test_chrome_cookies.py
@@ -13,6 +13,7 @@ import pytest
 
 OPENSSL_AVAILABLE = shutil.which("openssl") is not None
 
+from lib import chrome_cookies
 from lib.chrome_cookies import (
     CHROME_COOKIES_DB,
     CHROME_IV_HEX,
@@ -275,6 +276,33 @@ class TestUnencryptedCookies:
             )
 
         assert result == {"auth_token": "plain_token_value"}
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission model does not apply on Windows")
+    def test_temp_cookie_copy_never_world_readable(self, tmp_path):
+        """The temp copy must stay private immediately after copying content."""
+        db_path = tmp_path / "Cookies"
+        _create_chrome_cookies_db(str(db_path), [
+            (".x.com", "auth_token", "plain_token_value", b""),
+        ])
+        os.chmod(db_path, 0o644)
+
+        observed = {}
+        real_lock = chrome_cookies._lock_temp_cookie_copy
+
+        def spy(path):
+            observed["mode_after_copy"] = os.stat(path).st_mode & 0o777
+            return real_lock(path)
+
+        with mock.patch.object(chrome_cookies, "_lock_temp_cookie_copy", side_effect=spy):
+            result = _extract_chromium_cookies_macos(
+                db_path,
+                "Chrome Safe Storage",
+                ".x.com",
+                ["auth_token"],
+            )
+
+        assert result == {"auth_token": "plain_token_value"}
+        assert observed["mode_after_copy"] == 0o600
 
     def test_plain_value_returned(self, tmp_path):
         """Unencrypted cookies (value column populated) returned without decryption."""


### PR DESCRIPTION
## Summary

- replace `shutil.copy2()` with `shutil.copyfile()` when copying Chromium cookie DBs to a `mkstemp()` path
- keep the temp copy at `0600` immediately after content copy instead of briefly inheriting looser source DB permissions
- add a regression test that observes the temp file mode before the existing lock-down helper runs

## Validation

- `git diff --check`
- `PYTHONPATH=skills/last30days/scripts uv run pytest -q tests/test_chromium_browsers.py tests/test_env_cookies.py tests/test_permission_preflight.py tests/test_project_config_trust.py tests/test_chrome_cookies.py tests/test_cookie_extract.py`

## Security note

`copy2()` calls `copystat()` after copying file content, which can briefly copy source permissions such as `0644` onto the temp database. Since `mkstemp()` creates the destination as private, `copyfile()` preserves the safer destination mode while still copying the DB bytes needed for SQLite reads.