### PR TITLE
fix(hosted): don't overwrite same-day saved reports

### DIFF
--- a/skills/last30days/scripts/lib/hosted.py
+++ b/skills/last30days/scripts/lib/hosted.py
@@ -209,11 +209,25 @@ def _save_output(topic: str, content: str, emit: str, save_dir: str, suffix: str
     slug = _slugify(topic)
     extension = "json" if emit == "json" else "md"
     suffix_part = f"-{suffix}" if suffix else ""
-    out_path = path / f"{slug}-raw{suffix_part}.{extension}"
-    if out_path.exists():
-        out_path = path / f"{slug}-raw{suffix_part}-{datetime.now().strftime('%Y-%m-%d')}.{extension}"
-    out_path.write_text(content, encoding="utf-8")
-    return out_path
+    base = path / f"{slug}-raw{suffix_part}.{extension}"
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    candidates = [base]
+    candidates.append(path / f"{slug}-raw{suffix_part}-{date_str}.{extension}")
+    for i in range(1, 100):
+        candidates.append(path / f"{slug}-raw{suffix_part}-{date_str}-{i}.{extension}")
+    encoded = content.encode("utf-8")
+    for candidate in candidates:
+        try:
+            fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            continue
+        with os.fdopen(fd, "wb") as f:
+            f.write(encoded)
+        return candidate
+    # Fallback: all 101 candidates existed (extremely unlikely).
+    raise RuntimeError(
+        f"_save_output: could not find a unique filename after 101 attempts in {path}"
+    )
 
 
 def _render_complete(row: dict, topic: str, emit: str, save_dir, save_suffix: str) -> int:

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -7,6 +7,7 @@ import sys
 import types
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -283,6 +284,23 @@ class CliV3Tests(unittest.TestCase):
             self.assertEqual(".json", path.suffix)
             payload = json.loads(path.read_text())
             self.assertEqual("OpenClaw vs NanoClaw", payload["topic"])
+
+    def test_save_output_uses_unique_dated_fallback(self):
+        report = self.make_report()
+        with tempfile.TemporaryDirectory() as tmp:
+            save_dir = Path(tmp)
+            today = datetime.now().strftime("%Y-%m-%d")
+            base = save_dir / "openclaw-vs-nanoclaw-raw.md"
+            dated = save_dir / f"openclaw-vs-nanoclaw-raw-{today}.md"
+            base.write_text("base content", encoding="utf-8")
+            dated.write_text("dated content", encoding="utf-8")
+
+            saved = cli.save_output(report, "md", tmp)
+
+            self.assertEqual((save_dir / f"openclaw-vs-nanoclaw-raw-{today}-1.md").resolve(), saved)
+            self.assertEqual("base content", base.read_text(encoding="utf-8"))
+            self.assertEqual("dated content", dated.read_text(encoding="utf-8"))
+            self.assertTrue(saved.exists())
 
     def test_save_output_writes_utf8_encoded_markdown(self):
         report = self.make_report()

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -13,6 +13,7 @@ import io
 import json
 import sys
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -317,6 +318,30 @@ def test_save_dir_writes_raw_markdown(remote_env, monkeypatch, capsys, tmp_path)
     assert saved.exists()
     assert "# Raw markdown" in saved.read_text(encoding="utf-8")
     assert "Saved output to" in captured.err
+    assert TEST_KEY not in captured.err
+
+
+def test_save_dir_uses_unique_dated_fallback(remote_env, monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(hosted.http, "post", lambda *a, **k: dict(SUBMIT_OK))
+    poll_rows = [dict(POLL_COMPLETE)]
+    monkeypatch.setattr(hosted.http, "get", lambda *a, **k: poll_rows.pop(0))
+    today = datetime.now().strftime("%Y-%m-%d")
+    base = tmp_path / "test-topic-raw.md"
+    dated = tmp_path / f"test-topic-raw-{today}.md"
+    base.write_text("base content", encoding="utf-8")
+    dated.write_text("dated content", encoding="utf-8")
+
+    rc = hosted.run_hosted("Test Topic!", "default", emit="compact",
+                           save_dir=str(tmp_path), save_suffix="")
+    captured = capsys.readouterr()
+
+    saved = tmp_path / f"test-topic-raw-{today}-1.md"
+    assert rc == 0
+    assert saved.exists()
+    assert "# Raw markdown" in saved.read_text(encoding="utf-8")
+    assert base.read_text(encoding="utf-8") == "base content"
+    assert dated.read_text(encoding="utf-8") == "dated content"
+    assert f"Saved output to {saved.resolve()}" in captured.err
     assert TEST_KEY not in captured.err
 
 


### PR DESCRIPTION
Ports the exclusive-create collision handling that landed in #757 to the hosted save path (`lib/hosted.py:_save_output`), which had the same same-day overwrite bug. Covers both the local and hosted paths with tests (adapted to #757's `-1`, `-2` counter naming).

(Reworked by the maintainer on top of #757; the local-path half of the original PR landed there first.)
