### PR TITLE
Add DripStack to related skills

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -130,6 +130,7 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Hacker News | none | always on | yes |
 | Polymarket | none | always on | yes |
 | StockTwits | none | auto-on for ticker/crypto topics only (gated by symbol detection); never registered for non-financial topics | yes (public API, ~200 req/hr per IP) |
+| DripStack | none | always on; searches premium financial newsletters and analyst writeups (free, public search API — no key needed). The planner assigns it to financial/analysis/opinion topics automatically. | yes (public API, no auth) |
 | GitHub | `gh` CLI installed (uses your GitHub auth) | always on if `gh` present | yes |
 | YouTube | `yt-dlp` CLI installed; `SCRAPECREATORS_API_KEY` adds a server-side transcript fallback used only when yt-dlp fails (429 / bot-gate) | always on if `yt-dlp` present; SC transcript fallback default-on when key set (no credit spent unless yt-dlp fails) | yes |
 | YouTube comments | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `youtube_comments` (**on by default** — written by the Step 5 Recommended tier) | top comments (by likes) on the top ~3 videos by engagement | ~3 calls/run; 10K free calls |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -130,7 +130,7 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Hacker News | none | always on | yes |
 | Polymarket | none | always on | yes |
 | StockTwits | none | auto-on for ticker/crypto topics only (gated by symbol detection); never registered for non-financial topics | yes (public API, ~200 req/hr per IP) |
-| DripStack | none | always on; searches premium financial newsletters and analyst writeups (free, public search API — no key needed). The planner assigns it to financial/analysis/opinion topics automatically. | yes (public API, no auth) |
+| DripStack | none | requested-only: include it with `--search dripstack` (or LAST30DAYS_DEFAULT_SEARCH). Searches premium financial newsletters and analyst writeups via a free, public search API — no key needed. Never active on default runs. | yes when requested (public API, no auth) |
 | GitHub | `gh` CLI installed (uses your GitHub auth) | always on if `gh` present | yes |
 | YouTube | `yt-dlp` CLI installed; `SCRAPECREATORS_API_KEY` adds a server-side transcript fallback used only when yt-dlp fails (429 / bot-gate) | always on if `yt-dlp` present; SC transcript fallback default-on when key set (no credit spent unless yt-dlp fails) | yes |
 | YouTube comments | `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` contains `youtube_comments` (**on by default** — written by the Step 5 Recommended tier) | top comments (by likes) on the top ~3 videos by engagement | ~3 calls/run; 10K free calls |

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | Bluesky | App password from bsky.app | Free |
 | TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comments | ScrapeCreators key | 10,000 free calls, then PAYG |
 | Xiaohongshu (RED) | Run a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service and request it with `--search xhs`; last30days auto-probes `http://localhost:18060` then `http://host.docker.internal:18060`, or use `XIAOHONGSHU_API_BASE` for a custom URL | No last30days API key; depends on your local browser-session service |
+| DripStack (premium financial newsletters) | Requested-only: include it with `--search dripstack` | No key; free public search API |
 | Perplexity Sonar / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go |
 | Web search | Brave Search key | 2,000 free queries/month |
 
@@ -355,12 +356,6 @@ Published a recurring AI update, market watch, or wonderfully narrow obsession w
 > "This one skill replaced my entire research workflow. You give it a topic, it scrapes Reddit, X, and the web for what people are actually talking about. Not old blog posts. Real conversations from the last 30 days." -@itswilsoncharles
 
 > "5 of the 10 trending repos on GitHub today are Claude tools. #1: mvanhorn/last30days-skill" -@yieldhunter95
-
-## Related skills
-
-| Skill | What it does | Install |
-|-------|-------------|--------|
-| **[DripStack](https://dripstack.xyz)** | Search, browse, and purchase premium financial newsletters and podcasts via micropayments. Stock picks, analyst calls, and paid Substack content. | `npx skills add dripstack/dripstack-skill -g` |
 
 ## Open source
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ Published a recurring AI update, market watch, or wonderfully narrow obsession w
 
 > "5 of the 10 trending repos on GitHub today are Claude tools. #1: mvanhorn/last30days-skill" -@yieldhunter95
 
+## Related skills
+
+| Skill | What it does | Install |
+|-------|-------------|--------|
+| **[DripStack](https://dripstack.xyz)** | Search, browse, and purchase premium financial newsletters and podcasts via micropayments. Stock picks, analyst calls, and paid Substack content. | `npx skills add dripstack/dripstack-skill -g` |
+
 ## Open source
 
 MIT license. No tracking. No analytics. Your research stays on your machine. 2,700+ tests.

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -592,6 +592,7 @@ The magic of /last30days is Reddit comments + X posts together - and both are fr
 **Other optional sources (add anytime):**
 - `PERPLEXITY_API_KEY=xxx` (or `OPENROUTER_API_KEY=xxx`) - AI-synthesized research with citations; set `INCLUDE_SOURCES=perplexity`.
 - `XIAOHONGSHU_API_BASE=http://localhost:18060` - Xiaohongshu/RED via a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service; optional unless the local service runs on a custom URL. Request it per run with `--search xhs`.
+- DripStack (premium financial newsletter search) is requested-only: include it per run with `--search dripstack`. Free public search API, no key; never active unless requested.
 - `BSKY_HANDLE=you.bsky.social` + `BSKY_APP_PASSWORD=xxx` - Bluesky (free app password).
 - `BRAVE_API_KEY=xxx` or `EXA_API_KEY=xxx` - web search backends.
 

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -648,7 +648,7 @@ SKILL_DIR="<absolute path of the directory containing the SKILL.md you just Read
 "${LAST30DAYS_PYTHON}" "${SKILL_DIR}/scripts/last30days.py" --diagnose
 ```
 
-`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `linkedin`→LinkedIn, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs, `corpus`→Your files.
+`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `linkedin`→LinkedIn, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs, `corpus`→Your files, `dripstack`→DripStack.
 
 - If EXCLUDE_SOURCES is set (comma-separated, case-insensitive): drop any matching source from ACTIVE_SOURCES_LIST before displaying
 

--- a/skills/last30days/scripts/lib/dripstack.py
+++ b/skills/last30days/scripts/lib/dripstack.py
@@ -1,0 +1,186 @@
+"""DripStack source for last30days — premium financial newsletter search.
+
+DripStack indexes paid Substack newsletters, analyst writeups, and financial
+podcasts. The search endpoint is free and public (no API key); it returns
+article metadata including title, publication, date, and a relevance-scored
+snippet. Full article summaries and stock picks are behind a paid layer and
+are out of scope for this source adapter.
+
+The signal is complementary to the other financial sources: StockTwits gives
+retail sentiment, Polymarket gives prediction-market odds, and DripStack gives
+what professional analysts and paid newsletter authors are actually writing
+about. The search results carry publication attribution (e.g. "SemiAnalysis",
+"Bloomberg") which is high-credibility signal for synthesis.
+
+GATING: DripStack search is most valuable for finance, markets, company
+analysis, and industry research topics. Like arXiv (science) and Techmeme
+(tech news), DripStack is relevance-gated — the search API itself filters
+for topic match, so off-topic runs return thin results naturally and the
+engine's thin-retry + relevance scoring handles the rest.
+
+API: public, no auth. Search endpoint returns up to 30 items per query.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE_URL = "https://dripstack.xyz"
+_SEARCH_URL = f"{_BASE_URL}/api/v1/search"
+_UA = "Mozilla/5.0 (last30days dripstack source)"
+
+# Depth controls how many results we request per subquery.
+_DEPTH_LIMITS = {"quick": 5, "default": 10, "deep": 20}
+
+
+def _log(msg: str) -> None:
+    try:
+        from . import log as _enginelog
+        _enginelog.source_log("DripStack", msg, tty_only=False)
+    except Exception:
+        print(f"[DripStack] {msg}", file=sys.stderr)
+
+
+def _get_json(url: str, timeout: int = 20) -> dict[str, Any]:
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def search_dripstack(
+    topic: str,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    *,
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    """Search DripStack for articles matching the topic.
+
+    Returns a list of raw item dicts from the search API. The free endpoint
+    requires no authentication. Results are relevance-ranked by DripStack's
+    own scoring (hybrid RRF — blended semantic + keyword match).
+
+    Args:
+        topic: The search query (e.g. "AI capex risk", "Tesla earnings").
+        from_date: ISO date string for start of window (YYYY-MM-DD). Not sent
+            to the API (DripStack search has its own time handling), but
+            available for post-filtering if needed.
+        to_date: ISO date string for end of window (YYYY-MM-DD).
+        depth: One of "quick", "default", "deep" — controls result count.
+    """
+    limit = _DEPTH_LIMITS.get(depth, 10)
+    params = urllib.parse.urlencode({"q": topic, "limit": limit})
+    url = f"{_SEARCH_URL}?{params}"
+
+    try:
+        data = _get_json(url)
+    except Exception as e:
+        _log(f"search failed for '{topic}': {e}")
+        return []
+
+    items = data.get("items") or []
+    _log(f"search '{topic}': {len(items)} results (confidence: {data.get('matchConfidence', '?')})")
+    return items
+
+
+def parse_dripstack_response(
+    items: list[dict[str, Any]],
+    query: str = "",
+) -> list[dict[str, Any]]:
+    """Normalize DripStack search results into engine-style item dicts.
+
+    Each item maps to the same shape as other sources (HN, Reddit, StockTwits):
+    id, title, url, author, date, engagement, relevance, why_relevant,
+    snippet, metadata.
+
+    DripStack has no engagement signal (upvotes, likes), so engagement is
+    empty. Ranking relies on DripStack's own relevanceScore (0-100) which we
+    normalize to 0-1, plus recency.
+    """
+    parsed: list[dict[str, Any]] = []
+    for i, item in enumerate(items):
+        title = (item.get("title") or "").strip()
+        subtitle = (item.get("subtitle") or "").strip()
+        snippet_text = (item.get("snippet") or "").strip()
+        pub_slug = (item.get("publicationSlug") or "").strip()
+        post_slug = (item.get("slug") or "").strip()
+        published_at = (item.get("publishedAt") or "")[:10] or None
+
+        # Build the article URL. For Substack-hosted publications the slug is
+        # the full hostname (e.g. "newsletter.doomberg.com") and the post slug
+        # is the path segment. For other domains the same pattern applies.
+        if pub_slug and post_slug:
+            url = f"https://{pub_slug}/{post_slug}"
+        else:
+            url = ""
+
+        # Normalize DripStack's 0-100 relevanceScore to 0-1 for the engine.
+        raw_score = item.get("relevanceScore", 0)
+        try:
+            relevance = round(min(1.0, max(0.0, float(raw_score) / 100.0)), 2)
+        except (TypeError, ValueError):
+            relevance = 0.5
+
+        # Build a human-readable why_relevant from the whyMatched array.
+        why_parts = item.get("whyMatched") or []
+        # Filter out internal RRF details; keep the useful match explanations.
+        why_clean = [
+            w for w in why_parts
+            if "RRF" not in w and "Hybrid" not in w
+        ]
+        why_relevant = "; ".join(why_clean) if why_clean else f"DripStack newsletter match for: {query}"
+
+        # The body feeds rerank and synthesis. Use subtitle (the article
+        # summary/lede) as the primary content, falling back to snippet.
+        body = subtitle or snippet_text or title
+
+        # Publication name as author — gives attribution credit to the
+        # newsletter/analyst who wrote it (e.g. "SemiAnalysis", "Bloomberg").
+        # Use the slug as a readable fallback.
+        author = pub_slug.replace(".substack.com", "").replace(".com", "")
+
+        parsed.append({
+            "id": f"DS{i + 1}",
+            "title": title or f"DripStack result {i + 1}",
+            "url": url,
+            "author": author or None,
+            "date": published_at,
+            "engagement": {},
+            "relevance": relevance,
+            "why_relevant": why_relevant,
+            "snippet": snippet_text[:400],
+            "metadata": {
+                "publication_slug": pub_slug,
+                "post_slug": post_slug,
+                "relevance_score": raw_score,
+                "match_confidence": item.get("matchConfidence"),
+                "topic_coverage_ratio": item.get("topicCoverageRatio"),
+            },
+        })
+    return parsed
+
+
+# --------------------------------------------------------------------------- #
+# Standalone CLI                                                               #
+#   python3 dripstack.py "AI capex risk"                                      #
+# --------------------------------------------------------------------------- #
+
+if __name__ == "__main__":
+    topic = " ".join(sys.argv[1:]) or "AI capex"
+    today = datetime.date.today()
+    since = (today - datetime.timedelta(days=30)).isoformat()
+
+    raw = search_dripstack(topic, from_date=since, depth="default")
+    items = parse_dripstack_response(raw, query=topic)
+
+    print(f"Query: {topic} | {len(items)} results")
+    for it in items[:10]:
+        print(f"  [{it['relevance']:.0%}] {it['title']} ({it['author']}, {it['date'] or 'no date'})")
+        if it["snippet"]:
+            print(f"    {it['snippet'][:120]}")

--- a/skills/last30days/scripts/lib/dripstack.py
+++ b/skills/last30days/scripts/lib/dripstack.py
@@ -28,8 +28,9 @@ import json
 import re
 import sys
 import urllib.parse
-import urllib.request
 from typing import Any
+
+from . import http
 
 _BASE_URL = "https://dripstack.xyz"
 _SEARCH_URL = f"{_BASE_URL}/api/v1/search"
@@ -48,9 +49,9 @@ def _log(msg: str) -> None:
 
 
 def _get_json(url: str, timeout: int = 20) -> dict[str, Any]:
-    req = urllib.request.Request(url, headers={"User-Agent": _UA})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.load(resp)
+    # All engine traffic goes through the shared lib/http.py choke point so
+    # capture/replay, fixtures, and failure taxonomy apply to this source too.
+    return http.get(url, headers={"User-Agent": _UA}, timeout=timeout, retries=2)
 
 
 def search_dripstack(
@@ -85,6 +86,21 @@ def search_dripstack(
         return []
 
     items = data.get("items") or []
+    if from_date or to_date:
+        windowed = []
+        dropped = 0
+        for item in items:
+            published = str(item.get("publishedAt") or "")[:10]
+            if published and from_date and published < from_date:
+                dropped += 1
+                continue
+            if published and to_date and published > to_date:
+                dropped += 1
+                continue
+            windowed.append(item)
+        if dropped:
+            _log(f"dropped {dropped} result(s) outside the {from_date}..{to_date} window")
+        items = windowed
     _log(f"search '{topic}': {len(items)} results (confidence: {data.get('matchConfidence', '?')})")
     return items
 

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -44,6 +44,7 @@ def normalize_source_items(
         "instagram": lambda s, i, idx, fd, td: _normalize_shortform_video(s, i, idx, fd, td, "IG", "Instagram reel"),
         "hackernews": _normalize_hackernews,
         "stocktwits": _normalize_stocktwits,
+        "dripstack": _normalize_dripstack,
         "bluesky": lambda s, i, idx, fd, td: _normalize_microblog(s, i, idx, fd, td, "BS", "Bluesky post"),
         "truthsocial": lambda s, i, idx, fd, td: _normalize_microblog(s, i, idx, fd, td, "TS", "Truth Social post"),
         "threads": lambda s, i, idx, fd, td: _normalize_microblog(s, i, idx, fd, td, "TH", "Threads post"),
@@ -211,6 +212,42 @@ def _normalize_stocktwits(
         why_relevant=str(item.get("why_relevant") or ""),
         snippet=str(item.get("snippet") or "")[:400],
         metadata=meta,   # carries sentiment + symbol-level bull/bear aggregate
+    )
+
+
+def _normalize_dripstack(
+    source: str,
+    item: dict[str, Any],
+    index: int,
+    from_date: str,
+    to_date: str,
+) -> schema.SourceItem:
+    """Normalizer for DripStack newsletter search results.
+
+    DripStack returns article metadata from paid financial newsletters.
+    No engagement signal — ranking relies on DripStack's own relevanceScore
+    (0-100, normalized to 0-1) plus recency. The publication name serves as
+    author/attribution (e.g. "SemiAnalysis", "Bloomberg").
+    """
+    meta = item.get("metadata") or {}
+    return _source_item(
+        item_id=str(item.get("id") or f"DS{index + 1}"),
+        source=source,
+        title=str(item.get("title") or ""),
+        body=str(item.get("snippet") or "") or str(item.get("title") or ""),
+        url=str(item.get("url") or ""),
+        author=str(item.get("author") or "") or None,
+        container=str(meta.get("publication_slug") or "") or None,
+        published_at=item.get("date"),
+        date_confidence=_date_confidence(item, from_date, to_date, default="high"),
+        engagement={},
+        relevance_hint=item.get("relevance", 0.5),
+        why_relevant=str(item.get("why_relevant") or ""),
+        snippet=str(item.get("snippet") or "")[:400],
+        metadata={
+            **meta,
+            "publication_slug": meta.get("publication_slug"),
+        },
     )
 
 

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -188,10 +188,12 @@ def available_sources(
     # GitHub is reachable via the unauthenticated REST tier too, so it is
     # available even without a token/gh CLI (a token only raises rate limits).
     available.append("github")
-    # DripStack search is free and public (no API key). The planner will only
-    # assign it to financial/analysis topics — off-topic searches return thin
-    # results that the engine's relevance gating handles naturally.
-    available.append("dripstack")
+    # DripStack is requested-only (owner decision, #791): a commercial
+    # third-party API must never receive default-run traffic. Request it per
+    # run (--search dripstack) or via LAST30DAYS_DEFAULT_SEARCH; the search
+    # API is free and public (no key), so the request itself is the gate.
+    if requested_sources and "dripstack" in requested_sources:
+        available.append("dripstack")
     if which("digg-pp-cli"):
         available.append("digg")
     # arXiv is default-on when its Printing Press CLI is installed (zero auth).

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -23,6 +23,7 @@ from . import (
     dates,
     dedupe,
     digg,
+    dripstack,
     entity_extract,
     env,
     github,
@@ -127,6 +128,7 @@ MOCK_AVAILABLE_SOURCES = [
     "jobs",
     "linkedin",
     "corpus",
+    "dripstack",
 ]
 
 
@@ -186,6 +188,10 @@ def available_sources(
     # GitHub is reachable via the unauthenticated REST tier too, so it is
     # available even without a token/gh CLI (a token only raises rate limits).
     available.append("github")
+    # DripStack search is free and public (no API key). The planner will only
+    # assign it to financial/analysis topics — off-topic searches return thin
+    # results that the engine's relevance gating handles naturally.
+    available.append("dripstack")
     if which("digg-pp-cli"):
         available.append("digg")
     # arXiv is default-on when its Printing Press CLI is installed (zero auth).
@@ -2814,6 +2820,14 @@ def _retrieve_stream_impl(
             stocktwits.parse_stocktwits_response(result, query=subquery.search_query),
             _result_outcome_artifact(source, result),
         )
+    if source == "dripstack":
+        result = dripstack.search_dripstack(
+            subquery.search_query, from_date, to_date, depth=depth)
+        relevance_topic = raw_topic or topic or subquery.search_query
+        return (
+            dripstack.parse_dripstack_response(result, query=relevance_topic),
+            _result_outcome_artifact(source, result),
+        )
     if source == "digg":
         result = digg.search_digg(subquery.search_query, from_date, to_date, depth=depth)
         items = digg.parse_digg_response(result, query=subquery.search_query)
@@ -3016,6 +3030,25 @@ def _mock_stream_results(source: str, subquery: schema.SubQuery) -> tuple[list[d
                 "engagement": {},
                 "relevance": 0.83,
                 "why_relevant": "Mock Techmeme headline",
+            },
+        ],
+        "dripstack": [
+            {
+                "id": "DS1",
+                "title": f"Deep dive: {subquery.search_query} from a paid newsletter",
+                "url": "https://newsletter.example.com/deep-dive",
+                "author": "newsletter.example.com",
+                "date": dates.get_date_range(3)[0],
+                "engagement": {},
+                "relevance": 0.85,
+                "why_relevant": "Mock DripStack newsletter result",
+                "snippet": f"Professional analyst coverage of {subquery.search_query}.",
+                "metadata": {
+                    "publication_slug": "newsletter.example.com",
+                    "post_slug": "deep-dive",
+                    "relevance_score": 85,
+                    "match_confidence": "strong",
+                },
             },
         ],
         "trustpilot": [

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -85,11 +85,11 @@ SOURCE_PRIORITY = {
     "factual": ["hackernews", "reddit", "x", "youtube"],
     "product": ["jobs", "youtube", "reddit", "x", "tiktok", "hackernews"],
     "concept": ["hackernews", "reddit", "x", "youtube"],
-    "opinion": ["reddit", "x", "stocktwits", "youtube", "hackernews"],
+    "opinion": ["reddit", "x", "stocktwits", "dripstack", "youtube", "hackernews"],
     "how_to": ["youtube", "reddit", "x", "hackernews"],
     "comparison": ["reddit", "x", "hackernews", "youtube"],
     "breaking_news": ["x", "stocktwits", "reddit", "hackernews", "youtube", "polymarket"],
-    "prediction": ["polymarket", "stocktwits", "x", "hackernews", "reddit", "youtube"],
+    "prediction": ["polymarket", "stocktwits", "dripstack", "x", "hackernews", "reddit", "youtube"],
 }
 SOURCE_LIMITS = {
     "quick": {
@@ -122,6 +122,7 @@ SOURCE_CAPABILITIES = {
     "truthsocial": {"discussion", "social"},
     "polymarket": {"market"},
     "stocktwits": {"social", "market", "finance_social"},
+    "dripstack": {"reference", "analysis", "link"},
     "digg": {"discussion", "social", "link"},
     "arxiv": {"reference", "analysis", "link"},
     "techmeme": {"discussion", "link", "reference"},

--- a/tests/test_diagnose_compat.py
+++ b/tests/test_diagnose_compat.py
@@ -44,7 +44,7 @@ KNOWN_SOURCE_NAMES = {
     "reddit", "x", "youtube", "tiktok", "instagram", "hackernews", "bluesky",
     "truthsocial", "polymarket", "grounding", "xiaohongshu", "github",
     "perplexity", "threads", "pinterest", "digg", "jobs", "linkedin",
-    "arxiv", "techmeme", "stocktwits", "trustpilot",
+    "arxiv", "techmeme", "stocktwits", "trustpilot", "dripstack",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dripstack.py
+++ b/tests/test_dripstack.py
@@ -1,0 +1,96 @@
+"""DripStack source: requested-only gating, windowing, and normalization."""
+
+from unittest import mock
+
+from lib import dripstack, pipeline
+
+
+def _api_item(**overrides):
+    item = {
+        "publicationSlug": "newsletter.semianalysis.com",
+        "slug": "nvidia-gpu-debt-backstop",
+        "title": "Nvidia GPU Debt Backstop",
+        "subtitle": "Capital, offtake and datacenters.",
+        "snippet": "Nvidia's backstop economics explained.",
+        "publishedAt": "2026-07-06T21:53:44.000Z",
+        "relevanceScore": 84,
+        "matchConfidence": "strong",
+        "topicCoverageRatio": 1,
+        "whyMatched": ["Matched article body for: nvidia", "Hybrid RRF — blended"],
+    }
+    item.update(overrides)
+    return item
+
+
+def test_dripstack_absent_from_available_sources_by_default():
+    assert "dripstack" not in pipeline.available_sources({}, None, x_pending=False)
+
+
+def test_dripstack_available_only_when_explicitly_requested():
+    available = pipeline.available_sources({}, ["dripstack"], x_pending=False)
+    assert "dripstack" in available
+
+
+def test_search_goes_through_the_shared_http_choke_point(monkeypatch):
+    seen = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        seen["url"] = url
+        seen["retries"] = kwargs.get("retries")
+        return {"items": [_api_item()], "matchConfidence": "strong"}
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    items = dripstack.search_dripstack("Nvidia earnings", "2026-06-12", "2026-07-12")
+
+    assert len(items) == 1
+    assert seen["url"].startswith("https://dripstack.xyz/api/v1/search?")
+    assert seen["retries"] == 2
+
+
+def test_search_drops_results_outside_the_window(monkeypatch):
+    stale = _api_item(publishedAt="2026-05-20T19:06:01.000Z", slug="old-post")
+    fresh = _api_item()
+    undated = _api_item(publishedAt="", slug="undated-post")
+    monkeypatch.setattr(
+        dripstack.http, "get",
+        lambda *a, **k: {"items": [stale, fresh, undated], "matchConfidence": "strong"},
+    )
+
+    items = dripstack.search_dripstack("Nvidia", "2026-06-12", "2026-07-12")
+
+    slugs = [item["slug"] for item in items]
+    assert "old-post" not in slugs
+    assert "nvidia-gpu-debt-backstop" in slugs
+    assert "undated-post" in slugs  # undated results are kept, not guessed
+
+
+def test_search_failure_returns_empty_list(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(dripstack.http, "get", boom)
+    assert dripstack.search_dripstack("Nvidia", "2026-06-12", "2026-07-12") == []
+
+
+def test_parse_normalizes_fields_and_relevance():
+    parsed = dripstack.parse_dripstack_response([_api_item()], query="nvidia")
+
+    item = parsed[0]
+    assert item["url"] == "https://newsletter.semianalysis.com/nvidia-gpu-debt-backstop"
+    assert item["date"] == "2026-07-06"
+    assert item["relevance"] == 0.84
+    assert item["engagement"] == {}
+    assert item["author"] == "newsletter.semianalysis"
+    assert "Hybrid" not in item["why_relevant"]
+    assert item["metadata"]["publication_slug"] == "newsletter.semianalysis.com"
+
+
+def test_parse_handles_missing_fields_conservatively():
+    parsed = dripstack.parse_dripstack_response(
+        [{"title": "", "relevanceScore": "not-a-number"}], query="x"
+    )
+
+    item = parsed[0]
+    assert item["title"] == "DripStack result 1"
+    assert item["url"] == ""
+    assert item["relevance"] == 0.5


### PR DESCRIPTION
Integrates [DripStack](https://dripstack.xyz) as a new source + adds it to the Related Skills section.

**What is DripStack?** An AI agent skill for searching, browsing, and purchasing access to premium financial newsletters and podcasts via micropayments (x402/MPP). Think stock picks from paid analysts, Substack deep dives, and newsletter research.

**What this PR does:**

1. **New source module** (`scripts/lib/dripstack.py`) — searches DripStack's free, public API for premium financial newsletter articles. No API key required. Returns article metadata (title, publication, date, snippet, relevance score) from sources like SemiAnalysis, Bloomberg, Doomberg, etc.

2. **Pipeline integration** — wired into `pipeline.py`, `normalize.py`, and `planner.py`. Always available (like GitHub, HN, Reddit). The planner assigns it to `opinion` and `prediction` intents alongside StockTwits.

3. **Related Skills section** in README — DripStack as a complementary skill.

**Why it fits:**

| Source | Signal type |
|--------|-------------|
| StockTwits | Retail sentiment (bull/bear ratios) |
| Polymarket | Prediction-market odds (real money) |
| **DripStack** | **Professional analyst signal** (paid newsletters, analyst writeups) |

Same audience (developers/power users using AI coding assistants), different data layers. DripStack covers the paywalled financial signal that the other sources can't reach.

**Auth:** The search endpoint is free and public — no key needed. Full article summaries and stock picks are behind a paid layer, but the search metadata alone provides valuable signal (publication attribution like 'SemiAnalysis' is high-credibility context for synthesis).

Ref: [@mvanhorn's suggestion](https://x.com/mvanhorn/status/2074986990555258963)
