### PR TITLE
docs(solutions): compound discovery content pipeline learnings

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -48,7 +48,7 @@ The topic-less research mode: instead of researching a named topic, it finds wha
 
 ### Nomination
 
-A named candidate topic produced by Discovery's listing sweep: clustered items from the river feeds, given a concise name and a cheap seed-velocity rank. A Nomination is only a candidate - its seed rank decides which topics deserve an Enrichment pass and the display order of survivors; the Confidence floor judgment and the displayed velocity score are computed from the enriched evidence, never the seed score.
+A named candidate topic produced by Discovery's listing sweep: clustered items from the river feeds, given a short searchable name (by an LLM judge when a reasoning provider is available, by deterministic distillation otherwise) plus a Junk shape flag and a content-worthiness score that blends into its seed rank. A Nomination is only a candidate - its blended seed rank decides which topics deserve an Enrichment pass and the display order of survivors; the Confidence floor judgment and the displayed velocity score are computed from the enriched evidence, never the seed score. The Nomination's name doubles as its Enrichment pass search query and its research handoff, so naming happens before enrichment, never at render time.
 
 ### Enrichment pass
 
@@ -56,11 +56,25 @@ A full research-pipeline run executed on one Nomination's topic name during Disc
 
 ### Confidence floor
 
-The absolute evidence bar every Discovery topic must clear before it may rank: an engagement junk-gate first, then either independent cross-source corroboration or a genuinely strong single-source spike. The floor is absolute, not relative to the current pool - a relative bar would degrade with the pool, which is the failure it exists to prevent. Its thresholds are deliberately tunable; the behavior contract is only that sub-floor evidence never ranks.
+The absolute evidence bar every Discovery topic must clear before it may rank: an engagement junk-gate first, then either independent cross-source corroboration or a genuinely strong single-source spike. Topics with a Junk shape get a stricter read: the single-source spike bypass is off, and their corroboration is counted against the seed listing sources the sweep actually found - never the enriched corpus, because an Enrichment pass makes almost any topic look multi-source. The floor is absolute, not relative to the current pool - a relative bar would degrade with the pool, which is the failure it exists to prevent. Its thresholds are deliberately tunable; the behavior contract is only that sub-floor evidence never ranks.
 
 ### Nothing-solid
 
-The honest empty outcome of a Discovery run in which zero topics cleared the Confidence floor. A first-class result, not an error: the run reports that nothing in the window was strong enough to call a trend, and names the closest sub-floor candidate (the weak signal) so the user knows where the signal petered out. Rendering junk instead of Nothing-solid is the named failure this outcome replaced.
+The honest empty outcome of a Discovery run in which zero topics cleared the Confidence floor. A first-class result, not an error: the run reports that nothing in the window was strong enough to call a trend, and names the closest sub-floor candidate (the weak signal, preferring a non-junk-shaped one) so the user knows where the signal petered out. Rendering junk instead of Nothing-solid is the named failure this outcome replaced.
+
+### Junk shape
+
+A classification applied to a Nomination whose leading item reads as a help-me question, beginner ask, or personal musing rather than a story - the post shapes that engagement alone cannot distinguish from news. Junk shape does not exclude a topic outright; it removes the Confidence floor's single-source bypass so the topic surfaces only with independent seed-source corroboration.
+
+### Topic queue
+
+The persistent memory of what Discovery has surfaced: each surfaced topic is recorded per research store, so later runs can annotate repeats ("surfaced Nth time") and the user can mark stories Covered. On by default for every real Discovery run, with an engine toggle to disable; mock runs never write it.
+
+Identity in the queue is annotate-only: a new topic name that closely matches an earlier row (exact normalized match, else entity overlap) annotates the rendered card but never merges or rewrites rows - a false match costs one noisy line, never a hidden story. Queue annotations always describe the state before the current run, and a failed queue write degrades to a warning; it must never destroy a finished run's output.
+
+### Covered
+
+The user-set status on a Topic queue row meaning "I already produced content for this story." Set by marking a topic covered by its exact name; surfaced is the only other status. A resurfacing never un-covers a row, and a new name that fuzzily matches a Covered row is born Covered - so the mark survives the LLM judge renaming the same story across runs instead of silently re-pitching it.
 
 ## Flagged ambiguities
 

--- a/docs/solutions/architecture-patterns/discovery-topic-queue-design-conventions.md
+++ b/docs/solutions/architecture-patterns/discovery-topic-queue-design-conventions.md
@@ -1,0 +1,241 @@
+---
+title: "Persistent discovery topic queue: five interlocking design conventions"
+date: 2026-07-20
+category: architecture-patterns
+module: discovery-topic-queue
+problem_type: architecture_pattern
+component: database
+severity: high
+applies_when:
+  - "Adding default-on local persistence (SQLite, JSON state) hooked onto the end of an expensive pipeline run"
+  - "Building a fuzzy identity layer over LLM-named entities whose names drift across runs"
+  - "Reading a feature toggle in an engine where .env-file values only reach code through env.get_config's keys allowlist"
+  - "Recording per-item state in a loop where a later item could fuzzy-match a row written earlier in the same run"
+  - "Persisting user-set status (covered, dismissed, read) that must survive entity renames"
+tags:
+  - "discovery-topic-queue"
+  - "fuzzy-matching"
+  - "sqlite-persistence"
+  - "env-allowlist-opt-out"
+  - "two-phase-write"
+  - "covered-status-inheritance"
+  - "guarded-write-hook"
+  - "scoped-db"
+  - "llm-naming-drift"
+related_components:
+  - "skills/last30days/scripts/store.py"
+  - "skills/last30days/scripts/last30days.py"
+  - "skills/last30days/scripts/lib/env.py"
+  - "tests/test_store.py"
+  - "tests/test_discover_mode.py"
+---
+
+
+# Persistent discovery topic queue: five interlocking design conventions
+
+## Context
+
+PR #852 shipped a persistent topic queue for `/last30days discover`: every real
+discovery run records which topics it surfaced into a `discovery_topics` table in
+research.db, so the podcast/X-article pipeline remembers what it has already seen
+("surfaced 3rd time") and what the user already produced content for ("marked
+covered"). This is the design record for that queue - five conventions that were
+each load-bearing in review, two of them caught as real bugs (one P0). The
+seed-source corroboration change that landed in the same PR is documented
+separately in
+`docs/solutions/design-patterns/ranked-output-confidence-floor-honest-empty-state.md`
+(section 2b); this doc does not cover it.
+
+## Guidance
+
+### 1. Default-on, disabled only via the config allowlist - never bare os.environ
+
+The queue records every real (non-mock) run by default; the literal value `off`
+disables it. The knob is registered in `env.get_config`'s keys allowlist
+(`skills/last30days/scripts/lib/env.py:482`):
+
+```python
+# Discovery topic queue (podcast/X-article pipeline memory). Default
+# ON; the literal value "off" disables queue writes and annotations.
+('LAST30DAYS_DISCOVERY_QUEUE', None),
+```
+
+and read from the resolved config dict, never `os.environ`
+(`skills/last30days/scripts/last30days.py:1312-1314`):
+
+```python
+queue_setting = str(config.get("LAST30DAYS_DISCOVERY_QUEUE") or "").strip().lower()
+if queue_setting == "off" or not report.topics:
+    return report
+```
+
+WHY: `.env`-file users' values only reach the engine through the `get_config`
+allowlist merge - a bare `os.environ` read silently ignores them, a documented
+invisible-failure class in this repo. Scoped runs (`--save-dir`) write the scoped
+research.db via `store.scoped_db(_scoped_store_db(args))`
+(`last30days.py:432-437`, `store.py:41-53`), never the global one; `--mock` runs
+stay 100% side-effect-free (`last30days.py:1505`).
+
+### 2. Annotate-only fuzzy matching - a match stamps context, it never merges rows
+
+`store.match_discovery_topic` tries exact normalized-name match first, then the
+best entity-overlap candidate - the better of full `entity_key` token overlap and
+anchor-token overlap - at a conservative floor
+(`skills/last30days/scripts/store.py:810`, `898-938`):
+
+```python
+DISCOVERY_QUEUE_OVERLAP_THRESHOLD = 0.6
+...
+if best is not None and best_overlap >= DISCOVERY_QUEUE_OVERLAP_THRESHOLD:
+    return dict(best)
+```
+
+A fuzzy match only annotates the rendered card - the `Pipeline: surfaced Nth
+time, marked covered` line (`skills/last30days/scripts/lib/render.py:153-168`) -
+and never merges or rewrites queue rows (`store.py:806-809`, `906-907`).
+
+WHY: with annotate-only semantics a false-positive match costs one noisy line on
+one card; a false merge would silently collapse two distinct stories into one
+row and hide one of them forever. The threshold is tunable precisely because
+mislabeling is recoverable and data loss is not.
+
+### 3. Two-phase hook: match ALL topics before recording ANY
+
+`_annotate_and_record_discovery_queue` computes priors for every topic first,
+then records surfacings, inside one `store.scoped_db` block
+(`skills/last30days/scripts/last30days.py:1323-1345`):
+
+```python
+with store.scoped_db(_scoped_store_db(args)):
+    store.init_db()
+    # Phase 1: match EVERY topic before recording ANY. Interleaving
+    # match+record in one loop lets topic N fuzzy-match a same-anchor
+    # sibling row this very run recorded seconds earlier, falsely
+    # annotating a first-ever topic as "surfaced 2nd time".
+    priors = [store.match_discovery_topic(topic.name) for topic in report.topics]
+    # Phase 2: record this run's surfacings. ...
+    for topic, prior in zip(report.topics, priors):
+```
+
+WHY: one report often contains same-anchor siblings ("Gemma 4 chat templates" /
+"Gemma 4 tool calling fixes"). Interleaved match+record lets topic N fuzzy-match
+the row topic N-1 wrote seconds earlier, falsely annotating a first-ever topic
+as a repeat. Caught in review; regression-tested.
+
+### 4. Covered inheritance: fresh rows born covered, existing rows never mutated
+
+`record_discovery_surfacing(inherit_covered_at=...)` makes a fresh row start in
+`covered` status when its fuzzy-matched prior is covered; the `ON CONFLICT`
+update path deliberately never touches `status`/`covered_at`
+(`skills/last30days/scripts/store.py:842-895`):
+
+```python
+status = "covered" if inherit_covered_at else "surfaced"
+...
+ON CONFLICT(normalized_name) DO UPDATE SET
+    surface_count = surface_count + 1,
+    last_surfaced = excluded.last_surfaced,
+    last_run_ref = excluded.last_run_ref,
+    domain = CASE WHEN excluded.domain <> '' THEN excluded.domain ELSE domain END
+```
+
+The caller passes it when a topic's prior is covered
+(`last30days.py:1334-1344`). Locked by the flip-flop regression test
+`test_covered_status_survives_judge_rename_across_runs`
+(`tests/test_store.py:1082-1101`) and by
+`tests/test_store.py:1060-1079` (ON CONFLICT ignores `inherit_covered_at`).
+
+WHY: the LLM judge renames the same story across runs; without inheritance a
+rename forks a fresh uncovered row and the user's covered mark silently
+evaporates. Without the never-mutate rule, a stale inherit could flip a row the
+user just changed.
+
+### 5. Guarded, synchronous end-of-run write - never crash a finished pipeline
+
+The hook call in `_run_discover` is wrapped so a broken queue db degrades to a
+stderr warning and an unannotated report
+(`skills/last30days/scripts/last30days.py:1505-1515`):
+
+```python
+if not args.mock:
+    try:
+        report = _annotate_and_record_discovery_queue(report, args, config)
+    except (sqlite3.Error, OSError) as exc:
+        # A broken queue db (locked, read-only dir, corrupt) must never
+        # destroy a finished multi-minute pipeline run: warn and render
+        # the report without queue annotations (fields keep defaults).
+        sys.stderr.write(
+            f"[last30days] Warning: discovery queue unavailable ({exc}); "
+            "continuing without queue annotations.\n"
+        )
+```
+
+WHY: unguarded, a locked/read-only/corrupt research.db raises AFTER the
+multi-minute research pipeline finished and discards all of its output - the PR
+#852 code review's P0, empirically reproduced. The write also runs synchronously
+after the pipeline returns (`last30days.py:1308-1310` docstring): it touches
+disk, so the abandon-on-timeout daemon-thread pattern is forbidden here (see
+`docs/solutions/logic-errors/non-daemon-executor-threads-defeat-wall-clock-budget.md`).
+
+## Why This Matters
+
+Ranked by blast radius when a convention is violated:
+
+- Unguarded end-of-run write (5): the whole run's output is destroyed by a
+  bookkeeping failure, and only in degraded environments (locked db, read-only
+  dir), so it ships green and detonates on exactly the machines you cannot see.
+  This was the review's P0.
+- Interleaved match+record (3): the queue's core promise ("first time you've
+  seen this") is wrong on day one - a first-ever topic gets annotated "surfaced
+  2nd time" by its same-run sibling, and no cross-run test catches it because
+  the corruption happens inside a single run.
+- Bare os.environ read (1): `.env`-file users cannot turn the queue off; the
+  toggle works in the maintainer's shell and fails invisibly for everyone
+  configuring via file.
+- Merging on fuzzy match (2): a 0.6-overlap false positive stops being one
+  noisy line and becomes a hidden story - unrecoverable data loss from a
+  heuristic.
+- Mutating rows or skipping inheritance (4): user covered marks flip-flop with
+  judge naming drift, so the queue re-pitches stories the user already produced,
+  which is the exact failure the queue exists to prevent.
+
+## When to Apply
+
+- Any default-on local persistence bolted onto the end of an expensive pipeline:
+  the write must be guarded (degrade to a warning) and synchronous if it touches
+  disk.
+- Any fuzzy identity layer over LLM-named entities: keep matching annotate-only,
+  batch all matches before any writes in a run, and inherit user-set status onto
+  fresh rows instead of mutating existing ones.
+- Any new engine toggle in this repo: register it in `env.get_config`'s keys
+  allowlist and read it from the config dict, never bare `os.environ`.
+
+## Examples
+
+Covered flip-flop, the archetype 3-run scenario (mirrors
+`tests/test_store.py:1082-1101`):
+
+1. Run 1 surfaces "Gemma 4 chat templates"; the user records an episode and
+   runs `queue cover "Gemma 4 chat templates"` (row status: covered).
+2. Run 2's judge names the same story "Gemma 4 template fixes". Exact match
+   misses; fuzzy match (anchor overlap `gemma`/`4` at >= 0.6) finds the covered
+   prior, so the new row is recorded born covered and the card renders
+   `Pipeline: surfaced 2nd time, marked covered` instead of pitching it fresh.
+3. Run 3 resurfaces "Gemma 4 template fixes"; it exact-matches its own covered
+   row (`covered_at` still the run-1 date). Without convention 4, run 2 would
+   have forked an uncovered row and run 3 would re-pitch a story the user
+   already covered.
+
+Queue failure behavior: with research.db locked by another process, a discovery
+run still prints the full rendered report; stderr shows
+`[last30days] Warning: discovery queue unavailable (database is locked);
+continuing without queue annotations.` and the cards simply lack Pipeline lines.
+
+## Related
+
+- PR #852 - judged topic names, junk gate, angles, topic queue (this design).
+- `docs/solutions/design-patterns/ranked-output-confidence-floor-honest-empty-state.md`
+  section 2b - the seed-source corroboration rule from the same PR (not covered
+  here).
+- `docs/solutions/logic-errors/non-daemon-executor-threads-defeat-wall-clock-budget.md`
+  - why abandon-on-timeout daemon threads are forbidden for disk writers.

--- a/docs/solutions/design-patterns/ranked-output-confidence-floor-honest-empty-state.md
+++ b/docs/solutions/design-patterns/ranked-output-confidence-floor-honest-empty-state.md
@@ -1,6 +1,7 @@
 ---
 title: "Ranked-output features need an explicit confidence floor with an honest empty state"
 date: 2026-07-12
+last_updated: 2026-07-20
 category: design-patterns
 module: discover-trending
 problem_type: design_pattern
@@ -9,6 +10,7 @@ severity: medium
 applies_when:
   - "Any feature that ranks and displays top-N results from variable-quality inputs (search, trending, recommendations, discovery)"
   - "Quiet or over-broad query domains where feeds return thin or noisy data"
+  - "A gate measures corroboration or independence downstream of a stage of the same pipeline that amplifies that signal (enrichment, fan-out, retrieval expansion)"
 symptoms:
   - "Top-N ranker emits near-zero-engagement items (e.g., five 1-like tweets) as a trend list because top-N has no notion of 'none of this is good enough'"
 resolution_type: code_fix
@@ -21,8 +23,13 @@ tags:
   - trending
   - signal-quality
   - corroboration
+  - "seed-sources"
+  - "junk-shape"
+  - "source-independence"
 related_components:
   - "skills/last30days/scripts/lib/rerank.py"
+  - "skills/last30days/scripts/lib/pipeline.py"
+  - "tests/test_discover_floor.py"
 ---
 
 # Ranked-output features need an explicit confidence floor with an honest empty state
@@ -52,6 +59,8 @@ def passes_discovery_floor(
     source_count: int,
     engagement_total: float,
     item_count: int,
+    junk_shape: bool = False,
+    seed_source_count: int | None = None,
 ) -> bool:
     """Whether a discovery topic's evidence is strong enough to show a user.
 
@@ -60,12 +69,15 @@ def passes_discovery_floor(
     """
     if item_count <= 0 or engagement_total < FLOOR_MIN_ENGAGEMENT:
         return False
+    if junk_shape:
+        corroboration = seed_source_count if seed_source_count is not None else source_count
+        return corroboration >= FLOOR_MIN_SOURCES
     if source_count >= FLOOR_MIN_SOURCES:
         return True
     return engagement_total >= FLOOR_SINGLE_SOURCE_ENGAGEMENT
 ```
 
-The first check is the junk gate: `FLOOR_MIN_ENGAGEMENT = 25.0` means a 1-like tweet can never rank, no matter how empty the field is. The floor is judged per topic inside `run_discover()` (`skills/last30days/scripts/lib/pipeline.py`), before the topic is appended and before `topic_limit` is consulted - sub-floor evidence never enters the ranked list at all.
+(The `junk_shape` / `seed_source_count` branch landed in PR #852 - see section 2b.) The first check is the junk gate: `FLOOR_MIN_ENGAGEMENT = 25.0` means a 1-like tweet can never rank, no matter how empty the field is. The floor is judged per topic inside `run_discover()` (`skills/last30days/scripts/lib/pipeline.py`), before the topic is appended and before `topic_limit` is consulted - sub-floor evidence never enters the ranked list at all.
 
 ### 2. Make the clearing criteria composite: corroboration OR a genuinely strong spike
 
@@ -76,6 +88,31 @@ A single threshold is either too strict (kills real single-source stories) or to
 
 The regression tests in `tests/test_discover_floor.py` pin both edges of this policy directly (`test_passes_discovery_floor_policy`): `floor(source_count=2, engagement_total=30, item_count=2)` clears, `floor(source_count=1, engagement_total=100, item_count=3)` does not, `floor(source_count=1, engagement_total=1600, item_count=1)` does.
 
+### 2b. Count corroboration on the layer your own pipeline does not amplify
+
+PR #852 added a stricter path for junk-shaped topics (help-me posts, beginner asks, musings - flagged by the stage-1 judge or the `topic_shape` heuristics): they lose the single-source engagement bypass entirely (a 226-comment "help me choose" thread is a busy support thread, not a story) and must clear `FLOOR_MIN_SOURCES` via corroboration alone.
+
+The subtle half of that change is WHICH source count the corroboration check reads. The original design counted sources in the topic's enriched corpus - and the adversarial code review proved that check would never bind: the enrichment stage deliberately fans every nominated topic out to Reddit, X, YouTube, and the web, so a single-subreddit junk thread enriches into 4-6 "sources" of mentions of itself. A gate reading the post-fan-out count is checking that enrichment works, not that the topic is corroborated. The shipped gate counts distinct sources among the nomination's own seed listing items - what the river sweep actually found - which enrichment cannot inflate (`skills/last30days/scripts/lib/pipeline.py`, floor call site):
+
+```python
+junk_shape=nomination.junk_shape,
+# Junk corroboration counts distinct SEED listing sources, never
+# the enriched corpus - a successful enrichment pass is
+# multi-source for almost any topic, so it would never bind.
+seed_source_count=len({item.source for item in nomination.items}),
+```
+
+The two archetypes, side by side:
+
+| Topic | Seed listing sources | Enriched corpus sources | Enriched-count gate (never binds) | Seed-count gate (shipped) |
+|---|---|---|---|---|
+| Single-subreddit help-me thread (junk shape) | 1 | 4-6 | passes | fails |
+| Real story swept from Reddit AND Hacker News | 2 | 4-6 | passes | passes |
+
+Generalized rule: when a gate requires corroboration or independence, measure it on the signal layer your own system does not amplify - corroboration is evidence only when the corroborating signals could have failed to appear. This applies to any "N independent confirmations" threshold downstream of your own search fan-out, enrichment, crawling, or retrieval expansion. It does NOT apply when the downstream layer is genuinely independent evidence your pipeline cannot manufacture (human review verdicts, third-party confirmations) - there, the enriched layer is exactly what to count.
+
+Testing note: a unit test that feeds the gate's parameters directly cannot catch a never-binds design. At least one test must drive the full production path with the amplifier running and assert the gate still fires - `test_junk_corroboration_counts_seed_sources_not_enriched_corpus` in `tests/test_discover_floor.py` mocks enrichment to return a rich multi-source corpus and asserts the single-seed-source junk topic still fails, with the unit-level matrix in `test_passes_discovery_floor_junk_params` pinning that a high enriched `source_count` cannot rescue `seed_source_count=1`.
+
 ### 3. Make honest emptiness a first-class outcome, and name the nearest miss
 
 When zero topics survive the floor, the pipeline does not error, does not pad, and does not lower the bar. `run_discover()` sets `outcome = "ok" if topics else "nothing-solid"` on the `DiscoveryReport`, and while filtering it remembers the highest-scoring sub-floor candidate as `weak_signal` so the empty result can still say what came closest:
@@ -85,11 +122,22 @@ if not rerank.passes_discovery_floor(
     source_count=len(sources),
     engagement_total=native_total,
     item_count=len(evidence_items),
+    junk_shape=nomination.junk_shape,
+    # Junk corroboration counts distinct SEED listing sources, never
+    # the enriched corpus - a successful enrichment pass is
+    # multi-source for almost any topic, so it would never bind.
+    seed_source_count=len({item.source for item in nomination.items}),
 ):
     # Sub-floor evidence never ranks; remember what came closest so a
     # nothing-solid brief can still name the strongest weak signal.
-    if weak_signal is None or score > weak_signal[0]:
-        weak_signal = (score, entry.nomination.name)
+    # Junk-shaped failures are tracked separately: the brief prefers
+    # the strongest NON-junk failure and names a junk one only when
+    # every failure is junk-shaped (never empty when failures exist).
+    if nomination.junk_shape:
+        if junk_weak_signal is None or score > junk_weak_signal[0]:
+            junk_weak_signal = (score, nomination.name)
+    elif weak_signal is None or score > weak_signal[0]:
+        weak_signal = (score, nomination.name)
     continue
 ```
 
@@ -163,12 +211,15 @@ The strong-corpus side, from `tests/test_discover_floor.py`: a single 1,084-poin
 ```python
 if item_count <= 0 or engagement_total < FLOOR_MIN_ENGAGEMENT:
     return False
+if junk_shape:
+    corroboration = seed_source_count if seed_source_count is not None else source_count
+    return corroboration >= FLOOR_MIN_SOURCES
 if source_count >= FLOOR_MIN_SOURCES:
     return True
 return engagement_total >= FLOOR_SINGLE_SOURCE_ENGAGEMENT
 ```
 
-Three lines of gate, placed before the ranker, are the difference between a feature that fills five slots no matter what and one whose non-empty answers can be believed.
+A handful of lines of gate, placed before the ranker, are the difference between a feature that fills five slots no matter what and one whose non-empty answers can be believed.
 
 ## Related
 
@@ -177,3 +228,4 @@ Three lines of gate, placed before the ranker, are the difference between a feat
 - [Non-daemon executor threads defeat wall-clock budgets](../logic-errors/non-daemon-executor-threads-defeat-wall-clock-budget.md) - sibling learning from the same PR #816 rebuild: the process-lifetime half (enrichment budget enforcement) vs this doc's ranking-quality half.
 - [argparse optional-value flag dispatch](../conventions/argparse-optional-value-flag-dispatch-truthiness.md) - third lesson from the same PR #816: the CLI flag semantics that route into this feature.
 - [PR #816](https://github.com/mvanhorn/last30days-skill/pull/816) - the discovery rebuild that introduced `passes_discovery_floor()` and the nothing-solid empty state (released v3.14.0).
+- [PR #852](https://github.com/mvanhorn/last30days-skill/pull/852) - the discovery content pipeline that added the junk-shape branch and seed-source corroboration (section 2b).


### PR DESCRIPTION
Compounds the two verified learnings from PR #852 (discovery content pipeline) into the knowledge store, per the plan's Definition of Done.

- `docs/solutions/design-patterns/ranked-output-confidence-floor-honest-empty-state.md` - updated in place (high overlap): new section 2b documents seed-source corroboration (count independence at the layer before your own enrichment amplifies it), and the stale pre-#852 code excerpts are refreshed to the current floor signature and weak-signal split.
- `docs/solutions/architecture-patterns/discovery-topic-queue-design-conventions.md` - new; first institutional record for the topic-queue subsystem (default-on allowlisted persistence, annotate-only fuzzy matching, two-phase match-then-record, covered inheritance across naming drift, guarded end-of-run write).
- `CONCEPTS.md` - 3 new Discovery-cluster entries (Junk shape, Topic queue, Covered), 3 refreshed for post-#852 accuracy (Nomination, Confidence floor, Nothing-solid).

Grounding: mechanical claims validators clean on both docs; a read-only semantic validator checked 39 claims against the tree and GitHub - 36 verified, 0 contradicted, 0 unverifiable (2 verified-with-note for 1-line drift; 1 audit-brief-only item confirmed absent from the doc).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
