### PR TITLE
fix: register GITHUB_TOKEN and LAST30DAYS_REPORT_CACHE_TTL_SECONDS in env.py

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -454,6 +454,8 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('LAST30DAYS_REDDIT_BACKEND', None),
         # Doctor cache freshness window in seconds (doctor --cached).
         ('LAST30DAYS_DOCTOR_TTL', None),
+        # Report cache freshness window in seconds (last30days --cached).
+        ('LAST30DAYS_REPORT_CACHE_TTL_SECONDS', None),
         ('LAST30DAYS_REDDIT_SC_MIN_ITEMS', None),
         ('LAST30DAYS_STORE', None),
         ('LAST30DAYS_MEMORY_DIR', None),
@@ -472,6 +474,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('BRAVE_API_KEY', None),
         ('EXA_API_KEY', None),
         ('SERPER_API_KEY', None),
+        ('GITHUB_TOKEN', None),
         ('OPENROUTER_API_KEY', None),
         ('PERPLEXITY_API_KEY', None),
         ('LAST30DAYS_PERPLEXITY_MODE', 'sonar'),


### PR DESCRIPTION
## Summary

Fixes #724 and #732 in a single PR — both are the same missing-key bug pattern in `env.py`.

### #724 — GITHUB_TOKEN

`GITHUB_TOKEN` was missing from the `keys` tuple in `get_config()`. Users who set `GITHUB_TOKEN` in their `.env` file found it silently ignored:

- `config.get("GITHUB_TOKEN")` returned `None` (never loaded from `.env`)
- `resolve_token()` in `github.py` fell through to `os.environ.get("GITHUB_TOKEN")` — also `None` for `.env`-only users
- Fell back to `gh auth token` subprocess or returned `None`, resulting in unauthenticated GitHub API usage (severe rate limits)

### #732 — LAST30DAYS_REPORT_CACHE_TTL_SECONDS

Same pattern: `_report_cache_ttl_seconds()` reads from `os.environ` first, then `config.get()`, but the key was never loaded from `.env` into the config dict, so the default 3600s was always used.

## Fix

Added two entries to the `keys` tuple in `get_config()` (one line each):

```python
("GITHUB_TOKEN", None),
("LAST30DAYS_REPORT_CACHE_TTL_SECONDS", None),
```

Same pattern as every other env var in the list. No behavior change for users relying on `os.environ` or the `gh` CLI fallback.

## Verification

- All existing env tests pass (`test_env_v3`, `test_env_keychain`, `test_env_pass`, `test_env_default_search`, `test_env_include_sources_default`, `test_env_cookies`)
- Manual verification that both keys now appear in the config dict and pick up values from `os.environ`

Fixes #724
Fixes #732