### PR TITLE
fix(bird_x): trust valid JSON stdout from Bird CLI even on non-zero exit (handle search)

### DIFF
--- a/skills/last30days/scripts/lib/bird_x.py
+++ b/skills/last30days/scripts/lib/bird_x.py
@@ -270,11 +270,18 @@ def _run_bird_search(query: str, count: int, timeout: int) -> Dict[str, Any]:
         if terminal_error is not None:
             return terminal_error
 
-        if result.returncode != 0:
-            error = result.stderr.strip() or "Bird search failed"
-            return {"error": error, "items": []}
-
         output = result.stdout.strip()
+        if result.returncode != 0:
+            if not output:
+                error = result.stderr.strip() or "Bird search failed"
+                return {"error": error, "items": []}
+            # Windows/Node 24: the vendored Bird CLI uses native fetch (undici),
+            # and calling process.exit() while keep-alive sockets are still
+            # closing trips a libuv assertion -> non-zero exit code AFTER it has
+            # already written a complete, valid JSON result to stdout. Trust
+            # stdout when it has content; only treat a non-zero exit as a real
+            # failure when stdout is empty.
+
         if not output:
             return {"items": []}
 
@@ -442,11 +449,14 @@ def search_handles(
             _log(f"Handle search error for @{handle}: {e}")
             return []
 
-        if result.returncode != 0:
-            _log(f"Handle search failed for @{handle}: {result.stderr.strip()}")
-            return []
-
         output = result.stdout.strip()
+        if result.returncode != 0:
+            if not output:
+                _log(f"Handle search failed for @{handle}: {result.stderr.strip()}")
+                return []
+            # Windows/Node 24: benign libuv assertion can cause non-zero exit
+            # AFTER valid JSON is written to stdout. Trust stdout content.
+
         if not output:
             return []
 


### PR DESCRIPTION
PR #718 fixed the same Windows/Node 24 benign-exit-code bug in `_run_bird_search` (the primary search path) but the `_search_one_handle` closure inside `search_handles` (Phase 2 supplemental handle-search path) still discards valid JSON stdout on any non-zero exit.

Also adapted the `_run_bird_search` fix to the current code — the encoding fix from PR #718 is already covered by `subproc.run_with_timeout` (`text=True, encoding="utf-8", errors="replace"`), but the non-zero exit handling was still the old pattern.

### Changes

**`_run_bird_search`** (lines 273-285): Check `stdout` content before rejecting on non-zero exit. If stdout has content, trust it — only return error when both exit code is non-zero AND stdout is empty.

**`_search_one_handle`** (lines 452-461): Same fix — check stdout first; on Windows/Node 24 the Bird CLI can exit non-zero due to a benign libuv assertion after writing complete valid JSON to stdout.

Greptile review on PR #718 flagged this exact gap (score: 3/5): "the `_search_one_handle` closure inside `search_handles` (Phase 2 supplemental handle search) has the same two bugs but was not updated".