### PR TITLE
fix(pipeline): respect explicit source filters for company topics

### DIFF
--- a/changelog.d/842.fixed.md
+++ b/changelog.d/842.fixed.md
@@ -1,0 +1,1 @@
+Company-topic runs no longer auto-add the `jobs` source when an explicit `--search` / `requested_sources` filter is set; `--hiring-signals` still forces jobs.

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1956,7 +1956,10 @@ def run(
         available = [s for s in available if s != "grounding"]
     elif web_backend in ("brave", "exa", "serper", "parallel", "keyless") and "grounding" not in available:
         available.append("grounding")
-    if (hiring_signals_mode or _company_topic_likely(topic)) and "jobs" not in available:
+    if (
+        hiring_signals_mode
+        or (not requested_sources and _company_topic_likely(topic))
+    ) and "jobs" not in available:
         available.append("jobs")
     if hiring_signals_mode:
         config = dict(config)

--- a/tests/test_pipeline_v3.py
+++ b/tests/test_pipeline_v3.py
@@ -142,6 +142,30 @@ class PipelineV3Tests(unittest.TestCase):
         self.assertEqual(["jobs"], sorted(report.items_by_source))
         self.assertTrue(report.artifacts["hiring_signals"]["include"])
 
+    def test_explicit_sources_suppress_automatic_company_jobs(self):
+        report = pipeline.run(
+            topic="Listen Labs",
+            config={"LAST30DAYS_REASONING_PROVIDER": "gemini"},
+            depth="quick",
+            requested_sources=["grounding", "x"],
+            mock=True,
+        )
+        self.assertEqual({"grounding", "x"}, set(report.items_by_source))
+        self.assertTrue(
+            all("jobs" not in subquery.sources for subquery in report.query_plan.subqueries)
+        )
+
+    def test_hiring_signals_forces_jobs_with_explicit_non_jobs_sources(self):
+        report = pipeline.run(
+            topic="Listen Labs",
+            config={"LAST30DAYS_REASONING_PROVIDER": "gemini"},
+            depth="quick",
+            requested_sources=["grounding", "x"],
+            mock=True,
+            hiring_signals_mode=True,
+        )
+        self.assertEqual({"grounding", "jobs", "x"}, set(report.items_by_source))
+
     def test_standard_company_run_fetches_jobs_for_signal_gate(self):
         report = pipeline.run(
             topic="Listen Labs",


### PR DESCRIPTION
## Summary

Company-topic detection currently appends the `jobs` source even when a caller explicitly supplies `--search` / `requested_sources`. That widens a user-pinned source set and can trigger an unrequested retrieval lane.

This keeps automatic jobs discovery for normal company runs while making explicit source filters authoritative.

## Changes

- Only auto-add `jobs` for company-shaped topics when no explicit source list was supplied.
- Preserve `--hiring-signals` behavior: it still forces the jobs source even with other requested sources.
- Add regression coverage for the explicit-source case alongside the existing implicit-company and hiring-signals controls.

## Testing

- [x] Ran `python -m pytest -q --tb=short` — 3,167 passed, 5 skipped, 23 subtests passed.
- [x] Ran `git diff origin/main...HEAD --check`.

## Related Issues

Related to #664. That PR made quick-depth planning honor explicit plan sources; this closes the adjacent pipeline-level widening path for explicit `--search` filters.
