### PR TITLE
fix(ci): sync uv.lock so 'uv audit --locked' passes again

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.11.0"
+version = "3.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The Security workflow's **Dependency audit** job has been failing on every run (including on `main`) since the version bump to 3.11.1: `uv audit --locked` exits 2 with *"The lockfile at uv.lock needs to be updated"* before auditing anything, because `uv.lock` still records the project at 3.11.0.

This is verbatim `uv lock` output - the project's own version field only, **zero dependency changes**:

```
-version = "3.11.0"
+version = "3.11.1"
```

Receipts: `uv lock --check` passes locally with this change, and the Dependency audit job runs **green on this branch** ([fork CI run](https://github.com/SeanGearin/last30days-skill/pull/6/checks)) - same workflow, same `--locked` flag.