### PR TITLE
fix(reddit): fetch window should track the requested date range

### DIFF
--- a/changelog.d/860.fixed.md
+++ b/changelog.d/860.fixed.md
@@ -1,0 +1,1 @@
+Reddit fetch windows now track the requested date range so short `--days` runs no longer pull a depth-default month and discard everything outside the window.

--- a/skills/last30days/scripts/lib/reddit.py
+++ b/skills/last30days/scripts/lib/reddit.py
@@ -13,6 +13,7 @@ import sys
 import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait as futures_wait
+from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional, Set
 
 def _first_of(*values, default=None):
@@ -456,30 +457,49 @@ def _dedupe_posts(posts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 _TIMEFRAME_ORDER = {"hour": 0, "day": 1, "week": 2, "month": 3, "year": 4, "all": 5}
 
 
+def _days_to_reddit_bucket(days: float) -> str:
+    """Map a day count onto the smallest Reddit rolling bucket that covers it.
+
+    Adds one day of slack so calendar windows that cross a day boundary still
+    fit inside Reddit's rolling ``t=`` buckets (a yesterday→today request needs
+    ``week``, not ``day``).
+    """
+    covered = days + 1
+    if covered <= 1:
+        return "day"
+    if covered <= 7:
+        return "week"
+    if covered <= 31:
+        return "month"
+    if covered <= 366:
+        return "year"
+    return "all"
+
+
 def _window_to_time_filter(from_date: str, to_date: str) -> str:
     """Map a requested YYYY-MM-DD window onto Reddit's coarse `t` param.
 
-    Reddit's ``t=day|week|month`` buckets are rolling windows ending "now", not
-    calendar spans. A one-day request often covers yesterday→today, so ``t=day``
-    (last 24h) under-fetches yesterday morning and the later date filter cannot
-    recover those posts. Round up one bucket so the fetch covers the calendar
-    window; Phase 5 still trims to ``from_date``/``to_date``. Falls back to
-    ``month`` (previous behaviour) if the dates don't parse.
+    Reddit's ``t=day|week|month`` buckets are rolling windows ending *now*, not
+    calendar spans and not anchored to ``to_date``. Coverage therefore needs:
+
+    1. Span — a yesterday→today request needs more than rolling ``t=day``.
+    2. Historical reach — a one-day request ending two weeks ago still needs a
+       bucket that reaches ``from_date``; span-alone would pick ``week`` and
+       the API would omit the entire requested range.
+
+    Take the wider of the two; the caller then mins with the depth default.
+    Phase 5 still trims to ``from_date``/``to_date``. Falls back to ``month``
+    if the dates don't parse.
     """
     try:
-        span = (time.mktime(time.strptime(to_date, "%Y-%m-%d"))
-                - time.mktime(time.strptime(from_date, "%Y-%m-%d"))) / 86400
+        start = date.fromisoformat(from_date)
+        end = date.fromisoformat(to_date)
     except (ValueError, TypeError):
         return "month"
-    if span <= 1:
-        return "week"
-    if span <= 7:
-        return "month"
-    if span <= 31:
-        return "year"
-    if span <= 366:
-        return "year"
-    return "all"
+    span_days = max(0, (end - start).days)
+    # Age of from_date relative to "today" — Reddit always anchors to now.
+    age_days = max(0, (datetime.now(timezone.utc).date() - start).days)
+    return _days_to_reddit_bucket(max(span_days, age_days))
 
 
 def search_reddit(

--- a/skills/last30days/scripts/lib/reddit.py
+++ b/skills/last30days/scripts/lib/reddit.py
@@ -459,9 +459,12 @@ _TIMEFRAME_ORDER = {"hour": 0, "day": 1, "week": 2, "month": 3, "year": 4, "all"
 def _window_to_time_filter(from_date: str, to_date: str) -> str:
     """Map a requested YYYY-MM-DD window onto Reddit's coarse `t` param.
 
-    Reddit filters server-side only at hour/day/week/month granularity. Pick the
-    smallest bucket that covers the window. Falls back to 'month' (previous
-    behaviour) if the dates don't parse.
+    Reddit's ``t=day|week|month`` buckets are rolling windows ending "now", not
+    calendar spans. A one-day request often covers yesterday→today, so ``t=day``
+    (last 24h) under-fetches yesterday morning and the later date filter cannot
+    recover those posts. Round up one bucket so the fetch covers the calendar
+    window; Phase 5 still trims to ``from_date``/``to_date``. Falls back to
+    ``month`` (previous behaviour) if the dates don't parse.
     """
     try:
         span = (time.mktime(time.strptime(to_date, "%Y-%m-%d"))
@@ -469,11 +472,11 @@ def _window_to_time_filter(from_date: str, to_date: str) -> str:
     except (ValueError, TypeError):
         return "month"
     if span <= 1:
-        return "day"
-    if span <= 7:
         return "week"
-    if span <= 31:
+    if span <= 7:
         return "month"
+    if span <= 31:
+        return "year"
     if span <= 366:
         return "year"
     return "all"

--- a/skills/last30days/scripts/lib/reddit.py
+++ b/skills/last30days/scripts/lib/reddit.py
@@ -453,6 +453,32 @@ def _dedupe_posts(posts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return unique
 
 
+_TIMEFRAME_ORDER = {"hour": 0, "day": 1, "week": 2, "month": 3, "year": 4, "all": 5}
+
+
+def _window_to_time_filter(from_date: str, to_date: str) -> str:
+    """Map a requested YYYY-MM-DD window onto Reddit's coarse `t` param.
+
+    Reddit filters server-side only at hour/day/week/month granularity. Pick the
+    smallest bucket that covers the window. Falls back to 'month' (previous
+    behaviour) if the dates don't parse.
+    """
+    try:
+        span = (time.mktime(time.strptime(to_date, "%Y-%m-%d"))
+                - time.mktime(time.strptime(from_date, "%Y-%m-%d"))) / 86400
+    except (ValueError, TypeError):
+        return "month"
+    if span <= 1:
+        return "day"
+    if span <= 7:
+        return "week"
+    if span <= 31:
+        return "month"
+    if span <= 366:
+        return "year"
+    return "all"
+
+
 def search_reddit(
     topic: str,
     from_date: str,
@@ -480,7 +506,13 @@ def search_reddit(
         return {"items": [], "error": "No SCRAPECREATORS_API_KEY configured"}
 
     config = DEPTH_CONFIG.get(depth, DEPTH_CONFIG["default"])
-    timeframe = config["timeframe"]
+    # Fetch window must track the requested date range, not just the depth
+    # default. Otherwise a --days 1 request fetches a month of relevance-
+    # sorted posts and Phase 5 discards everything outside 24h (0 on quiet
+    # days). Use the tighter of {window-derived, depth default}.
+    _depth_tf = config["timeframe"]
+    _window_tf = _window_to_time_filter(from_date, to_date)
+    timeframe = _window_tf if _TIMEFRAME_ORDER.get(_window_tf, 3) <= _TIMEFRAME_ORDER.get(_depth_tf, 3) else _depth_tf
     intent = infer_query_intent(topic)
 
     # === Phase 1: Query Expansion ===

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -264,10 +264,43 @@ if __name__ == "__main__":
     unittest.main()
 
 
-def test_window_to_time_filter_rounds_up_for_rolling_buckets():
-    """Calendar windows need the next Reddit rolling bucket (Greptile on #860)."""
+def test_window_to_time_filter_rounds_up_for_rolling_buckets(monkeypatch):
+    """Recent calendar windows need the next Reddit rolling bucket (Greptile on #860)."""
+    from datetime import date
     from lib import reddit
 
+    class _FrozenDateTime:
+        @staticmethod
+        def now(tz=None):
+            class _D:
+                @staticmethod
+                def date():
+                    return date(2026, 7, 24)
+            return _D()
+
+    monkeypatch.setattr(reddit, "datetime", _FrozenDateTime)
     assert reddit._window_to_time_filter("2026-07-23", "2026-07-24") == "week"
     assert reddit._window_to_time_filter("2026-07-17", "2026-07-24") == "month"
-    assert reddit._window_to_time_filter("2026-06-24", "2026-07-24") == "year"
+    assert reddit._window_to_time_filter("2026-06-24", "2026-07-24") == "month"
+    # Just past the month bucket (+1 slack) needs year.
+    assert reddit._window_to_time_filter("2026-06-23", "2026-07-24") == "year"
+
+
+def test_window_to_time_filter_covers_historical_from_date(monkeypatch):
+    """Short historical windows must still reach from_date (Greptile follow-up on #860)."""
+    from datetime import date
+    from lib import reddit
+
+    class _FrozenDateTime:
+        @staticmethod
+        def now(tz=None):
+            class _D:
+                @staticmethod
+                def date():
+                    return date(2026, 7, 24)
+            return _D()
+
+    monkeypatch.setattr(reddit, "datetime", _FrozenDateTime)
+    # One-day request ending two weeks ago: span alone would pick "week" and
+    # miss the entire range; age of from_date requires "month".
+    assert reddit._window_to_time_filter("2026-07-09", "2026-07-10") == "month"

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -262,3 +262,12 @@ class TestEnrichmentBudget(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_window_to_time_filter_rounds_up_for_rolling_buckets():
+    """Calendar windows need the next Reddit rolling bucket (Greptile on #860)."""
+    from lib import reddit
+
+    assert reddit._window_to_time_filter("2026-07-23", "2026-07-24") == "week"
+    assert reddit._window_to_time_filter("2026-07-17", "2026-07-24") == "month"
+    assert reddit._window_to_time_filter("2026-06-24", "2026-07-24") == "year"


### PR DESCRIPTION
## Problem

At a short window (`--days 1`), the main Reddit backend can silently return **0 posts** even when the subreddits are active.

`search_reddit()` sets its fetch window from the **depth config** — `timeframe = config["timeframe"]` (`"month"` at default depth) — regardless of the caller's `from_date`/`to_date`. So a 24-hour request fetches a **month** of relevance-sorted posts, and Phase 5's date filter then discards everything outside the 24h window. On a day when none of the month's top-relevance posts happen to fall in the last 24h, the whole source drops to zero — and because `errors_by_source` stays empty, it fails silently.

## Fix

Derive the fetch `timeframe` from the **requested window**, capped by the depth default:

- Add `_window_to_time_filter(from_date, to_date)` mapping the span onto Reddit's coarse `t` buckets (`day`/`week`/`month`/`year`/`all`), falling back to `"month"` on unparseable dates.
- Use the **tighter** of {window-derived, depth default}, so a `--days 1` sweep fetches `day` while wider requests still respect the depth ceiling.

Self-contained (no new imports; uses the already-imported `time`). Narrow behavior change limited to the fetch window; ranking/dedup/enrichment untouched.
