### PR TITLE
fix(http): sanitize non-ASCII in URL before urllib.request to prevent latin-1 encode crash (fixes #817)

### DIFF
--- a/skills/last30days/scripts/lib/http.py
+++ b/skills/last30days/scripts/lib/http.py
@@ -8,7 +8,7 @@ import time
 import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional, Union
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 from . import log as _log
 
@@ -83,6 +83,9 @@ def request(
         if filtered:
             separator = "&" if ("?" in url) else "?"
             url = f"{url}{separator}{urlencode(filtered)}"
+    # Encode any non-ASCII characters to prevent UnicodeEncodeError from
+    # http.client.HTTPConnection.putrequest (which uses latin-1 internally).
+    url = quote(url, safe='/:@!$&\'()*+,;=-._~%?#[]=+')
 
     data = None
     if json_data is not None:


### PR DESCRIPTION
Fixes #817

## Problem

Non-Latin-script topics (Arabic, CJK, Cyrillic, etc.) cause TikTok and Instagram ScrapeCreators requests to crash with:

> ```
> UnicodeEncodeError: 'latin-1' codec can't encode character '\u0627' in position 28: ordinal not in range(256)
> ```

The root cause is that `http.client.HTTPConnection.putrequest` internally encodes the request URL as latin-1. If any Unicode character bypasses `urlencode` and remains raw in the URL string, the request line encoding fails.

While `urllib.parse.urlencode` handles standard cases correctly, Python version/platform edge cases can leave certain Unicode codepoints unencoded in the URL string before it reaches `http.client`.

## Fix

Added a `urllib.parse.quote` pass on the URL string after `urlencode` construction in `http.request()`, using a safe set that preserves all valid URL structural characters (`/:` etc. + existing percent-encoded sequences). This guarantees the URL is always 100% ASCII-safe before being passed to `urllib.request.Request`, regardless of Python version or platform edge cases.

`safe='/:@!$&\'()*+,;=-._~%?#[]=+'` preserves:
- URL scheme/path separators (`://`)
- Query string structure (`?`, `=`, `&`)
- Existing percent-encoded sequences (`%`)
- Space encoding (`+`)
- All RFC 3986 unreserved and reserved characters

## Testing

- `test_http_v3.py`: 14/14 passed
- `test_grounding_v3.py`: 26/26 passed
- `test_env_v3.py`: 7/7 passed
- `test_env_cookies.py`: 9/9 passed
- `test_env_keychain.py`: 13/13 passed
- `test_env_include_sources_default.py`: 1/1 passed