### PR TITLE
Added: Docs option: quick first run for /last30days

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,7 @@ npx skills add mvanhorn/last30days-skill -g -a claude-code
 
 ### Quick Try-Link
 
-```
 [Try Last30Days Research Skill in Telegram or WhatsApp](https://app.clawmama.run/skills/2ne05f/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_mvanhorn_last30days_skill)
-```
 
 The native plugin and the `npx skills` install can coexist. Note that Claude Code does not dedupe across install methods: if you have both the marketplace plugin and the `npx skills` copy active, `/last30days` will show two entries. Use one install method per machine.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ If you'd rather use the agent-skills install path on Claude Code, that's also su
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
+### Quick Try-Link
+
+```
+[Try Last30Days Research Skill in Telegram or WhatsApp](https://app.clawmama.run/skills/2ne05f/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_mvanhorn_last30days_skill)
+```
+
 The native plugin and the `npx skills` install can coexist. Note that Claude Code does not dedupe across install methods: if you have both the marketplace plugin and the `npx skills` copy active, `/last30days` will show two entries. Use one install method per machine.
 
 ### Grok (xAI Build CLI)


### PR DESCRIPTION

#740

## Summary

This PR adds a "Quick Try" link to the README to give new users a lower-friction first-run experience. It allows them to test the `/last30days` skill via a hosted Telegram or WhatsApp agent before needing to configure local API keys and source authentication. 

## Changes

- Added a "Quick Try" section to `README.md` immediately following the Claude Code section.
- Inserted the ClawMama Skill catalog link for Telegram/WhatsApp alongside the existing installation paths.

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short`
*(Note: Since this is purely a documentation update, no application logic was altered. Markdown rendering was visually verified).*

## Related Issues

Closes #740