### PR TITLE
fix: log _load_last_report_cache failure to stderr instead of silent swallow (#787)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -758,7 +758,8 @@ def _load_last_report_cache(
                 return None
             return entity_reports[0][1], entity_reports, cache_path
         return entity_reports[0][1], None, cache_path
-    except Exception:
+    except Exception as exc:
+        sys.stderr.write(f"[last30days] Cache read failed, regenerating: {exc}\n")
         return None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.11.0"
+version = "3.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

`_load_last_report_cache()` caught all `Exception` and silently returned `None` (cache miss) with zero diagnostic output. If the cache file at `~/.config/last30days/last-report.json` is corrupted, truncated, or version-mismatched, users had no way to know why the cache was being regenerated on every run — wasted token spend and lost performance.

## Change

`last30days.py:762-763` — replaced `except Exception: return None` with:

```python
except Exception as exc:
    sys.stderr.write(f"[last30days] Cache read failed, regenerating: {exc}\n")
    return None
``"

The function still returns `None` (cache miss → regenerate), but now emits a diagnostic so users can identify and fix the root cause.

Fixes #787.