### PR TITLE
fix: close file descriptors properly in last30days.py (#774)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -437,7 +437,8 @@ def parse_competitors_plan(raw: str | None) -> dict[str, dict]:
     plan_str = raw
     if os.path.isfile(plan_str):
         try:
-            plan_str = open(plan_str, encoding="utf-8").read()
+            with open(plan_str, encoding="utf-8") as f:
+                plan_str = f.read()
         except (OSError, UnicodeDecodeError) as exc:
             sys.stderr.write(f"[CompetitorsPlan] Cannot read plan file: {exc}\n")
             raise SystemExit(2)
@@ -1171,7 +1172,8 @@ def main() -> int:
             plan_str = args.plan
             if os.path.isfile(plan_str):
                 try:
-                    plan_str = open(plan_str, encoding="utf-8").read()
+                    with open(plan_str, encoding="utf-8") as f:
+                        plan_str = f.read()
                 except (OSError, UnicodeDecodeError) as exc:
                     sys.stderr.write(f"[Planner] Cannot read --plan file: {exc}\n")
                     raise SystemExit(2)

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.11.0"
+version = "3.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #774

This PR wraps two `open().read()` calls with context managers to prevent file descriptor leaks.

- Line 440 (parse_competitors_plan): wrapped with `with open()`
- Line 1174 (main): wrapped with `with open()`

This ensures FDs are closed immediately instead of waiting for garbage collection, preventing resource exhaustion on environments with strict limits or PyPy.

---
*Developed with assistance from Claude AI.*