### PR TITLE
fix(pipeline): pass missing trustpilot params in retry call

### DIFF
--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -584,6 +584,8 @@ def run(
                             tiktok_hashtags=tiktok_hashtags,
                             tiktok_creators=tiktok_creators,
                             ig_creators=ig_creators,
+                            trustpilot_domain=trustpilot_domain,
+                            trustpilot_domain_is_hint=trustpilot_domain_is_hint,
                         )
                     except Exception as retry_exc:
                         bundle.errors_by_source[source] = f"{exc} (retried once, still failed: {retry_exc})"


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `run()` function's transient error retry logic where `trustpilot_domain` and `trustpilot_domain_is_hint` were omitted during the secondary `_retrieve_stream` call. This omission caused the retry attempt to lose the user-supplied Trustpilot domain flag, forcing brand detection to run from scratch and potentially surface incorrect company reviews after a 5xx error.

## Changes

- **Modified File:** `skills/last30days/scripts/lib/pipeline.py`
  - Updated the `_retrieve_stream` retry call inside the `as_completed` loop to explicitly pass `trustpilot_domain=trustpilot_domain` and `trustpilot_domain_is_hint=trustpilot_domain_is_hint`.

## Testing

- [x] Verified that when a transient 5xx error is simulated on the initial stream retrieval, the subsequent retry successfully retains and uses the explicit `--trustpilot-domain` context rather than falling back to default brand discovery.
- [x] Ran `uv run python -m pytest -q --tb=short`

## Related Issues

- **None (Direct Contribution):** Submitted directly as a PR per maintainer guidelines ("I don't assign — submit PRs directly"). 
- **Contextual Alignment:** Relates generally to the repo's network resilience and scraper failure handling paradigms seen in past issues like #78 (silent scraper failures) and tracking with open discussion #384 (explicit per-source failure mode signaling).
- **Keywords/Tags:** `bug`, `pipeline`, `trustpilot`, `retry-logic`, `WAF-bypass`