### PR TITLE
fix(env): locale-decoder fallback for non-UTF-8 .env files

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import locale
 import os
 import sys
 from dataclasses import dataclass
@@ -172,20 +173,29 @@ def load_env_file(path: Path) -> dict[str, str]:
         return env
     _check_file_permissions(path)
 
-    with open(path, 'r', encoding='utf-8-sig') as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if '=' in line:
-                key, _, value = line.partition('=')
-                key = key.strip()
-                value = value.strip()
-                # Remove quotes if present
-                if value and value[0] in ('"', "'") and value[-1] == value[0]:
-                    value = value[1:-1]
-                if key and value:
-                    env.update({key: value})
+    # Prefer UTF-8 (utf-8-sig transparently strips a BOM written by Windows
+    # editors like Notepad). Fall back to the locale decoder for a genuinely
+    # locale-encoded .env (e.g. cp1252) so an existing file that loaded before
+    # keeps loading. If it decodes as neither, let UnicodeDecodeError surface
+    # rather than corrupting keys/secrets with replacement characters.
+    try:
+        text = path.read_text(encoding='utf-8-sig')
+    except UnicodeDecodeError:
+        text = path.read_text(encoding=locale.getpreferredencoding(False))
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if '=' in line:
+            key, _, value = line.partition('=')
+            key = key.strip()
+            value = value.strip()
+            # Remove quotes if present
+            if value and value[0] in ('"', "'") and value[-1] == value[0]:
+                value = value[1:-1]
+            if key and value:
+                env.update({key: value})
     return env
 
 

--- a/tests/test_env_encoding.py
+++ b/tests/test_env_encoding.py
@@ -1,0 +1,31 @@
+from lib import env
+
+
+def test_load_env_file_strips_utf8_bom(tmp_path):
+    # A Windows editor (e.g. Notepad) commonly saves .env with a UTF-8 BOM.
+    # Without an explicit encoding, open() prepends the BOM to the first key,
+    # corrupting it (KeyError below). utf-8-sig transparently strips the BOM.
+    env_path = tmp_path / ".env"
+    env_path.write_bytes("DISPLAY_NAME=café\nREAL_KEY=ok\n".encode("utf-8-sig"))
+
+    loaded = env.load_env_file(env_path)
+
+    assert loaded["DISPLAY_NAME"] == "café"
+    assert loaded["REAL_KEY"] == "ok"
+
+
+def test_load_env_file_falls_back_to_locale_encoding(tmp_path, monkeypatch):
+    # A pre-existing .env saved in a legacy codepage (e.g. cp1252 on Windows)
+    # loaded fine when open() used the locale decoder. Force the fallback locale
+    # to cp1252 so the test is deterministic on any runner, and assert the value
+    # decodes correctly rather than being replaced/corrupted.
+    monkeypatch.setattr(
+        env.locale, "getpreferredencoding", lambda do_setlocale=True: "cp1252"
+    )
+    env_path = tmp_path / ".env"
+    env_path.write_bytes("DISPLAY_NAME=Jos\xe9\nREAL_KEY=ok\n".encode("cp1252"))
+
+    loaded = env.load_env_file(env_path)
+
+    assert loaded["DISPLAY_NAME"] == "José"
+    assert loaded["REAL_KEY"] == "ok"


### PR DESCRIPTION
Adds a locale-decoder fallback on top of the utf-8-sig read from #715: a genuinely locale-encoded `.env` (e.g. cp1252) that loaded before keeps loading instead of crashing. If it decodes as neither utf-8 nor the locale encoding, `UnicodeDecodeError` surfaces rather than corrupting keys/secrets with replacement characters.

Tests cover the UTF-8 BOM case and the locale-fallback case (deterministic via a forced cp1252 locale).

(Trimmed by the maintainer: the core utf-8-sig read landed via #715. Closes #714 together with it.)
