### PR TITLE
fix(env): register DEGRADED_TRANSCRIPT_THRESHOLD so .env value is picked up

### DIFF
--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -516,6 +516,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('LAST30DAYS_YOUTUBE_SSH_HOST', None),
         ('LAST30DAYS_REPORT_CACHE_TTL_SECONDS', None),
         ('LAST30DAYS_TRANSCRIPT_TIMEOUT', None),
+        ('DEGRADED_TRANSCRIPT_THRESHOLD', None),
         (KEYCHAIN_ALIASES_ENV, None),
         # Whisper transcription provider for caption-free audio/video. Groq's
         # free tier is preferred; OPENAI_API_KEY is the paid backstop (already


### PR DESCRIPTION
## Problem

`DEGRADED_TRANSCRIPT_THRESHOLD` is used via `config.get("DEGRADED_TRANSCRIPT_THRESHOLD")` in `quality_nudge.py:205` but is never registered in `env.py`'s keys tuple. Users who set this in their `.env` file find it silently ignored — `config.get(...)` always returns `None`, falling through to the hardcoded `DEFAULT_DEGRADED_TRANSCRIPT_THRESHOLD` (0.5) regardless of what the user configured.

This is the same pattern as the previously fixed `FUN_LEVEL` (PR #708) and `LAST30DAYS_REPORT_CACHE_TTL_SECONDS` (PR #732) — a user-facing env var referenced by `config.get()` but absent from the keys list.

## Change

`env.py`: Added `('DEGRADED_TRANSCRIPT_THRESHOLD', None)` to the `get_config()` keys tuple next to the other YouTube/transcript-related keys.

No KEYCHAIN_KEYS or setup-script change needed — it is not a credential.

## Verification

- 40 env/keychain/pass/doc-contract tests pass
- 53 quality_nudge tests pass
- Env doc contract test confirms all documented keys remain registered
