### PR TITLE
fix(store): guard store_findings against None engagement_score on update path

### DIFF
--- a/changelog.d/796.fixed.md
+++ b/changelog.d/796.fixed.md
@@ -1,0 +1,1 @@
+`store_findings` no longer raises `TypeError` when a re-sighted finding carries `engagement_score: None`.

--- a/skills/last30days/scripts/store.py
+++ b/skills/last30days/scripts/store.py
@@ -484,7 +484,7 @@ def store_findings(
 
         for url, f in with_urls:
             existing = existing_by_url.get(url)
-            new_engagement = f.get("engagement_score", 0)
+            new_engagement = f.get("engagement_score") or 0
             if existing:
                 update_rows.append((
                     max(new_engagement, existing["engagement_score"] or 0),

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1204,6 +1204,48 @@ def test_list_discovery_queue_orders_by_last_surfaced_and_filters_status(temp_db
     assert [r["name"] for r in covered] == ["Covered topic"]
 
 
+def test_store_findings_none_engagement_on_update_does_not_crash(temp_db):
+    """Regression: store_findings must not TypeError when an update-path finding
+    carries engagement_score=None.
+
+    .get("engagement_score", 0) only substitutes 0 for an *absent* key, so a
+    present-but-None value reached max(None, existing) on the update branch.
+    store_findings accepts arbitrary List[Dict[str, Any]] callers, so the
+    boundary must stay null-safe (engagement_score is float | None in schema.py).
+    """
+    topic_id = store.add_topic("None Engagement Topic")["id"]
+    url = "https://example.com/none-engagement"
+    base = {
+        "source": "reddit",
+        "source_url": url,
+        "source_title": "T",
+        "author": "",
+        "content": "",
+        "summary": "",
+        "relevance_score": 0.5,
+    }
+
+    # First sighting carries a real engagement score.
+    run1 = store.record_run(topic_id, source_mode="test", status="running")
+    store.store_findings(run1, topic_id, [{**base, "engagement_score": 5.0}])
+
+    # Re-sighting the same URL with engagement_score=None takes the UPDATE branch;
+    # before the fix this raised TypeError from max(None, 5.0).
+    run2 = store.record_run(topic_id, source_mode="test", status="running")
+    counts = store.store_findings(run2, topic_id, [{**base, "engagement_score": None}])
+    assert counts["updated"] == 1
+
+    con = sqlite3.connect(str(temp_db))
+    try:
+        stored = con.execute(
+            "SELECT engagement_score FROM findings WHERE source_url = ?", (url,)
+        ).fetchone()[0]
+    finally:
+        con.close()
+    # max(None -> 0, existing 5.0) keeps the higher real score.
+    assert stored == 5.0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 


### PR DESCRIPTION
## What

`store_findings` raises `TypeError` when a re-sighted finding carries `engagement_score: None`.

## Why

On the update branch the incoming score is read with a defaulted `.get`, then compared:

```python
new_engagement = f.get("engagement_score", 0)            # store.py:427
...
max(new_engagement, existing["engagement_score"] or 0)   # store.py:430
```

`dict.get(key, 0)` only substitutes `0` when the key is **absent**. A key that is *present with value `None`* passes straight through, so `new_engagement` becomes `None` and `max(None, <float>)` raises:

```
TypeError: '>' not supported between instances of 'float' and 'NoneType'
```

Note the asymmetry: the `existing` side on line 430 is already guarded with `or 0`, but the `new_engagement` side is not. `engagement_score` is declared `float | None` in `lib/schema.py`, and `lib/fusion.py` can re-introduce `None` via `metadata.get("engagement_score")`, so `None` is a first-class runtime value for this field.

## Scope (honest framing)

This is **boundary hardening**, not a fix for a crash reachable through the normal pipeline. The two producers that feed `store_findings` via `findings_from_report` — `finding_from_candidate` (`candidate.engagement or 0`) and the supplement dict (`item.engagement_score or 0.0`) — already coerce `None → 0` before the dict is built. But `store_findings(List[Dict[str, Any]])` is a public function that accepts arbitrary dicts, so any other or future caller passing a raw finding with `engagement_score: None` hits the crash. This makes the boundary null-safe and symmetric with line 430.

## Fix

```diff
-            new_engagement = f.get("engagement_score", 0)
+            new_engagement = f.get("engagement_score") or 0
```

## Test

Adds `test_store_findings_none_engagement_on_update_does_not_crash` to `tests/test_store.py`: it stores a finding with a real score, re-sights the same URL with `engagement_score: None`, and asserts no crash plus that `max(None→0, existing)` preserves the higher real score. The test reproduces the `TypeError` on `main` and passes with this change.

Verified locally (Python 3.12.13, pytest 9.1.0, deps from `uv.lock`):

- `tests/test_store.py` — **28 passed** (the 27 existing tests + this one)
- store-consumer blast radius (`test_store`, `test_internals_v3`, `test_watchlist_commands`, `test_fusion_v3`, `test_signals_v3`, `test_briefing_v3`, `test_schema_v3`) — **179 passed**, 0 failed
