### PR TITLE
fix: register LAST30DAYS_DEBUG in env keys, lazy resolution, fix xai_x crash

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -357,6 +357,14 @@ Web search has **no** env pin — pin it per-run with `--web-backend=<name>` onl
 
 ---
 
+## Debug mode (`--debug`)
+
+Add `--debug` to any run to emit verbose `[DEBUG]` log lines to stderr from the source modules (X API, HTTP, etc.). Helpful for diagnosing API errors or unexpected behavior.
+
+**Always-on alternative:** set `LAST30DAYS_DEBUG=true` in your `.env` or export it from your shell. The flag still works as before; the env var is purely additive — works whether shell-exported or set in `.env`.
+
+---
+
 ## Trend monitoring (`--store` + watchlist + briefings)
 
 The default behavior - one slug-named file per topic, overwritten on rerun - is the snapshot mode. For continuous monitoring, the repo ships three components most users miss:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -428,6 +428,9 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
     }
 
     keys = [
+        # Debug flag; also exported to os.environ below so log.py's lazy
+        # os.environ.get() picks up .env values after get_config() runs.
+        ('LAST30DAYS_DEBUG', None),
         ('XAI_API_KEY', None),
         ('GOOGLE_API_KEY', None),
         ('GEMINI_API_KEY', None),
@@ -501,6 +504,12 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
 
     for key, default in keys:
         config[key] = os.environ.get(key) or merged_env.get(key, default)
+
+    # Export debug flag to os.environ so log.py's lazy os.environ.get()
+    # picks up .env values. setdefault ensures a shell-exported value is
+    # never overwritten by the (lower-priority) .env value.
+    if config.get('LAST30DAYS_DEBUG'):
+        os.environ.setdefault('LAST30DAYS_DEBUG', config['LAST30DAYS_DEBUG'])
 
     # Backward-compat: ScrapeCreators' own examples and tutorials use the
     # SCRAPE_CREATORS_API_KEY spelling (with underscore between SCRAPE and

--- a/skills/last30days/scripts/lib/log.py
+++ b/skills/last30days/scripts/lib/log.py
@@ -3,12 +3,15 @@
 import os
 import sys
 
-DEBUG = os.environ.get("LAST30DAYS_DEBUG", "").lower() in ("1", "true", "yes")
+
+def is_debug() -> bool:
+    val = os.environ.get("LAST30DAYS_DEBUG", "")
+    return val.lower() in ("1", "true", "yes", "on")
 
 
 def debug(msg: str) -> None:
     """Log debug message to stderr (only when LAST30DAYS_DEBUG is set)."""
-    if DEBUG:
+    if is_debug():
         sys.stderr.write(f"[DEBUG] {msg}\n")
         sys.stderr.flush()
 

--- a/skills/last30days/scripts/lib/xai_x.py
+++ b/skills/last30days/scripts/lib/xai_x.py
@@ -141,7 +141,7 @@ def parse_x_response(response: Dict[str, Any]) -> List[Dict[str, Any]]:
         error = response["error"]
         err_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
         _log_error(f"xAI API error: {err_msg}")
-        if http.DEBUG:
+        if log.is_debug():
             _log_error(f"Full error response: {json.dumps(response, indent=2)[:1000]}")
         return items
 


### PR DESCRIPTION
## Summary

`LAST30DAYS_DEBUG` had three bugs:

1. **Not registered in CONFIGURATION_KEYS** — .env values were silently ignored.
2. **Eager module-level os.environ.get() in log.py** — --debug flag and .env values never picked up.
3. **http.DEBUG in xai_x.py:144** — AttributeError on xAI API errors.