### PR TITLE
fix(ci): make changelog-guard workflow parseable again

### DIFF
--- a/.github/scripts/read_manifest_version.py
+++ b/.github/scripts/read_manifest_version.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Print the lockstep version string from a manifest file on stdin.
+
+Used by .github/workflows/changelog-guard.yml so version parsing stays out of
+the YAML ``run: |`` block (column-0 Python inside that block breaks Actions).
+
+Usage:
+  git show REF:path | python3 .github/scripts/read_manifest_version.py path
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def version_from(path: str, text: str) -> str:
+    if path.endswith("pyproject.toml"):
+        match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', text)
+        return match.group(1) if match else ""
+    if path.endswith("SKILL.md"):
+        match = re.search(r'(?m)^version:\s*"([^"]+)"\s*$', text)
+        return match.group(1) if match else ""
+    if path.endswith("uv.lock"):
+        match = re.search(
+            r'(?ms)^\[\[package\]\]\nname = "last30days-skill"\nversion = "([^"]+)"',
+            text,
+        )
+        return match.group(1) if match else ""
+    if path.endswith("marketplace.json"):
+        data = json.loads(text)
+        plugins = data.get("plugins") or []
+        return plugins[0].get("version", "") if plugins else ""
+    data = json.loads(text)
+    return data.get("version", "") or ""
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: read_manifest_version.py PATH < manifest",
+            file=sys.stderr,
+        )
+        return 2
+    path = argv[1]
+    text = sys.stdin.read()
+    sys.stdout.write(version_from(path, text))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/read_manifest_version.py
+++ b/.github/scripts/read_manifest_version.py
@@ -28,11 +28,13 @@ def version_from(path: str, text: str) -> str:
             text,
         )
         return match.group(1) if match else ""
-    if path.endswith("marketplace.json"):
+    try:
         data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+    if path.endswith("marketplace.json"):
         plugins = data.get("plugins") or []
         return plugins[0].get("version", "") if plugins else ""
-    data = json.loads(text)
     return data.get("version", "") or ""
 
 

--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -76,33 +76,15 @@ jobs:
             exit 1
           fi
 
+          # Keep version parsing in .github/scripts/ — a prior inline
+          # python3 -c block used column-0 source and made Actions refuse
+          # to parse this workflow (every run failed with empty jobs).
           version_at() {
             local ref="$1"
             local path="$2"
-            git show "${ref}:${path}" 2>/dev/null | PATH_ARG="${path}" python3 -c '
-import json, os, re, sys
-path = os.environ["PATH_ARG"]
-text = sys.stdin.read()
-if path.endswith("pyproject.toml"):
-    m = re.search(r"(?m)^version\s*=\s*\"([^\"]+)\"\s*$", text)
-    print(m.group(1) if m else "")
-elif path.endswith("SKILL.md"):
-    m = re.search(r"(?m)^version:\s*\"([^\"]+)\"\s*$", text)
-    print(m.group(1) if m else "")
-elif path.endswith("uv.lock"):
-    m = re.search(
-        r"(?ms)^\[\[package\]\]\nname = \"last30days-skill\"\nversion = \"([^\"]+)\"",
-        text,
-    )
-    print(m.group(1) if m else "")
-elif path.endswith("marketplace.json"):
-    data = json.loads(text)
-    plugins = data.get("plugins") or []
-    print(plugins[0].get("version", "") if plugins else "")
-else:
-    data = json.loads(text)
-    print(data.get("version", ""))
-'
+            git show "${ref}:${path}" 2>/dev/null \
+              | python3 .github/scripts/read_manifest_version.py "${path}" \
+              || true
           }
 
           VERSION_PATHS=(

--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -82,9 +82,10 @@ jobs:
           version_at() {
             local ref="$1"
             local path="$2"
-            git show "${ref}:${path}" 2>/dev/null \
-              | python3 .github/scripts/read_manifest_version.py "${path}" \
-              || true
+            # Fail closed: do not swallow helper/parse errors with || true.
+            # Callers only invoke this after git cat-file confirms the blob.
+            git show "${ref}:${path}" \
+              | python3 .github/scripts/read_manifest_version.py "${path}"
           }
 
           VERSION_PATHS=(

--- a/tests/test_changelog_workflow.py
+++ b/tests/test_changelog_workflow.py
@@ -57,6 +57,67 @@ class TestChangelogWorkflow(unittest.TestCase):
         ):
             self.assertTrue((workflows / name).is_file(), msg=name)
 
+    def test_changelog_guard_run_blocks_stay_indented(self) -> None:
+        """Column-0 lines inside ``run: |`` break Actions YAML parsing."""
+        path = ROOT / ".github" / "workflows" / "changelog-guard.yml"
+        lines = path.read_text(encoding="utf-8").splitlines()
+        in_run = False
+        run_indent = 0
+        for lineno, line in enumerate(lines, 1):
+            match = re.match(r"^(\s*)run:\s*\|\s*$", line)
+            if match:
+                in_run = True
+                run_indent = len(match.group(1))
+                continue
+            if not in_run or not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= run_indent:
+                in_run = False
+                continue
+            self.assertGreater(
+                indent,
+                run_indent,
+                msg=f"{path}:{lineno} must stay indented inside run: |",
+            )
+
+    def test_read_manifest_version_helper(self) -> None:
+        script = ROOT / ".github" / "scripts" / "read_manifest_version.py"
+        self.assertTrue(script.is_file())
+        spec = importlib.util.spec_from_file_location("read_manifest_version", script)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self.assertEqual(
+            mod.version_from("pyproject.toml", 'version = "3.18.1"\n'),
+            "3.18.1",
+        )
+        self.assertEqual(
+            mod.version_from("skills/last30days/SKILL.md", 'version: "3.18.1"\n'),
+            "3.18.1",
+        )
+        self.assertEqual(
+            mod.version_from(
+                "uv.lock",
+                '[[package]]\nname = "last30days-skill"\nversion = "3.18.1"\n',
+            ),
+            "3.18.1",
+        )
+        self.assertEqual(
+            mod.version_from(
+                ".claude-plugin/plugin.json",
+                json.dumps({"version": "3.18.1"}),
+            ),
+            "3.18.1",
+        )
+        self.assertEqual(
+            mod.version_from(
+                ".claude-plugin/marketplace.json",
+                json.dumps({"plugins": [{"version": "3.18.1"}]}),
+            ),
+            "3.18.1",
+        )
+
     def test_pr_template_has_agent_and_relationship_sections(self) -> None:
         text = (ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(
             encoding="utf-8"

--- a/tests/test_changelog_workflow.py
+++ b/tests/test_changelog_workflow.py
@@ -12,6 +12,39 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _assert_run_blocks_indented(text: str, *, label: str) -> None:
+    """Fail if a ``run: |`` block contains under-indented (esp. column-0) lines.
+
+    A prior bug treated indent <= run_indent as "end of block" and skipped the
+    assertion, so column-0 Python inside the scalar never failed the test.
+    """
+    in_run = False
+    run_indent = 0
+    for lineno, line in enumerate(text.splitlines(), 1):
+        match = re.match(r"^(\s*)run:\s*\|\s*$", line)
+        if match:
+            in_run = True
+            run_indent = len(match.group(1))
+            continue
+        if not in_run or not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent > run_indent:
+            continue
+        # Valid block end: a YAML key or list item at/above the run: indent.
+        # Column-0 (or any non-key dedent) is the Actions parse failure.
+        looks_like_yaml = bool(
+            re.match(r"^\s*(- )?[A-Za-z_][\w-]*\s*:", line)
+            or re.match(r"^\s*-\s+\S", line)
+        )
+        if indent == 0 or not looks_like_yaml:
+            raise AssertionError(
+                f"{label}:{lineno} under-indented inside run: | "
+                f"(indent={indent}, run_indent={run_indent}): {line!r}"
+            )
+        in_run = False
+
+
 def _load_prepare_release():
     path = ROOT / ".github" / "scripts" / "prepare_release.py"
     spec = importlib.util.spec_from_file_location("prepare_release", path)
@@ -60,26 +93,23 @@ class TestChangelogWorkflow(unittest.TestCase):
     def test_changelog_guard_run_blocks_stay_indented(self) -> None:
         """Column-0 lines inside ``run: |`` break Actions YAML parsing."""
         path = ROOT / ".github" / "workflows" / "changelog-guard.yml"
-        lines = path.read_text(encoding="utf-8").splitlines()
-        in_run = False
-        run_indent = 0
-        for lineno, line in enumerate(lines, 1):
-            match = re.match(r"^(\s*)run:\s*\|\s*$", line)
-            if match:
-                in_run = True
-                run_indent = len(match.group(1))
-                continue
-            if not in_run or not line.strip():
-                continue
-            indent = len(line) - len(line.lstrip(" "))
-            if indent <= run_indent:
-                in_run = False
-                continue
-            self.assertGreater(
-                indent,
-                run_indent,
-                msg=f"{path}:{lineno} must stay indented inside run: |",
-            )
+        _assert_run_blocks_indented(
+            path.read_text(encoding="utf-8"),
+            label=str(path),
+        )
+
+    def test_run_block_indent_checker_rejects_column_zero(self) -> None:
+        malformed = (
+            "jobs:\n"
+            "  guard:\n"
+            "    steps:\n"
+            "      - name: Enforce\n"
+            "        run: |\n"
+            "          set -euo pipefail\n"
+            "import json\n"
+        )
+        with self.assertRaises(AssertionError):
+            _assert_run_blocks_indented(malformed, label="synthetic")
 
     def test_read_manifest_version_helper(self) -> None:
         script = ROOT / ".github" / "scripts" / "read_manifest_version.py"
@@ -117,6 +147,8 @@ class TestChangelogWorkflow(unittest.TestCase):
             ),
             "3.18.1",
         )
+        with self.assertRaises(SystemExit):
+            mod.version_from(".claude-plugin/plugin.json", "{not-json")
 
     def test_pr_template_has_agent_and_relationship_sections(self) -> None:
         text = (ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(


### PR DESCRIPTION
## Summary
- Changelog guard has been failing on every PR with a workflow-file parse error (empty jobs), so fragment / `skip-changelog` rules were never enforced.
- Root cause: column-0 Python inside the `run: |` block broke YAML parsing.
- Move version reading to `.github/scripts/read_manifest_version.py` and add regression tests for indentation + the helper.

Policy unchanged: engine/skill changes need a `changelog.d/` fragment **or** the `skip-changelog` label — not a fragment on every PR.

## Follow-up (repo settings)
`main` still has no branch protection / rulesets, so GitHub “mergeable” only means no conflicts. After this lands, require the **Changelog guard** check on `main` so green mergeability reflects the fragment-or-skip decision.

## Test plan
- [x] `actionlint .github/workflows/changelog-guard.yml`
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/changelog-guard.yml"))'`
- [x] `uv run pytest tests/test_changelog_workflow.py -v`
- [ ] Confirm the Changelog guard job runs (non-empty) on this PR and passes with `skip-changelog`

## Agent disclosure
- AI agent assisted with this change.

### Relationship to this change
- Agent drafted the fix and tests; human requested the PR after diagnosing the broken guard.