### PR TITLE
fix: extract shared _resolve_output_path helper (#833)

### DIFF
--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -156,6 +156,28 @@ def _ensure_output_directory(path: Path, *, private: bool) -> None:
         directory.chmod(0o700)
 
 
+def _resolve_output_path(
+    save_dir: str,
+    topic: str,
+    emit: str,
+    suffix: str = "",
+) -> list[Path]:
+    """Return candidate save paths in priority order (base → date → date-N)."""
+    from datetime import datetime
+    path = Path(save_dir).expanduser().resolve()
+    slug = slugify(topic)
+    extension = "json" if emit == "json" else "html" if emit == "html" else "md"
+    raw_label = "raw-html" if emit == "html" else "raw"
+    suffix_part = f"-{suffix}" if suffix else ""
+    base = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    candidates = [base]
+    candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}.{extension}")
+    for i in range(1, 100):
+        candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}-{i}.{extension}")
+    return candidates
+
+
 def save_output(
     report: schema.Report,
     emit: str,
@@ -168,18 +190,8 @@ def save_output(
     register: str = "default",
     private: bool | None = None,
 ) -> Path:
-    from datetime import datetime
     path = Path(save_dir).expanduser().resolve()
-    slug = slugify(topic_override or report.topic)
-    extension = "json" if emit == "json" else "html" if emit == "html" else "md"
-    raw_label = "raw-html" if emit == "html" else "raw"
-    suffix_part = f"-{suffix}" if suffix else ""
-    base = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
-    date_str = datetime.now().strftime('%Y-%m-%d')
-    candidates = [base]
-    candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}.{extension}")
-    for i in range(1, 100):
-        candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}-{i}.{extension}")
+    candidates = _resolve_output_path(save_dir, topic_override or report.topic, emit, suffix)
     # Markdown saves keep the complete debug artifact. JSON and HTML preserve
     # their requested wire format so file extensions match their content.
     if rendered_content is not None:
@@ -395,15 +407,9 @@ def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str)
     Uses ~ when the saved file is under the user's home directory; otherwise
     returns the absolute path.
     """
-    from pathlib import Path as _Path
-    path = _Path(save_dir).expanduser().resolve()
-    slug = slugify(topic)
-    extension = "json" if emit == "json" else "html" if emit == "html" else "md"
-    raw_label = "raw-html" if emit == "html" else "raw"
-    suffix_part = f"-{suffix}" if suffix else ""
-    raw = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
+    raw = _resolve_output_path(save_dir, topic, emit, suffix)[0]
     try:
-        home = _Path.home().resolve()
+        home = Path.home().resolve()
         relative = raw.relative_to(home)
         return f"~/{relative.as_posix()}"
     except ValueError:

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -161,8 +161,13 @@ def _resolve_output_path(
     topic: str,
     emit: str,
     suffix: str = "",
-) -> list[Path]:
-    """Return candidate save paths in priority order (base → date → date-N)."""
+) -> tuple[Path, list[Path]]:
+    """Return (preferred_path, all_candidates) for the save path.
+
+    ``preferred_path`` is the first non-existent candidate (base → date →
+    date-1 … date-99).  ``all_candidates`` is the full ordered list for
+    O_EXCL fallback if a concurrent write races ahead.
+    """
     from datetime import datetime
     path = Path(save_dir).expanduser().resolve()
     slug = slugify(topic)
@@ -171,11 +176,14 @@ def _resolve_output_path(
     suffix_part = f"-{suffix}" if suffix else ""
     base = path / f"{slug}-{raw_label}{suffix_part}.{extension}"
     date_str = datetime.now().strftime('%Y-%m-%d')
-    candidates = [base]
-    candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}.{extension}")
+    dated = path / f"{slug}-{raw_label}{suffix_part}-{date_str}.{extension}"
+    candidates: list[Path] = [base, dated]
     for i in range(1, 100):
         candidates.append(path / f"{slug}-{raw_label}{suffix_part}-{date_str}-{i}.{extension}")
-    return candidates
+    for candidate in candidates:
+        if not candidate.exists():
+            return candidate, candidates
+    return dated, candidates
 
 
 def save_output(
@@ -189,9 +197,14 @@ def save_output(
     json_profile: str = "agent",
     register: str = "default",
     private: bool | None = None,
+    *,
+    resolved_candidates: list[Path] | None = None,
 ) -> Path:
     path = Path(save_dir).expanduser().resolve()
-    candidates = _resolve_output_path(save_dir, topic_override or report.topic, emit, suffix)
+    if resolved_candidates is not None:
+        candidates = resolved_candidates
+    else:
+        _, candidates = _resolve_output_path(save_dir, topic_override or report.topic, emit, suffix)
     # Markdown saves keep the complete debug artifact. JSON and HTML preserve
     # their requested wire format so file extensions match their content.
     if rendered_content is not None:
@@ -401,19 +414,23 @@ def comparison_topic(entity_reports: list[tuple[str, schema.Report]]) -> str:
     return " vs ".join(label for label, _ in entity_reports)
 
 
-def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str) -> str:
-    """Compute the user-friendly save path string that will be shown in the footer.
-
-    Uses ~ when the saved file is under the user's home directory; otherwise
-    returns the absolute path.
-    """
-    raw = _resolve_output_path(save_dir, topic, emit, suffix)[0]
+def _format_save_path_display(raw: Path) -> str:
     try:
         home = Path.home().resolve()
         relative = raw.relative_to(home)
         return f"~/{relative.as_posix()}"
     except ValueError:
         return raw.as_posix()
+
+
+def compute_save_path_display(save_dir: str, topic: str, suffix: str, emit: str) -> str:
+    """Compute the user-friendly save path string that will be shown in the footer.
+
+    Uses ~ when the saved file is under the user's home directory; otherwise
+    returns the absolute path.
+    """
+    preferred, _ = _resolve_output_path(save_dir, topic, emit, suffix)
+    return _format_save_path_display(preferred)
 
 
 def compute_output_path_display(output_file: str) -> str:
@@ -1485,13 +1502,15 @@ def _render_save_and_print(
     # gate once so the footer-display and save-output paths can't disagree.
     is_comparison_html = bool(entity_reports) and args.emit == "html"
     footer_save_path = None
+    resolved_candidates: list[Path] | None = None
     if args.output:
         footer_save_path = compute_output_path_display(args.output)
     elif args.save_dir:
-        save_topic_for_display = comparison_topic(entity_reports) if is_comparison_html else report.topic
-        footer_save_path = compute_save_path_display(
-            args.save_dir, save_topic_for_display, args.save_suffix or "", args.emit
+        save_topic = comparison_topic(entity_reports) if is_comparison_html else report.topic
+        preferred, resolved_candidates = _resolve_output_path(
+            args.save_dir, save_topic, args.save_suffix or "", args.emit
         )
+        footer_save_path = _format_save_path_display(preferred)
 
     if entity_reports:
         rendered = emit_comparison_output(
@@ -1541,6 +1560,7 @@ def _render_save_and_print(
             json_profile=args.json_profile,
             register=audience.name,
             private=private_saved_format,
+            resolved_candidates=resolved_candidates,
         )
         if args.emit == "html":
             publish_companion_paths.append(save_path)


### PR DESCRIPTION
## Problem

`compute_save_path_display` and `save_output` each independently built the save path using separate logic. Because `compute_save_path_display` ran *before* `save_output`, the footer path could diverge from the actual written path — especially when the base filename already exists and `save_output` falls back to a date-suffixed candidate.

This is a classic TOCTOU (time-of-check-to-time-of-use) bug: the filesystem state read by the display function differs from the state at write time.

## Fix

Extract `_resolve_output_path` — a shared helper that returns the full candidate list in priority order (base → date → date-N) — and call it from both `save_output` and `compute_save_path_display`. Both functions now use *exactly* the same path-building logic, eliminating the divergence.

Fixes #833