### PR TITLE
feat(grok): add native Grok plugin and marketplace support

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "last30days-skill",
+  "owner": {
+    "name": "Matt Van Horn",
+    "url": "https://github.com/mvanhorn"
+  },
+  "description": "Marketplace for the last30days research plugin",
+  "plugins": [
+    {
+      "name": "last30days",
+      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+      "version": "3.11.1",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mvanhorn/last30days-skill.git"
+      },
+      "homepage": "https://github.com/mvanhorn/last30days-skill",
+      "keywords": [
+        "last30days",
+        "last 30 days"
+      ]
+    }
+  ]
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "last30days",
+  "version": "3.11.1",
+  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+  "author": {
+    "name": "Matt Van Horn",
+    "email": "mvanhorn@gmail.com",
+    "url": "https://github.com/mvanhorn"
+  },
+  "homepage": "https://github.com/mvanhorn/last30days-skill",
+  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "license": "MIT",
+  "keywords": [
+    "last30days",
+    "last 30 days"
+  ],
+  "skills": "./skills/"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # last30days Skill
 
-Agent Skills package for researching any topic across Reddit, X, YouTube, and web. Installable across Claude Code (most common host), Codex, Cursor, GitHub Copilot, Gemini CLI, and 50+ other [Agent Skills](https://agentskills.io) hosts. Python scripts with multi-source search aggregation.
+Agent Skills package for researching any topic across Reddit, X, YouTube, and web. Installable across Claude Code (most common host), Codex, Cursor, GitHub Copilot, Gemini CLI, Grok (xAI), and 50+ other [Agent Skills](https://agentskills.io) hosts. Python scripts with multi-source search aggregation.
 
 ## Structure
 - `skills/last30days/SKILL.md` — canonical skill definition / runtime spec the model reads when the slash command fires
@@ -43,7 +43,7 @@ Python 3.12+ required. Use `uv` for the env; the venv lives at `.venv/`.
 - Do not reduce `fail_under` in `pyproject.toml` (`[tool.coverage.report]`) without documenting why in the PR. The coverage gate is a floor meant to rise over time, not to be relaxed when new code is under-tested.
 - Every `lib/*.py` call to `log.source_log(...)` must pass `tty_only=False`. The default is `True`, which silently drops every line when stderr isn't a TTY (Claude Code, Codex, CI, captured output) — turning source observability into invisible failure. Enforced by `tests/test_source_log_visibility.py`.
 - **CLI-gated optional sources** (Digg via `digg-pp-cli`, YouTube via `yt-dlp`) activate only when `shutil.which` resolves the binary on the **agent subprocess PATH** — not merely when the file exists on disk. First-run setup installs Digg through `@mvanhorn/printing-press-library` (default `$HOME/.local/bin`); Hermes/OpenClaw gateways often need that directory on PATH. Setup must distinguish PATH-visible installs from off-PATH binaries and must not claim "now active" unless the engine gate would pass. See `docs/solutions/integration-issues/digg-cli-agent-path-setup-wizard.md`.
-- **First-run onboarding is consent-driven, model-led, and host-split.** The setup subprocess does only mechanical work (cookie reads, tool installs, GitHub device-auth, and emitting the engine-owned welcome via `--welcome`) — it cannot prompt, so consent lives in `SKILL.md` Step 0. Two flows avoid model-authored prose that Claude Code folds or the model skips: in the **Modal Flow** the welcome pitch is embedded in the setup modal's question (the AskUserQuestion modal is the only always-fully-visible surface — a separate welcome message or `--welcome` Bash run gets buried behind "ctrl+o to expand"); the **Non-Modal Prose Flow** still uses `last30days.py --welcome` (relayed verbatim) since it has no modal. The GitHub device code is surfaced by a two-command split — `setup --github-start` returns the code fast (foreground, copies to clipboard) and `setup --github-poll` waits for authorization (`setup --github` still chains both for back-compat). Step 0 has TWO branches: a **Claude Code Modal Flow** (the restored v3.0.0 `AskUserQuestion`-driven NUX — welcome, Auto/Manual/Skip, cookie consent, ScrapeCreators offer, `INCLUDE_SOURCES` opt-in, first-topic picker) for hosts with modals, and a **Non-Modal Prose Flow** for hosts without (OpenClaw, Codex, Cursor, Gemini CLI). Both ask before reading cookies, surface the macOS Full Disk Access fix on permission-denied, and offer the ScrapeCreators GitHub signup (10,000 free calls) on every first run. A successful `setup --github` persists `SCRAPECREATORS_API_KEY` automatically (via `setup_wizard.write_api_key`, 0o600) and masks the key in stdout. Do NOT collapse the modal flow back into a bare silent `setup` call or flatten it to prose-only — the guided modals are the feature (they eroded once and were restored). The onboarding contract is locked by `tests/test_onboarding_contract.py`. The Step 5 source opt-in is two tiers, both comment-enabled: **Recommended** (TikTok + Instagram posts AND top comments, plus YouTube comments — `INCLUDE_SOURCES=tiktok,instagram,youtube_comments,tiktok_comments,instagram_comments`) and **Everything** (also Threads + Pinterest). Comments are on by default (posts on → comments on for all three platforms); **Threads and Pinterest are the only opt-in extras**, appearing only in the Step 5 Everything option, never in the welcome or the Step 4 offer. Instagram comments are fetched via ScrapeCreators (`/v2/instagram/post/comments`, ranked by `comment_like_count`) with full vote-weighting parity to YouTube/TikTok (a dedicated `_instagram_engagement` carve-out, the `_VOTE_LOG_REFERENCE`/label/threshold entries). The cross-platform "Top Community Comments" list (`render._render_top_comments`) selects **round-robin by within-platform rank** (every platform's #1, then #2, then #3) so a viral platform can't crowd out a smaller one, and drops the per-platform absolute floor so a less-watched video's killer low-vote comment still surfaces.
+- **First-run onboarding is consent-driven, model-led, and host-split.** The setup subprocess does only mechanical work (cookie reads, tool installs, GitHub device-auth, and emitting the engine-owned welcome via `--welcome`) — it cannot prompt, so consent lives in `SKILL.md` Step 0. Two flows avoid model-authored prose that Claude Code folds or the model skips: in the **Modal Flow** the welcome pitch is embedded in the setup modal's question (the AskUserQuestion modal is the only always-fully-visible surface — a separate welcome message or `--welcome` Bash run gets buried behind "ctrl+o to expand"); the **Non-Modal Prose Flow** still uses `last30days.py --welcome` (relayed verbatim) since it has no modal. The GitHub device code is surfaced by a two-command split — `setup --github-start` returns the code fast (foreground, copies to clipboard) and `setup --github-poll` waits for authorization (`setup --github` still chains both for back-compat). Step 0 has TWO branches: a **Claude Code Modal Flow** (the restored v3.0.0 `AskUserQuestion`-driven NUX — welcome, Auto/Manual/Skip, cookie consent, ScrapeCreators offer, `INCLUDE_SOURCES` opt-in, first-topic picker) for hosts with modals, and a **Non-Modal Prose Flow** for hosts without (OpenClaw, Codex, Cursor, Gemini CLI, Grok). Both ask before reading cookies, surface the macOS Full Disk Access fix on permission-denied, and offer the ScrapeCreators GitHub signup (10,000 free calls) on every first run. A successful `setup --github` persists `SCRAPECREATORS_API_KEY` automatically (via `setup_wizard.write_api_key`, 0o600) and masks the key in stdout. Do NOT collapse the modal flow back into a bare silent `setup` call or flatten it to prose-only — the guided modals are the feature (they eroded once and were restored). The onboarding contract is locked by `tests/test_onboarding_contract.py`. The Step 5 source opt-in is two tiers, both comment-enabled: **Recommended** (TikTok + Instagram posts AND top comments, plus YouTube comments — `INCLUDE_SOURCES=tiktok,instagram,youtube_comments,tiktok_comments,instagram_comments`) and **Everything** (also Threads + Pinterest). Comments are on by default (posts on → comments on for all three platforms); **Threads and Pinterest are the only opt-in extras**, appearing only in the Step 5 Everything option, never in the welcome or the Step 4 offer. Instagram comments are fetched via ScrapeCreators (`/v2/instagram/post/comments`, ranked by `comment_like_count`) with full vote-weighting parity to YouTube/TikTok (a dedicated `_instagram_engagement` carve-out, the `_VOTE_LOG_REFERENCE`/label/threshold entries). The cross-platform "Top Community Comments" list (`render._render_top_comments`) selects **round-robin by within-platform rank** (every platform's #1, then #2, then #3) so a viral platform can't crowd out a smaller one, and drops the per-platform absolute floor so a less-watched video's killer low-vote comment still surfaces.
 
 ## Security hygiene
 - Never commit real API keys, browser cookies, auth tokens, app passwords, access tokens, or `.env` contents.
@@ -59,13 +59,53 @@ Update `CONFIGURATION.md` when:
 
 - adding a new env var (e.g. `LAST30DAYS_*`, `BSKY_*`, `*_API_KEY`)
 - adding a new CLI flag that affects configuration (e.g. `--store`, `--web-backend`)
-- adding a new per-client install pattern (Claude Code, Gemini, Codex, Cursor, Hermes…)
+- adding a new per-client install pattern (Claude Code, Gemini, Codex, Cursor, Grok, Hermes…)
 - adding a new optional source that requires its own credential
 - changing the priority order of config layers (per-run flag > env > `.env` file > defaults)
 
 Keep the existing structure organized by how often each layer is touched: per-run flags → env vars / `.env` → optional trend-monitoring stack → per-client patterns. Add new content into the right section rather than appending at the end.
 
 When a new config concept lands in `SKILL.md` or `AGENTS.md`, mirror the user-facing knob in `CONFIGURATION.md` so non-agent readers can configure the skill without reverse-engineering it from the runtime spec.
+
+## Plugin manifests (Grok)
+
+The repo doubles as a native Grok Build plugin via `.grok-plugin/plugin.json` + `.grok-plugin/marketplace.json`. Grok also reads `.claude-plugin/*` for compatibility; the native pair is the first-class lane and what an official xAI marketplace listing points at. The self-hosted catalog uses a bare Git URL source (`{"source":"url","url":"https://github.com/mvanhorn/last30days-skill.git"}`) so `grok plugin marketplace add mvanhorn/last30days-skill` tracks HEAD — not a self-referential local `path: "."` (Grok does not enumerate those). Version lockstep with Claude/Codex/Gemini manifests is enforced by `tests/test_plugin_contract.py`. Validate with `grok plugin validate .`.
+
+## Submitting to the xAI plugin marketplace
+
+Getting last30days into xAI's official catalog (`xai-org/plugin-marketplace`) is an outbound PR to *their* repo — an index that only points at our source, so nothing of last30days is vendored there. Do this **after** the change you want to ship has merged to `main`: the entry pins a commit that must already exist.
+
+1. Fork `xai-org/plugin-marketplace` and branch from `main`.
+2. Get the commit to pin — a full 40-char lowercase SHA; a branch, tag, or short SHA is rejected by their validator:
+   ```bash
+   git ls-remote https://github.com/mvanhorn/last30days-skill.git HEAD
+   ```
+3. Add one entry to their `.grok-plugin/marketplace.json` under `plugins[]`, a remote source pinned to that SHA:
+   ```json
+   {
+     "name": "last30days",
+     "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+     "category": "productivity",
+     "source": {
+       "source": "url",
+       "url": "https://github.com/mvanhorn/last30days-skill.git",
+       "sha": "<full-40-char-sha-from-step-2>"
+     },
+     "homepage": "https://github.com/mvanhorn/last30days-skill",
+     "keywords": ["last30days", "last 30 days"]
+   }
+   ```
+4. Regenerate their component index (never hand-edit it) and validate exactly as their CI does:
+   ```bash
+   python3 scripts/generate-plugin-index.py
+   python3 scripts/validate-catalog.py
+   python3 scripts/generate-plugin-index.py --check
+   ```
+5. Open the PR, fill in their template, and wait for code-owner review.
+
+To roll out a later update in their catalog, bump the pinned `sha` in the existing entry — never open a second, parallel entry.
+
+Do not confuse this with our own `.grok-plugin/marketplace.json`: that file makes this repo directly addable as a Grok marketplace (`grok plugin marketplace add mvanhorn/last30days-skill`) and uses a **bare URL** source (no SHA) so it tracks HEAD; the xAI entry above lives in *their* repo and uses a **remote** source pinned to a SHA.
 
 ## Beta channel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Native Grok Build (xAI) plugin and marketplace lane: `.grok-plugin/plugin.json` + `.grok-plugin/marketplace.json` so `grok plugin install mvanhorn/last30days-skill` and `grok plugin marketplace add mvanhorn/last30days-skill` work as first-class install paths. The self-hosted catalog uses a bare Git URL source (tracks HEAD); submitting to the official `xai-org/plugin-marketplace` remains a post-merge SHA-pinned outbound PR documented in `AGENTS.md`.
+
 ## [3.11.0] - 2026-07-05
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -62,7 +62,7 @@ HTML follow-up renders also write a structured `last-report.json` cache beside `
 On the very first `/last30days` run (no `~/.config/last30days/.env`, or `SETUP_COMPLETE` not set), the skill runs a consent-driven onboarding the model drives in chat. It takes one of two forms depending on the host:
 
 - **Claude Code Modal Flow** - the restored v3.0.0 guided NUX, used on hosts with `AskUserQuestion` (Claude Code). A welcome message, then modals for Auto/Manual/Skip setup, cookie consent, the ScrapeCreators signup offer, a TikTok/Instagram `INCLUDE_SOURCES` opt-in, and a first-topic picker.
-- **Non-Modal Prose Flow** - the same work done conversationally on hosts without modals (OpenClaw, Codex, Cursor, Gemini CLI, raw CLI).
+- **Non-Modal Prose Flow** - the same work done conversationally on hosts without modals (OpenClaw, Codex, Cursor, Gemini CLI, Grok, raw CLI).
 
 Both share the same consent points:
 
@@ -416,6 +416,13 @@ The skill is built to flex around different client environments. Four patterns t
 The Codex marketplace catalog points at the repository root URL: Codex clones the repo, reads the
 root `.codex-plugin/plugin.json`, and loads skills from `./skills/`. The Agent Skills install
 command documented in the README remains the broadest cross-host path.
+
+**Grok note:** the repository includes `.grok-plugin/plugin.json` and `.grok-plugin/marketplace.json`
+so xAI's Grok Build CLI (`grok`) can install last30days as a native plugin. Grok also reads the
+Claude Code manifests for compatibility; the native pair is the first-class lane. The Grok
+marketplace catalog uses a bare Git URL source (no commit pin) so `grok plugin marketplace add
+mvanhorn/last30days-skill` tracks HEAD — the same pattern as the Codex catalog. `npx skills add`
+remains a valid cross-host fallback.
 
 ### 1. Trusted per-client `.claude/last30days.env`
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The v3 foundations are all still here: the pre-research brain that resolves the 
 | Surface | Install | Updates |
 |---------|---------|---------|
 | **Claude Code** (recommended) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via marketplace, or `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` then `grok plugin install last30days` | `grok plugin update last30days` |
 | **Codex, Cursor, Copilot, Gemini CLI, or any of 50+ [Agent Skills](https://agentskills.io) hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
 | **claude.ai** (web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) and upload via claude.ai > Customize > Skills > + > Create skill > Upload a skill | Re-download and re-upload |
 | **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) and drag into Settings > Extensions | Re-download and drag the new bundle in |
@@ -172,6 +173,23 @@ npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
 The native plugin and the `npx skills` install can coexist. Note that Claude Code does not dedupe across install methods: if you have both the marketplace plugin and the `npx skills` copy active, `/last30days` will show two entries. Use one install method per machine.
+
+### Grok (xAI Build CLI)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installs last30days as a native plugin. Direct install tracks the repository:
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+Or add this repo as a marketplace source, then install by plugin name:
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+Add `--trust` to skip the install confirmation. Update with `grok plugin update last30days`. Grok also reads the Claude Code manifests for compatibility; the native `.grok-plugin/` pair is the first-class lane (and what an official [xAI marketplace](https://github.com/xai-org/plugin-marketplace) listing points at). `npx skills add` remains a valid cross-host fallback.
 
 ### Codex, Cursor, Copilot, Gemini CLI, and other Agent Skills hosts
 

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -44,6 +44,31 @@ class TestPluginContract(unittest.TestCase):
             plugin["source"],
         )
 
+    def test_grok_plugin_manifest_uses_repo_skill_root(self) -> None:
+        manifest = _json(ROOT / ".grok-plugin" / "plugin.json")
+
+        self.assertEqual("last30days", manifest["name"])
+        self.assertEqual("./skills/", manifest["skills"])
+
+    def test_grok_marketplace_points_at_repo_root_plugin(self) -> None:
+        marketplace = _json(ROOT / ".grok-plugin" / "marketplace.json")
+        plugins = marketplace.get("plugins") or []
+        plugin_by_name = {plugin["name"]: plugin for plugin in plugins}
+
+        self.assertEqual("last30days-skill", marketplace["name"])
+        self.assertIn("last30days", plugin_by_name)
+        plugin = plugin_by_name["last30days"]
+        self.assertEqual(
+            {
+                "source": "url",
+                "url": "https://github.com/mvanhorn/last30days-skill.git",
+            },
+            plugin["source"],
+        )
+        # Grok rejects self-referential local marketplace sources (path "." / "./").
+        self.assertNotEqual("local", plugin["source"].get("type"))
+        self.assertNotIn(plugin["source"].get("path"), {".", "./"})
+
     def test_versions_match_across_manifests(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         version = pyproject["project"]["version"]
@@ -51,12 +76,18 @@ class TestPluginContract(unittest.TestCase):
         self.assertEqual(version, _skill_version())
         self.assertEqual(version, _json(ROOT / ".claude-plugin" / "plugin.json")["version"])
         self.assertEqual(version, _json(ROOT / ".codex-plugin" / "plugin.json")["version"])
+        self.assertEqual(version, _json(ROOT / ".grok-plugin" / "plugin.json")["version"])
         self.assertEqual(version, _json(ROOT / "gemini-extension.json")["version"])
 
         marketplace = _json(ROOT / ".claude-plugin" / "marketplace.json")
         plugins = marketplace.get("plugins") or []
         self.assertEqual(1, len(plugins))
         self.assertEqual(version, plugins[0]["version"])
+
+        grok_marketplace = _json(ROOT / ".grok-plugin" / "marketplace.json")
+        grok_plugins = grok_marketplace.get("plugins") or []
+        self.assertEqual(1, len(grok_plugins))
+        self.assertEqual(version, grok_plugins[0]["version"])
 
     def test_claude_marketplace_has_current_schema_shape(self) -> None:
         marketplace = _json(ROOT / ".claude-plugin" / "marketplace.json")

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -58,6 +58,7 @@ class TestPluginContract(unittest.TestCase):
         self.assertEqual("last30days-skill", marketplace["name"])
         self.assertIn("last30days", plugin_by_name)
         plugin = plugin_by_name["last30days"]
+        # Exact dict equality locks the bare Git URL source (anti-self-referential-local).
         self.assertEqual(
             {
                 "source": "url",
@@ -65,9 +66,6 @@ class TestPluginContract(unittest.TestCase):
             },
             plugin["source"],
         )
-        # Grok rejects self-referential local marketplace sources (path "." / "./").
-        self.assertNotEqual("local", plugin["source"].get("type"))
-        self.assertNotIn(plugin["source"].get("path"), {".", "./"})
 
     def test_versions_match_across_manifests(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -96,6 +94,16 @@ class TestPluginContract(unittest.TestCase):
         self.assertNotIn("description", marketplace)
         self.assertIn("metadata", marketplace)
         self.assertIn("description", marketplace["metadata"])
+
+    def test_grok_marketplace_has_current_schema_shape(self) -> None:
+        marketplace = _json(ROOT / ".grok-plugin" / "marketplace.json")
+
+        self.assertNotIn("$schema", marketplace)
+        self.assertNotIn("metadata", marketplace)
+        self.assertIsInstance(marketplace["description"], str)
+        self.assertIn("name", marketplace)
+        self.assertIn("owner", marketplace)
+        self.assertIn("plugins", marketplace)
 
     def test_workflows_do_not_reference_removed_root_scripts_dir(self) -> None:
         # The root-level scripts/ directory was removed; workflows must not


### PR DESCRIPTION
## Summary

last30days can now install as a first-class **Grok Build (xAI)** plugin — not only through Claude Code compatibility. Users can `grok plugin install` / `marketplace add` against this repo today, and maintainers have a turn-key runbook for a later SHA-pinned listing in `xai-org/plugin-marketplace`.

## What changed

- Native `.grok-plugin/plugin.json` + `.grok-plugin/marketplace.json`, reusing the existing `skills/` tree (no converter).
- Self-hosted catalog uses a **bare Git URL** source (no SHA) so marketplace installs track HEAD — same pattern as the Codex catalog, and avoids Grok's self-referential local-source rejection.
- Brand-scoped keywords (`last30days`, `last 30 days`) for Grok's proactive plugin CTA.
- Version lockstep extended in `tests/test_plugin_contract.py`.
- README / CONFIGURATION / AGENTS / CHANGELOG docs, including the outbound xAI submission procedure.

## Design decisions

- **Native pair over compat-only.** Grok already reads `.claude-plugin/*`, but the native manifests are what qualify for the official marketplace and control CTA metadata.
- **Bare URL here; SHA pin only in xAI's catalog.** Direct install and our self-hosted marketplace stay zero-churn; the official catalog's supply-chain rule is a post-merge maintainer PR, not automated from this change.

## Testing

- [x] `grok plugin validate .` → valid (`last30days` 3.11.1, 1 skill + hooks)
- [x] `uv run pytest tests/test_plugin_contract.py` → 7 passed
- [ ] Ran `uv run python -m pytest -q --tb=short`

## Related Issues

None.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Grok_4.5-000000)
