### PR TITLE
fix: register GITHUB_TOKEN and LAST30DAYS_REPORT_CACHE_TTL_SECONDS in env.py config keys

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -510,6 +510,14 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         # resolved above via openai_auth).
         ('GROQ_API_KEY', None),
         ('LAST30DAYS_YT_SUB_LANGS', 'en,es,pt'),
+        # GitHub auth token — used by lib/github.py for higher API rate
+        # limits. Must be in the keys list so .env values are loaded into
+        # config; otherwise config.get("GITHUB_TOKEN") silently returns None.
+        ('GITHUB_TOKEN', None),
+        # Report cache TTL in seconds (doctor cache + last-report.json reuse).
+        # Must be in the keys list so .env values are loaded into config;
+        # otherwise config.get(...) silently falls back to the default.
+        ('LAST30DAYS_REPORT_CACHE_TTL_SECONDS', None),
     ]
 
     for key, default in keys:

--- a/tests/test_env_v3.py
+++ b/tests/test_env_v3.py
@@ -70,6 +70,28 @@ class EnvV3Tests(unittest.TestCase):
         for key, value in overrides.items():
             self.assertEqual(value, config[key])
 
+    def test_get_config_loads_github_token_from_env(self):
+        """GITHUB_TOKEN must be in the config keys list so .env values
+        are not silently ignored (issue #724)."""
+        with mock.patch.object(env, "CONFIG_FILE", None), \
+             mock.patch.object(env, "_find_project_env", return_value=None), \
+             mock.patch("lib.env._load_keychain", return_value={}), \
+             mock.patch("lib.env._load_pass", return_value={}), \
+             mock.patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_test_token"}, clear=False):
+            config = env.get_config()
+        self.assertEqual("ghp_test_token", config["GITHUB_TOKEN"])
+
+    def test_get_config_loads_report_cache_ttl_from_env(self):
+        """LAST30DAYS_REPORT_CACHE_TTL_SECONDS must be in the config keys
+        list so .env values are not silently ignored (issue #732)."""
+        with mock.patch.object(env, "CONFIG_FILE", None), \
+             mock.patch.object(env, "_find_project_env", return_value=None), \
+             mock.patch("lib.env._load_keychain", return_value={}), \
+             mock.patch("lib.env._load_pass", return_value={}), \
+             mock.patch.dict(os.environ, {"LAST30DAYS_REPORT_CACHE_TTL_SECONDS": "7200"}, clear=False):
+            config = env.get_config()
+        self.assertEqual("7200", config["LAST30DAYS_REPORT_CACHE_TTL_SECONDS"])
+
 
 class XurlSafePathGatingTests(unittest.TestCase):
     """F1: the safe/diagnose path (probe=False — what doctor uses) never


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN` and `LAST30DAYS_REPORT_CACHE_TTL_SECONDS` are silently ignored when set in `~/.config/last30days/.env` because they are missing from the `keys` tuple in `get_config()`.

Code that calls `config.get("GITHUB_TOKEN")` (in `lib/github.py`, `lib/pipeline.py`, `lib/doctor.py`) and `config.get("LAST30DAYS_REPORT_CACHE_TTL_SECONDS")` (in `last30days.py`) returns `None` even when the user has configured them in their `.env` file.

This means:
- **Issue #724**: Users who set `GITHUB_TOKEN` in `.env` for higher GitHub API rate limits get silently degraded to unauthenticated requests.
- **Issue #732**: Users who set `LAST30DAYS_REPORT_CACHE_TTL_SECONDS` in `.env` to tune the report cache window get the default TTL instead.

## Fix

Add both env vars to the `keys` list in `get_config()` so values from `.env` files are loaded into the config dict.

## Testing

Added two tests to `tests/test_env_v3.py`:
- `test_get_config_loads_github_token_from_env` — verifies `GITHUB_TOKEN` is loaded from env into config
- `test_get_config_loads_report_cache_ttl_from_env` — verifies `LAST30DAYS_REPORT_CACHE_TTL_SECONDS` is loaded from env into config

All existing tests continue to pass (test_env_v3, test_github, test_doctor, test_doctor_cache, test_env_keychain, test_doc_flag_contract).

Fixes #724
Fixes #732