### PR TITLE
fix(hooks): avoid bash 5.3 heredoc deadlock in the session-start hook

### DIFF
--- a/hooks/scripts/check-config.sh
+++ b/hooks/scripts/check-config.sh
@@ -143,8 +143,11 @@ else
   LAST_RUN_FILE="$HOME/.config/last30days/last-run.json"
 fi
 LAST_RUN_LINE=""
+# python3 -c, NOT a heredoc: bash 5.3 feeds heredocs to the child through a
+# pipe and can deadlock in heredoc_write inside command substitution, hanging
+# this hook forever at session start (observed on Homebrew bash 5.3.15).
 if [[ -n "$LAST_RUN_FILE" && -f "$LAST_RUN_FILE" ]] && command -v python3 &>/dev/null; then
-  LAST_RUN_LINE=$(LAST_RUN_FILE="$LAST_RUN_FILE" python3 - <<'PY' 2>/dev/null || true
+  LAST_RUN_LINE=$(LAST_RUN_FILE="$LAST_RUN_FILE" python3 -c '
 import datetime
 import json
 import os
@@ -165,8 +168,7 @@ try:
     print(f"  Last run: \"{topic}\" · {ago} · {total} results")
 except Exception:
     pass
-PY
-)
+' 2>/dev/null || true)
 fi
 
 # Detect capability that doesn't need a config file: yt-dlp on PATH.
@@ -179,25 +181,24 @@ fi
 
 # If setup has never been run, show welcome message for new users
 if [[ -z "$SETUP_COMPLETE" && -z "$CONFIG_FILE" && -z "${ENV_OPENAI_API_KEY:-${OPENAI_API_KEY:-}}" && -z "${ENV_SCRAPECREATORS_API_KEY:-${SCRAPECREATORS_API_KEY:-}}" && -z "${ENV_AUTH_TOKEN:-${AUTH_TOKEN:-}}" && -z "${ENV_XAI_API_KEY:-${XAI_API_KEY:-}}" ]]; then
+  # printf, NOT cat-with-heredoc: see the bash 5.3 heredoc deadlock note above.
   if [[ -n "$HAS_YTDLP" ]]; then
     # YouTube is already working via the on-system yt-dlp binary — don't list
     # it as something the wizard needs to unlock. See #394.
-    cat <<'EOF'
-/last30days: Ready to use. Run /last30days to get started — setup takes 30 seconds.
-  Research any topic across Reddit, HN, X, YouTube, Polymarket (last 30 days).
-
-Reddit, Hacker News, Polymarket, and YouTube (yt-dlp detected) work out of the box.
-The setup wizard can unlock X/Twitter and more.
-  Detected: yt-dlp is installed (YouTube transcripts ready, no setup needed).
-EOF
+    printf '%s\n' \
+      '/last30days: Ready to use. Run /last30days to get started — setup takes 30 seconds.' \
+      '  Research any topic across Reddit, HN, X, YouTube, Polymarket (last 30 days).' \
+      '' \
+      'Reddit, Hacker News, Polymarket, and YouTube (yt-dlp detected) work out of the box.' \
+      'The setup wizard can unlock X/Twitter and more.' \
+      '  Detected: yt-dlp is installed (YouTube transcripts ready, no setup needed).'
   else
-    cat <<'EOF'
-/last30days: Ready to use. Run /last30days to get started — setup takes 30 seconds.
-  Research any topic across Reddit, HN, X, YouTube, Polymarket (last 30 days).
-
-Reddit, Hacker News, and Polymarket work out of the box.
-The setup wizard can unlock X/Twitter, YouTube, and more.
-EOF
+    printf '%s\n' \
+      '/last30days: Ready to use. Run /last30days to get started — setup takes 30 seconds.' \
+      '  Research any topic across Reddit, HN, X, YouTube, Polymarket (last 30 days).' \
+      '' \
+      'Reddit, Hacker News, and Polymarket work out of the box.' \
+      'The setup wizard can unlock X/Twitter, YouTube, and more.'
   fi
   if [[ -n "$LAST_RUN_LINE" ]]; then
     echo "$LAST_RUN_LINE"


### PR DESCRIPTION
## What

The `check-config.sh` session-start hook hangs forever under Homebrew bash 5.3.15. Bash 5.3 feeds heredocs to the child process through a pipe, and inside command substitution it can block permanently in `heredoc_write` before `python3` is ever exec'd (stack: `command_substitute -> parse_and_execute -> do_redirections -> heredoc_write -> write`). `/bin/bash` 3.2 is unaffected.

This surfaced after Homebrew's 2026-07-11 bash upgrade: every session start left an orphaned hung `check-config.sh` process, and the four hook-driven test files (`test_check_config_memory_dir`, `test_check_config_ytdlp_detection`, `test_diagnose_compat`, `test_last_run_state`) timed out whenever `bash` on PATH resolved to 5.3.15.

## Fix

Remove every heredoc from the hook, since a session-start hook must never hang:

- The last-run summary now uses `python3 -c` (code passed as an argument, no pipe at all) instead of `python3 - <<'PY'` inside command substitution.
- The two new-user welcome blocks use `printf '%s\n'` instead of `cat <<'EOF'`.

Output is byte-identical in all three paths.

## Verification

- Before: the hook hung indefinitely under `/opt/homebrew/bin/bash` 5.3.15 (killed only by timeout); after: 15/15 clean runs, ~0.14s each.
- `/bin/bash` 3.2 path still passes (0.13s).
- All 41 tests across the four hook-driven test files pass under Homebrew bash 5.3.15 with no PATH pinning.
- Full pytest suite green.
