### PR TITLE
fix(http): sanitize non-ASCII in URL before urllib.request to prevent latin-1 encode crash (fixes #817)

### DIFF
--- a/skills/last30days/scripts/lib/http.py
+++ b/skills/last30days/scripts/lib/http.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar, copy_context
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit, quote
 
 from . import health
 from . import log as _log
@@ -556,6 +556,9 @@ def request(
         if filtered:
             separator = "&" if ("?" in url) else "?"
             url = f"{url}{separator}{urlencode(filtered)}"
+    # Encode any non-ASCII characters to prevent UnicodeEncodeError from
+    # http.client.HTTPConnection.putrequest (which uses latin-1 internally).
+    url = quote(url, safe='/:@!$&\'()*+,;=-._~%?#[]=+')
 
     fixture_request = _fixture_request(method, url, json_data, raw)
     fixture_redactions = _fixture_redactions(url, headers, json_data)


### PR DESCRIPTION
Fixes #817

## Problem

Non-Latin-script topics (Arabic, CJK, Cyrillic, etc.) cause TikTok and Instagram ScrapeCreators requests to crash with:

> ```
> UnicodeEncodeError: 'latin-1' codec can't encode character '\u0627' in position 28: ordinal not in range(256)
> ```

## Fix

Added a `urllib.parse.quote` pass on the URL string after `urlencode` construction in `http.request()`, using a safe set that preserves all valid URL structural characters. This guarantees the URL is always 100% ASCII-safe before being passed to `urllib.request.Request`.

`safe='/:@!$&\'()*+,;=-._~%?#[]=+'`

## Testing

- `test_http_v3.py`: 14/14 passed
- `test_grounding_v3.py`: 28/28 passed
- `test_env_v3.py`: 13/13 passed