### PR TITLE
feat(dripstack): add free publication browsing, paid post fetch, and tiered docs

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -135,7 +135,7 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Hacker News | none | always on | yes |
 | Polymarket | none | always on | yes |
 | StockTwits | none | auto-on for ticker/crypto topics only (gated by symbol detection); never registered for non-financial topics | yes (public API, ~200 req/hr per IP) |
-| DripStack | none | opt-in only: per run with `--search dripstack`, or persistently with `INCLUDE_SOURCES=dripstack` in `.env`. Searches premium financial newsletters and analyst writeups via a free, public search API — no key needed. Never active without the opt-in. | yes when opted in (public API, no auth) |
+| DripStack | `DRIPSTACK_API_KEY` (optional, for full article summaries) | opt-in only: per run with `--search dripstack`, or persistently with `INCLUDE_SOURCES=dripstack` in `.env`. Free endpoints: topic search, publication listing/search, and post metadata (titles, dates, prices) — no key needed. With `DRIPSTACK_API_KEY`: full synthesized article summaries and stock picks. Never active without the opt-in. | yes when opted in (free: search + publication browsing; paid: full summaries with `DRIPSTACK_API_KEY` + preloaded credits at [dripstack.xyz](https://dripstack.xyz) - My Profile > Dashboard > API Keys > + Create Api Key) |
 | GitHub | `gh` CLI installed (uses your GitHub auth) | always on if `gh` present | yes |
 | YouTube | `yt-dlp` CLI installed; `SCRAPECREATORS_API_KEY` adds a server-side transcript fallback used only when yt-dlp fails (429 / bot-gate) | always on if `yt-dlp` present; SC transcript fallback default-on when key set (no credit spent unless yt-dlp fails) | yes |
 | YouTube comments | `yt-dlp` CLI installed — **free and keyless, no API key and no opt-in needed**. Falls back to `SCRAPECREATORS_API_KEY` + `INCLUDE_SOURCES` containing `youtube_comments` only when yt-dlp is absent. Suppress with `EXCLUDE_SOURCES=youtube_comments`. | top comments (by likes) on the top ~3 videos by engagement | yes — free via yt-dlp (no credits spent) |
@@ -184,6 +184,11 @@ INCLUDE_SOURCES=tiktok,instagram
 # INCLUDE_SOURCES=tiktok,instagram,perplexity
 # LAST30DAYS_PERPLEXITY_MODE=sonar  # sonar | search | both
 # LAST30DAYS_PERPLEXITY_MODEL=sonar-pro  # sonar | sonar-pro | sonar-reasoning-pro
+# DripStack — free search + publication browsing with no key; add
+# DRIPSTACK_API_KEY for full synthesized article summaries (requires preloaded
+# credits at dripstack.xyz — My Profile > Dashboard > API Keys > + Create Api Key)
+# DRIPSTACK_API_KEY=<your-dripstack-key>
+# INCLUDE_SOURCES=tiktok,instagram,dripstack
 
 # X authentication (one option only)
 AUTH_TOKEN=<your-auth-token>

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ These platforms don't have relationships with each other. X doesn't know what Re
 | Bluesky | App password from bsky.app | Free |
 | TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comments | ScrapeCreators key | 10,000 free calls, then PAYG |
 | Xiaohongshu (RED) | Run a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service and opt in with `--search xhs` per run or `INCLUDE_SOURCES=xiaohongshu` in `.env`; last30days auto-probes `http://localhost:18060` then `http://host.docker.internal:18060`, or use `XIAOHONGSHU_API_BASE` for a custom URL | No last30days API key; depends on your local browser-session service |
-| DripStack (premium financial newsletters) | Opt-in: `--search dripstack` per run, or `INCLUDE_SOURCES=dripstack` in `.env` | No key; free public search API |
+| DripStack (premium financial newsletters) | Opt-in: `--search dripstack` per run, or `INCLUDE_SOURCES=dripstack` in `.env`. Free search and publication browsing; full article summaries require `DRIPSTACK_API_KEY` with preloaded credits | Free discovery (search, publications, post metadata); full summaries require an API key with preloaded balance (create at [dripstack.xyz](https://dripstack.xyz) - My Profile > Dashboard > API Keys > + Create Api Key) |
 | Perplexity Sonar / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go |
 | Web search | Brave Search key | 2,000 free queries/month |
 

--- a/changelog.d/837.added.md
+++ b/changelog.d/837.added.md
@@ -1,0 +1,1 @@
+Add DripStack as an optional publication/post source.

--- a/skills/last30days/scripts/lib/dripstack.py
+++ b/skills/last30days/scripts/lib/dripstack.py
@@ -1,24 +1,30 @@
 """DripStack source for last30days — premium financial newsletter search.
 
 DripStack indexes paid Substack newsletters, analyst writeups, and financial
-podcasts. The search endpoint is free and public (no API key); it returns
-article metadata including title, publication, date, and a relevance-scored
-snippet. Full article summaries and stock picks are behind a paid layer and
-are out of scope for this source adapter.
+podcasts. The API has two tiers:
+
+  Free (no auth): search, publication listing, publication search, and post
+  metadata (titles, dates, prices). These endpoints power discovery — they
+  tell you *what* analysts are writing about with publication attribution
+  (e.g. "SemiAnalysis", "Bloomberg").
+
+  Paid (DRIPSTACK_API_KEY): full synthesized article summaries and stock
+  picks. Requires an API key from dripstack.xyz (My Profile > Dashboard >
+  API Keys > + Create Api Key) with preloaded credits. The post endpoint
+  returns HTTP 402 when unauthenticated; with a key, the bearer token is
+  sent on retry.
 
 The signal is complementary to the other financial sources: StockTwits gives
 retail sentiment, Polymarket gives prediction-market odds, and DripStack gives
 what professional analysts and paid newsletter authors are actually writing
-about. The search results carry publication attribution (e.g. "SemiAnalysis",
-"Bloomberg") which is high-credibility signal for synthesis.
+about. The search results carry publication attribution which is high-
+credibility signal for synthesis.
 
 GATING: DripStack search is most valuable for finance, markets, company
 analysis, and industry research topics. Like arXiv (science) and Techmeme
 (tech news), DripStack is relevance-gated — the search API itself filters
 for topic match, so off-topic runs return thin results naturally and the
 engine's thin-retry + relevance scoring handles the rest.
-
-API: public, no auth. Search endpoint returns up to 30 items per query.
 """
 
 from __future__ import annotations
@@ -34,6 +40,8 @@ from . import http
 
 _BASE_URL = "https://dripstack.xyz"
 _SEARCH_URL = f"{_BASE_URL}/api/v1/search"
+_PUBLICATIONS_URL = f"{_BASE_URL}/api/v1/publications"
+_PUBLICATION_SEARCH_URL = f"{_BASE_URL}/api/v1/publications/search"
 _UA = "Mozilla/5.0 (last30days dripstack source)"
 
 # Depth controls how many results we request per subquery.
@@ -48,10 +56,13 @@ def _log(msg: str) -> None:
         print(f"[DripStack] {msg}", file=sys.stderr)
 
 
-def _get_json(url: str, timeout: int = 20) -> dict[str, Any]:
+def _get_json(url: str, timeout: int = 20, headers: dict[str, str] | None = None) -> dict[str, Any]:
     # All engine traffic goes through the shared lib/http.py choke point so
     # capture/replay, fixtures, and failure taxonomy apply to this source too.
-    return http.get(url, headers={"User-Agent": _UA}, timeout=timeout, retries=2)
+    merged = {"User-Agent": _UA}
+    if headers:
+        merged.update(headers)
+    return http.get(url, headers=merged, timeout=timeout, retries=2)
 
 
 def search_dripstack(
@@ -184,12 +195,161 @@ def parse_dripstack_response(
 
 
 # --------------------------------------------------------------------------- #
+# Publication browsing (free) and post fetch (paid)                            #
+# --------------------------------------------------------------------------- #
+
+
+def get_publications(timeout: int = 20) -> list[dict[str, Any]]:
+    """List all curated publications. Free, no auth required.
+
+    Returns a list of publication dicts with slug, title, description,
+    siteUrl, and lastSyncedAt.
+    """
+    try:
+        data = _get_json(_PUBLICATIONS_URL, timeout=timeout)
+    except Exception as e:
+        _log(f"list publications failed: {e}")
+        return []
+    return data.get("publications") or []
+
+
+def search_publications(query: str, timeout: int = 20) -> list[dict[str, Any]]:
+    """Search publications by name, author, or slug. Free, no auth required.
+
+    Args:
+        query: Publication name, author, podcast show, newsletter, or slug.
+            Minimum 2 characters.
+
+    Returns up to 3 matches with publicationSlug, title, author, siteUrl.
+    """
+    if len(query.strip()) < 2:
+        return []
+    params = urllib.parse.urlencode({"q": query})
+    url = f"{_PUBLICATION_SEARCH_URL}?{params}"
+    try:
+        data = _get_json(url, timeout=timeout)
+    except Exception as e:
+        _log(f"search publications failed for '{query}': {e}")
+        return []
+    return data.get("items") or []
+
+
+def get_publication_posts(
+    pub_slug: str,
+    limit: int = 10,
+    timeout: int = 20,
+) -> dict[str, Any]:
+    """Get publication metadata and recent post list. Free, no auth required.
+
+    Args:
+        pub_slug: Publication slug (the normalized host, e.g.
+            "newsletter.semianalysis.com").
+        limit: Max posts to return (1-100).
+
+    Returns the full publication detail dict including a "posts" list with
+    title, slug, subtitle, publishedAt, and priceCents per post. Returns an
+    empty dict on failure.
+    """
+    params = urllib.parse.urlencode({"limit": limit})
+    url = f"{_PUBLICATIONS_URL}/{urllib.parse.quote(pub_slug, safe='')}?{params}"
+    try:
+        return _get_json(url, timeout=timeout)
+    except Exception as e:
+        _log(f"get publication posts failed for '{pub_slug}': {e}")
+        return {}
+
+
+def get_publication_post(
+    pub_slug: str,
+    post_slug: str,
+    api_key: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Fetch a single post's synthesized summary. Paid; requires api_key.
+
+    Without an API key, the endpoint returns HTTP 402 (payment required).
+    With a key, the bearer token is sent on the first attempt. If the key
+    is missing, returns an empty dict without hitting the endpoint.
+
+    Args:
+        pub_slug: Publication slug.
+        post_slug: Post slug from the publication feed.
+        api_key: Optional DripStack API key (starts with pk_drip_). When
+            None, the fetch is skipped to avoid a guaranteed 402.
+        timeout: HTTP timeout in seconds.
+
+    Returns the post dict with synthesizedSummary on success, empty dict
+    on failure or missing key.
+    """
+    if not api_key:
+        return {}
+    encoded_pub = urllib.parse.quote(pub_slug, safe="")
+    encoded_post = urllib.parse.quote(post_slug, safe="")
+    url = f"{_PUBLICATIONS_URL}/{encoded_pub}/{encoded_post}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        return _get_json(url, timeout=timeout, headers=headers)
+    except http.HTTPError as e:
+        if e.status_code == 402:
+            _log(f"post '{pub_slug}/{post_slug}' requires payment (402)")
+        elif e.status_code == 404:
+            _log(f"post '{pub_slug}/{post_slug}' not found (404)")
+        elif e.status_code == 503:
+            _log(f"post '{pub_slug}/{post_slug}' summary not ready (503)")
+        else:
+            _log(f"fetch post '{pub_slug}/{post_slug}' failed: {e}")
+        return {}
+    except Exception as e:
+        _log(f"fetch post '{pub_slug}/{post_slug}' failed: {e}")
+        return {}
+
+
+# --------------------------------------------------------------------------- #
 # Standalone CLI                                                               #
 #   python3 dripstack.py "AI capex risk"                                      #
+#   python3 dripstack.py --publications                                       #
+#   python3 dripstack.py --search-pub semianalysis                            #
+#   python3 dripstack.py --pub-posts newsletter.semianalysis.com              #
 # --------------------------------------------------------------------------- #
 
 if __name__ == "__main__":
-    topic = " ".join(sys.argv[1:]) or "AI capex"
+    args = sys.argv[1:]
+
+    if args and args[0] == "--publications":
+        pubs = get_publications()
+        print(f"{len(pubs)} publications:")
+        for p in pubs:
+            desc = (p.get("description") or "")[:80]
+            print(f"  {p['slug']} - {p.get('title') or '(untitled)'}")
+            if desc:
+                print(f"    {desc}")
+        sys.exit(0)
+
+    if args and args[0] == "--search-pub":
+        q = " ".join(args[1:]) or ""
+        results = search_publications(q)
+        print(f"{len(results)} matches for '{q}':")
+        for r in results:
+            print(f"  {r['publicationSlug']} - {r.get('title') or '(untitled)'} ({r.get('author') or '?'})")
+        sys.exit(0)
+
+    if args and args[0] == "--pub-posts":
+        slug = args[1] if len(args) > 1 else ""
+        if not slug:
+            print("Usage: dripstack.py --pub-posts <publication-slug>", file=sys.stderr)
+            sys.exit(1)
+        detail = get_publication_posts(slug)
+        posts = detail.get("posts") or []
+        title = detail.get("title") or slug
+        print(f"{title} - {len(posts)} posts:")
+        for p in posts:
+            date = (p.get("publishedAt") or "")[:10] or "no date"
+            price = p.get("priceCents")
+            price_str = f" (${price / 100:.2f})" if isinstance(price, (int, float)) else ""
+            print(f"  [{date}] {p['title']}{price_str}")
+        sys.exit(0)
+
+    topic = " ".join(args) or "AI capex"
     today = datetime.date.today()
     since = (today - datetime.timedelta(days=30)).isoformat()
 

--- a/tests/test_dripstack.py
+++ b/tests/test_dripstack.py
@@ -129,3 +129,181 @@ def test_include_sources_tolerates_whitespace_around_commas():
         {"INCLUDE_SOURCES": "linkedin, dripstack"}, None, x_pending=False
     )
     assert "dripstack" in available
+
+
+# --------------------------------------------------------------------------- #
+# Publication browsing (free)                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _publication(**overrides):
+    pub = {
+        "slug": "newsletter.semianalysis.com",
+        "title": "SemiAnalysis",
+        "description": "Analysis of semiconductors, AI, and cloud.",
+        "siteUrl": "https://newsletter.semianalysis.com",
+        "lastSyncedAt": "2026-07-06T08:30:00Z",
+    }
+    pub.update(overrides)
+    return pub
+
+
+def _post_summary(**overrides):
+    post = {
+        "slug": "nvidia-gpu-debt-backstop",
+        "title": "Nvidia GPU Debt Backstop",
+        "subtitle": "Capital, offtake and datacenters.",
+        "publishedAt": "2026-07-06T21:53:44.000Z",
+        "priceCents": 500,
+    }
+    post.update(overrides)
+    return post
+
+
+def test_get_publications_returns_list(monkeypatch):
+    pubs = [_publication(), _publication(slug="stratechery", title="Stratechery")]
+    monkeypatch.setattr(
+        dripstack.http, "get",
+        lambda *a, **k: {"publications": pubs},
+    )
+    result = dripstack.get_publications()
+    assert len(result) == 2
+    assert result[0]["slug"] == "newsletter.semianalysis.com"
+
+
+def test_get_publications_returns_empty_on_failure(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(dripstack.http, "get", boom)
+    assert dripstack.get_publications() == []
+
+
+def test_search_publications_returns_matches(monkeypatch):
+    items = [_publication(), _publication(slug="stratechery")]
+    monkeypatch.setattr(
+        dripstack.http, "get",
+        lambda *a, **k: {"items": items},
+    )
+    result = dripstack.search_publications("semianalysis")
+    assert len(result) == 2
+
+
+def test_search_publications_rejects_short_query():
+    assert dripstack.search_publications("a") == []
+    assert dripstack.search_publications("") == []
+
+
+def test_search_publications_returns_empty_on_failure(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(dripstack.http, "get", boom)
+    assert dripstack.search_publications("semianalysis") == []
+
+
+def test_get_publication_posts_returns_detail(monkeypatch):
+    detail = {
+        "slug": "newsletter.semianalysis.com",
+        "title": "SemiAnalysis",
+        "posts": [_post_summary(), _post_summary(slug="other-post")],
+    }
+    seen = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        seen["url"] = url
+        return detail
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    result = dripstack.get_publication_posts("newsletter.semianalysis.com", limit=5)
+    assert len(result["posts"]) == 2
+    assert "newsletter.semianalysis.com" in seen["url"]
+    assert "limit=5" in seen["url"]
+
+
+def test_get_publication_posts_returns_empty_on_failure(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(dripstack.http, "get", boom)
+    assert dripstack.get_publication_posts("newsletter.semianalysis.com") == {}
+
+
+# --------------------------------------------------------------------------- #
+# Paid post fetch                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_publication_post_skips_without_key():
+    assert dripstack.get_publication_post("pub", "post", api_key=None) == {}
+    assert dripstack.get_publication_post("pub", "post", api_key="") == {}
+
+
+def test_get_publication_post_sends_bearer_auth(monkeypatch):
+    seen = {}
+    post_data = {"synthesizedSummary": "Nvidia backstop explained...", "title": "Nvidia GPU Debt Backstop"}
+
+    def fake_get(url, headers=None, **kwargs):
+        seen["url"] = url
+        seen["headers"] = headers
+        return post_data
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    result = dripstack.get_publication_post(
+        "newsletter.semianalysis.com",
+        "nvidia-gpu-debt-backstop",
+        api_key="pk_drip_test123",
+    )
+    assert result == post_data
+    assert seen["headers"]["Authorization"] == "Bearer pk_drip_test123"
+    assert "nvidia-gpu-debt-backstop" in seen["url"]
+
+
+def test_get_publication_post_returns_empty_on_402(monkeypatch):
+    from lib import http
+
+    def fake_get(url, headers=None, **kwargs):
+        raise http.HTTPError("HTTP 402: Payment Required", status_code=402)
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    result = dripstack.get_publication_post(
+        "pub", "post", api_key="pk_drip_test123"
+    )
+    assert result == {}
+
+
+def test_get_publication_post_returns_empty_on_404(monkeypatch):
+    from lib import http
+
+    def fake_get(url, headers=None, **kwargs):
+        raise http.HTTPError("HTTP 404: Not Found", status_code=404)
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    result = dripstack.get_publication_post(
+        "pub", "post", api_key="pk_drip_test123"
+    )
+    assert result == {}
+
+
+def test_get_publication_post_returns_empty_on_503(monkeypatch):
+    from lib import http
+
+    def fake_get(url, headers=None, **kwargs):
+        raise http.HTTPError("HTTP 503: Service Unavailable", status_code=503)
+
+    monkeypatch.setattr(dripstack.http, "get", fake_get)
+    result = dripstack.get_publication_post(
+        "pub", "post", api_key="pk_drip_test123"
+    )
+    assert result == {}
+
+
+def test_get_publication_post_returns_empty_on_network_error(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(dripstack.http, "get", boom)
+    result = dripstack.get_publication_post(
+        "pub", "post", api_key="pk_drip_test123"
+    )
+    assert result == {}


### PR DESCRIPTION
## Summary

Add free publication browsing endpoints and paid post fetch support to the DripStack source. Clarify the two-tier access model (free discovery vs paid full summaries) across README and CONFIGURATION.

## Changes

- `get_publications()` — free, list curated publications
- `search_publications(q)` — free, find publications by name/author
- `get_publication_posts(pub_slug)` — free, get post list with metadata
- `get_publication_post(pub_slug, post_slug, api_key)` — paid, fetch synthesized summary with bearer auth
- Extended CLI: `--publications`, `--search-pub`, `--pub-posts` subcommands
- Updated `_get_json()` to accept optional extra headers
- README BYOK table: two-tier description with dripstack.xyz setup path
- CONFIGURATION: `DRIPSTACK_API_KEY` in source table and `.env` skeleton

## Testing

- [x] Ran `uv run python -m pytest -q --tb=short`
- 13 new tests covering success, failure, auth, 402/404/503 handling
- 24/24 passing

## Related Issues

None