### PR TITLE
fix: wrap open() calls in 'with' to close file descriptors promptly (#774)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -437,7 +437,8 @@ def parse_competitors_plan(raw: str | None) -> dict[str, dict]:
     plan_str = raw
     if os.path.isfile(plan_str):
         try:
-            plan_str = open(plan_str, encoding="utf-8").read()
+            with open(plan_str, encoding="utf-8") as f:
+                plan_str = f.read()
         except (OSError, UnicodeDecodeError) as exc:
             sys.stderr.write(f"[CompetitorsPlan] Cannot read plan file: {exc}\n")
             raise SystemExit(2)
@@ -1171,7 +1172,8 @@ def main() -> int:
             plan_str = args.plan
             if os.path.isfile(plan_str):
                 try:
-                    plan_str = open(plan_str, encoding="utf-8").read()
+                    with open(plan_str, encoding="utf-8") as f:
+                        plan_str = f.read()
                 except (OSError, UnicodeDecodeError) as exc:
                     sys.stderr.write(f"[Planner] Cannot read --plan file: {exc}\n")
                     raise SystemExit(2)

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.11.0"
+version = "3.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Two call sites used `open(plan_str).read()` without a `with` statement, leaving the file descriptor open until garbage collection:

1. **`parse_competitors_plan()` at `last30days.py:440`** — reads a `--competitors-plan` JSON file.
2. **`main()` at `last30days.py:1174`** — reads a `--plan` JSON file.

While CPython's refcounting closes these promptly, PyPy and other implementations may defer finalization. In a long-running or descriptor-constrained environment, leaked handles can accumulate.

Both sites already had proper `try/except` wrapping for `OSError` / `UnicodeDecodeError`, so this is purely a resource-management fix with no behavior change.

## Changes

| File | Change |
|---|---|
| `last30days.py:440` | `open(...).read()` → `with open(...) as f: f.read()` |
| `last30days.py:1174` | `open(...).read()` → `with open(...) as f: f.read()` |

Fixes #774.