### PR TITLE
fix(doctor): detect GITHUB_TOKEN from process env

### DIFF
--- a/skills/last30days/scripts/lib/doctor.py
+++ b/skills/last30days/scripts/lib/doctor.py
@@ -303,7 +303,7 @@ def _polymarket_record(config):
 
 
 def _github_record(config):
-    authed = bool(config.get("GITHUB_TOKEN") or shutil.which("gh"))
+    authed = bool(env.read_secret_env("GITHUB_TOKEN") or shutil.which("gh"))
     detail = (
         "authenticated tier (GITHUB_TOKEN or gh CLI)"
         if authed

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -172,6 +172,28 @@ class KeylessEnvironment(unittest.TestCase):
         self.assertIn("last30days doctor", out)
 
 
+class GitHubAuthDetection(unittest.TestCase):
+    """GitHub doctor auth must mirror the real fetcher token source."""
+
+    def test_github_env_token_without_gh_reports_authenticated_tier(self):
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "dummy-github-secret-000"}), \
+             mock.patch("lib.doctor.shutil.which", return_value=None):
+            record = _build({})["sources"]["github"]
+
+        self.assertEqual("ok", record["tier"])
+        self.assertEqual("ok", record["status"])
+        self.assertEqual("authenticated tier (GITHUB_TOKEN or gh CLI)", record["detail"])
+
+    def test_github_without_env_token_or_gh_reports_unauthenticated_tier(self):
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": ""}), \
+             mock.patch("lib.doctor.shutil.which", return_value=None):
+            record = _build({})["sources"]["github"]
+
+        self.assertEqual("ok", record["tier"])
+        self.assertEqual("ok", record["status"])
+        self.assertIn("unauthenticated REST tier", record["detail"])
+
+
 class UnconfiguredXWithBrokenNode(unittest.TestCase):
     """F9 repro: no X configuration + a broken node runtime must read as
     off/unconfigured with the cookie fix on bird — never a configured-but-


### PR DESCRIPTION
`doctor`'s GitHub check reads `config.get("GITHUB_TOKEN")`, but `GITHUB_TOKEN` isn't a registered config key, so it's always `None` — while the actual fetcher (`lib/github.py`) reads it from the environment via `env.read_secret_env`. As a result, a user with `GITHUB_TOKEN` exported (and no `gh` CLI) is reported as unauthenticated even though GitHub calls authenticate fine.

Fix: `doctor` detects the token the same way the fetcher does. Adds two tests (env token without gh → authenticated; neither → unauthenticated).