### PR TITLE
fix(pipeline): forward pinned parameters in thin-source retry logic

### DIFF
--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1795,4 +1795,5 @@ def _mock_stream_results(source: str, subquery: schema.SubQuery) -> tuple[list[d
             "webSearchQueries": [subquery.search_query],
             "resultCount": 1,
         }
-    return payloads.get(source, []), {}
+    return payloads.get(source, []), {} 
+ 

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1796,3 +1796,4 @@ def _mock_stream_results(source: str, subquery: schema.SubQuery) -> tuple[list[d
             "resultCount": 1,
         }
     return payloads.get(source, []), {}
+

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -653,6 +653,10 @@ def run(
         settings=settings,
         web_backend=web_backend,
         skip_sources=_github_skip_retry,
+        subreddits=subreddits,
+        tiktok_hashtags=tiktok_hashtags,
+        tiktok_creators=tiktok_creators,
+        ig_creators=ig_creators,
     )
 
     # Reclassify partial failures as DEGRADED instead of silently dropping them.
@@ -1141,6 +1145,10 @@ def _retry_thin_sources(
     settings: dict[str, Any],
     web_backend: str = "auto",
     skip_sources: set[str] | None = None,
+    subreddits: list[str] | None = None,
+    tiktok_hashtags: list[str] | None = None,
+    tiktok_creators: list[str] | None = None,
+    ig_creators: list[str] | None = None,
 ) -> None:
     """Retry sources with thin results using simplified core subject query."""
     if depth == "quick":
@@ -1201,6 +1209,10 @@ def _retry_thin_sources(
             rate_limit_lock=rate_limit_lock,
             web_backend=web_backend,
             raw_topic=topic,
+            subreddits=subreddits,
+            tiktok_hashtags=tiktok_hashtags,
+            tiktok_creators=tiktok_creators,
+            ig_creators=ig_creators,
         )
         normalized = _normalize_score_dedupe(
             source,

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1795,5 +1795,4 @@ def _mock_stream_results(source: str, subquery: schema.SubQuery) -> tuple[list[d
             "webSearchQueries": [subquery.search_query],
             "resultCount": 1,
         }
-    return payloads.get(source, []), {} 
- 
+    return payloads.get(source, []), {}


### PR DESCRIPTION
## Summary

This PR fixes a bug in `_retry_thin_sources` where `subreddits`, `tiktok_hashtags`, `tiktok_creators`, and `ig_creators` were silently dropped during Phase 2b retry attempts. When these targeted sources returned low-volume data (<3 items) in Phase 1, the fallback retry fired without the user's explicit constraints—falling back to broad public discovery instead of honoring pinned `--subreddits`, `--tiktok-creators`, or `--ig-creators` flags.

## Changes

- **Modified File:** `skills/last30days/scripts/lib/pipeline.py`
  - Updated the `_retry_thin_sources` function signature to accept `subreddits`, `tiktok_hashtags`, `tiktok_creators`, and `ig_creators`.
  - Updated the primary call site within `run()` to correctly pass all four parameters down into `_retry_thin_sources`.
  - Updated `_retry_one_source` to forward these parameters cleanly into the inner `_retrieve_stream` call, mirroring the exact signature used in Phase 1.

## Why This Matters

Unlike strict 5xx network error retries, the thin-source retry logic fires under regular operational conditions on lower-volume topics. Because it fails silently without throwing an exception, users simply receive weak or misattributed generic fallback results with no warnings. This is particularly problematic for niche brand monitoring where dedicated subreddits naturally have low volume and depend heavily on accurate retries. 

*Note: `trustpilot` remains safely isolated from this path via the existing `_skip` set (line 1159).*

## Testing

- [x] Verified that when low-volume/thin streams trigger Phase 2b retries, the explicit subreddits and social creator arrays are preserved in the subsequent stream retrieval signature rather than defaulting to generic public indices.
- [x] Ran `uv run python -m pytest -q --tb=short`

## Related Issues

- **None (Direct Contribution):** Submitted directly as a PR per maintainer guidelines ("I don't assign — submit PRs directly").
- **Structurally Related:** This pattern is structurally identical to the parameter dropping fixed in #794 (the transient error retry bug), but targets the high-frequency thin-source code path across Reddit, TikTok, and Instagram modules.
- **Keywords/Tags:** `bug`, `pipeline`, `social-sources`, `retry-logic`, `data-integrity`