### PR TITLE
docs: add five localized READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ Agents open most PRs. Follow this so `CHANGELOG.md` stops conflicting and versio
 - Keep examples safe by redacting secrets and avoiding copy/pasteable live credentials in docs, fixtures, and test data.
 - Do not weaken or disable the advisory security workflow (`.github/workflows/security.yml`) without explaining why in the PR description or review thread.
 
+## Maintaining README translations
+
+`README.md` is the canonical English README. When changing it, reflect the same substantive updates in `README.fr.md`, `README.de.md`, `README.es.md`, `README.pt-BR.md`, `README.ja.md`, and `README.zh-CN.md`, preserving commands, links, tables, and reciprocal language navigation.
+
 ## Maintaining CONFIGURATION.md
 
 `CONFIGURATION.md` is the user-facing configuration reference — save paths, per-source API keys, web-search backend priority, trend-monitoring stack, per-client install patterns. Distinct from `SKILL.md` (the canonical runtime spec).

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,382 @@
+# /last30days
+
+[English](README.md) | [Français](README.fr.md) | Deutsch | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+
+<p align="center">
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/mvanhorn/last30days-skill">
+    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
+  </a>
+  <br/>
+  <a href="https://trendshift.io/repositories/21997" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
+</p>
+
+**Eine von KI-Agenten geführte Suchmaschine, die durch Upvotes, Likes und echtes Geld bewertet wird – nicht durch Redakteure.**
+
+Diese README-Datei verfolgt die aktuelle v3-Pipeline. Die Laufzeit-Skill-Spezifikation befindet sich in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), was die Quelle der Wahrheit für das neueste Befehls- und Setup-Verhalten ist.
+
+**Claude Code (empfohlen – automatische Updates über den Marktplatz):**
+```
+/plugin marketplace add mvanhorn/last30days-skill
+/plugin install last30days
+```
+
+**Codex, Cursor, Copilot, Gemini CLI oder einer von über 50 [Agent Skills](https://agentskills.io)-Hosts:**
+```
+npx skills add mvanhorn/last30days-skill -g
+```
+(`-g` wird global für Ihren Benutzer installiert und ist in allen Projekten verfügbar. Legen Sie es auf den Bereich pro Projekt ab.)
+
+Weitere Installationsoptionen (claude.ai web, OpenClaw, manuell) finden Sie unten im Abschnitt [Installation](#installieren).
+
+Keine Konfiguration. Reddit, HN, Polymarket und GitHub funktionieren sofort. Führen Sie es einmal aus und der Einrichtungsassistent schaltet X, YouTube, TikTok, arXiv, Techmeme und mehr in 30 Sekunden frei.
+
+---
+
+Reddit-Upvotes. X mag. YouTube-Transkripte. TikTok-Engagement. Polymarket-Quoten, gestützt durch echtes Geld und Insiderinformationen. Das sind Millionen von Menschen, die jeden Tag mit ihrer Aufmerksamkeit und ihrem Geldbeutel abstimmen. /last30days durchsucht alles parallel, bewertet es danach, womit sich echte Menschen tatsächlich beschäftigen, und ein KI-Agent-Juror fasst es in einem Briefing zusammen.
+
+Google fasst Redakteure zusammen. /last30days durchsucht Personen.
+
+Sie können diese Suche nirgendwo anders erhalten, da keine einzelne KI Zugriff auf alles hat. Die Google-Suche berührt keine Reddit-Kommentare oder X-Beiträge. ChatGPT hat einen Deal mit Reddit, kann aber weder X noch TikTok durchsuchen. Gemini hat YouTube, aber nicht Reddit. Claude hat von Haus aus keine davon. Jede Plattform ist ein ummauerter Garten mit eigener API, eigenen Token und eigener Authentifizierung. Aber Sie können Ihre eigenen Schlüssel und Browsersitzungen mitbringen, und plötzlich kann ein KI-Agent alle auf einmal durchsuchen, sie miteinander vergleichen und Ihnen sagen, worauf es wirklich ankommt.
+
+Das ist die Freischaltung. Keine bessere Suchmaschine. Ein Dutzend nicht verbundener Plattformen, überbrückt von einem Agenten.
+
+```
+/last30days Peter Steinberger
+```
+
+Du hast morgen ein Treffen. Sie googeln sie. Sie erhalten ihr LinkedIn ab 2023. /last30days zeigt Ihnen, was sie diesen Monat tatsächlich tun: Sie sind OpenAI beigetreten, um an Codex zu arbeiten, kämpfen gegen das Verbot von Drittanbieter-Agenten durch Anthropic, versenden 23 PRs mit einer Zusammenführungsrate von 85 %, entwickeln „LobsterOS“ für die geräteübergreifende Agentenkontrolle und r/ClaudeCode erreichte 569 positive Stimmen bei der Debatte darüber, ob er ein Held oder „unerträglich“ ist. Verstreut über X-Posts, Reddit-Threads, YouTube-Transkripte und GitHub-Commits. Nichts davon war bei Google.
+
+## Warum das existiert
+
+Ich habe es gebaut, um in der KI mithalten zu können. Alles ändert sich jeden Tag und die Reddit- und X-Nerds sind immer die Ersten, die den Überblick behalten. Ich brauchte bessere Eingabeaufforderungen und die Trainingsdaten lagen immer Monate hinter dem zurück, was die Community bereits herausgefunden hatte.
+
+Aber es wurde etwas Größeres. Jetzt führe ich es vor einem Verkaufsgespräch durch, um die Wahrheit über ein Unternehmen in den letzten 30 Tagen zu erfahren. Vor einem Meeting die neuesten Tweets und Podcast-Transkripte einer anderen Person lesen. Informieren Sie sich vor einer Disney World-Reise darüber, welche Fahrgeschäfte geschlossen sind und was die Community über Genie+ sagt. Bevor ich etwas baue, muss ich wissen, auf welche Probleme die Leute tatsächlich stoßen.
+
+Wenn Sie sich mit einem CEO treffen, haben Sie dann alle Tweets und YouTube-Transkripte der letzten 30 Tage gelesen? Ich habe.
+
+## Quellen, bewertet von den Leuten
+
+| Quelle | Was die Leute dir sagen |
+|--------|--------------------------|
+| **Reddit** | Der ungefilterte Take. Top-Kommentare mit echten Upvote-Zählungen, kostenlos, kein API-Schlüssel. Die wahren Meinungen, die Google vergräbt. |
+| **X / Twitter** | Der heiße Take, der Expertenthread, die bahnbrechende Reaktion. Zuerst wissen, zuerst argumentieren. |
+| **YouTube** | Der 45-minütige Tieftauchgang. Vollständige Transkripte wurden nach den fünf zitierfähigen Sätzen durchsucht, auf die es ankommt. |
+| **TikTok** | Der Ersteller erreicht 3,6 Millionen Menschen mit einer Einstellung, die Sie bei Google nie finden werden. |
+| **Instagram-Reels** | Die Influencer-Perspektive mit Spoken-Word-Transkripten. Das visuelle Kultursignal. |
+| **Hacker-News** | Der Entwicklerkonsens. 825 Punkte, 899 Kommentare. Wo technische Leute tatsächlich streiten. |
+| **Polymarkt** | Keine Meinungen. Chancen. Unterstützt durch echtes Geld. 96 % Vertrauen in die Albumverkäufe. 4 % bei einer Akquisition. |
+| **GitHub** | Für Leute: PR-Geschwindigkeit, Top-Repos nach Stars, Versionshinweise. Für Themen: Probleme und Diskussionen. |
+| **Digg** | Kuratierte Story-Cluster aus Diggs AI 1000-Bestenliste (~1000 AI-Konten mit hohem Signalwert auf X) mit zuordenbaren Inline-Zitaten (keine X-Authentifizierung erforderlich). Automatisch aktiviert, wenn sich `digg-pp-cli` auf PATH befindet. |
+| **arXiv** | Die Papiere hinter dem Hype. Neue Recherche im Fenster, kostenlos, kein API-Schlüssel. Automatisch aktiviert, wenn sich `arxiv-pp-cli` auf PATH befindet (das Setup beim ersten Start installiert es). |
+| **Techmeme** | Die redaktionelle Ebene der Tech-News, mit Datumsfenster für Ihre 30 Tage. Kostenlos, kein API-Schlüssel. Automatisch aktiviert, wenn sich `techmeme-pp-cli` auf PATH befindet (das Setup beim ersten Start installiert es). |
+| **LinkedIn** | Das professionelle Signal. Beiträge und Artikel, wobei die Artikel als hohes Signal gewichtet werden. |
+| **StockTwits** | Händlerstimmung. Wird automatisch aktiviert, wenn es sich bei Ihrem Thema um einen Ticker oder eine Kryptowährung handelt. |
+| **Threads** | Die Post-Twitter-Textebene. Gespräche von YouTubern und Marken. |
+| **Pinterest** | Visuelle Entdeckung. Pins, Speicherungen und Kommentare zu Produkten und Ideen. |
+| **Xiaohongshu (ROT)** | Chinesische Lifestyle-, Produkt- und Schöpfersignale. Wird explizit mit `--search xhs` angefordert, wenn ein angemeldetes x-mcp-Browser-Plugin oder ein `xiaohongshu-mcp`-Dienst lokal ausgeführt wird. |
+| **Bluesky** | Die dezentrale soziale Schicht. AT-Protokollbeiträge aus der Post-Twitter-Migration. |
+| **Perplexität** | Grounded Sonar-Synthese, rohe Such-API-Zeilen und Deep Research. |
+| **Web** | Die redaktionelle Berichterstattung, die Blog-Vergleiche. Ein Signal von vielen, nicht das einzige. |
+
+Community-Mitwirkende fügen immer mehr hinzu. Truth Social und andere Nischenquellen sind in Arbeit, weitere sind in Vorbereitung.
+
+Ein Reddit-Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blog-Beitrag, den niemand liest. Ein TikTok mit 3,6 Millionen Aufrufen verrät Ihnen mehr darüber, was kulturell relevant ist, als eine Pressemitteilung. Mit Polymarket-Quoten, die durch ein Volumen von 66.000 US-Dollar untermauert werden, lässt sich schwerer argumentieren als mit der Vermutung eines Experten.
+
+Die Synthese orientiert sich daran, womit sich echte Menschen tatsächlich beschäftigt haben. Soziale Relevanz, nicht SEO-Relevanz.
+
+## Wofür die Leute es tatsächlich verwenden
+
+**Vor einem Meeting.** `/last30days Peter Steinberger` – trat dem Codex-Team von OpenAI bei und kämpfte gegen das Verbot von Drittanbieter-Agenten durch Anthropic. 23 PRs wurden mit einer Zusammenführungsrate von 85 % auf GitHub zusammengeführt und LobsterOS für die geräteübergreifende Agentensteuerung entwickelt. r/ClaudeCode: „Seit der Veröffentlichung von OpenClaw war allgemein bekannt, dass man irgendwann gesperrt wird, wenn man es über etwas anderes als die API ausführt“ (227 positive Stimmen). Das ist nicht auf LinkedIn.
+
+**Zum Lesen von Einstellungssignalen.** `/last30days Listen Labs --hiring-signals` – Aktuelle Stellen- und Karriereseiten werden zu zitierten Beweisen für Schwerpunktverlagerungen: Einstellungen in den Bereichen Unternehmenssicherheit, Kundenerfolg, Infrastruktur oder Produkterweiterung. Der Bericht sagt, was die Einstellung zu signalisieren scheint, nicht was die Roadmap bewirken wird.
+
+**Um das Thema zu finden, bevor es seinen Höhepunkt erreicht.** Fragen Sie `/last30days what's exploding in AI agents?` und der Skill wechselt in den Entdeckungsmodus: Die Engine durchsucht Reddit-Kategorielisten, Hacker News-Front/Best-Storys, Diggs AI 1000-Feed und X, wenn sie authentifiziert ist; Ihr Agent beurteilt die Nominierungen (Namen, Junk-Filterung, Inhaltswürdigkeit) und schreibt Podcast-/X-Artikel-Betrachtungen; dann erhalten Sie 5–10 Themen mit Geschwindigkeitsranking. Zu jedem Ergebnis gehören quellenübergreifende Zahlen, ein Momentum-Label und ein sofort einsatzbereites `/last30days "<topic>"`-Follow-up.
+
+**Wenn etwas ausfällt.** `/last30days Kanye West` – Großbritannien hat sein Visum blockiert, das Wireless Festival abgesagt, Sponsoren sind geflohen. Aber BULLY debütierte auf Platz 2 der Billboard-Charts. Fantano kam von seinem „Yay Sabbatical“ zurück, um es zu rezensieren (653.000 Aufrufe). SoFi Homecoming brachte Lauryn Hill und Travis Scott für 44 Songs heraus. Polymarket: „Wird Kanye erneut twittern?“ 86 % Ja. 23 Reddit-Threads, 17 YouTube-Videos, 86.000 Upvotes.
+
+**Zum Vergleichen von Werkzeugen.** `/last30days OpenClaw vs Hermes vs Paperclip` – „Das sind keine Konkurrenten, es sind Schichten.“ OpenClaw ist der Vollstrecker (351.000 GitHub-Sterne, live), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Die Anzahl der Sterne wird live von der GitHub-API abgerufen, nicht von veralteten Blogbeiträgen. Side-by-Side-Tisch mit Architektur, Speicher, Sicherheit, Best-for. Per @IMJustinBrooke: „OpenClaw = Charmander, Hermes = Charizard.“
+
+**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Frist für die Wiedereröffnung der Straße von Hormus durch den Iran am Dienstag. Zwei US-Kampfflugzeuge abgeschossen. Öl bei 126 $/Barrel. Die IEA nannte es „die größte Versorgungsstörung in der Geschichte des globalen Ölmarktes“. Polymarket: Waffenstillstand bis 31.12. bei 74 %. 27 X-Beiträge, 10 YouTube-Videos, 20 Prognosemärkte.
+
+**Vor einer Reise.** `/last30days Universal Epic Universe` – Erweiterung bereits im Bau. Genehmigung für „Projekt 680“ eingereicht. Feuerwerksshow von der Infrastruktur bestätigt, aber unangekündigt. Wartezeiten: Mine-Cart Madness durchschnittlich 148 Minuten. Noch gibt es keine Jahreskarte und die Einheimischen sind frustriert. Stardust Racers wegen Renovierungsarbeiten bis zum 5. April außer Betrieb.
+
+**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` – JSON-strukturierte Eingabeaufforderungen ersetzen die Tag-Suppe. Das verschachtelte Format von @pictsbyai verhindert „Concept Bleeding“. Der Edit-First-Workflow übertrifft die Regeneration. Dann schreibt es Ihnen eine Produktionsaufforderung, die genau das verwendet, was die Community als funktionierend bezeichnet hat.
+
+## Was ist neu
+
+Seit der Ankündigung von v3.3 im Mai, ab v3.11.1 (Juli 2026): 175 zusammengeführte PRs – 122 davon von 52 Community-Mitwirkenden – in 15 Veröffentlichungen. Das ist gelandet.
+
+### Erstklassig im OpenAI Codex
+
+/last30days ist jetzt ein natives Codex-Plugin mit geführter Einrichtung – kein Port, ein Bürger erster Klasse. Renderer-fähige Zitate bedeuten, dass sich die Codex-Ausgabe wie eine kurze Zusammenfassung und nicht wie eine URL-Suppe liest (#694) und die gleiche Engine auf Claude Code-, Cursor-, Copilot-, Gemini CLI-, Claude Desktop-, OpenClaw- und über 50 Agent Skills-Hosts läuft. Codex-Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex-Authentifizierungskorrektur von [@tmchow](https://github.com/tmchow) (#698).
+
+### arXiv, Techmeme und Digg – kostenlos, keine API-Schlüssel
+
+arXiv bringt die Papiere hinter dem Hype und Techmeme bringt die redaktionelle Tech-News-Ebene – kostenlos, keine Schlüssel und das Erstinstallationssetup installiert ihre CLIs, sodass sie automatisch aktiviert werden (#709). Die AI 1000-Story-Cluster von Digg kommen auf die gleiche Weise ohne X-Authentifizierung an – das Setup installiert die kostenlose Digg-CLI für Sie (#590). Trustpilot bietet Opt-in für die Recherche von Verbrauchermarken an.
+
+### Free Reddit steigerte echte Punktzahlen und Top-Kommentare
+
+Die öffentliche .json-API von Reddit ist gestorben; Der freie Weg kam stärker zurück. Schlüsselloses RSS + Shreddit-Scraping (#457), dedizierte Subreddit-Erkennung mit echten Upvote-Zählungen über Arctic-Shift (#696) und eine Relevanzuntergrenze, damit ein viraler Off-Topic-Beitrag Ihr Briefing nicht kapern kann (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API-Schlüssel. Echte Punkte. Top-Kommentare inklusive.
+
+### Die besten Kommentare in jedem Briefing
+
+Kommentare sind jetzt eine standardmäßige Ebene für alle Quellen: Instagram-Kommentare mit rangbasierter Diversität, sodass nicht alle fünf heißen Takes aus einem Beitrag stammen (#751), YouTube-Kommentare plus ein ScrapeCreators-Transkript-Backup für den Fall, dass yt-dlp ausfällt (#637) und durch Crowd-Voting in „Best Takes“ gewichtete Kommentare, damit die witzigsten Zeilen der Community die Wertung überleben (#592, #608).
+
+### Ein Arztbefehl
+
+Fordern Sie eine Gesundheitsprüfung an, und der Arzt führt jede Quelle durch und verschreibt dann genaue Korrekturen – welcher Schlüssel fehlt, welche CLI außerhalb von PATH liegt, welches Cookie abgelaufen ist (#753). Keine Vermutung mehr, warum X dünn zurückkam.
+
+### X-Suche, neu erstellt
+
+Die X-Pipeline wurde grundlegend überarbeitet: FROM- und ABOUT-Spuren, damit sowohl die eigenen Beiträge einer Person als auch die Konversation über sie einen Rang haben (#610), personenbezogene Unterabfrage-Begriffsklärung (#611), Erstanbieter-Autorenschaftserdung mit Interaktionssignal-Rangliste (#613) und eine einzige X-Quelle mit automatischem Backend-Failover (#622). Plus ein ehrlicher `--diagnose`, der tatsächlich die Authentifizierung prüft (#609).
+
+### Weitere Quellen sind beigetreten
+
+LinkedIn über ScrapeCreators, mit Artikeln mit hohem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits wird automatisch für Ticker- und Krypto-Themen aktiviert ([@wtiwana](https://github.com/wtiwana), #658). Perplexity wuchs mit direkten API-Modi und asynchroner Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
+
+### Von der Community gehärtet
+
+Die Sicherheitswelle war fast ausschließlich Community-Arbeit: Korrekturen gespeicherter XSS im HTML-Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), gesperrte temporäre Cookie-Dateien, Supply-Chain-gehärtetes CI mit OpenSSF Scorecard und Build-Herkunftsbescheinigung ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans plus ein PR-Abhängigkeitsüberprüfungs-Gate ([@23241a6749](https://github.com/23241a6749)), eine Testabdeckungsuntergrenze, die bei 60 % eingeführt und seitdem auf 84 % erhöht wurde ([@gourab5139014](https://github.com/gourab5139014)) und ein Hermes-Sicherheitsscan, der alle KRITISCHEN Befunde bereinigt (#768).
+
+### Reicht weiter
+
+Hebräische und nicht-lateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-fähige Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Windows-Kompatibilitätswelle. Cookie-Extraktion aus der gesamten Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS-Schlüsselbund- und Linux-Pass(1)-Anmeldeinformationsquellen. `--as-of` historischer Rückblick ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestelltes Python 3.12 über UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Lesen der Stellenseiten eines Unternehmens. Watchlist-Deltas zwischen Läufen.
+
+### Noch in der Box von v3
+
+Die v3-Grundlagen sind alle noch vorhanden: das Gehirn vor der Forschung, das die richtigen Handles, Subreddits und Hashtags auflöst, bevor ein einzelner API-Aufruf ausgelöst wird (erstellt von [@j-sperling](https://github.com/j-sperling)); Best Takes punkten neben Relevanz auch durch Humor und Viralität; Cross-Source-Cluster-Zusammenführung; Single-Pass-Vergleiche („CLI vs. MCP“ in 3 Minuten, nicht 12); automatisch ermittelte `--competitors`-Vergleiche; GitHub-Personenmodus (`--github-user=steipete`); ELI5-Modus („eli5 on“ nach jedem Lauf); und gemeinsam nutzbare, eigenständige HTML-Briefs (`--emit=html`). Konfigurationsknöpfe befinden sich in [CONFIGURATION.md](CONFIGURATION.md).
+
+## Installieren
+
+| Oberfläche | Installieren | Aktualisierungen |
+|---------|---------|---------|
+| **Claude Code** (empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatisch über den Marktplatz oder `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` dann `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI oder einer von über 50 [Agent Skills](https://agentskills.io)-Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [`last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) herunterladen und über claude.ai hochladen > Anpassen > Fertigkeiten > + > Fertigkeit erstellen > Fertigkeit hochladen | Erneut herunterladen und erneut hochladen |
+| **Claude Desktop** | [Laden Sie `.mcpb` für Ihre Plattform herunter](https://github.com/mvanhorn/last30days-skill/releases/latest) und ziehen Sie es in Einstellungen > Erweiterungen | Laden Sie das neue Paket erneut herunter und ziehen Sie es in |
+| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+
+### Claude Code (empfohlen)
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+Empfohlen, da der Claude Code-Marktplatz Aktualisierungen für Sie übernimmt – der Plugin-Cache ist versioniert und wird automatisch aktualisiert, wenn eine neue Version veröffentlicht wird. Führen Sie `claude plugin update last30days@last30days-skill` aus, um eine Prüfung zu erzwingen.
+
+Wenn Sie lieber den Agent-Skills-Installationspfad für Claude Code verwenden möchten, wird dies ebenfalls unterstützt:
+
+```
+npx skills add mvanhorn/last30days-skill -g -a claude-code
+```
+
+Das native Plugin und die `npx skills`-Installation können nebeneinander existieren. Beachten Sie, dass Claude Code nicht über alle Installationsmethoden hinweg dedupliziert: Wenn Sie sowohl das Marktplatz-Plugin als auch die `npx skills`-Kopie aktiv haben, zeigt `/last30days` zwei Einträge an. Verwenden Sie eine Installationsmethode pro Computer.
+
+### Grok (xAI Build CLI)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installiert last30days als natives Plugin. Die direkte Installation verfolgt das Repository:
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+Oder fügen Sie dieses Repo als Marktplatzquelle hinzu und installieren Sie es dann nach Plugin-Namen:
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+Fügen Sie `--trust` hinzu, um die Installationsbestätigung zu überspringen. Update mit `grok plugin update last30days`. Grok liest aus Kompatibilitätsgründen auch die Claude-Code-Manifeste; Das native `.grok-plugin/`-Paar ist die erstklassige Spur (und worauf ein offizieller [xAI-Marktplatz](https://github.com/xai-org/plugin-marketplace)-Eintrag hinweist). `npx skills add` bleibt ein gültiger hostübergreifender Fallback.
+
+### Codex, Cursor, Copilot, Gemini CLI und andere Agent Skills-Hosts
+
+Installation über die offene [Agent Skills](https://agentskills.io) CLI – unterstützt mehr als 50 Kabelbäume, einschließlich `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` und mehr (vollständige Liste im [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+
+```bash
+npx skills add mvanhorn/last30days-skill -g
+```
+
+Das Flag `-g` (global) wird in Ihrem Benutzerverzeichnis installiert, sodass der Skill in allen Projekten verfügbar ist. Ohne `-g` wird `npx skills` projektlokal in `./.skills/` installiert (mit dem Repo festgeschrieben). Für ein „Research-the-World“-Tool ist Globalität genau das Richtige für Sie.
+
+Codex-Desktop- und andere Ordnermodus-Hosts können sowohl in normalen Ordnern als auch in Git-Repos funktionieren. Bitten Sie vor der ersten Recherche den Host-Agenten, das gebündelte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen. Beim Auschecken einer Quelle lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Es zeigt die Konfigurationsquelle, den Browser-Cookie-Plan, geplante Schreibvorgänge, optionale Befehle und die ignorierte Projektkonfiguration an, ohne Cookies zu lesen, Dateien zu schreiben oder Recherchen durchzuführen.
+
+Standardmäßig wird dies für den von `npx skills` erkannten Kabelbaum installiert. So zielen Sie auf eine bestimmte (oder mehrere) Zielgruppe ab:
+
+```bash
+npx skills add mvanhorn/last30days-skill -g -a codex
+npx skills add mvanhorn/last30days-skill -g -a cursor
+npx skills add mvanhorn/last30days-skill -g -a gemini-cli
+npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+```
+
+Später aktualisieren mit:
+
+```bash
+npx skills update last30days -g
+```
+
+Oder aktualisieren Sie alles, was Sie global installiert haben, über `npx skills`:
+
+```bash
+npx skills update -g
+```
+
+Mit `npx skills list -g` und `npx skills remove last30days -g` auflisten und entfernen.
+
+### claude.ai (web)
+
+1. [`last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) von der neuesten Version herunterladen
+2. Gehen Sie zu [claude.ai > Anpassen > Skills](https://claude.ai/customize/skills)
+3. Klicken Sie im Bedienfeld „Fähigkeiten“ auf die Schaltfläche „`+`“ > klicken Sie auf „`Create skill`“ > „`Upload a skill`“ und durchsuchen Sie die Datei bzw. legen Sie sie dort ab
+
+Aktivieren Sie zuerst „Codeausführung und Dateierstellung“ unter „Fähigkeiten“ – ohne diese Funktion funktionieren die Fertigkeiten nicht.
+
+### Claude Desktop
+
+Claude Desktop installiert `/last30days` als MCP-Server über ein `.mcpb`-Bundle (ein One-Click-Model-Context-Protocol-Paket).
+
+1. Gehen Sie zur [neuesten Version](https://github.com/mvanhorn/last30days-skill/releases/latest) und laden Sie `.mcpb` für Ihre Plattform herunter:
+- macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+- macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+- Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Öffnen Sie Claude Desktop, gehen Sie zu Einstellungen > Erweiterungen und ziehen Sie die Datei hinein.
+3. Wenn Sie dazu aufgefordert werden, fügen Sie API-Schlüssel für die Quellen ein, die Sie aktivieren möchten. Jedes Feld ist optional – die Engine wechselt in den reinen Webmodus, wenn Sie sie alle überspringen. Schlüssel werden in Ihrem Betriebssystem-Schlüsselbund gespeichert.
+4. Starten Sie Claude Desktop neu. Bitten Sie Claude, „Peter Steinberger“ oder ein anderes Thema zu recherchieren, und das Tool `research` wird aufgerufen.
+
+**Hostanforderung:** Python 3.12+ auf PATH. Das Bundle liefert die Engine-Quelle, verwendet aber Ihren lokalen Python-Interpreter. Installation von [python.org](https://www.python.org/downloads/) unter Windows; macOS und die meisten Linux-Distributionen liefern eine kompatible Version aus.
+
+**Schlüssel werden nicht mit dem Code-Skill synchronisiert.** Claude Desktop und Claude Code verwalten von Natur aus separate Anmeldeinformationsspeicher. Wenn Sie `~/.config/last30days/.env` bereits für den Code-Skill konfiguriert haben, geben Sie die gleichen Schlüssel hier einmal erneut ein.
+
+Die Windows-Unterstützung wird zurückgestellt, bis die Manifest-Einstiegspunkte pro Plattform geklärt sind. in einer Folgeausgabe verfolgen.
+
+### OpenClaw
+
+```bash
+clawhub install last30days-official
+```
+
+Für X/Twitter-Aktionsworkflows außerhalb der `/last30days`-Recherche, z. B. Posten
+Tweets oder Antworten, Follower-Export, Medienverwaltung, Monitore und Giveaways
+zeichnet, verwenden Sie [TweetClaw](https://github.com/Xquik-dev/tweetclaw) als Begleiter
+OpenClaw-Plugin. TweetClaw wird von Xquik-dev verwaltet und ist nur als aufgeführt
+optionaler Begleitpfad, keine last30days-Abhängigkeit oder -Befürwortung.
+
+### Handbuch (Entwickler)
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill.git
+ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
+```
+
+Der Symlink hält die Installation während der Bearbeitung mit Ihrem Arbeitsbaum synchron – ein erneutes Kopieren ist nicht erforderlich. Erstellen Sie für `claude.ai` die Datei `.skill` aus der Quelle: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
+
+Reddit (mit Kommentaren), Hacker News, Polymarket und GitHub funktionieren sofort. Nullkonfiguration. Führen Sie `/last30days` einmal aus und der Setup-Assistent schaltet in 30 Sekunden weitere Quellen frei, einschließlich der kostenlosen arXiv- und Techmeme-CLIs.
+
+## Bringen Sie Ihre eigenen Schlüssel mit
+
+Diese Plattformen unterhalten keine Beziehungen untereinander. X weiß nicht, was Reddit denkt. YouTube sieht TikTok nicht. Aber Sie können Ihre eigenen API-Schlüssel und Browser-Token mitbringen und haben plötzlich Zugriff auf alle gleichzeitig.
+
+| Quellen | Was Sie brauchen | Kosten |
+|---------|---------------|------|
+| Reddit (mit Kommentaren) + HN + Polymarket + GitHub + StockTwits | Nichts | Kostenlos |
+| arXiv + Techmeme | Kostenlose CLIs, automatisch installiert bei der Erstinstallation | Kostenlos |
+| X / Twitter | Melden Sie sich in einem beliebigen Browser bei x.com an oder stellen Sie `XQUIK_API_KEY` / `XAI_API_KEY` | ein Browser-Cookies sind kostenlos; Schlüssel sind anbieterspezifisch |
+| YouTube | `brew install yt-dlp` | Kostenlos |
+| Blauer Himmel | App-Passwort von bsky.app | Kostenlos |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube-Kommentare | ScrapeCreators-Schlüssel | 10.000 kostenlose Anrufe, dann PAYG |
+| Xiaohongshu (ROT) | Führen Sie ein angemeldetes x-mcp-Browser-Plugin oder einen `xiaohongshu-mcp`-Dienst aus und melden Sie sich mit `--search xhs` pro Lauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env` an. last30days prüft automatisch `http://localhost:18060` und dann `http://host.docker.internal:18060`, oder verwenden Sie `XIAOHONGSHU_API_BASE` für eine benutzerdefinierte URL | Kein last30days-API-Schlüssel; hängt von Ihrem lokalen Browser-Sitzungsdienst ab |
+| DripStack (Premium-Finanz-Newsletter) | Opt-in: `--search dripstack` pro Lauf oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Such-API |
+| Perplexity Sonar / Such-API / Deep Research | Perplexity-Schlüssel oder OpenRouter-Schlüssel als Sonar-Fallback | Zahlen Sie nach Belieben |
+| Websuche | Brave-Suchschlüssel | 2.000 kostenlose Abfragen/Monat |
+
+### macOS-Schlüsselbund (optional)
+
+Unter macOS können Sie Schlüssel im System-Schlüsselbund statt in einer `.env`-Datei speichern. Der Skill erkennt sie automatisch als Quelle mit der niedrigsten Priorität – `.env`-Dateien und Prozessumgebung gewinnen bei Kollisionen immer noch.
+
+```bash
+# Interactive setup — prompts for each known key, skip with empty input
+skills/last30days/scripts/setup-keychain.sh
+
+# Or store a single key by hand
+security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
+
+# Inspect / clean up
+skills/last30days/scripts/setup-keychain.sh --list
+skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
+```
+
+Elemente werden unter dem Dienstnamen `last30days-<KEY>` für den aktuellen Benutzer gespeichert. Auf Nicht-Darwin-Plattformen ist der Loader ein No-Op, sodass es für Linux-/Windows-Benutzer keine Verhaltensänderung gibt.
+
+Besitzen Sie bereits Schlüssel unter verschiedenen Namen des Schlüsselbunddienstes? Legen Sie die in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschriebene nicht geheime `LAST30DAYS_KEYCHAIN_ALIASES`-Zuordnung fest, anstatt Geheimnisse zu kopieren.
+
+Unter [CONFIGURATION.md](CONFIGURATION.md) finden Sie die vollständige Schlüsselmatrix pro Quelle, die Argumentationsanbieterpriorität und die Back-End-Priorität für die Websuche.
+
+## Konfiguration
+
+Zwei Dinge, die Sie wahrscheinlich am ersten Tag wissen wollen:
+
+**Wo Forschungsdateien gespeichert werden.** `LAST30DAYS_MEMORY_DIR` ist standardmäßig `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreiben Sie dies, indem Sie diese Umgebungsvariable auf einen beliebigen Pfad in Ihrer Shell oder auf `--save-dir <path>` pro Lauf festlegen. Verwenden Sie `--output <file>`, wenn Sie das gerenderte Ergebnis in einem exakten Pfad benötigen, und verwenden Sie dabei das von `--emit` ausgewählte Format. Verwenden Sie `--save-suffix=<name>`, um mehrere Variationen desselben Themas getrennt zu halten (z. B. pro Kunde). Jeder `--save-dir`-Lauf erzeugt `<slug>-raw[-suffix].md`. Führen Sie `python3 skills/last30days/scripts/last30days.py --preflight` aus, um geplante Schreibvorgänge vor einem Forschungslauf zu überprüfen.
+
+**Strukturierte Ausgabe für Agenten und Workflows.** Fragen Sie `/last30days` nach maschinenlesbarem JSON, um das stabile, versionierte Agentenprofil zu erhalten. Für die direkte Verwendung der Engine in Skripten oder bei der Entwicklung führen Sie `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` aus; Fügen Sie `--json-profile=raw` nur hinzu, wenn Sie den unversionierten internen `Report`-Dump benötigen. Siehe die [JSON-Exportfeldreferenz und Versionierungsrichtlinie](docs/reference/json-export.md).
+
+**Themenlose Entdeckung.** Bitten Sie `/last30days what's trending in AI agents?` darum, eine Rangfolge-Entdeckungsbeschreibung zu erhalten, anstatt ein Thema zu recherchieren, das Sie bereits kennen. Auf einem Agent-Host wird dadurch das vom Host beurteilte Protokoll mit drei Befehlen ausgeführt (das Modell benennt Themen, filtert Junk, bewertet die Würdigkeit und schreibt die Inhaltsaspekte). Für die direkte Verwendung der Engine in Skripten oder Cron führen Sie `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (einmalig: deterministische Themennamen, keine Winkel); Fügen Sie `--emit=json` für den versionierten Discovery-Vertrag hinzu. Die Entdeckung schließt sich gegenseitig mit einem Positionsthema und `--drill` aus.
+
+**Trendüberwachung über Läufe hinweg.** Der Standardmodus erzeugt pro Lauf einen neuen Markdown-Snapshot. Um Ergebnisse im Laufe der Zeit zu sammeln, fügen Sie `--store` hinzu, um sie in einer SQLite-Datenbank zu speichern, und verwenden Sie dann [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) für geplante Ausführungen (mit optionaler Slack-/Webhook-Bereitstellung für neue Ergebnisse) und [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche/wöchentliche Zusammenfassungen. Das vollständige Trittfrequenzmuster finden Sie in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+
+**Eine abonnierbare Forschungsbibliothek.** Bitten Sie `/last30days`, Ihren Bibliotheks-Feed zu erstellen, oder verwenden Sie `python3 skills/last30days/scripts/last30days.py library feed` direkt für die Skripterstellung und Entwicklung. Es wandelt gespeicherte Kurzbriefe in `index.html`, einen lokalen Atom `feed.xml` und lesbare Kurzbriefseiten um. Fügen Sie `--publish` nur hinzu, wenn Sie den HTML-Index und die kurzen Seiten hosten möchten. Die Veröffentlichung erfolgt standardmäßig mit ausdrücklicher Einwilligung und ist öffentlich. Um den Atom-Feed abonnierbar zu machen, hosten Sie das generierte Ausgabeverzeichnis auf einem statischen Host wie GitHub Pages.
+
+**Durchsuchen Sie alles, was Sie recherchiert haben.** Fragen Sie `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für den direkten Motorgebrauch `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` ausführen. Die Suche ist offline und deterministisch: Sie indiziert inkrementell dieselben gespeicherten Briefings, die vom Bibliotheks-Feed verwendet werden, führt übereinstimmende Filialsichtungen pro Durchlauf zusammen und gruppiert die Ergebnisse nach Thema und Datum. Bei neuen Durchläufen wird auch ein kompakter Abschnitt „Aus Ihrer Bibliothek“ angezeigt, wenn sich frühere Recherchen mit dem aktuellen Thema überschneiden. Legen Sie `LAST30DAYS_LIBRARY_CONTEXT=off` fest, um diesen passiven Kontext zu deaktivieren.
+
+Client-spezifische Wrapper-Skripte, benutzerdefinierte Kategorie-Peer-Subreddits und der experimentelle Beta-Kanal für laufende Anpassungen sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md) dokumentiert.
+
+## Showcase: Community-Recherche-Feeds
+
+Haben Sie ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine wunderbar enge Obsession mit last30days veröffentlicht? Teilen Sie die URL der öffentlichen Bibliothek – oder die Atom-URL nach dem Hosten von `feed.xml` auf einem statischen Host – im [Community-Showcase-Thread](https://github.com/mvanhorn/last30days-skill/issues/532). Community-Feeds werden hier verlinkt, sobald ihre Besitzer sie einreichen. Der Thread ist in der Zwischenzeit der Sammelpunkt.
+
+## Wie es funktioniert
+
+1. **Sie geben ein Thema ein.** Person, Unternehmen, Produkt, Technologie, „X vs. Y.“ Irgendetwas.
+2. **Der Agent entscheidet, wer zählt.** Findet X-Handles (einschließlich Gründer), GitHub-Repos, Subreddits, TikTok-Hashtags und YouTube-Kanäle. Für „Kanye West“ gibt es R/Hiphopheads, @kanyewest und „Bully Review“ auf YouTube. Für „OpenClaw“ löst es openclaw/openclaw auf GitHub auf und ruft Live-Star-Zählungen ab.
+3. **Alle Quellen werden parallel durchsucht.** Erweiterung mit mehreren Abfragen. Ergebnisse bewertet nach Engagement, Relevanz und Aktualität.
+4. **Die Tiefe, die niemand sonst hat.** Vollständige YouTube-Transkripte von Reaktionsvideos. Top-Reddit-Kommentare mit Upvote-Zählungen. TikTok-Untertitel. Polymarket-Quoten. Nicht nur Titel und Links.
+5. **Gleiche Geschichte, zusammengeführt.** Wireless Festival auf Reddit angekündigt, auf X besprochen, Ticketpreise auf TikTok = ein Cluster, nicht drei separate Artikel.
+6. **In einem Brief zusammengefasst.** Basierend auf spezifischen Daten. Zitiert nach Quelle. Geordnet nach dem, womit sich die Leute tatsächlich beschäftigen. Nicht „Hier ist, was ich gefunden habe.“ Es heißt: „Hier kommt es darauf an.“
+7. **Dann wird es Ihr Experte.** Nach einem Durchlauf weiß Ihre Claude-Sitzung alles, was die Community weiß. Stellen Sie weitere Fragen. Lassen Sie Eingabeaufforderungen schreiben, E-Mails entwerfen, Reisen planen und Systeme erstellen – alles basiert auf dem, was gerade real ist.
+
+## Was die Leute sagen
+
+> „Ich habe einen Claude-Code-Skill gefunden, der jedes Thema der letzten 30 Tage auf Reddit, -@itsjasonai
+
+> „Diese eine Fähigkeit hat meinen gesamten Recherche-Workflow ersetzt. Sie geben ihm ein Thema, es durchsucht Reddit, X und das Web nach dem, worüber die Leute tatsächlich sprechen. Keine alten Blog-Beiträge. Echte Gespräche der letzten 30 Tage.“ -@itswilsoncharles
+
+> „5 der 10 angesagten Repos auf GitHub sind heute Claude-Tools. #1: mvanhorn/last30days-skill“ -@yieldhunter95
+
+## Open Source
+
+MIT-Lizenz. Keine Nachverfolgung. Keine Analyse. Ihre Forschung bleibt auf Ihrem Computer. Über 2.700 Tests.
+
+Gebaut mit Python 3.12+, yt-dlp, Node.js (vom Anbieter bereitgestellter Bird-Client für die X-Suche) und der ScrapeCreators-API. v3-Engine-Architektur von [@j-sperling](https://github.com/j-sperling).
+
+Siehe [CONTRIBUTING.md](CONTRIBUTING.md) zum Öffnen einer PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) für die vollständige Liste der Community-Mitwirkenden und [CHANGELOG.md](CHANGELOG.md) für den Versionsverlauf.
+
+## Sterngeschichte
+
+<a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+  </picture>
+</a>
+
+---
+
+**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)

--- a/README.de.md
+++ b/README.de.md
@@ -16,151 +16,151 @@
   </a>
 </p>
 
-**Eine von KI-Agenten geführte Suchmaschine, die durch Upvotes, Likes und echtes Geld bewertet wird – nicht durch Redakteure.**
+**Eine von KI-Agenten geführte Suchmaschine, bewertet durch Upvotes, Likes und echtes Geld – nicht durch Redakteure.**
 
-Diese README-Datei verfolgt die aktuelle v3-Pipeline. Die Laufzeit-Skill-Spezifikation befindet sich in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), was die Quelle der Wahrheit für das neueste Befehls- und Setup-Verhalten ist.
+Dieses README verfolgt die aktuelle v3-Pipeline. Die Runtime-Skill-Spezifikation befindet sich in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), was die Quelle der Wahrheit für das neueste Befehls- und Setup-Verhalten ist.
 
-**Claude Code (empfohlen – automatische Updates über den Marktplatz):**
+**Claude Code (empfohlen — automatische Aktualisierungen über den Marktplatz):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI oder einer von über 50 [Agent Skills](https://agentskills.io)-Hosts:**
+**Codex, Cursor, Copilot, Gemini CLI, oder einer von 50+ [Agent Skills](https://agentskills.io) Hosts:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` wird global für Ihren Benutzer installiert und ist in allen Projekten verfügbar. Legen Sie es auf den Bereich pro Projekt ab.)
+(`-g` installiert sich global für deinen Nutzer und ist in allen Projekten verfügbar. Setze es in den Umfang pro Projekt.)
 
-Weitere Installationsoptionen (claude.ai web, OpenClaw, manuell) finden Sie unten im Abschnitt [Installation](#installieren).
+Weitere Installationsoptionen (claude.ai Web, OpenClaw, Handbuch) im folgenden Abschnitt [Install](#installation) .
 
-Keine Konfiguration. Reddit, HN, Polymarket und GitHub funktionieren sofort. Führen Sie es einmal aus und der Einrichtungsassistent schaltet X, YouTube, TikTok, arXiv, Techmeme und mehr in 30 Sekunden frei.
+Null Konfiguration. Reddit, HN, Polymarketund GitHub funktionieren sofort. Führe es einmal aus und der Setup-Wizard schaltet X, YouTube, TikTok, arXiv, Techmemeund mehr in 30 Sekunden frei.
 
 ---
 
-Reddit-Upvotes. X mag. YouTube-Transkripte. TikTok-Engagement. Polymarket-Quoten, gestützt durch echtes Geld und Insiderinformationen. Das sind Millionen von Menschen, die jeden Tag mit ihrer Aufmerksamkeit und ihrem Geldbeutel abstimmen. /last30days durchsucht alles parallel, bewertet es danach, womit sich echte Menschen tatsächlich beschäftigen, und ein KI-Agent-Juror fasst es in einem Briefing zusammen.
+Reddit Upvotes. X Likes. YouTube Transkripte. TikTok Engagement. Polymarket Chancen, die durch echtes Geld und Insiderinformationen gestützt sind. Das sind Millionen von Menschen, die jeden Tag mit Aufmerksamkeit und Geldbörse abstimmen. /last30days durchsucht alles parallel, bewertet es nach dem, worauf echte Menschen tatsächlich interagieren, und ein KI-Agenten-Richter fasst es zu einem Briefing zusammen.
 
-Google fasst Redakteure zusammen. /last30days durchsucht Personen.
+Google aggregiert Redakteure. /last30days sucht nach Leuten.
 
-Sie können diese Suche nirgendwo anders erhalten, da keine einzelne KI Zugriff auf alles hat. Die Google-Suche berührt keine Reddit-Kommentare oder X-Beiträge. ChatGPT hat einen Deal mit Reddit, kann aber weder X noch TikTok durchsuchen. Gemini hat YouTube, aber nicht Reddit. Claude hat von Haus aus keine davon. Jede Plattform ist ein ummauerter Garten mit eigener API, eigenen Token und eigener Authentifizierung. Aber Sie können Ihre eigenen Schlüssel und Browsersitzungen mitbringen, und plötzlich kann ein KI-Agent alle auf einmal durchsuchen, sie miteinander vergleichen und Ihnen sagen, worauf es wirklich ankommt.
+Du kannst diese Suche nirgendwo anders bekommen, weil keine einzelne KI Zugriff auf alles hat. Google Suche berührt Reddit Kommentare oder X Beiträge nicht. ChatGPT hat einen Deal mit Reddit , kann aber nicht X oder TikToksuchen. Gemini hat YouTube , aber nicht Reddit. Claude hat keine davon nativ. Jede Plattform ist ein abgeschotteter Garten mit eigenem API, eigenen Tokens, eigener Authentifizierung. Aber du kannst deine eigenen Schlüssel und Browsersitzungen mitbringen, und plötzlich kann ein KI-Agent alle gleichzeitig durchsuchen, sie gegeneinander bewerten und dir sagen, was wirklich zählt.
 
-Das ist die Freischaltung. Keine bessere Suchmaschine. Ein Dutzend nicht verbundener Plattformen, überbrückt von einem Agenten.
+Das ist die Entsperrung. Keine bessere Suchmaschine. Ein Dutzend getrennte Plattformen, von einem Agenten überbrückt.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Du hast morgen ein Treffen. Sie googeln sie. Sie erhalten ihr LinkedIn ab 2023. /last30days zeigt Ihnen, was sie diesen Monat tatsächlich tun: Sie sind OpenAI beigetreten, um an Codex zu arbeiten, kämpfen gegen das Verbot von Drittanbieter-Agenten durch Anthropic, versenden 23 PRs mit einer Zusammenführungsrate von 85 %, entwickeln „LobsterOS“ für die geräteübergreifende Agentenkontrolle und r/ClaudeCode erreichte 569 positive Stimmen bei der Debatte darüber, ob er ein Held oder „unerträglich“ ist. Verstreut über X-Posts, Reddit-Threads, YouTube-Transkripte und GitHub-Commits. Nichts davon war bei Google.
+Du hast morgen ein Meeting. Du Google sie. Du bekommst ihre LinkedIn von 2023. /last30days zeigt dir, was sie diesen Monat tatsächlich machen: OpenAI beigetreten, um an Codexzu arbeiten, gegen Anthropic's Verbot von Drittanbieteragenten zu kämpfen, 23 PRs mit 85 % Merge Rate ausgeliefert, "LobsterOS" für geräteübergreifende Agentensteuerung gebaut und r/ClaudeCode erreichte 569 Upvotes, in denen diskutiert wurde, ob er ein Held oder "unerträglich" ist. Über X Beiträge verteilt, Reddit Threads, YouTube Transkripte und GitHub Commits. Nichts davon war auf Google.
 
 ## Warum das existiert
 
-Ich habe es gebaut, um in der KI mithalten zu können. Alles ändert sich jeden Tag und die Reddit- und X-Nerds sind immer die Ersten, die den Überblick behalten. Ich brauchte bessere Eingabeaufforderungen und die Trainingsdaten lagen immer Monate hinter dem zurück, was die Community bereits herausgefunden hatte.
+Ich habe es gebaut, um mit KI Schritt zu halten. Alles ändert sich jeden Tag und die Reddit und X Nerds sind immer zuerst dran. Ich brauchte bessere Prompts, und die Trainingsdaten lagen immer Monate hinter dem, was die Community bereits herausgefunden hatte.
 
-Aber es wurde etwas Größeres. Jetzt führe ich es vor einem Verkaufsgespräch durch, um die Wahrheit über ein Unternehmen in den letzten 30 Tagen zu erfahren. Vor einem Meeting die neuesten Tweets und Podcast-Transkripte einer anderen Person lesen. Informieren Sie sich vor einer Disney World-Reise darüber, welche Fahrgeschäfte geschlossen sind und was die Community über Genie+ sagt. Bevor ich etwas baue, muss ich wissen, auf welche Probleme die Leute tatsächlich stoßen.
+Aber daraus wurde etwas Größeres. Jetzt führe ich es vor einem Verkaufsgespräch durch, um die Wahrheit der letzten 30 Tage über ein Unternehmen zu erfahren. Vor einem Meeting, um die aktuellen Tweets und Podcast-Transkripte von jemandem zu lesen. Vor einer Disney World Reise, um zu wissen, welche Fahrgeschäfte geschlossen sind und was die Community über Genie+sagt. Bevor ich etwas entwickle, um zu wissen, auf welche Probleme die Leute tatsächlich stoßen.
 
-Wenn Sie sich mit einem CEO treffen, haben Sie dann alle Tweets und YouTube-Transkripte der letzten 30 Tage gelesen? Ich habe.
+Wenn du dich mit einem CEO triffst, hast du alle Tweets und YouTube Transkripte der letzten 30 Tage gelesen? Ja, habe ich.
 
-## Quellen, bewertet von den Leuten
+## Quellen, von den Leuten bewertet
 
-| Quelle | Was die Leute dir sagen |
+| Quelle | Was die Leute dir sagen. |
 |--------|--------------------------|
-| **Reddit** | Der ungefilterte Take. Top-Kommentare mit echten Upvote-Zählungen, kostenlos, kein API-Schlüssel. Die wahren Meinungen, die Google vergräbt. |
-| **X / Twitter** | Der heiße Take, der Expertenthread, die bahnbrechende Reaktion. Zuerst wissen, zuerst argumentieren. |
-| **YouTube** | Der 45-minütige Tieftauchgang. Vollständige Transkripte wurden nach den fünf zitierfähigen Sätzen durchsucht, auf die es ankommt. |
-| **TikTok** | Der Ersteller erreicht 3,6 Millionen Menschen mit einer Einstellung, die Sie bei Google nie finden werden. |
-| **Instagram-Reels** | Die Influencer-Perspektive mit Spoken-Word-Transkripten. Das visuelle Kultursignal. |
-| **Hacker-News** | Der Entwicklerkonsens. 825 Punkte, 899 Kommentare. Wo technische Leute tatsächlich streiten. |
-| **Polymarkt** | Keine Meinungen. Chancen. Unterstützt durch echtes Geld. 96 % Vertrauen in die Albumverkäufe. 4 % bei einer Akquisition. |
-| **GitHub** | Für Leute: PR-Geschwindigkeit, Top-Repos nach Stars, Versionshinweise. Für Themen: Probleme und Diskussionen. |
-| **Digg** | Kuratierte Story-Cluster aus Diggs AI 1000-Bestenliste (~1000 AI-Konten mit hohem Signalwert auf X) mit zuordenbaren Inline-Zitaten (keine X-Authentifizierung erforderlich). Automatisch aktiviert, wenn sich `digg-pp-cli` auf PATH befindet. |
-| **arXiv** | Die Papiere hinter dem Hype. Neue Recherche im Fenster, kostenlos, kein API-Schlüssel. Automatisch aktiviert, wenn sich `arxiv-pp-cli` auf PATH befindet (das Setup beim ersten Start installiert es). |
-| **Techmeme** | Die redaktionelle Ebene der Tech-News, mit Datumsfenster für Ihre 30 Tage. Kostenlos, kein API-Schlüssel. Automatisch aktiviert, wenn sich `techmeme-pp-cli` auf PATH befindet (das Setup beim ersten Start installiert es). |
-| **LinkedIn** | Das professionelle Signal. Beiträge und Artikel, wobei die Artikel als hohes Signal gewichtet werden. |
-| **StockTwits** | Händlerstimmung. Wird automatisch aktiviert, wenn es sich bei Ihrem Thema um einen Ticker oder eine Kryptowährung handelt. |
-| **Threads** | Die Post-Twitter-Textebene. Gespräche von YouTubern und Marken. |
-| **Pinterest** | Visuelle Entdeckung. Pins, Speicherungen und Kommentare zu Produkten und Ideen. |
-| **Xiaohongshu (ROT)** | Chinesische Lifestyle-, Produkt- und Schöpfersignale. Wird explizit mit `--search xhs` angefordert, wenn ein angemeldetes x-mcp-Browser-Plugin oder ein `xiaohongshu-mcp`-Dienst lokal ausgeführt wird. |
-| **Bluesky** | Die dezentrale soziale Schicht. AT-Protokollbeiträge aus der Post-Twitter-Migration. |
-| **Perplexität** | Grounded Sonar-Synthese, rohe Such-API-Zeilen und Deep Research. |
-| **Web** | Die redaktionelle Berichterstattung, die Blog-Vergleiche. Ein Signal von vielen, nicht das einzige. |
+| **Reddit** | Die ungefilterte Sichtweise. Top-Kommentare mit echten Upvote-Zählen, kostenlos, kein API Schlüssel. Die echten Meinungen, die Google vergräbt. |
+| **X / Twitter** | Die heiße Meinung, der Experten-Thread, die Bruchreaktion. Zuerst weiß er, streitet zuerst. |
+| **YouTube** | Der 45-minütige Tieftauchgang. Vollständige Transkripte, gesucht nach den 5 zitierfähigen Sätzen, die zählen. |
+| **TikTok** | Der Creator erreicht 3,6 Millionen Leute mit einer Einnahme, die du auf Googlenie finden wirst. |
+| **Instagram Reels** | Die Influencer-Perspektive mit gesprochenen Transkripten. Das visuelle Kultursignal. |
+| **Hacker News** | Der Konsens der Entwickler. 825 Punkte, 899 Kommentare. Wo Techniker tatsächlich streiten. |
+| **Polymarket** | Nicht Meinungen. Chancen. Gedeckt durch echtes Geld. 96% Vertrauen bei Albumverkäufen. 4% bei einer Übernahme. |
+| **GitHub** | Für Personen: PR Geschwindigkeit, Top-Repos nach Sternen, Veröffentlichungshinweise. Für Themen: Themen und Diskussionen. |
+| **Digg** | Kuratierte Story-Cluster aus der AI 1000-Bestenliste von Digg(~1000 High-Signal-KI-Konten auf X), mit zuschreibbaren Inline-Quotes (keine X Authentifizierung erforderlich). Automatisch aktiviert, wenn `digg-pp-cli` auf PATHist. |
+| **arXiv** | Die Papiere hinter dem Hype. Neue Forschung im Fenster, kostenlos, kein API Schlüssel. Automatisch aktiviert, wenn `arxiv-pp-cli` PATH aktiviert ist (Erstlauf-Setup installiert es). |
+| **Techmeme** | Die Tech-News-Redaktionsebene, datumsabhängig auf deine 30 Tage. Kostenlos, kein API Schlüssel. Automatisch aktiviert, wenn `techmeme-pp-cli` PATH aktiviert ist (Erstlauf-Setup installiert es). |
+| **LinkedIn** | Das professionelle Signal. Beiträge und Artikel, wobei Artikel als High Signal gewichtet sind. |
+| **StockTwits** | Händler-Gefühl. Aktiviert sich automatisch, wenn Ihr Thema ein Ticker oder eine Krypto-Karte ist. |
+| **Threads** | Die Post-Twitter-Textebene. Gespräche von Schöpfern und Marken. |
+| **Pinterest** | Visuelle Entdeckung. Pins, Speicherstände und Kommentare zu Produkten und Ideen. |
+| **Xiaohongshu (RED)** | Chinesischer Lebensstil, Produkt und Creator-Signale. Explizit angefordert mit `--search xhs` , wenn ein eingeloggtes x-mcp-Browser-Plugin oder `xiaohongshu-mcp` Dienst lokal läuft. |
+| **Bluesky** | Die dezentrale soziale Schicht. AT Protocol-Beiträge aus der Post-Twitter-Migration. |
+| **Perplexity** | Geerdete Sonar-Synthese, rohe Suche API Reihen und Tiefe Forschung. |
+| **Web** | Die redaktionelle Berichterstattung, die Blogvergleiche. Ein Signal von vielen, nicht das einzige. |
 
-Community-Mitwirkende fügen immer mehr hinzu. Truth Social und andere Nischenquellen sind in Arbeit, weitere sind in Vorbereitung.
+Community-Mitwirkende fügen immer mehr hinzu. Truth Social und andere Nischenquellen sind in der Engine, weitere sind unterwegs.
 
-Ein Reddit-Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blog-Beitrag, den niemand liest. Ein TikTok mit 3,6 Millionen Aufrufen verrät Ihnen mehr darüber, was kulturell relevant ist, als eine Pressemitteilung. Mit Polymarket-Quoten, die durch ein Volumen von 66.000 US-Dollar untermauert werden, lässt sich schwerer argumentieren als mit der Vermutung eines Experten.
+Ein Reddit Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blogbeitrag, den niemand gelesen hat. Ein TikTok mit 3,6 Millionen Aufrufen sagt mehr darüber aus, was kulturell relevant ist, als eine Pressemitteilung. Polymarket Quoten mit 66.000 Dollar Volumen sind schwerer zu bestreiten als die Vermutung eines Experten.
 
-Die Synthese orientiert sich daran, womit sich echte Menschen tatsächlich beschäftigt haben. Soziale Relevanz, nicht SEO-Relevanz.
+Die Synthese rangiert nach dem, womit echte Menschen tatsächlich beschäftigt waren. Soziale Relevanz, nicht SEO Relevanz.
 
-## Wofür die Leute es tatsächlich verwenden
+## Wofür die Leute es tatsächlich nutzen
 
-**Vor einem Meeting.** `/last30days Peter Steinberger` – trat dem Codex-Team von OpenAI bei und kämpfte gegen das Verbot von Drittanbieter-Agenten durch Anthropic. 23 PRs wurden mit einer Zusammenführungsrate von 85 % auf GitHub zusammengeführt und LobsterOS für die geräteübergreifende Agentensteuerung entwickelt. r/ClaudeCode: „Seit der Veröffentlichung von OpenClaw war allgemein bekannt, dass man irgendwann gesperrt wird, wenn man es über etwas anderes als die API ausführt“ (227 positive Stimmen). Das ist nicht auf LinkedIn.
+**Vor einem Meeting.** `/last30days Peter Steinberger` – bin dem Codex-Team von OpenAIbeigetreten und habe gegen Anthropics Verbot von Drittanbieteragenten gekämpft, 23 PRs mit einer Fusionsrate von 85 % auf GitHubfusioniert und LobsterOS für geräteübergreifende Agentensteuerung gebaut. r/ClaudeCode: "Seit OpenClaw veröffentlicht wurde, war allgemein bekannt, dass man, wenn man es über etwas anderes als das APIlaufen lässt, irgendwann gebannt wird" (227 Upvotes). Das liegt nicht an LinkedIn.
 
-**Zum Lesen von Einstellungssignalen.** `/last30days Listen Labs --hiring-signals` – Aktuelle Stellen- und Karriereseiten werden zu zitierten Beweisen für Schwerpunktverlagerungen: Einstellungen in den Bereichen Unternehmenssicherheit, Kundenerfolg, Infrastruktur oder Produkterweiterung. Der Bericht sagt, was die Einstellung zu signalisieren scheint, nicht was die Roadmap bewirken wird.
+**Um Einstellungssignale zu lesen.** `/last30days Listen Labs --hiring-signals` – aktuelle Job- und Karriereseiten werden zu zitierten Belegen für Fokusverschiebungen: Einstellungen in Unternehmenssicherheit, Kundenerfolg, Infrastruktur oder Produktexpansion. Der Bericht sagt, was die Einstellung zu signalisieren scheint, nicht was die Roadmap liefern wird.
 
-**Um das Thema zu finden, bevor es seinen Höhepunkt erreicht.** Fragen Sie `/last30days what's exploding in AI agents?` und der Skill wechselt in den Entdeckungsmodus: Die Engine durchsucht Reddit-Kategorielisten, Hacker News-Front/Best-Storys, Diggs AI 1000-Feed und X, wenn sie authentifiziert ist; Ihr Agent beurteilt die Nominierungen (Namen, Junk-Filterung, Inhaltswürdigkeit) und schreibt Podcast-/X-Artikel-Betrachtungen; dann erhalten Sie 5–10 Themen mit Geschwindigkeitsranking. Zu jedem Ergebnis gehören quellenübergreifende Zahlen, ein Momentum-Label und ein sofort einsatzbereites `/last30days "<topic>"`-Follow-up.
+**Um das Thema zu finden, bevor es seinen Höhepunkt erreicht.** Frag `/last30days what's exploding in AI agents?` und die Fähigkeit wechselt in den Discovery-Modus: Die Engine durchsucht Reddit Kategorienlisten, Hacker News Front-/Best-Stories, den AI 1000-Feed von Diggund X bei Authentifizierung; dein Agent bewertet die Nominierungen (Namen, Junk-Filtering, Inhaltswertigkeit) und schreibt Podcast-/ X-Artikel-Winkel; dann bekommst du 5–10 Velocity-bewertete Themen. Jedes Ergebnis enthält Querseitennummern, ein Momentum-Label und eine startklare `/last30days "<topic>"` Folge.
 
-**Wenn etwas ausfällt.** `/last30days Kanye West` – Großbritannien hat sein Visum blockiert, das Wireless Festival abgesagt, Sponsoren sind geflohen. Aber BULLY debütierte auf Platz 2 der Billboard-Charts. Fantano kam von seinem „Yay Sabbatical“ zurück, um es zu rezensieren (653.000 Aufrufe). SoFi Homecoming brachte Lauryn Hill und Travis Scott für 44 Songs heraus. Polymarket: „Wird Kanye erneut twittern?“ 86 % Ja. 23 Reddit-Threads, 17 YouTube-Videos, 86.000 Upvotes.
+**Wenn etwas fällt.** `/last30days Kanye West` - UK blockierte sein Visum, das Wireless Festival wurde gestrichen, Sponsoren flohen. Aber BULLY debütierte auf #2 bei Billboard. Fantano kam von seinem "Yay Sabbatical" zurück, um es zu rezensieren (653.000 Aufrufe). SoFi Homecoming brachte Lauryn Hill und Travis Scott für 44 Songs heraus. Polymarket: "Wird Kanye wieder twittern?" 86% Ja. 23 Reddit Threads, 17 YouTube Videos, 86.000 Upvotes.
 
-**Zum Vergleichen von Werkzeugen.** `/last30days OpenClaw vs Hermes vs Paperclip` – „Das sind keine Konkurrenten, es sind Schichten.“ OpenClaw ist der Vollstrecker (351.000 GitHub-Sterne, live), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Die Anzahl der Sterne wird live von der GitHub-API abgerufen, nicht von veralteten Blogbeiträgen. Side-by-Side-Tisch mit Architektur, Speicher, Sicherheit, Best-for. Per @IMJustinBrooke: „OpenClaw = Charmander, Hermes = Charizard.“
+**Um Werkzeuge zu vergleichen.** `/last30days OpenClaw vs Hermes vs Paperclip` – "Das sind keine Konkurrenten, das sind Schichten." OpenClaw ist der Testamentsvollstrecker (351.000 GitHub Sterne, live), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Sternzählungen werden live aus dem GitHub APIgezogen, nicht veraltete Blogbeiträge. Nebeneinander-Tabelle mit Architektur, Speicher, Sicherheit, Best-for. Laut @IMJustinBrooke: "OpenClaw = Glurak, Hermes = Glurak."
 
-**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Frist für die Wiedereröffnung der Straße von Hormus durch den Iran am Dienstag. Zwei US-Kampfflugzeuge abgeschossen. Öl bei 126 $/Barrel. Die IEA nannte es „die größte Versorgungsstörung in der Geschichte des globalen Ölmarktes“. Polymarket: Waffenstillstand bis 31.12. bei 74 %. 27 X-Beiträge, 10 YouTube-Videos, 20 Prognosemärkte.
+**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Deadline am Dienstag für Iran, die Straße von Hormus wieder zu öffnen. Zwei US-Kampfflugzeuge abgeschossen. Öl zu 126 Dollar pro Barrel. Die IEA bezeichnete es als "die größte Versorgungsstörung in der Geschichte des globalen Ölmarktes." Polymarket: Waffenstillstand bis zum 31. Dezember bei 74%. 27 X Beiträge, 10 YouTube Videos, 20 Prognosemärkte.
 
-**Vor einer Reise.** `/last30days Universal Epic Universe` – Erweiterung bereits im Bau. Genehmigung für „Projekt 680“ eingereicht. Feuerwerksshow von der Infrastruktur bestätigt, aber unangekündigt. Wartezeiten: Mine-Cart Madness durchschnittlich 148 Minuten. Noch gibt es keine Jahreskarte und die Einheimischen sind frustriert. Stardust Racers wegen Renovierungsarbeiten bis zum 5. April außer Betrieb.
+**Vor einer Reise.** `/last30days Universal Epic Universe` - Erweiterung bereits im Bau. "Projekt 680"-Genehmigung eingereicht. Feuerwerksshow von der Infrastruktur bestätigt, aber unangekündigt. Wartezeiten: Mine-Cart Madness dauert durchschnittlich 148 Minuten. Noch keine Jahreskarte, und die Einheimischen sind frustriert. Stardust Racers sind bis zum 5. April zur Renovierung eingestellt.
 
-**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` – JSON-strukturierte Eingabeaufforderungen ersetzen die Tag-Suppe. Das verschachtelte Format von @pictsbyai verhindert „Concept Bleeding“. Der Edit-First-Workflow übertrifft die Regeneration. Dann schreibt es Ihnen eine Produktionsaufforderung, die genau das verwendet, was die Community als funktionierend bezeichnet hat.
+**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` - JSON-strukturierte Prompts ersetzen Tag-Soup. @pictsbyaiverschachteltes Format verhindert "Concept Bleeding". Der Workflow, der zuerst auf Bearbeitung basiert, ist besser als Regeneration. Dann schreibt er dir einen Produktionsprompt, der genau das verwendet, was die Community als funktionierend bezeichnet.
 
-## Was ist neu
+## Was gibt's Neues
 
-Seit der Ankündigung von v3.3 im Mai, ab v3.11.1 (Juli 2026): 175 zusammengeführte PRs – 122 davon von 52 Community-Mitwirkenden – in 15 Veröffentlichungen. Das ist gelandet.
+Seit der Ankündigung von v3.3 im Mai, Stand v3.11.1 (Juli 2026): 175 wurden PRs fusioniert – davon 122 von 52 Community-Beitragenden – über 15 Releases verteilt. Das ist es, was gelandet ist.
 
-### Erstklassig im OpenAI Codex
+### Erste Klasse auf OpenAI Codex
 
-/last30days ist jetzt ein natives Codex-Plugin mit geführter Einrichtung – kein Port, ein Bürger erster Klasse. Renderer-fähige Zitate bedeuten, dass sich die Codex-Ausgabe wie eine kurze Zusammenfassung und nicht wie eine URL-Suppe liest (#694) und die gleiche Engine auf Claude Code-, Cursor-, Copilot-, Gemini CLI-, Claude Desktop-, OpenClaw- und über 50 Agent Skills-Hosts läuft. Codex-Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex-Authentifizierungskorrektur von [@tmchow](https://github.com/tmchow) (#698).
+/last30days ist jetzt ein natives Codex -Plugin mit geführter Einrichtung – kein Port, sondern ein erstklassiger Bürger. Renderer-bewusste Zitate bedeuten, dass Codex Ausgabe wie ein Brief statt wie eine URL-Suppe (#694) wirkt, und dieselbe Engine läuft auf Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawund 50+ Agent Skills Hosts. Codex Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex Authentifizierungskorrektur von [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmeme und Digg – kostenlos, keine API-Schlüssel
+### arXiv, Techmemeund Digg – kostenlos, keine API Schlüssel
 
-arXiv bringt die Papiere hinter dem Hype und Techmeme bringt die redaktionelle Tech-News-Ebene – kostenlos, keine Schlüssel und das Erstinstallationssetup installiert ihre CLIs, sodass sie automatisch aktiviert werden (#709). Die AI 1000-Story-Cluster von Digg kommen auf die gleiche Weise ohne X-Authentifizierung an – das Setup installiert die kostenlose Digg-CLI für Sie (#590). Trustpilot bietet Opt-in für die Recherche von Verbrauchermarken an.
+arXiv bringt die Zeitungen hinter dem Hype und Techmeme bringt die redaktionelle Tech-News-Ebene – kostenlos, null Schlüssel und First-Run-Setup installiert ihre CLI, sodass sie automatisch aktiviert werden (#709). Digg's AI 1000 Story-Cluster kommen ohne X Authentifizierung auf die gleiche Weise an – die Einrichtung installiert die kostenlose Digg CLI für dich (#590). Trustpilot Opt-in für Verbrauchermarkenforschung.
 
-### Free Reddit steigerte echte Punktzahlen und Top-Kommentare
+### Kostenlose Reddit echte Punktzahlen und Top-Kommentare hervorgebracht
 
-Die öffentliche .json-API von Reddit ist gestorben; Der freie Weg kam stärker zurück. Schlüsselloses RSS + Shreddit-Scraping (#457), dedizierte Subreddit-Erkennung mit echten Upvote-Zählungen über Arctic-Shift (#696) und eine Relevanzuntergrenze, damit ein viraler Off-Topic-Beitrag Ihr Briefing nicht kapern kann (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API-Schlüssel. Echte Punkte. Top-Kommentare inklusive.
+Redditöffentliche .json API starb; der kostenlose Weg kam stärker zurück. Schlüsselloses RSS + Shreddit-Scraping (#457), dedizierte Subreddit-Entdeckung mit echten Upvote-Zahlen über arctic-shift (#696) und ein Relevanzboden, damit ein viraler Off-Topic-Beitrag dein Briefing nicht kapern kann (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API Schlüssel. Echte Wertungen. Top-Kommentare eingeschlossen.
 
 ### Die besten Kommentare in jedem Briefing
 
-Kommentare sind jetzt eine standardmäßige Ebene für alle Quellen: Instagram-Kommentare mit rangbasierter Diversität, sodass nicht alle fünf heißen Takes aus einem Beitrag stammen (#751), YouTube-Kommentare plus ein ScrapeCreators-Transkript-Backup für den Fall, dass yt-dlp ausfällt (#637) und durch Crowd-Voting in „Best Takes“ gewichtete Kommentare, damit die witzigsten Zeilen der Community die Wertung überleben (#592, #608).
+Kommentare sind jetzt eine Standard-Ebene über Quellen hinweg: Instagram-Kommentare mit rangbasierter Diversität, damit fünf heiße Meinungen nicht alle aus einem Beitrag stammen (#751), YouTube Kommentare plus ein ScrapeCreators Transkript-Backup für den Fall, dass yt-DLP ausfällt (#637), und von der Menge gestimmte Kommentare werden in Best Takes gewichtet, damit die lustigsten Zeilen der Community die Bewertung überleben (#592, #608).
 
 ### Ein Arztbefehl
 
-Fordern Sie eine Gesundheitsprüfung an, und der Arzt führt jede Quelle durch und verschreibt dann genaue Korrekturen – welcher Schlüssel fehlt, welche CLI außerhalb von PATH liegt, welches Cookie abgelaufen ist (#753). Keine Vermutung mehr, warum X dünn zurückkam.
+Bitten Sie um eine Gesundheitsuntersuchung, der Arzt überprüft alle Quellen und verschreibt dann genaue Lösungen – welcher Schlüssel fehlt, welcher CLI fehlt PATH, welcher Keks abgelaufen ist (#753). Kein Raten mehr, warum X dünn war.
 
-### X-Suche, neu erstellt
+### X Suche, wieder aufgebaut
 
-Die X-Pipeline wurde grundlegend überarbeitet: FROM- und ABOUT-Spuren, damit sowohl die eigenen Beiträge einer Person als auch die Konversation über sie einen Rang haben (#610), personenbezogene Unterabfrage-Begriffsklärung (#611), Erstanbieter-Autorenschaftserdung mit Interaktionssignal-Rangliste (#613) und eine einzige X-Quelle mit automatischem Backend-Failover (#622). Plus ein ehrlicher `--diagnose`, der tatsächlich die Authentifizierung prüft (#609).
+Die X -Pipeline wurde grundständig überarbeitet: FROM- und ABOUT-Lanes, sodass die eigenen Beiträge und das Gespräch darüber beide rangieren (#610), person-bewusste Subquery-Disambiguierung (#611), First-Party-Autoren-Grounding mit Interaktionssignal-Ranking (#613) und eine einzelne X -Quelle mit automatischem Backend-Failover (#622). Außerdem eine ehrliche `--diagnose` , die tatsächlich die Authentifizierung prüft (#609).
 
-### Weitere Quellen sind beigetreten
+### Weitere Quellen wurden aufgenommen
 
-LinkedIn über ScrapeCreators, mit Artikeln mit hohem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits wird automatisch für Ticker- und Krypto-Themen aktiviert ([@wtiwana](https://github.com/wtiwana), #658). Perplexity wuchs mit direkten API-Modi und asynchroner Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn über ScrapeCreators, mit Artikeln mit hohem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits aktiviert sich automatisch für Ticker- und Krypto-Themen ([@wtiwana](https://github.com/wtiwana), #658). Perplexity wuchs direkt API Modi und asynchron Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Von der Community gehärtet
+### Von der Gemeinschaft gehärtet
 
-Die Sicherheitswelle war fast ausschließlich Community-Arbeit: Korrekturen gespeicherter XSS im HTML-Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), gesperrte temporäre Cookie-Dateien, Supply-Chain-gehärtetes CI mit OpenSSF Scorecard und Build-Herkunftsbescheinigung ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans plus ein PR-Abhängigkeitsüberprüfungs-Gate ([@23241a6749](https://github.com/23241a6749)), eine Testabdeckungsuntergrenze, die bei 60 % eingeführt und seitdem auf 84 % erhöht wurde ([@gourab5139014](https://github.com/gourab5139014)) und ein Hermes-Sicherheitsscan, der alle KRITISCHEN Befunde bereinigt (#768).
+Die Sicherheitswelle bestand fast ausschließlich aus Community-Arbeit: gespeicherte XSS-Korrekturen im HTML Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), gesperrte Cookie-Temp-Dateien, Supply-Chain-gehärtetes CI mit OpenSSF Scorecard und Build-Herkunftsattestation ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans sowie ein PR Abhängigkeits-Review-Gate ([@23241a6749](https://github.com/23241a6749)), ein Testdeckungsboden mit 60 % eingeführt und inzwischen auf 84 % erhöht ([@gourab5139014](https://github.com/gourab5139014)), und ein Hermes-Sicherheitsscan, der von allen KRITISCHEN Befunden freigearbeitet wurde (#768).
 
-### Reicht weiter
+### Weitere Reichweiten
 
-Hebräische und nicht-lateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-fähige Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Windows-Kompatibilitätswelle. Cookie-Extraktion aus der gesamten Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS-Schlüsselbund- und Linux-Pass(1)-Anmeldeinformationsquellen. `--as-of` historischer Rückblick ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestelltes Python 3.12 über UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Lesen der Stellenseiten eines Unternehmens. Watchlist-Deltas zwischen Läufen.
+Hebräische und nicht-lateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-bewusste Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Windows Kompatibilitätswelle. Cookie-Extraktion über die gesamte Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS Keychain und Linux Pass(1)-Berechtigungsquellen. `--as-of` historischer Rückblick ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestellt Python 3.12 über UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Lesen der Jobseiten eines Unternehmens. Watchlist-Deltas zwischen den Durchläufen.
 
-### Noch in der Box von v3
+### Immer noch in der Box von v3
 
-Die v3-Grundlagen sind alle noch vorhanden: das Gehirn vor der Forschung, das die richtigen Handles, Subreddits und Hashtags auflöst, bevor ein einzelner API-Aufruf ausgelöst wird (erstellt von [@j-sperling](https://github.com/j-sperling)); Best Takes punkten neben Relevanz auch durch Humor und Viralität; Cross-Source-Cluster-Zusammenführung; Single-Pass-Vergleiche („CLI vs. MCP“ in 3 Minuten, nicht 12); automatisch ermittelte `--competitors`-Vergleiche; GitHub-Personenmodus (`--github-user=steipete`); ELI5-Modus („eli5 on“ nach jedem Lauf); und gemeinsam nutzbare, eigenständige HTML-Briefs (`--emit=html`). Konfigurationsknöpfe befinden sich in [CONFIGURATION.md](CONFIGURATION.md).
+Die v3-Grundlagen sind alle noch vorhanden: das Pre-Research-Gehirn, das die richtigen Handles, Subreddits und Hashtags löst, bevor ein einzelner API Aufruf auslöst (von [@j-sperling](https://github.com/j-sperling)gebaut); Best Takes Bewertung von Humor und Viralität neben Relevanz; Cross-Source-Cluster-Zusammenführung; Einzelpass-Vergleiche ("CLI 1 vs. MCP" in 3 Minuten, nicht 12); automatisch entdeckte `--competitors` Vergleiche; GitHub Person-Modus (`--github-user=steipete`); ELI5 Modus ("eli5 an" nach jedem Durchlauf); und teilbare, eigenständige HTML Briefs (`--emit=html`). Konfigurationsknöpfe befinden sich in [CONFIGURATION.md](CONFIGURATION.md).
 
-## Installieren
+## Installation
 
-| Oberfläche | Installieren | Aktualisierungen |
+| Oberfläche | Installation | Aktualisierungen |
 |---------|---------|---------|
-| **Claude Code** (empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatisch über den Marktplatz oder `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` dann `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI oder einer von über 50 [Agent Skills](https://agentskills.io)-Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [`last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) herunterladen und über claude.ai hochladen > Anpassen > Fertigkeiten > + > Fertigkeit erstellen > Fertigkeit hochladen | Erneut herunterladen und erneut hochladen |
-| **Claude Desktop** | [Laden Sie `.mcpb` für Ihre Plattform herunter](https://github.com/mvanhorn/last30days-skill/releases/latest) und ziehen Sie es in Einstellungen > Erweiterungen | Laden Sie das neue Paket erneut herunter und ziehen Sie es in |
+| **Claude Code**(empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto über Marktplatz oder `claude plugin update last30days@last30days-skill` |
+| **Grok**(xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` dann `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLIoder einer von 50+ [Agent Skills](https://agentskills.io) Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(Web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) und hochladen über claude.ai > > Fähigkeiten anpassen > + > Fertigkeit erstellen > eine Fähigkeit hochladen | Neues Herunterladen und erneutes Hochladen |
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) und ziehen in Einstellungen > Erweiterungen | Lade das neue Bundle neu herunter und ziehe es hinein |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (empfohlen)
@@ -169,46 +169,46 @@ Die v3-Grundlagen sind alle noch vorhanden: das Gehirn vor der Forschung, das di
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Empfohlen, da der Claude Code-Marktplatz Aktualisierungen für Sie übernimmt – der Plugin-Cache ist versioniert und wird automatisch aktualisiert, wenn eine neue Version veröffentlicht wird. Führen Sie `claude plugin update last30days@last30days-skill` aus, um eine Prüfung zu erzwingen.
+Empfohlen, weil der Claude Code Marktplatz Updates für dich verarbeitet – der Plugin-Cache ist versioniert und aktualisiert sich automatisch, wenn eine neue Version veröffentlicht wird. Führe `claude plugin update last30days@last30days-skill` aus, um eine Überprüfung zu erzwingen.
 
-Wenn Sie lieber den Agent-Skills-Installationspfad für Claude Code verwenden möchten, wird dies ebenfalls unterstützt:
+Wenn du lieber den Agent-Skills-Installationspfad auf Claude Codenutzen möchtest, wird das ebenfalls unterstützt:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-Das native Plugin und die `npx skills`-Installation können nebeneinander existieren. Beachten Sie, dass Claude Code nicht über alle Installationsmethoden hinweg dedupliziert: Wenn Sie sowohl das Marktplatz-Plugin als auch die `npx skills`-Kopie aktiv haben, zeigt `/last30days` zwei Einträge an. Verwenden Sie eine Installationsmethode pro Computer.
+Das native Plugin und die `npx skills` Installation können koexistieren. Beachte, dass Claude Code nicht über Installationsmethoden hinweg dedupliziert: Wenn du sowohl das Marketplace-Plugin als auch die `npx skills` Kopie aktiv hast, werden `/last30days` zwei Einträge angezeigt. Nutze pro Maschine eine Installationsmethode.
 
 ### Grok (xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installiert last30days als natives Plugin. Die direkte Installation verfolgt das Repository:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) Installationen dauern 30 Tage als natives Plugin. Die direkte Installation verfolgt das Repository:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Oder fügen Sie dieses Repo als Marktplatzquelle hinzu und installieren Sie es dann nach Plugin-Namen:
+Oder füge dieses Repository als Marktplatzquelle hinzu und installiere dann nach Plugin-Namen:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Fügen Sie `--trust` hinzu, um die Installationsbestätigung zu überspringen. Update mit `grok plugin update last30days`. Grok liest aus Kompatibilitätsgründen auch die Claude-Code-Manifeste; Das native `.grok-plugin/`-Paar ist die erstklassige Spur (und worauf ein offizieller [xAI-Marktplatz](https://github.com/xai-org/plugin-marketplace)-Eintrag hinweist). `npx skills add` bleibt ein gültiger hostübergreifender Fallback.
+Füge `--trust` hinzu, um die Installationsbestätigung zu überspringen. Aktualisiere mit `grok plugin update last30days`. Grok liest auch die Claude Code Manifeste zur Kompatibilität; das native `.grok-plugin/` -Paar ist die First-Class-Lane (und was ein offizieller [xAI marketplace](https://github.com/xai-org/plugin-marketplace) auflistet). `npx skills add` bleibt ein gültiger Cross-Host-Fallback.
 
-### Codex, Cursor, Copilot, Gemini CLI und andere Agent Skills-Hosts
+### Codex, Cursor, Copilot, Gemini CLIund andere Agent Skills Hosts
 
-Installation über die offene [Agent Skills](https://agentskills.io) CLI – unterstützt mehr als 50 Kabelbäume, einschließlich `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` und mehr (vollständige Liste im [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Installieren Sie über die offene [Agent Skills](https://agentskills.io) CLI – unterstützt 50+ Kabelbäume, darunter `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`und mehr (vollständige Liste auf dem [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-Das Flag `-g` (global) wird in Ihrem Benutzerverzeichnis installiert, sodass der Skill in allen Projekten verfügbar ist. Ohne `-g` wird `npx skills` projektlokal in `./.skills/` installiert (mit dem Repo festgeschrieben). Für ein „Research-the-World“-Tool ist Globalität genau das Richtige für Sie.
+Das `-g` (globale) Flag wird in deinem Benutzerverzeichnis installiert, sodass die Skill in allen Projekten verfügbar ist. Ohne `-g`installiert `npx skills` projektlokal in `./.skills/` (mit dem Repository committiert). Für ein Research-the-World-Tool ist global das Richtige dafür.
 
-Codex-Desktop- und andere Ordnermodus-Hosts können sowohl in normalen Ordnern als auch in Git-Repos funktionieren. Bitten Sie vor der ersten Recherche den Host-Agenten, das gebündelte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen. Beim Auschecken einer Quelle lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Es zeigt die Konfigurationsquelle, den Browser-Cookie-Plan, geplante Schreibvorgänge, optionale Befehle und die ignorierte Projektkonfiguration an, ohne Cookies zu lesen, Dateien zu schreiben oder Recherchen durchzuführen.
+Codex Desktop- und andere Ordnermodus-Hosts können sowohl in normalen Ordnern als auch in Git-Repos funktionieren. Vor der ersten Recherche bitten Sie den Host-Agenten, das mitgelieferte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen; bei einem Quellcode-Checkout lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Er zeigt die Konfigurationsquelle, den Browser-Cookie-Plan, geplante Schreibvorgänge, optionale Befehle und ignorierte Projektkonfigurationen an, ohne Cookies zu lesen, Dateien zu schreiben oder Recherchen durchzuführen.
 
-Standardmäßig wird dies für den von `npx skills` erkannten Kabelbaum installiert. So zielen Sie auf eine bestimmte (oder mehrere) Zielgruppe ab:
+Standardmäßig wird dies für das Kabelbaum installiert, das `npx skills` erkennt. Um eine bestimmte (oder mehrere) anzuvisieren:
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Später aktualisieren mit:
+Update später mit:
 
 ```bash
 npx skills update last30days -g
 ```
 
-Oder aktualisieren Sie alles, was Sie global installiert haben, über `npx skills`:
+Oder aktualisiere alles, was du installiert hast, global über `npx skills`:
 
 ```bash
 npx skills update -g
 ```
 
-Mit `npx skills list -g` und `npx skills remove last30days -g` auflisten und entfernen.
+Liste und Entferne mit `npx skills list -g` und `npx skills remove last30days -g`.
 
-### claude.ai (web)
+### claude.ai (Web)
 
-1. [`last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) von der neuesten Version herunterladen
-2. Gehen Sie zu [claude.ai > Anpassen > Skills](https://claude.ai/customize/skills)
-3. Klicken Sie im Bedienfeld „Fähigkeiten“ auf die Schaltfläche „`+`“ > klicken Sie auf „`Create skill`“ > „`Upload a skill`“ und durchsuchen Sie die Datei bzw. legen Sie sie dort ab
+1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) aus der neuesten Veröffentlichung
+2. Geh zu [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Klicke auf die `+` -Taste im Skills-Panel > klicke auf `Create skill` > `Upload a skill` und durchstöber/leg die Datei ein
 
-Aktivieren Sie zuerst „Codeausführung und Dateierstellung“ unter „Fähigkeiten“ – ohne diese Funktion funktionieren die Fertigkeiten nicht.
+Aktiviere zuerst "Code-Ausführung und Dateierstellung" unter Capabilities – Skills laufen ohne diese nicht aus.
 
 ### Claude Desktop
 
-Claude Desktop installiert `/last30days` als MCP-Server über ein `.mcpb`-Bundle (ein One-Click-Model-Context-Protocol-Paket).
+Claude Desktop installiert `/last30days` als MCP -Server über ein `.mcpb` -Bundle (ein One-Click Model Context Protocol-Paket).
 
-1. Gehen Sie zur [neuesten Version](https://github.com/mvanhorn/last30days-skill/releases/latest) und laden Sie `.mcpb` für Ihre Plattform herunter:
-- macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-- macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-- Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+1. Gehen Sie zum [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) und laden Sie die `.mcpb` für Ihre Plattform herunter:
+   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
 2. Öffnen Sie Claude Desktop, gehen Sie zu Einstellungen > Erweiterungen und ziehen Sie die Datei hinein.
-3. Wenn Sie dazu aufgefordert werden, fügen Sie API-Schlüssel für die Quellen ein, die Sie aktivieren möchten. Jedes Feld ist optional – die Engine wechselt in den reinen Webmodus, wenn Sie sie alle überspringen. Schlüssel werden in Ihrem Betriebssystem-Schlüsselbund gespeichert.
-4. Starten Sie Claude Desktop neu. Bitten Sie Claude, „Peter Steinberger“ oder ein anderes Thema zu recherchieren, und das Tool `research` wird aufgerufen.
+3. Wenn du aufgefordert wirst, füge API Schlüssel für die Quellen ein, die du aktivieren möchtest. Jedes Feld ist optional – die Engine verschlechtert sich in den reinen Webmodus, wenn du alle überspringst. Schlüssel werden in deinem Betriebssystem-Schlüsselbund gespeichert.
+4. Starte Claude Desktopneu. Bitte Claude , "Peter Steinberger" oder ein anderes Thema zu recherchieren, und es wird das `research` Tool aufgerufen.
 
-**Hostanforderung:** Python 3.12+ auf PATH. Das Bundle liefert die Engine-Quelle, verwendet aber Ihren lokalen Python-Interpreter. Installation von [python.org](https://www.python.org/downloads/) unter Windows; macOS und die meisten Linux-Distributionen liefern eine kompatible Version aus.
+**Host-Anforderung:** Python 3.12+ auf PATH. Das Bundle liefert die Engine-Quelle, verwendet aber deinen lokalen Python -Interpreter. Installiere von [python.org](https://www.python.org/downloads/) auf Windows; macOS und die meisten Linux Distributionen liefern eine kompatible Version aus.
 
-**Schlüssel werden nicht mit dem Code-Skill synchronisiert.** Claude Desktop und Claude Code verwalten von Natur aus separate Anmeldeinformationsspeicher. Wenn Sie `~/.config/last30days/.env` bereits für den Code-Skill konfiguriert haben, geben Sie die gleichen Schlüssel hier einmal erneut ein.
+**Schlüssel synchronisieren sich nicht mit der Code-Fähigkeit.** Claude Desktop und Claude Code pflegen absichtlich separate Zugangsdatenspeicher. Wenn du `~/.config/last30days/.env` bereits für die Code-Fähigkeit konfiguriert hast, gibst du dieselben Schlüssel hier einmal erneut ein.
 
-Die Windows-Unterstützung wird zurückgestellt, bis die Manifest-Einstiegspunkte pro Plattform geklärt sind. in einer Folgeausgabe verfolgen.
+Windows Unterstützung wird aufgeschoben, bis die Einstiegspunkte pro Plattform geregelt sind; eine Folgeangelegenheit verfolgen.
 
 ### OpenClaw
 
@@ -263,11 +263,11 @@ Die Windows-Unterstützung wird zurückgestellt, bis die Manifest-Einstiegspunkt
 clawhub install last30days-official
 ```
 
-Für X/Twitter-Aktionsworkflows außerhalb der `/last30days`-Recherche, z. B. Posten
-Tweets oder Antworten, Follower-Export, Medienverwaltung, Monitore und Giveaways
-zeichnet, verwenden Sie [TweetClaw](https://github.com/Xquik-dev/tweetclaw) als Begleiter
-OpenClaw-Plugin. TweetClaw wird von Xquik-dev verwaltet und ist nur als aufgeführt
-optionaler Begleitpfad, keine last30days-Abhängigkeit oder -Befürwortung.
+Für X/Twitter-Aktionsworkflows außerhalb `/last30days` Forschung, wie zum Beispiel Beiträge
+Tweets oder Antworten, Follower-Export, Medienhandhabung, Monitore und Gewinnspiele
+Bei Draws [TweetClaw](https://github.com/Xquik-dev/tweetclaw) als Begleiter verwenden
+OpenClaw Plugin. TweetClaw wird von Xquik-dev gepflegt und nur als ein
+Optionaler Begleitpfad, keine Abhängigkeit oder Unterstützung der letzten 30 Tage.
 
 ### Handbuch (Entwickler)
 
@@ -276,30 +276,30 @@ git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-Der Symlink hält die Installation während der Bearbeitung mit Ihrem Arbeitsbaum synchron – ein erneutes Kopieren ist nicht erforderlich. Erstellen Sie für `claude.ai` die Datei `.skill` aus der Quelle: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
+Der Symlink hält die Installation beim Bearbeiten synchron mit deinem Arbeitsbaum – kein erneutes Kopieren erforderlich. Für `claude.ai`baue die `.skill` -Datei aus der Quelle: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
 
-Reddit (mit Kommentaren), Hacker News, Polymarket und GitHub funktionieren sofort. Nullkonfiguration. Führen Sie `/last30days` einmal aus und der Setup-Assistent schaltet in 30 Sekunden weitere Quellen frei, einschließlich der kostenlosen arXiv- und Techmeme-CLIs.
+Reddit (mit Kommentaren), Hacker News, Polymarketund GitHub funktionieren sofort. Null Konfiguration. Führe `/last30days` einmal aus und der Setup-Wizard schaltet in 30 Sekunden weitere Quellen frei, einschließlich der kostenlosen arXiv und Techmeme CLIs.
 
 ## Bringen Sie Ihre eigenen Schlüssel mit
 
-Diese Plattformen unterhalten keine Beziehungen untereinander. X weiß nicht, was Reddit denkt. YouTube sieht TikTok nicht. Aber Sie können Ihre eigenen API-Schlüssel und Browser-Token mitbringen und haben plötzlich Zugriff auf alle gleichzeitig.
+Diese Plattformen haben keine Beziehungen zueinander. X weiß nicht, was Reddit denkt. YouTube sieht TikToknicht. Aber du kannst deine eigenen API Schlüssel und Browser-Tokens mitbringen, und plötzlich hast du Zugriff auf alle auf einmal.
 
-| Quellen | Was Sie brauchen | Kosten |
+| Quellen | Was du brauchst | Kosten |
 |---------|---------------|------|
 | Reddit (mit Kommentaren) + HN + Polymarket + GitHub + StockTwits | Nichts | Kostenlos |
-| arXiv + Techmeme | Kostenlose CLIs, automatisch installiert bei der Erstinstallation | Kostenlos |
-| X / Twitter | Melden Sie sich in einem beliebigen Browser bei x.com an oder stellen Sie `XQUIK_API_KEY` / `XAI_API_KEY` | ein Browser-Cookies sind kostenlos; Schlüssel sind anbieterspezifisch |
+| arXiv + Techmeme | Kostenlose CLIS, automatisch durch Erststart-Einrichtung installiert | Kostenlos |
+| X / Twitter | Melden Sie sich in jedem Browser bei x.com an oder stellen Sie `XQUIK_API_KEY` / `XAI_API_KEY` | Browser-Cookies sind kostenlos; Schlüssel sind anbieterspezifisch |
 | YouTube | `brew install yt-dlp` | Kostenlos |
-| Blauer Himmel | App-Passwort von bsky.app | Kostenlos |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube-Kommentare | ScrapeCreators-Schlüssel | 10.000 kostenlose Anrufe, dann PAYG |
-| Xiaohongshu (ROT) | Führen Sie ein angemeldetes x-mcp-Browser-Plugin oder einen `xiaohongshu-mcp`-Dienst aus und melden Sie sich mit `--search xhs` pro Lauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env` an. last30days prüft automatisch `http://localhost:18060` und dann `http://host.docker.internal:18060`, oder verwenden Sie `XIAOHONGSHU_API_BASE` für eine benutzerdefinierte URL | Kein last30days-API-Schlüssel; hängt von Ihrem lokalen Browser-Sitzungsdienst ab |
-| DripStack (Premium-Finanz-Newsletter) | Opt-in: `--search dripstack` pro Lauf oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Such-API |
-| Perplexity Sonar / Such-API / Deep Research | Perplexity-Schlüssel oder OpenRouter-Schlüssel als Sonar-Fallback | Zahlen Sie nach Belieben |
-| Websuche | Brave-Suchschlüssel | 2.000 kostenlose Abfragen/Monat |
+| Bluesky | App-Passwort von bsky.app | Kostenlos |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube Kommentare | ScrapeCreators Schlüssel | 10.000 kostenlose Anrufe, dann PAYG |
+| Xiaohongshu (RED) | Führen Sie ein eingeloggtes x-mcp-Browser-Plugin oder `xiaohongshu-mcp` Dienst aus und melden Sie sich mit `--search xhs` pro Durchlauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env`an; die letzten 30 Tage testen automatisch `http://localhost:18060` dann `http://host.docker.internal:18060`, oder verwenden Sie `XIAOHONGSHU_API_BASE` für eine benutzerdefinierte URL | Kein Last 30days API Key; hängt von deinem lokalen Browser-Session-Dienst ab |
+| DripStack (Premium-Finanznewsletter) | Opt-in: `--search dripstack` pro Durchlauf oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Suche API |
+| Perplexity Sonar / Suche API / Tiefe Forschung | Perplexity Schlüssel oder OpenRouter-Schlüssel als Sonar-Fallback | Zahle nach Beginn. |
+| Web Suche | Brave Suchtaste | 2.000 kostenlose Anfragen pro Monat |
 
-### macOS-Schlüsselbund (optional)
+### macOS Keychain (optional)
 
-Unter macOS können Sie Schlüssel im System-Schlüsselbund statt in einer `.env`-Datei speichern. Der Skill erkennt sie automatisch als Quelle mit der niedrigsten Priorität – `.env`-Dateien und Prozessumgebung gewinnen bei Kollisionen immer noch.
+Auf macOS kannst du Schlüssel im System Keychain statt in einer `.env` -Datei speichern. Die Fähigkeit erkennt sie automatisch als Quelle mit niedrigster Priorität – `.env` die Dateien und die Prozessumgebung gewinnen trotzdem bei der Kollision.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,59 +313,59 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Elemente werden unter dem Dienstnamen `last30days-<KEY>` für den aktuellen Benutzer gespeichert. Auf Nicht-Darwin-Plattformen ist der Loader ein No-Op, sodass es für Linux-/Windows-Benutzer keine Verhaltensänderung gibt.
+Elemente werden unter Service-Namen `last30days-<KEY>` für den aktuellen Nutzer gespeichert. Auf Nicht-Darwin-Plattformen ist der Loader ein No-Op, sodass es keine Verhaltensänderung für Linux/Windows Nutzer gibt.
 
-Besitzen Sie bereits Schlüssel unter verschiedenen Namen des Schlüsselbunddienstes? Legen Sie die in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschriebene nicht geheime `LAST30DAYS_KEYCHAIN_ALIASES`-Zuordnung fest, anstatt Geheimnisse zu kopieren.
+Haben Sie bereits Schlüssel unter verschiedenen Keychain Service-Namen? Stellen Sie das in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschriebene nicht-geheime `LAST30DAYS_KEYCHAIN_ALIASES` Mapping ein, anstatt Geheimnisse zu kopieren.
 
-Unter [CONFIGURATION.md](CONFIGURATION.md) finden Sie die vollständige Schlüsselmatrix pro Quelle, die Argumentationsanbieterpriorität und die Back-End-Priorität für die Websuche.
+Siehe [CONFIGURATION.md](CONFIGURATION.md) für die vollständige Schlüsselmatrix pro Quelle, Priorität des Reasoning-Providers und die Backend-Priorität der Websuche.
 
 ## Konfiguration
 
-Zwei Dinge, die Sie wahrscheinlich am ersten Tag wissen wollen:
+Zwei Dinge, die du wahrscheinlich am ersten Tag wissen solltest:
 
-**Wo Forschungsdateien gespeichert werden.** `LAST30DAYS_MEMORY_DIR` ist standardmäßig `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreiben Sie dies, indem Sie diese Umgebungsvariable auf einen beliebigen Pfad in Ihrer Shell oder auf `--save-dir <path>` pro Lauf festlegen. Verwenden Sie `--output <file>`, wenn Sie das gerenderte Ergebnis in einem exakten Pfad benötigen, und verwenden Sie dabei das von `--emit` ausgewählte Format. Verwenden Sie `--save-suffix=<name>`, um mehrere Variationen desselben Themas getrennt zu halten (z. B. pro Kunde). Jeder `--save-dir`-Lauf erzeugt `<slug>-raw[-suffix].md`. Führen Sie `python3 skills/last30days/scripts/last30days.py --preflight` aus, um geplante Schreibvorgänge vor einem Forschungslauf zu überprüfen.
+**Wo Forschungsdateien gespeichert sind.** `LAST30DAYS_MEMORY_DIR` standardmäßig auf `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreiben Sie, indem Sie diesen Env-Var auf einen beliebigen Pfad in Ihrer Shell oder `--save-dir <path>` pro Durchlauf setzen. Verwenden Sie `--output <file>` , wenn Sie das gerenderte Ergebnis auf einem exakten Pfad benötigen, und verwenden Sie das von `--emit`gewählte Format. Verwenden Sie `--save-suffix=<name>` , um mehrere Varianten desselben Themas getrennt zu halten (z. B. pro Client). Jeder `--save-dir` Run erzeugt `<slug>-raw[-suffix].md`. Führen Sie `python3 skills/last30days/scripts/last30days.py --preflight` aus, um geplante Schreibarbeiten vor einem Forschungslauf zu überprüfen.
 
-**Strukturierte Ausgabe für Agenten und Workflows.** Fragen Sie `/last30days` nach maschinenlesbarem JSON, um das stabile, versionierte Agentenprofil zu erhalten. Für die direkte Verwendung der Engine in Skripten oder bei der Entwicklung führen Sie `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` aus; Fügen Sie `--json-profile=raw` nur hinzu, wenn Sie den unversionierten internen `Report`-Dump benötigen. Siehe die [JSON-Exportfeldreferenz und Versionierungsrichtlinie](docs/reference/json-export.md).
+**Strukturierte Ausgabe für Agenten und Workflows.** Fragen Sie `/last30days` nach maschinenlesbaren JSON , um das stabile, versionierte Agentenprofil zu erhalten. Für den direkten Einsatz in der Engine in Skripten oder Entwicklung führen Sie `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`aus ; fügen Sie `--json-profile=raw` nur dann hinzu, wenn Sie den unversionierten internen `Report` Dump benötigen. Siehe das [JSON export field reference and versioning policy](docs/reference/json-export.md).
 
-**Themenlose Entdeckung.** Bitten Sie `/last30days what's trending in AI agents?` darum, eine Rangfolge-Entdeckungsbeschreibung zu erhalten, anstatt ein Thema zu recherchieren, das Sie bereits kennen. Auf einem Agent-Host wird dadurch das vom Host beurteilte Protokoll mit drei Befehlen ausgeführt (das Modell benennt Themen, filtert Junk, bewertet die Würdigkeit und schreibt die Inhaltsaspekte). Für die direkte Verwendung der Engine in Skripten oder Cron führen Sie `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (einmalig: deterministische Themennamen, keine Winkel); Fügen Sie `--emit=json` für den versionierten Discovery-Vertrag hinzu. Die Entdeckung schließt sich gegenseitig mit einem Positionsthema und `--drill` aus.
+**Themenlose Entdeckung.** Bitten Sie `/last30days what's trending in AI agents?` , ein ranglistetes Discovery-Briefing zu erhalten, anstatt ein bereits bekanntes Thema zu recherchieren – auf einem Agentenhost läuft das Drei-Befehle-Host-Judged Protocol (das Modell benennt Themen, filtert Müll, bewertet den Wert und schreibt die Inhaltswinkel). Für den direkten Einsatz in Skripten oder Cron, führen Sie `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (One-Shot: deterministische Themennamen, keine Angles); fügen Sie `--emit=json` für den versionierten Discovery-Vertrag hinzu. Discovery schließt sich gegenseitig mit einem Positionsthema und `--drill`aus.
 
-**Trendüberwachung über Läufe hinweg.** Der Standardmodus erzeugt pro Lauf einen neuen Markdown-Snapshot. Um Ergebnisse im Laufe der Zeit zu sammeln, fügen Sie `--store` hinzu, um sie in einer SQLite-Datenbank zu speichern, und verwenden Sie dann [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) für geplante Ausführungen (mit optionaler Slack-/Webhook-Bereitstellung für neue Ergebnisse) und [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche/wöchentliche Zusammenfassungen. Das vollständige Trittfrequenzmuster finden Sie in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Trendüberwachung über Durchläufe hinweg.** Der Standardmodus erzeugt pro Durchlauf einen frischen Markdown-Snapshot. Um Erkenntnisse im Laufe der Zeit zu sammeln, fügen Sie `--store` hinzu, um in einer SQLite-Datenbank gespeichert zu werden, verwenden Sie [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) dann für geplante Durchläufe (mit optionalem Slack / Webhook-Delivery bei neuen Ergebnissen) und [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche/wöchentliche Digests. Das vollständige Rhythmusmuster ist in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Eine abonnierbare Forschungsbibliothek.** Bitten Sie `/last30days`, Ihren Bibliotheks-Feed zu erstellen, oder verwenden Sie `python3 skills/last30days/scripts/last30days.py library feed` direkt für die Skripterstellung und Entwicklung. Es wandelt gespeicherte Kurzbriefe in `index.html`, einen lokalen Atom `feed.xml` und lesbare Kurzbriefseiten um. Fügen Sie `--publish` nur hinzu, wenn Sie den HTML-Index und die kurzen Seiten hosten möchten. Die Veröffentlichung erfolgt standardmäßig mit ausdrücklicher Einwilligung und ist öffentlich. Um den Atom-Feed abonnierbar zu machen, hosten Sie das generierte Ausgabeverzeichnis auf einem statischen Host wie GitHub Pages.
+**Eine abonnierbare Forschungsbibliothek.** Bitten Sie `/last30days` , Ihren Bibliotheksfeed zu erstellen, oder verwenden Sie `python3 skills/last30days/scripts/last30days.py library feed` direkt für Skripting und Entwicklung. Sie wandelt gespeicherte Briefs in `index.html`, ein lokales Atom- `feed.xml`und lesbare Brief-Seiten um. Fügen Sie `--publish` nur dann hinzu, wenn Sie den HTML Index und die Brief-Seiten gehostet haben möchten; die Veröffentlichung ist standardmäßig explizit opt-in und öffentlich. Um den Atom-Feed abonnierbar zu machen, hosten Sie das generierte Ausgabeverzeichnis auf einem statischen Host wie GitHub Pages.
 
-**Durchsuchen Sie alles, was Sie recherchiert haben.** Fragen Sie `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für den direkten Motorgebrauch `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` ausführen. Die Suche ist offline und deterministisch: Sie indiziert inkrementell dieselben gespeicherten Briefings, die vom Bibliotheks-Feed verwendet werden, führt übereinstimmende Filialsichtungen pro Durchlauf zusammen und gruppiert die Ergebnisse nach Thema und Datum. Bei neuen Durchläufen wird auch ein kompakter Abschnitt „Aus Ihrer Bibliothek“ angezeigt, wenn sich frühere Recherchen mit dem aktuellen Thema überschneiden. Legen Sie `LAST30DAYS_LIBRARY_CONTEXT=off` fest, um diesen passiven Kontext zu deaktivieren.
+**Durchsuche alles, was du recherchiert hast.** Frag `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für die direkte Engine-Nutzung führe `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`aus. Die Suche ist offline und deterministisch: Sie indexiert schrittweise dieselben gespeicherten Briefs, die vom Bibliotheksfeed verwendet werden, führt übereinstimmende Shop-Sichtungen pro Durchlauf zusammen und gruppiert Ergebnisse nach Thema und Datum. Frische Durchläufe zeigen außerdem einen kompakten Abschnitt **Aus deiner Bibliothek** an, wenn frühere Forschung das aktuelle Thema überschneidet; setze `LAST30DAYS_LIBRARY_CONTEXT=off` so ein, dass dieser passive Kontext deaktiviert wird.
 
-Client-spezifische Wrapper-Skripte, benutzerdefinierte Kategorie-Peer-Subreddits und der experimentelle Beta-Kanal für laufende Anpassungen sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md) dokumentiert.
+Pro-Client-Wrapper-Skripte, benutzerdefinierte Kategorie-Peer-Subreddits und der experimentelle Beta-Kanal für laufende Anpassungen sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md)dokumentiert.
 
-## Showcase: Community-Recherche-Feeds
+## Showcase: Community-Forschungsfeeds
 
-Haben Sie ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine wunderbar enge Obsession mit last30days veröffentlicht? Teilen Sie die URL der öffentlichen Bibliothek – oder die Atom-URL nach dem Hosten von `feed.xml` auf einem statischen Host – im [Community-Showcase-Thread](https://github.com/mvanhorn/last30days-skill/issues/532). Community-Feeds werden hier verlinkt, sobald ihre Besitzer sie einreichen. Der Thread ist in der Zwischenzeit der Sammelpunkt.
+Hast du ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine wunderbar enge Obsession mit den letzten 30 Tagen veröffentlicht? Teile die URL der öffentlichen Bibliothek – oder die Atom-URL nach dem Hosting `feed.xml` auf einem statischen Host – in [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532)Community-Feeds werden hier verlinkt, sobald ihre Eigentümer sie einreichen; der Thread ist in der Zwischenzeit der Sammelpunkt.
 
 ## Wie es funktioniert
 
-1. **Sie geben ein Thema ein.** Person, Unternehmen, Produkt, Technologie, „X vs. Y.“ Irgendetwas.
-2. **Der Agent entscheidet, wer zählt.** Findet X-Handles (einschließlich Gründer), GitHub-Repos, Subreddits, TikTok-Hashtags und YouTube-Kanäle. Für „Kanye West“ gibt es R/Hiphopheads, @kanyewest und „Bully Review“ auf YouTube. Für „OpenClaw“ löst es openclaw/openclaw auf GitHub auf und ruft Live-Star-Zählungen ab.
-3. **Alle Quellen werden parallel durchsucht.** Erweiterung mit mehreren Abfragen. Ergebnisse bewertet nach Engagement, Relevanz und Aktualität.
-4. **Die Tiefe, die niemand sonst hat.** Vollständige YouTube-Transkripte von Reaktionsvideos. Top-Reddit-Kommentare mit Upvote-Zählungen. TikTok-Untertitel. Polymarket-Quoten. Nicht nur Titel und Links.
-5. **Gleiche Geschichte, zusammengeführt.** Wireless Festival auf Reddit angekündigt, auf X besprochen, Ticketpreise auf TikTok = ein Cluster, nicht drei separate Artikel.
-6. **In einem Brief zusammengefasst.** Basierend auf spezifischen Daten. Zitiert nach Quelle. Geordnet nach dem, womit sich die Leute tatsächlich beschäftigen. Nicht „Hier ist, was ich gefunden habe.“ Es heißt: „Hier kommt es darauf an.“
-7. **Dann wird es Ihr Experte.** Nach einem Durchlauf weiß Ihre Claude-Sitzung alles, was die Community weiß. Stellen Sie weitere Fragen. Lassen Sie Eingabeaufforderungen schreiben, E-Mails entwerfen, Reisen planen und Systeme erstellen – alles basiert auf dem, was gerade real ist.
+1. **Du tippst ein Thema ein.** Person, Unternehmen, Produkt, Technologie, "X vs. Y." Alles.
+2. **Der Agent entscheidet, wer zählt.** Findet X Handles (einschließlich Gründer), GitHub Reposis, Subreddits, TikTok Hashtags YouTube Kanäle. Für "Kanye West" kennt es r/hiphopheads, @kanyewestund "bully review" auf YouTube. Für "OpenClaw" wird openclaw/openclaw auf GitHub aufgelöst und live die Sternenzahlen angezeigt.
+3. **Alle Quellen wurden parallel gesucht.** Multi-Query-Erweiterung. Ergebnisse bewertet nach Engagement, Relevanz, Frische.
+4. **Die Tiefe, die sonst niemand hat.** Vollständige YouTube Transkripte aus Reaktionsvideos. Top Reddit Kommentare mit Upvote-Zählen. TikTok Bildunterschriften. Polymarket Chancen. Nicht nur Titel und Links.
+5. **Gleiche Geschichte, fusioniert.** Wireless Festival am Redditangekündigt, besprochen am X, Ticketpreise auf TikTok = ein Cluster, nicht drei separate Artikel.
+6. **Zusammengefasst in einem Brief.** Basierend auf spezifischen Daten. Zitiert von der Quelle. Bewertet nach dem, womit sich die Leute tatsächlich beschäftigen. Nicht "Hier ist, was ich gefunden habe." Es ist "Hier ist, was zählt."
+7. **Dann wird es dein Experte.** Nach einem Durchlauf weiß deine Claude Sitzung alles, was die Community weiß. Stelle Nachfragen. Lass sie Prompts schreiben, E-Mails entwerfen, Reisen planen, Architektursysteme aufbauen – alles basiert auf dem, was gerade real ist.
 
 ## Was die Leute sagen
 
-> „Ich habe einen Claude-Code-Skill gefunden, der jedes Thema der letzten 30 Tage auf Reddit, -@itsjasonai
+> "Ich habe eine Claude Code Fähigkeit gefunden, die jedes Thema aus den letzten 30 Tagen Reddit, X, YouTubeund HN erforscht. Dann schreibt er die Prompts für dich. Ich habe vor jedem Inhalt, den ich schreibe, manuell Reddit und X nach Recherchen gesucht. Tab für Tab. Faden für Faden. Das ist der Teil, der 90 Minuten dauert. Das eliminiert es." -@itsjasonai
 
-> „Diese eine Fähigkeit hat meinen gesamten Recherche-Workflow ersetzt. Sie geben ihm ein Thema, es durchsucht Reddit, X und das Web nach dem, worüber die Leute tatsächlich sprechen. Keine alten Blog-Beiträge. Echte Gespräche der letzten 30 Tage.“ -@itswilsoncharles
+> "Diese eine Fähigkeit hat meinen gesamten Recherche-Workflow ersetzt. Du gibst ihm ein Thema, sie sammelt Reddit, Xund das Web nach dem, worüber die Leute tatsächlich sprechen. Keine alten Blogbeiträge. Echte Gespräche der letzten 30 Tage." -@itswilsoncharles
 
-> „5 der 10 angesagten Repos auf GitHub sind heute Claude-Tools. #1: mvanhorn/last30days-skill“ -@yieldhunter95
+> "5 der 10 trendigen Repos auf GitHub heute sind Claude Werkzeuge. #1: Mvanhorn/last30days-Fähigkeit" -@yieldhunter95
 
 ## Open Source
 
-MIT-Lizenz. Keine Nachverfolgung. Keine Analyse. Ihre Forschung bleibt auf Ihrem Computer. Über 2.700 Tests.
+MIT-Lizenz. Kein Tracking. Keine Analyse. Deine Forschung bleibt auf deinem Rechner. 2.700+ Tests.
 
-Gebaut mit Python 3.12+, yt-dlp, Node.js (vom Anbieter bereitgestellter Bird-Client für die X-Suche) und der ScrapeCreators-API. v3-Engine-Architektur von [@j-sperling](https://github.com/j-sperling).
+Gebaut mit Python 3.12+, yt-dlp, Node.js (bereitgestellt Bird Client für X Suche) und ScrapeCreators API. v3-Engine-Architektur von [@j-sperling](https://github.com/j-sperling).
 
-Siehe [CONTRIBUTING.md](CONTRIBUTING.md) zum Öffnen einer PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) für die vollständige Liste der Community-Mitwirkenden und [CHANGELOG.md](CHANGELOG.md) für den Versionsverlauf.
+Siehe [CONTRIBUTING.md](CONTRIBUTING.md) , um einen PRzu öffnen, [CONTRIBUTORS.md](CONTRIBUTORS.md) für die vollständige Liste der Community-Mitwirkenden und [CHANGELOG.md](CHANGELOG.md) für die Versionshistorie.
 
 ## Sterngeschichte
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,382 @@
+# /last30days
+
+[English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | Español | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+
+<p align="center">
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/mvanhorn/last30days-skill">
+    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
+  </a>
+  <br/>
+  <a href="https://trendshift.io/repositories/21997" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
+</p>
+
+**Un motor de búsqueda con IA dirigido por agentes puntuado por votos positivos, me gusta y dinero real, no por editores.**
+
+Este archivo README rastrea la canalización v3 actual. La especificación de habilidad en tiempo de ejecución se encuentra en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la fuente de verdad para el comportamiento de configuración y comando más reciente.
+
+**Claude Code (recomendado: actualizaciones automáticas a través del mercado):**
+```
+/plugin marketplace add mvanhorn/last30days-skill
+/plugin install last30days
+```
+
+**Codex, Cursor, Copilot, Gemini CLI o cualquiera de los más de 50 [hosts de Agent Skills](https://agentskills.io):**
+```
+npx skills add mvanhorn/last30days-skill -g
+```
+(`-g` se instala globalmente para su usuario, disponible en todos los proyectos. Colóquelo en el alcance por proyecto).
+
+Más opciones de instalación (claude.ai web, OpenClaw, manual) en la sección [Install](#instalación) a continuación.
+
+Configuración cero. Reddit, HN, Polymarket y GitHub funcionan de inmediato. Ejecútelo una vez y el asistente de configuración desbloqueará X, YouTube, TikTok, arXiv, Techmeme y más en 30 segundos.
+
+---
+
+Votos positivos de Reddit. A X le gusta. Transcripciones de YouTube. Compromiso de TikTok. Cuotas de polimercado respaldadas por dinero real e información privilegiada. Son millones de personas votando con su atención y sus billeteras todos los días. /last30days lo busca todo en paralelo, lo califica según lo que realmente interactúan las personas reales y un juez agente de IA lo sintetiza en un resumen.
+
+Editores agregados de Google. /last30days busca personas.
+
+No puede realizar esta búsqueda en ningún otro lugar porque ninguna IA tiene acceso a toda ella. La búsqueda de Google no toca los comentarios de Reddit ni las publicaciones X. ChatGPT tiene un acuerdo con Reddit pero no puede buscar X ni TikTok. Gemini tiene YouTube pero no Reddit. Claude no tiene ninguno de ellos de forma nativa. Cada plataforma es un jardín vallado con su propia API, sus propios tokens, su propia autenticación. Pero puedes traer tus propias claves y sesiones de navegador y, de repente, un agente de IA puede buscarlas todas a la vez, compararlas entre sí y decirte lo que realmente importa.
+
+Ese es el desbloqueo. No hay un motor de búsqueda mejor. Una docena de plataformas desconectadas, unidas por un agente.
+
+```
+/last30days Peter Steinberger
+```
+
+Tienes una reunión mañana. Los buscas en Google. Obtendrá su LinkedIn a partir de 2023. /last30days le brinda lo que realmente están haciendo este mes: se unió a OpenAI para trabajar en Codex, luchó contra la prohibición de Anthropic sobre agentes externos, envió 23 PR con una tasa de fusión del 85%, creó "LobsterOS" para el control de agentes entre dispositivos y r/ClaudeCode alcanzó 569 votos a favor debatiendo si es un héroe o "insoportable". Distribuidos en X publicaciones, hilos de Reddit, transcripciones de YouTube y confirmaciones de GitHub. Nada de eso estaba en Google.
+
+## Por qué existe esto
+
+Lo construí para mantenerme al día con la IA. Todo cambia todos los días y los nerds de Reddit y X siempre están al tanto de ello. Necesitaba mejores indicaciones y los datos de capacitación siempre estaban meses por detrás de lo que la comunidad ya había descubierto.
+
+Pero se convirtió en algo más grande. Ahora lo ejecuto antes de una llamada de ventas para conocer la verdad de los últimos 30 días sobre una empresa. Antes de una reunión para leer los tweets recientes y las transcripciones de podcasts de alguien. Antes de un viaje a Disney World, para saber qué atracciones están cerradas y qué dice la comunidad sobre Genie+. Antes de construir algo, debo saber qué problemas enfrenta realmente la gente.
+
+Si se reúne con un director ejecutivo, ¿ha leído todos sus tweets y transcripciones de YouTube de los últimos 30 días? Tengo.
+
+## Fuentes, puntuadas por la gente
+
+| Fuente | Lo que te dice la gente |
+|--------|--------------------------|
+| **Reddit** | La toma sin filtrar. Comentarios principales con recuentos reales de votos a favor, gratis, sin clave API. Las opiniones reales que Google entierra. |
+| **X/Twitter** | La toma caliente, el hilo experto, la reacción de ruptura. Primero en saber, primero en discutir. |
+| **YouTube** | La inmersión profunda de 45 minutos. Se buscaron en las transcripciones completas las cinco frases citables que importan. |
+| **TikTok** | El creador llega a 3,6 millones de personas con una versión que nunca encontrarás en Google. |
+| **Instagram Reels** | La perspectiva del influencer con transcripciones de palabras habladas. La señal de la cultura visual. |
+| **Hacker News** | El consenso de los desarrolladores. 825 puntos, 899 comentarios. Donde los técnicos realmente discuten. |
+| **Polymarket** | No opiniones. Impares. Respaldado por dinero real. 96% de confianza en las ventas de álbumes. 4% en una adquisición. |
+| **GitHub** | Para personas: velocidad de relaciones públicas, principales repositorios por estrellas, notas de la versión. Para temas: cuestiones y debates. |
+| **Digg** | Grupos de historias seleccionados de la tabla de clasificación AI 1000 de Digg (~1000 cuentas de AI de alta señal en X), con citas en línea atribuibles (no se requiere autenticación X). Habilitado automáticamente cuando `digg-pp-cli` está en PATH. |
+| **arXiv** | Los periódicos detrás del revuelo. Nueva investigación en la ventana, gratuita, sin clave API. Se habilita automáticamente cuando `arxiv-pp-cli` está en PATH (la configuración de primera ejecución lo instala). |
+| **Tecmeme** | La capa editorial de noticias tecnológicas, con ventana de fecha a sus 30 días. Gratis, sin clave API. Se habilita automáticamente cuando `techmeme-pp-cli` está en PATH (la configuración de primera ejecución lo instala). |
+| **LinkedIn** | La señal profesional. Publicaciones y artículos, con artículos ponderados como señal alta. |
+| **StockTwits** | Sentimiento del comerciante. Se activa automáticamente cuando su tema es un ticker o una criptomoneda. |
+| **Hilos** | La capa de texto posterior a Twitter. Conversaciones de creadores y marcas. |
+| **Pinterest** | Descubrimiento visual. Fija, guarda y comenta productos e ideas. |
+| **Xiaohongshu (ROJO)** | Señales de creadores, productos y estilos de vida chinos. Se solicita explícitamente con `--search xhs` cuando se ejecuta localmente un complemento de navegador x-mcp conectado o un servicio `xiaohongshu-mcp`. |
+| **Cielo azul** | La capa social descentralizada. Publicaciones de AT Protocol de la migración posterior a Twitter. |
+| **Perplejidad** | Síntesis de Grounded Sonar, filas de API de búsqueda sin procesar e investigación profunda. |
+| **Web** | La cobertura editorial, las comparaciones de blogs. Una señal de muchas, no la única. |
+
+Los contribuyentes de la comunidad siguen agregando más. Truth Social y otras fuentes de nicho están en el motor y hay más en camino.
+
+Un hilo de Reddit con 1500 votos a favor es una señal más fuerte que una publicación de blog que nadie leyó. Un TikTok con 3,6 millones de visitas te dice más sobre lo que es culturalmente relevante que un comunicado de prensa. Las probabilidades de los polimercados respaldadas por un volumen de 66.000 dólares son más difíciles de discutir que las suposiciones de un experto.
+
+La síntesis se clasifica según lo que realmente hizo la gente real. Relevancia social, no relevancia SEO.
+
+## Para qué lo usa realmente la gente
+
+**Antes de una reunión.** `/last30days Peter Steinberger`: se unió al equipo Codex de OpenAI, luchando contra la prohibición de Anthropic sobre agentes externos, 23 RP se fusionaron a una tasa de fusión del 85 % en GitHub, creando LobsterOS para el control de agentes entre dispositivos. r/ClaudeCode: "Desde que se lanzó OpenClaw, era ampliamente conocido que si lo ejecutabas a través de cualquier otra cosa que no fuera la API, eventualmente serías baneado" (227 votos a favor). Eso no está en LinkedIn.
+
+**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals`: las páginas de empleos y carreras actuales se convierten en evidencia citada de cambios de enfoque: contratación en seguridad empresarial, éxito del cliente, infraestructura o expansión de productos. El informe dice lo que parece indicar la contratación, no lo que ofrecerá la hoja de ruta.
+
+**Para encontrar el tema antes de que alcance su punto máximo.** Pregunte a `/last30days what's exploding in AI agents?` y la habilidad cambiará al modo de descubrimiento: el motor barre los listados de categorías de Reddit, las mejores historias de Hacker News, el feed AI 1000 de Digg y X cuando se autentica; su agente juzga las nominaciones (nombres, filtrado de basura, valor del contenido) y escribe ángulos de podcasts/artículos X; luego obtienes entre 5 y 10 temas clasificados por velocidad. Cada resultado incluye números de fuentes cruzadas, una etiqueta de impulso y un seguimiento `/last30days "<topic>"` listo para ejecutar.
+
+**Cuando algo cae.** `/last30days Kanye West` - Reino Unido bloqueó su visa, Wireless Festival canceló, los patrocinadores huyeron. Pero BULLY debutó en el puesto número 2 en Billboard. Fantano regresó de su "año sabático" para revisarlo (653.000 visitas). SoFi Homecoming presentó a Lauryn Hill y Travis Scott para 44 canciones. Polymarket: "¿Kanye volverá a twittear?" 86% Sí. 23 hilos de Reddit, 17 vídeos de YouTube, 86.000 votos a favor.
+
+**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip`: "Estos no son competidores, son capas". OpenClaw es el ejecutor (351.000 estrellas de GitHub, en vivo), Hermes es el cerebro que se mejora a sí mismo (31.000 estrellas), Paperclip es el organigrama (49.000 estrellas). El conteo de estrellas se obtuvo en vivo de la API de GitHub, no de publicaciones de blog obsoletas. Mesa de lado a lado con arquitectura, memoria, seguridad, lo mejor para. Según @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard".
+
+**Para entender el mundo.** `/last30days Iran vs USA` - Día 38 de la guerra. La fecha límite del martes de Trump para que Irán reabra el Estrecho de Ormuz. Dos aviones de combate estadounidenses derribados. Petróleo a 126 dólares el barril. La AIE lo calificó como "la mayor interrupción del suministro en la historia del mercado mundial del petróleo". Polymarket: alto el fuego antes del 31 de diciembre al 74%. 27 publicaciones X, 10 videos de YouTube, 20 mercados de predicción.
+
+**Antes de un viaje.** `/last30days Universal Epic Universe` - Ampliación ya en construcción. Permiso "Proyecto 680" presentado. Espectáculo de fuegos artificiales confirmado por infraestructura pero sin previo aviso. Tiempos de espera: Mine-Cart Madness con un promedio de 148 minutos. Aún no hay un pase anual y los lugareños están frustrados. Stardust Racers estará en remodelación hasta el 5 de abril.
+
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting`: las indicaciones estructuradas en JSON están reemplazando la sopa de etiquetas. El formato anidado de @pictsbyai evita la "sangrado de conceptos". El flujo de trabajo que da prioridad a la edición supera a la regeneración. Luego le escribe un mensaje de producción utilizando exactamente lo que la comunidad dijo que funciona.
+
+## ¿Qué hay de nuevo?
+
+Desde el anuncio de la v3.3 en mayo, a partir de la v3.11.1 (julio de 2026): 175 RP fusionados (122 de ellos de 52 contribuyentes de la comunidad) en 15 versiones. Esto es lo que aterrizó.
+
+### Primera clase en OpenAI Codex
+
+/last30days es ahora un complemento nativo de Codex con configuración guiada: no un puerto, un ciudadano de primera clase. Las citas con reconocimiento de renderizador significan que la salida del Codex se lee como un resumen en lugar de una sopa de URL (#694), y el mismo motor se ejecuta en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw y más de 50 hosts de Agent Skills. Manifiesto del complemento Codex por [@rfoust](https://github.com/rfoust) (#686), corrección de autenticación del Codex por [@tmchow](https://github.com/tmchow) (#698).
+
+### arXiv, Techmeme y Digg: gratis, sin claves API
+
+arXiv trae los artículos detrás de la publicidad y Techmeme trae la capa editorial de noticias tecnológicas: gratuita, sin claves y la configuración de primera ejecución instala sus CLI para que se activen automáticamente (#709). Los grupos de historias AI 1000 de Digg llegan sin autenticación X de la misma manera: el programa de instalación instala la CLI gratuita de Digg (#590). Trustpilot ofrece la opción de participar en la investigación de marcas de consumo.
+
+### Free Reddit aumentó las puntuaciones reales y los comentarios principales
+
+La API pública .json de Reddit murió; el camino libre volvió con más fuerza. RSS sin llave + shreddit scraping (#457), descubrimiento de subreddit dedicado con conteos reales de votos positivos a través de arctic-shift (#696) y un piso de relevancia para que una publicación viral fuera de tema no pueda secuestrar su resumen (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave API. Puntuaciones reales. Comentarios principales incluidos.
+
+### Los mejores comentarios en cada brief
+
+Los comentarios ahora son una capa predeterminada en todas las fuentes: comentarios de Instagram con diversidad basada en clasificación, por lo que cinco tomas interesantes no provienen todas de una publicación (n.° 751), comentarios de YouTube más una copia de seguridad de la transcripción de ScrapeCreators para cuando yt-dlp se tache (n.° 637) y comentarios votados por la multitud ponderados en las mejores tomas para que las líneas más divertidas de la comunidad sobrevivan la puntuación (n.° 592, n.° 608).
+
+### Un comando médico
+
+Solicite una verificación de estado y el médico ejecutará todas las fuentes y luego prescribe las soluciones exactas: qué clave falta, qué CLI está fuera de RUTA, qué cookie expiró (#753). Ya no tendrás que adivinar por qué X volvió a adelgazar.
+
+### Búsqueda X, reconstruida
+
+El canal X recibió una revisión integral: carriles FROM y ACERCA de para que las publicaciones de una persona y la conversación sobre ellas se clasifiquen (n.° 610), desambiguación de subconsultas con reconocimiento de persona (n.° 611), base de autoría propia con clasificación de señales de interacción (n.° 613) y una única fuente X con conmutación automática por error de backend (n.° 622). Además de un `--diagnose` honesto que realmente prueba la autenticación (#609).
+
+### Más fuentes se unieron
+
+LinkedIn vía ScrapeCreators, con artículos de alta señal ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente para temas de ticker y cripto ([@wtiwana](https://github.com/wtiwana), #658). La perplejidad aumentó en los modos API directos y en la investigación profunda asíncrona ([@sk-holmes](https://github.com/sk-holmes), #629).
+
+### Endurecido por la comunidad
+
+La ola de seguridad fue casi en su totalidad trabajo comunitario: correcciones de XSS almacenado en el renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies bloqueados, CI reforzado en la cadena de suministro con OpenSSF Scorecard y atestación de procedencia de compilación ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), escaneos de Semgrep y OSV-Scanner más una puerta de revisión de dependencia de relaciones públicas ([@23241a6749](https://github.com/23241a6749)), un piso de cobertura de prueba introducido al 60% y desde entonces elevado al 84% ([@gourab5139014](https://github.com/gourab5139014)) y un análisis de seguridad de Hermes eliminó todos los hallazgos CRÍTICOS (#768).
+
+### Llega más lejos
+
+Lenguas hebreas y no latinas ([@dudyme](https://github.com/dudyme)). Tokenización compatible con CJK para fuentes chinas ([@An-idd](https://github.com/An-idd)). Una ola de compatibilidad con Windows. Extracción de cookies en toda la familia Chromium: Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)), además de fuentes de credenciales macOS Keychain y Linux pass(1). Revisión histórica de `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 con aprovisionamiento automático a través de uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Deltas de la lista de seguimiento entre ejecuciones.
+
+### Todavía en la caja de v3
+
+Los fundamentos de la v3 todavía están aquí: el cerebro previo a la investigación que resuelve los identificadores, subreddits y hashtags correctos antes de que se active una única llamada API (creado por [@j-sperling](https://github.com/j-sperling)); Best Takes puntúa por humor y viralidad junto con relevancia; fusión de clústeres de fuentes cruzadas; comparaciones de un solo paso ("CLI vs MCP" en 3 minutos, no 12); comparaciones de `--competitors` descubiertas automáticamente; Modo persona de GitHub (`--github-user=steipete`); modo ELI5 ("eli5 activado" después de cualquier ejecución); y resúmenes HTML independientes y compartibles (`--emit=html`). Las perillas de configuración se encuentran en [CONFIGURATION.md](CONFIGURATION.md).
+
+## Instalar
+
+| Superficie | Instalar | Actualizaciones |
+|---------|---------|---------|
+| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto a través del mercado, o `claude plugin update last30days@last30days-skill` |
+| **Grok** (CLI de compilación xAI) | `grok plugin marketplace add mvanhorn/last30days-skill` luego `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI o cualquiera de los más de 50 [hosts de Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Descargue `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y cárguelo a través de claude.ai > Personalizar > Habilidades > + > Crear habilidad > Cargar una habilidad | Volver a descargar y volver a subir |
+| **Claude Desktop** | [Descargue el `.mcpb` para su plataforma ](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrástrelo a Configuración > Extensiones | Vuelva a descargar y arrastre el nuevo paquete a |
+| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+
+### Claude Code (recomendado)
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+Recomendado porque el mercado de Claude Code maneja las actualizaciones por usted: la caché del complemento tiene versiones y se actualiza automáticamente cuando se publica una nueva versión. Ejecute `claude plugin update last30days@last30days-skill` para forzar una verificación.
+
+Si prefiere utilizar la ruta de instalación de habilidades del agente en Claude Code, también es compatible:
+
+```
+npx skills add mvanhorn/last30days-skill -g -a claude-code
+```
+
+El complemento nativo y la instalación `npx skills` pueden coexistir. Tenga en cuenta que Claude Code no realiza deduplicación entre métodos de instalación: si tiene activos tanto el complemento del mercado como la copia `npx skills`, `/last30days` mostrará dos entradas. Utilice un método de instalación por máquina.
+
+### Grok (CLI de compilación xAI)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) se instala los últimos 30 días como complemento nativo. La instalación directa rastrea el repositorio:
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+O agregue este repositorio como fuente del mercado, luego instálelo por el nombre del complemento:
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+Agregue `--trust` para omitir la confirmación de instalación. Actualización con `grok plugin update last30days`. Grok también lee los manifiestos del Claude Code para comprobar la compatibilidad; el par nativo `.grok-plugin/` es el carril de primera clase (y a qué apunta un listado oficial [xAI Marketplace](https://github.com/xai-org/plugin-marketplace)). `npx skills add` sigue siendo una alternativa válida entre hosts.
+
+### Codex, Cursor, Copilot, Gemini CLI y otros hosts de Agent Skills
+
+Instale a través de la CLI abierta [Agent Skills](https://agentskills.io): admite más de 50 arneses, incluidos `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` y más (lista completa en el repositorio [vercel-labs/skills](https://github.com/vercel-labs/skills)).
+
+```bash
+npx skills add mvanhorn/last30days-skill -g
+```
+
+El indicador `-g` (global) se instala en su directorio de usuarios para que la habilidad esté disponible en todos los proyectos. Sin `-g`, `npx skills` instala el proyecto localmente en `./.skills/` (comprometido con el repositorio). Para una herramienta de investigación del mundo, lo que desea es global.
+
+El escritorio Codex y otros hosts en modo carpeta pueden funcionar en carpetas normales, así como en repositorios Git. Antes de la primera investigación, solicite al agente anfitrión que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio de habilidades cargado; en un pago de origen, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Muestra el origen de la configuración, el plan de cookies del navegador, las escrituras planificadas, los comandos opcionales y la configuración del proyecto ignorada sin leer cookies, escribir archivos ni realizar investigaciones.
+
+De forma predeterminada, esto se instala para cualquier arnés que detecte `npx skills`. Para apuntar a uno específico (o varios):
+
+```bash
+npx skills add mvanhorn/last30days-skill -g -a codex
+npx skills add mvanhorn/last30days-skill -g -a cursor
+npx skills add mvanhorn/last30days-skill -g -a gemini-cli
+npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+```
+
+Actualiza más tarde con:
+
+```bash
+npx skills update last30days -g
+```
+
+O actualice todo lo que ha instalado globalmente a través de `npx skills`:
+
+```bash
+npx skills update -g
+```
+
+Listar y eliminar con `npx skills list -g` y `npx skills remove last30days -g`.
+
+### claude.ai (web)
+
+1. [Descargue `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) desde la última versión
+2. Vaya a [claude.ai > Personalizar > Skills](https://claude.ai/customize/skills)
+3. Haga clic en el botón `+` en el panel Habilidades > haga clic en `Create skill` > `Upload a skill` y busque/solte el archivo en
+
+Habilite primero "Ejecución de código y creación de archivos" en Capacidades; las habilidades no se ejecutarán sin él.
+
+### Claude Desktop
+
+Claude Desktop instala `/last30days` como servidor MCP a través de un paquete `.mcpb` (un paquete de protocolo de contexto modelo con un solo clic).
+
+1. Vaya a la [última versión](https://github.com/mvanhorn/last30days-skill/releases/latest) y descargue `.mcpb` para su plataforma:
+- macOS Apple Silicio: `last30days-pp-mcp-darwin-arm64.mcpb`
+-Mac OS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+-Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Abra Claude Desktop, vaya a Configuración > Extensiones y arrastre el archivo.
+3. Cuando se le solicite, pegue las claves API para las fuentes que desea habilitar. Cada campo es opcional: el motor pasa al modo solo web si los omite todos. Las claves se almacenan en el llavero de su sistema operativo.
+4. Reinicie Claude Desktop. Pídale a Claude que "investigue a Peter Steinberger" o cualquier tema y llamará a la herramienta `research`.
+
+**Requisito de host:** Python 3.12+ en PATH. El paquete incluye el código fuente del motor pero utiliza su intérprete de Python local. Instalar desde [python.org](https://www.python.org/downloads/) en Windows; macOS y la mayoría de las distribuciones de Linux incluyen una versión compatible.
+
+**Las claves no se sincronizan con la habilidad Código.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados por diseño. Si ya configuró `~/.config/last30days/.env` para la habilidad Código, volverá a ingresar las mismas claves aquí una vez.
+
+La compatibilidad con Windows se aplaza hasta que se resuelvan los puntos de entrada del manifiesto por plataforma; seguimiento en un número de seguimiento.
+
+### Garra Abierta
+
+```bash
+clawhub install last30days-official
+```
+
+Para flujos de trabajo de acciones de X/Twitter fuera de la investigación de `/last30days`, como publicaciones
+tweets o respuestas, exportación de seguidores, manejo de medios, monitores y obsequios
+dibuja, usa [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como compañero
+Complemento OpenClaw. TweetClaw es mantenido por Xquik-dev y aparece solo como un
+ruta complementaria opcional, no una dependencia o respaldo de los últimos 30 días.
+
+### Manual (desarrollador)
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill.git
+ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
+```
+
+El enlace simbólico mantiene la instalación sincronizada con su árbol de trabajo mientras edita, sin necesidad de volver a copiarlo. Para `claude.ai`, cree el archivo `.skill` desde el origen: `bash skills/last30days/scripts/build-skill.sh` produce `dist/last30days.skill`.
+
+Reddit (con comentarios), Hacker News, Polymarket y GitHub funcionan de inmediato. Configuración cero. Ejecute `/last30days` una vez y el asistente de configuración desbloqueará más fuentes en 30 segundos, incluidas las CLI gratuitas de arXiv y Techmeme.
+
+## Trae tus propias llaves
+
+Estas plataformas no tienen relaciones entre sí. X no sabe lo que piensa Reddit. YouTube no ve TikTok. Pero puedes traer tus propias claves API y tokens de navegador y, de repente, tendrás acceso a todos ellos a la vez.
+
+| Fuentes | Lo que necesitas | Costo |
+|---------|---------------|------|
+| Reddit (con comentarios) + HN + Polymarket + GitHub + StockTwits | Nada | Gratis |
+| arXiv + Techmeme | CLI gratuitos, autoinstalados mediante la configuración de primera ejecución | Gratis |
+| X/Twitter | Inicie sesión en x.com en cualquier navegador o configure `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratuitas; las claves son específicas del proveedor |
+| Youtube | `brew install yt-dlp` | Gratis |
+| Cielo azul | Contraseña de la aplicación de bsky.app | Gratis |
+| TikTok + Instagram + Hilos + Pinterest + LinkedIn + Comentarios de YouTube | Clave ScrapeCreators | 10.000 llamadas gratis, luego PAYG |
+| Xiaohongshu (ROJO) | Ejecute un complemento de navegador x-mcp conectado o un servicio `xiaohongshu-mcp` y opte por `--search xhs` por ejecución o `INCLUDE_SOURCES=xiaohongshu` en `.env`; Los últimos 30 días sondean automáticamente `http://localhost:18060` y luego `http://host.docker.internal:18060`, o use `XIAOHONGSHU_API_BASE` para una URL personalizada | Sin clave API de los últimos 30 días; depende del servicio de sesión de su navegador local |
+| DripStack (boletines financieros premium) | Optar por: `--search dripstack` por ejecución, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin llave; API de búsqueda pública gratuita |
+| Sonar de perplejidad / API de búsqueda / Investigación profunda | Clave de perplejidad o clave de OpenRouter como respaldo de Sonar | Paga sobre la marcha |
+| Búsqueda web | Tecla de búsqueda valiente | 2.000 consultas gratuitas/mes |
+
+### Llavero macOS (opcional)
+
+En macOS, puede almacenar claves en el llavero del sistema en lugar de en un archivo `.env`. La habilidad los selecciona automáticamente como la fuente de menor prioridad: los archivos `.env` y el entorno de proceso aún ganan en caso de colisión.
+
+```bash
+# Interactive setup — prompts for each known key, skip with empty input
+skills/last30days/scripts/setup-keychain.sh
+
+# Or store a single key by hand
+security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
+
+# Inspect / clean up
+skills/last30days/scripts/setup-keychain.sh --list
+skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
+```
+
+Los elementos se almacenan con el nombre de servicio `last30days-<KEY>` para el usuario actual. En plataformas que no son Darwin, el cargador no funciona, por lo que no hay ningún cambio de comportamiento para los usuarios de Linux/Windows.
+
+¿Ya tienes claves con diferentes nombres de servicios de llavero? Configure la asignación `LAST30DAYS_KEYCHAIN_ALIASES` no secreta descrita en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) en lugar de copiar secretos.
+
+Consulte [CONFIGURATION.md](CONFIGURATION.md) para obtener la matriz de claves completa por fuente, la prioridad del proveedor de razonamiento y la prioridad del backend de búsqueda web.
+
+## Configuración
+
+Dos cosas que probablemente querrás saber el primer día:
+
+**Donde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` tiene como valor predeterminado `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Anule estableciendo esa var env en cualquier ruta en su shell, o `--save-dir <path>` por ejecución. Utilice `--output <file>` cuando necesite el resultado renderizado en una ruta exacta, utilizando el formato seleccionado por `--emit`. Utilice `--save-suffix=<name>` para mantener separadas múltiples variaciones del mismo tema (por ejemplo, por cliente). Cada ejecución de `--save-dir` produce `<slug>-raw[-suffix].md`. Ejecute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar las escrituras planificadas antes de realizar una investigación.
+
+**Salida estructurada para agentes y flujos de trabajo.** Solicite a `/last30days` un JSON legible por máquina para recibir el perfil de agente versionado y estable. Para uso directo del motor en scripts o desarrollo, ejecute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; agregue `--json-profile=raw` solo cuando necesite el volcado interno sin versión de `Report`. Consulte la [referencia del campo de exportación JSON y política de versiones](docs/reference/json-export.md).
+
+**Descubrimiento sin temas.** Solicite a `/last30days what's trending in AI agents?` que obtenga un resumen de descubrimiento clasificado en lugar de investigar un tema que ya conoce; en un host de agente, esto ejecuta el protocolo de tres comandos evaluado por el host (el modelo nombra los temas, filtra la basura, califica el valor y escribe los ángulos del contenido). Para uso directo del motor en scripts o cron, ejecute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nombres de temas deterministas, sin ángulos); agregue `--emit=json` para el contrato de descubrimiento versionado. Discovery es mutuamente excluyente con un tema posicional y `--drill`.
+
+**Monitoreo de tendencias entre ejecuciones.** El modo predeterminado produce una nueva instantánea de rebajas por ejecución. Para acumular hallazgos a lo largo del tiempo, agregue `--store` para persistir en una base de datos SQLite, luego use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con entrega opcional de Slack/webhook en nuevos hallazgos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios/semanales. El patrón de cadencia completo se encuentra en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+
+**Una biblioteca de investigación a la que se puede suscribir.** Solicite a `/last30days` que cree el feed de su biblioteca o utilice `python3 skills/last30days/scripts/last30days.py library feed` directamente para secuencias de comandos y desarrollo. Convierte resúmenes guardados en `index.html`, un Atom `feed.xml` local y páginas breves legibles. Agregue `--publish` solo cuando desee alojar el índice HTML y las páginas breves; la publicación es explícita y pública de forma predeterminada. Para que se pueda suscribir la fuente Atom, aloje el directorio de salida generado en un host estático como GitHub Pages.
+
+**Busca todo lo que has investigado.** Pregúntale a `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para uso directo del motor, ejecute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda está fuera de línea y es determinista: indexa incrementalmente los mismos resúmenes guardados utilizados por el feed de la biblioteca, fusiona avistamientos de tiendas coincidentes por ejecución y agrupa los resultados por tema y fecha. Las tiradas nuevas también aparecen en una sección compacta **De su biblioteca** cuando investigaciones anteriores se superponen con el tema actual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para deshabilitar ese contexto pasivo.
+
+Los scripts de contenedor por cliente, los subreddits de pares de categorías personalizados y el canal beta experimental para personalizaciones en progreso también se documentan en [CONFIGURATION.md](CONFIGURATION.md).
+
+## Escaparate: feeds de investigación de la comunidad
+
+¿Publicó una actualización recurrente de IA, una observación del mercado o una obsesión maravillosamente estrecha con los últimos 30 días? Comparta la URL de la biblioteca pública (o la URL de Atom después de alojar `feed.xml` en un host estático) en [el hilo de presentación de la comunidad](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds de la comunidad se vincularán aquí a medida que sus propietarios los envíen; Mientras tanto, el hilo es el punto de recogida.
+
+## Cómo funciona
+
+1. **Escribes un tema.** Persona, empresa, producto, tecnología, "X vs Y". Cualquier cosa.
+2. **El agente decide quién importa.** Encuentra X identificadores (incluidos los fundadores), repositorios de GitHub, subreddits, hashtags de TikTok y canales de YouTube. Para "Kanye West" conoce r/hiphopheads, @kanyewest y "bully review" en YouTube. Para "OpenClaw", resuelve openclaw/openclaw en GitHub y obtiene recuentos de estrellas en vivo.
+3. **Todas las fuentes buscadas en paralelo.** Expansión de consultas múltiples. Resultados puntuados por compromiso, relevancia y frescura.
+4. **La profundidad que nadie más tiene.** Transcripciones completas de YouTube de videos de reacciones. Principales comentarios de Reddit con recuentos de votos a favor. Subtítulos de TikTok. Cuotas de polimercado. No sólo títulos y enlaces.
+5. **La misma historia, fusionada.** Wireless Festival anunciado en Reddit, discutido en X, precios de las entradas en TikTok = un grupo, no tres artículos separados.
+6. **Sintetizado en un resumen.** Basado en datos específicos. Citado por fuente. Clasificados según lo que realmente interactúa con la gente. No "esto es lo que encontré". Es "esto es lo que importa".
+7. **Entonces se convierte en tu experto.** Después de una ejecución, tu sesión de Claude sabe todo lo que sabe la comunidad. Haga preguntas de seguimiento. Pídale que escriba indicaciones, redacte correos electrónicos, planifique viajes, diseñe sistemas, todo ello basado en lo que es real en este momento.
+
+## Lo que dice la gente
+
+> "Encontré una habilidad de Claude Code que investiga cualquier tema en Reddit, X, YouTube y HN de los últimos 30 días. Luego escribe las indicaciones por ti. He estado buscando manualmente en Reddit y X para investigar antes de cada contenido que escribo. Pestaña por pestaña. Hilo por hilo. Esa es la parte que lleva 90 minutos. Esto lo elimina". -@itsjasonai
+
+> "Esta habilidad reemplazó todo mi flujo de trabajo de investigación. Le das un tema, busca en Reddit, X y la web lo que la gente realmente está hablando. No publicaciones de blogs antiguas. Conversaciones reales de los últimos 30 días". -@itswilsoncharles
+
+> "5 de los 10 repositorios de tendencia en GitHub hoy en día son herramientas de Claude. #1: mvanhorn/last30days-skill" -@yieldhunter95
+
+## Código abierto
+
+Licencia MIT. Sin seguimiento. Sin análisis. Su investigación permanece en su máquina. Más de 2700 pruebas.
+
+Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird suministrado para búsqueda X) y API ScrapeCreators. Arquitectura del motor v3 por [@j-sperling](https://github.com/j-sperling).
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para abrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para obtener la lista completa de contribuyentes de la comunidad y [CHANGELOG.md](CHANGELOG.md) para ver el historial de versiones.
+
+## Historia de las estrellas
+
+<a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+  </picture>
+</a>
+
+---
+
+**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)

--- a/README.es.md
+++ b/README.es.md
@@ -16,151 +16,151 @@
   </a>
 </p>
 
-**Un motor de búsqueda con IA dirigido por agentes puntuado por votos positivos, me gusta y dinero real, no por editores.**
+**Un motor de búsqueda liderado por agentes de IA, puntuado por votos positivos, me gusta y dinero real, no por editores.**
 
-Este archivo README rastrea la canalización v3 actual. La especificación de habilidad en tiempo de ejecución se encuentra en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la fuente de verdad para el comportamiento de configuración y comando más reciente.
+Este README rastrea la pipeline v3 actual. La especificación de habilidad en tiempo de ejecución reside en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la fuente de verdad para el comportamiento más reciente de comandos y configuración.
 
-**Claude Code (recomendado: actualizaciones automáticas a través del mercado):**
+**Claude Code (recomendado — actualizaciones automáticas vía marketplace):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI o cualquiera de los más de 50 [hosts de Agent Skills](https://agentskills.io):**
+**Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ [Agent Skills](https://agentskills.io) presentadores:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` se instala globalmente para su usuario, disponible en todos los proyectos. Colóquelo en el alcance por proyecto).
+(`-g` se instala globalmente para tu usuario, disponible en todos los proyectos. Hazlo por proyecto por ámbito.)
 
-Más opciones de instalación (claude.ai web, OpenClaw, manual) en la sección [Install](#instalación) a continuación.
+Más opciones de instalación (claude.ai web, OpenClaw, manual) en la sección de [Install](#instalación) abajo.
 
-Configuración cero. Reddit, HN, Polymarket y GitHub funcionan de inmediato. Ejecútelo una vez y el asistente de configuración desbloqueará X, YouTube, TikTok, arXiv, Techmeme y más en 30 segundos.
+Cero configuración. Reddit, HN, Polymarkety GitHub funcionan inmediatamente. Ejecuta una vez y el asistente de configuración desbloquea X, YouTube, TikTok, arXiv, Techmemey más en 30 segundos.
 
 ---
 
-Votos positivos de Reddit. A X le gusta. Transcripciones de YouTube. Compromiso de TikTok. Cuotas de polimercado respaldadas por dinero real e información privilegiada. Son millones de personas votando con su atención y sus billeteras todos los días. /last30days lo busca todo en paralelo, lo califica según lo que realmente interactúan las personas reales y un juez agente de IA lo sintetiza en un resumen.
+Reddit votos positivos. X me gusta. YouTube transcripciones. TikTok interacción. Polymarket probabilidades respaldadas por dinero real e información privilegiada. Eso son millones de personas votando con su atención y su cartera cada día. /last30days lo busca todo en paralelo, lo puntua según lo que realmente interactúan las personas reales, y un juez agente de IA lo sintetiza en un solo informe.
 
-Editores agregados de Google. /last30days busca personas.
+Google agrega editores. /last30days busca personas.
 
-No puede realizar esta búsqueda en ningún otro lugar porque ninguna IA tiene acceso a toda ella. La búsqueda de Google no toca los comentarios de Reddit ni las publicaciones X. ChatGPT tiene un acuerdo con Reddit pero no puede buscar X ni TikTok. Gemini tiene YouTube pero no Reddit. Claude no tiene ninguno de ellos de forma nativa. Cada plataforma es un jardín vallado con su propia API, sus propios tokens, su propia autenticación. Pero puedes traer tus propias claves y sesiones de navegador y, de repente, un agente de IA puede buscarlas todas a la vez, compararlas entre sí y decirte lo que realmente importa.
+No puedes encontrar esta búsqueda en ningún otro sitio porque ninguna IA tiene acceso a todas. Google búsqueda no toca Reddit comentarios ni X publicaciones. ChatGPT tiene un acuerdo con Reddit pero no puede buscar X ni TikTok. Gemini tiene YouTube pero no Reddit. Claude no tiene ninguno de ellos de forma nativa. Cada plataforma es un jardín amurallado con su propio API, sus propios tokens, su propia autenticación. Pero puedes traer tus propias claves y sesiones de navegador, y de repente un agente de IA puede buscarlas todas a la vez, puntuarlas entre sí y decirte qué es lo que realmente importa.
 
-Ese es el desbloqueo. No hay un motor de búsqueda mejor. Una docena de plataformas desconectadas, unidas por un agente.
+Ese es el desbloqueo. No hay un motor de búsqueda mejor. Una docena de plataformas desconectadas, conectadas por un agente.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Tienes una reunión mañana. Los buscas en Google. Obtendrá su LinkedIn a partir de 2023. /last30days le brinda lo que realmente están haciendo este mes: se unió a OpenAI para trabajar en Codex, luchó contra la prohibición de Anthropic sobre agentes externos, envió 23 PR con una tasa de fusión del 85%, creó "LobsterOS" para el control de agentes entre dispositivos y r/ClaudeCode alcanzó 569 votos a favor debatiendo si es un héroe o "insoportable". Distribuidos en X publicaciones, hilos de Reddit, transcripciones de YouTube y confirmaciones de GitHub. Nada de eso estaba en Google.
+Tienes una reunión mañana. Les Google a ellos. Obtienes su LinkedIn de 2023. /last30days te da lo que realmente están haciendo este mes: se unió a OpenAI para trabajar en Codex, luchar contra la prohibición de Anthropic sobre agentes externos, enviar 23 PRs con un 85% de tasa de fusión, construir "LobsterOS" para control de agentes entre dispositivos, y r/ClaudeCode alcanzó 569 votos positivos debatiendo si es un héroe o "insoportable". Dispersos por X publicaciones, hilos de Reddit , transcripciones de YouTube y GitHub commits. Nada de eso estaba en Google.
 
 ## Por qué existe esto
 
-Lo construí para mantenerme al día con la IA. Todo cambia todos los días y los nerds de Reddit y X siempre están al tanto de ello. Necesitaba mejores indicaciones y los datos de capacitación siempre estaban meses por detrás de lo que la comunidad ya había descubierto.
+Lo construí para mantenerme al día en IA. Todo cambia cada día y los frikis de Reddit y X siempre están al pendiente primero. Necesitaba mejores indicaciones, y los datos de entrenamiento siempre iban meses por detrás de lo que la comunidad ya había descubierto.
 
-Pero se convirtió en algo más grande. Ahora lo ejecuto antes de una llamada de ventas para conocer la verdad de los últimos 30 días sobre una empresa. Antes de una reunión para leer los tweets recientes y las transcripciones de podcasts de alguien. Antes de un viaje a Disney World, para saber qué atracciones están cerradas y qué dice la comunidad sobre Genie+. Antes de construir algo, debo saber qué problemas enfrenta realmente la gente.
+Pero se convirtió en algo más grande. Ahora lo hago antes de una llamada de ventas para saber la verdad de los últimos 30 días sobre un negocio. Antes de una reunión para leer los tuits recientes y las transcripciones de podcasts de alguien. Antes de un viaje Disney World para saber qué atracciones están cerradas y qué dice la comunidad sobre Genie+. Antes de construir nada para saber qué problemas están enfrentando realmente las personas.
 
-Si se reúne con un director ejecutivo, ¿ha leído todos sus tweets y transcripciones de YouTube de los últimos 30 días? Tengo.
+Si te reúnes con un CEO, ¿has leído todos sus tuits y transcripciones de YouTube de los últimos 30 días? Sí.
 
-## Fuentes, puntuadas por la gente
+## Fuentes, puntuadas por el pueblo
 
 | Fuente | Lo que te dice la gente |
 |--------|--------------------------|
-| **Reddit** | La toma sin filtrar. Comentarios principales con recuentos reales de votos a favor, gratis, sin clave API. Las opiniones reales que Google entierra. |
-| **X/Twitter** | La toma caliente, el hilo experto, la reacción de ruptura. Primero en saber, primero en discutir. |
-| **YouTube** | La inmersión profunda de 45 minutos. Se buscaron en las transcripciones completas las cinco frases citables que importan. |
-| **TikTok** | El creador llega a 3,6 millones de personas con una versión que nunca encontrarás en Google. |
-| **Instagram Reels** | La perspectiva del influencer con transcripciones de palabras habladas. La señal de la cultura visual. |
+| **Reddit** | La opinión sin filtros. Mejores comentarios con recuentos reales de votos, gratis, sin API clave. Las opiniones reales que Google entierra. |
+| **X / Twitter** | La opinión polémica, el hilo de expertos, la reacción de rompimiento. Primero en saber, primero en discutir. |
+| **YouTube** | La inmersión profunda de 45 minutos. En las transcripciones completas buscaron las 5 frases memorables que importan. |
+| **TikTok** | El creador llega a 3,6 millones de personas con una opinión que nunca encontrarás en Google. |
+| **Instagram Reels** | La perspectiva del influencer con transcripciones habladas. La señal cultural visual. |
 | **Hacker News** | El consenso de los desarrolladores. 825 puntos, 899 comentarios. Donde los técnicos realmente discuten. |
-| **Polymarket** | No opiniones. Impares. Respaldado por dinero real. 96% de confianza en las ventas de álbumes. 4% en una adquisición. |
-| **GitHub** | Para personas: velocidad de relaciones públicas, principales repositorios por estrellas, notas de la versión. Para temas: cuestiones y debates. |
-| **Digg** | Grupos de historias seleccionados de la tabla de clasificación AI 1000 de Digg (~1000 cuentas de AI de alta señal en X), con citas en línea atribuibles (no se requiere autenticación X). Habilitado automáticamente cuando `digg-pp-cli` está en PATH. |
-| **arXiv** | Los periódicos detrás del revuelo. Nueva investigación en la ventana, gratuita, sin clave API. Se habilita automáticamente cuando `arxiv-pp-cli` está en PATH (la configuración de primera ejecución lo instala). |
-| **Tecmeme** | La capa editorial de noticias tecnológicas, con ventana de fecha a sus 30 días. Gratis, sin clave API. Se habilita automáticamente cuando `techmeme-pp-cli` está en PATH (la configuración de primera ejecución lo instala). |
-| **LinkedIn** | La señal profesional. Publicaciones y artículos, con artículos ponderados como señal alta. |
-| **StockTwits** | Sentimiento del comerciante. Se activa automáticamente cuando su tema es un ticker o una criptomoneda. |
-| **Hilos** | La capa de texto posterior a Twitter. Conversaciones de creadores y marcas. |
-| **Pinterest** | Descubrimiento visual. Fija, guarda y comenta productos e ideas. |
-| **Xiaohongshu (ROJO)** | Señales de creadores, productos y estilos de vida chinos. Se solicita explícitamente con `--search xhs` cuando se ejecuta localmente un complemento de navegador x-mcp conectado o un servicio `xiaohongshu-mcp`. |
-| **Cielo azul** | La capa social descentralizada. Publicaciones de AT Protocol de la migración posterior a Twitter. |
-| **Perplejidad** | Síntesis de Grounded Sonar, filas de API de búsqueda sin procesar e investigación profunda. |
-| **Web** | La cobertura editorial, las comparaciones de blogs. Una señal de muchas, no la única. |
+| **Polymarket** | No opiniones. Probabilidades. Respaldado por dinero real. 96% de confianza en las ventas del álbum. 4% en una adquisición. |
+| **GitHub** | Para la gente: PR Velocity, repositorios principales por estrellas, notas de lanzamiento. Para temas: temas y debates. |
+| **Digg** | Agrupaciones de historias seleccionadas de la tabla de clasificación AI 1000 de Digg(~1000 cuentas de IA de alta señal en X), con comillas en línea atribuibles (sin necesidad de autenticación X ). Autoactivado cuando `digg-pp-cli` está en PATH. |
+| **arXiv** | Los papeles detrás del bombo. Nueva investigación en la ventana, gratis, sin API clave. Autoactivado cuando `arxiv-pp-cli` está en PATH (la primera configuración lo instala). |
+| **Techmeme** | La capa editorial de noticias tecnológicas, con fecha de 30 días. Gratis, sin API clave. Activado automáticamente cuando `techmeme-pp-cli` está en PATH (la primera ejecución lo instala). |
+| **LinkedIn** | La señal profesional. Publicaciones y artículos, con los artículos ponderados como alta señal. |
+| **StockTwits** | Sentimiento del trader. Se activa automáticamente cuando tu tema es un ticker o una criptomoneda. |
+| **Threads** | La capa de texto post-Twitter. Conversaciones de creadores y marcas. |
+| **Pinterest** | Descubrimiento visual. Pines, guarda y comenta productos e ideas. |
+| **Xiaohongshu (RED)** | Señales de estilo de vida, producto y creador chino. Solicitado explícitamente con `--search xhs` cuando un plugin de navegador x-mcp o servicio de `xiaohongshu-mcp` iniciado sesión está ejecutándose localmente. |
+| **Bluesky** | La capa social descentralizada. Publicaciones del Protocolo AT desde la migración posterior a Twitter. |
+| **Perplexity** | Síntesis de sonar en tierra, filas de búsqueda API puro e investigación profunda. |
+| **Web** | La cobertura editorial, las comparaciones en blogs. Una señal entre muchas, no la única. |
 
-Los contribuyentes de la comunidad siguen agregando más. Truth Social y otras fuentes de nicho están en el motor y hay más en camino.
+Los colaboradores de la comunidad siguen añadiendo más. Truth Social y otras fuentes de nicho están en el motor con más en camino.
 
-Un hilo de Reddit con 1500 votos a favor es una señal más fuerte que una publicación de blog que nadie leyó. Un TikTok con 3,6 millones de visitas te dice más sobre lo que es culturalmente relevante que un comunicado de prensa. Las probabilidades de los polimercados respaldadas por un volumen de 66.000 dólares son más difíciles de discutir que las suposiciones de un experto.
+Un hilo Reddit con 1.500 votos positivos es una señal más fuerte que una entrada de blog que nadie ha leído. Un TikTok con 3,6 millones de visualizaciones te dice más sobre lo que es culturalmente relevante que una nota de prensa. Polymarket cuotas respaldadas por 66.000 dólares en volumen son más difíciles de discutir que la suposición de un experto.
 
-La síntesis se clasifica según lo que realmente hizo la gente real. Relevancia social, no relevancia SEO.
+La síntesis se clasifica según lo que realmente se relacionó la gente real. Relevancia social, no SEO relevancia.
 
-## Para qué lo usa realmente la gente
+## Para qué la gente realmente lo usa
 
-**Antes de una reunión.** `/last30days Peter Steinberger`: se unió al equipo Codex de OpenAI, luchando contra la prohibición de Anthropic sobre agentes externos, 23 RP se fusionaron a una tasa de fusión del 85 % en GitHub, creando LobsterOS para el control de agentes entre dispositivos. r/ClaudeCode: "Desde que se lanzó OpenClaw, era ampliamente conocido que si lo ejecutabas a través de cualquier otra cosa que no fuera la API, eventualmente serías baneado" (227 votos a favor). Eso no está en LinkedIn.
+**Antes de una reunión.** `/last30days Peter Steinberger` - se unió al equipo Codex de OpenAI, luchando contra la prohibición de agentes externos de Anthropic, 23 PRs fusionados con un 85% de tasa de fusión en GitHub, construyendo LobsterOS para el control de agentes entre dispositivos. Código r/Claude: "Desde que OpenClaw se lanzó, era bien sabido que si lo pasabas por cualquier cosa que no fuera la API, acabarían siendo baneados" (227 votos positivos). Eso no es culpa LinkedIn.
 
-**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals`: las páginas de empleos y carreras actuales se convierten en evidencia citada de cambios de enfoque: contratación en seguridad empresarial, éxito del cliente, infraestructura o expansión de productos. El informe dice lo que parece indicar la contratación, no lo que ofrecerá la hoja de ruta.
+**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals` - las páginas actuales de empleos y carreras se citan como evidencias de cambios de enfoque: contratación hacia seguridad empresarial, éxito del cliente, infraestructura o expansión de productos. El informe dice lo que parece señalar la contratación, no lo que la hoja de ruta presentará.
 
-**Para encontrar el tema antes de que alcance su punto máximo.** Pregunte a `/last30days what's exploding in AI agents?` y la habilidad cambiará al modo de descubrimiento: el motor barre los listados de categorías de Reddit, las mejores historias de Hacker News, el feed AI 1000 de Digg y X cuando se autentica; su agente juzga las nominaciones (nombres, filtrado de basura, valor del contenido) y escribe ángulos de podcasts/artículos X; luego obtienes entre 5 y 10 temas clasificados por velocidad. Cada resultado incluye números de fuentes cruzadas, una etiqueta de impulso y un seguimiento `/last30days "<topic>"` listo para ejecutar.
+**Para encontrar el tema antes de que alcance su punto máximo.** Pregúntale `/last30days what's exploding in AI agents?` y la habilidad cambia a modo descubrimiento: el motor barre Reddit listados de categorías, Hacker News historias principales/mejores, el feed AI 1000 de Diggy X cuando está autenticado; tu agente juzga las nominaciones (nombres, filtrado basura, calidad de contenido) y escribe podcast / X-ángulos de artículo; luego obtienes de 5 a 10 temas clasificados por velocidad. Cada resultado incluye números de fuentes cruzadas, una etiqueta de impulso y un seguimiento `/last30days "<topic>"` listo para publicarse.
 
-**Cuando algo cae.** `/last30days Kanye West` - Reino Unido bloqueó su visa, Wireless Festival canceló, los patrocinadores huyeron. Pero BULLY debutó en el puesto número 2 en Billboard. Fantano regresó de su "año sabático" para revisarlo (653.000 visitas). SoFi Homecoming presentó a Lauryn Hill y Travis Scott para 44 canciones. Polymarket: "¿Kanye volverá a twittear?" 86% Sí. 23 hilos de Reddit, 17 vídeos de YouTube, 86.000 votos a favor.
+**Cuando algo cae.** `/last30days Kanye West` - Reino Unido bloqueó su visado, el Wireless Festival canceló, los patrocinadores huyeron. Pero BULLY debutó en el puesto #2 en Billboard. Fantano volvió de su "Yay sabático" para reseñarlo (653.000 visualizaciones). SoFi Homecoming trajo a Lauryn Hill y Travis Scott para 44 canciones. Polymarket: «¿Volverá a tuitear Kanye?» 86% Sí. 23 hilos Reddit , 17 vídeos YouTube , 86.000 votos positivos.
 
-**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip`: "Estos no son competidores, son capas". OpenClaw es el ejecutor (351.000 estrellas de GitHub, en vivo), Hermes es el cerebro que se mejora a sí mismo (31.000 estrellas), Paperclip es el organigrama (49.000 estrellas). El conteo de estrellas se obtuvo en vivo de la API de GitHub, no de publicaciones de blog obsoletas. Mesa de lado a lado con arquitectura, memoria, seguridad, lo mejor para. Según @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard".
+**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Estos no son competidores, son capas." OpenClaw es el albacea (351K GitHub estrellas, en directo), Hermes es el cerebro que se auto-mejora (31K estrellas), Paperclip es el organigrama (49K estrellas). Recuento de estrellas extraído en directo del GitHub API, no entradas de blog obsoletas. Mesa lado a lado con arquitectura, memoria, seguridad, lo mejor para. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
 
-**Para entender el mundo.** `/last30days Iran vs USA` - Día 38 de la guerra. La fecha límite del martes de Trump para que Irán reabra el Estrecho de Ormuz. Dos aviones de combate estadounidenses derribados. Petróleo a 126 dólares el barril. La AIE lo calificó como "la mayor interrupción del suministro en la historia del mercado mundial del petróleo". Polymarket: alto el fuego antes del 31 de diciembre al 74%. 27 publicaciones X, 10 videos de YouTube, 20 mercados de predicción.
+**Para entender el mundo.** `/last30days Iran vs USA` - Día 38 de la guerra. La fecha límite del martes de Trump para que Irán reabra el Estrecho de Ormuz. Dos aviones de guerra estadounidenses derribados. Petróleo a 126 dólares por barril. La AIE lo calificó como "la mayor interrupción del suministro en la historia del mercado global del petróleo." Polymarket: alto el fuego para el 31 de diciembre al 74%. 27 publicaciones X , 10 vídeos YouTube , 20 mercados de predicción.
 
-**Antes de un viaje.** `/last30days Universal Epic Universe` - Ampliación ya en construcción. Permiso "Proyecto 680" presentado. Espectáculo de fuegos artificiales confirmado por infraestructura pero sin previo aviso. Tiempos de espera: Mine-Cart Madness con un promedio de 148 minutos. Aún no hay un pase anual y los lugareños están frustrados. Stardust Racers estará en remodelación hasta el 5 de abril.
+**Antes de un viaje.** `/last30days Universal Epic Universe` - Expansión ya en construcción. Permiso "Proyecto 680" presentado. Espectáculo de fuegos artificiales confirmado por infraestructura pero sin avisar. Tiempos de espera: Locura de vagonetas de mina de media 148 minutos. Aún no hay pase anual y los locales están frustrados. Stardust Racers en reformas hasta el 5 de abril.
 
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting`: las indicaciones estructuradas en JSON están reemplazando la sopa de etiquetas. El formato anidado de @pictsbyai evita la "sangrado de conceptos". El flujo de trabajo que da prioridad a la edición supera a la regeneración. Luego le escribe un mensaje de producción utilizando exactamente lo que la comunidad dijo que funciona.
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - Los prompts estructurados JSONestán reemplazando a la sopa de etiquetas. El formato anidado de @pictsbyaievita el "sangrado conceptual". El flujo de trabajo de edición primero vence a la regeneración. Luego te escribe un prompt de producción usando exactamente lo que la comunidad dijo que funciona.
 
-## ¿Qué hay de nuevo?
+## Qué hay de nuevo
 
-Desde el anuncio de la v3.3 en mayo, a partir de la v3.11.1 (julio de 2026): 175 RP fusionados (122 de ellos de 52 contribuyentes de la comunidad) en 15 versiones. Esto es lo que aterrizó.
+Desde el anuncio de la v3.3 en mayo, a partir de la v3.11.1 (julio de 2026): 175 se fusionaron PRs —122 de 52 colaboradores de la comunidad— en 15 lanzamientos. Esto fue lo que me consiguió.
 
 ### Primera clase en OpenAI Codex
 
-/last30days es ahora un complemento nativo de Codex con configuración guiada: no un puerto, un ciudadano de primera clase. Las citas con reconocimiento de renderizador significan que la salida del Codex se lee como un resumen en lugar de una sopa de URL (#694), y el mismo motor se ejecuta en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw y más de 50 hosts de Agent Skills. Manifiesto del complemento Codex por [@rfoust](https://github.com/rfoust) (#686), corrección de autenticación del Codex por [@tmchow](https://github.com/tmchow) (#698).
+/last30days ahora es un plugin nativo de Codex con configuración guiada: no es un puerto, es un ciudadano de primera clase. Las citas conscientes del renderizador hacen que Codex salida se lea como un brief en lugar de una sopa de URL (#694), y el mismo motor funciona en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawy 50+ hosts Agent Skills . Codex manifiesto del plugin por [@rfoust](https://github.com/rfoust) (#686), Codex corrección de autenticación por [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmeme y Digg: gratis, sin claves API
+### arXiv, Techmemey Digg - gratis, sin llaves API
 
-arXiv trae los artículos detrás de la publicidad y Techmeme trae la capa editorial de noticias tecnológicas: gratuita, sin claves y la configuración de primera ejecución instala sus CLI para que se activen automáticamente (#709). Los grupos de historias AI 1000 de Digg llegan sin autenticación X de la misma manera: el programa de instalación instala la CLI gratuita de Digg (#590). Trustpilot ofrece la opción de participar en la investigación de marcas de consumo.
+arXiv trae a los periódicos detrás del bombo y Techmeme trae la capa editorial de noticias tecnológicas - gratis, cero llaves, y la configuración de primera ejecución instala sus CLIpara que se activen automáticamente (#709). Los clusters de historias AI 1000 de Diggllegan sin X autenticación de la misma manera: configuración instala el Digg CLI gratuito para ti (#590). Trustpilot se lanza opt-in para investigación de marca de consumo.
 
-### Free Reddit aumentó las puntuaciones reales y los comentarios principales
+### Free Reddit ha hecho crecer puntuaciones reales y comentarios destacados
 
-La API pública .json de Reddit murió; el camino libre volvió con más fuerza. RSS sin llave + shreddit scraping (#457), descubrimiento de subreddit dedicado con conteos reales de votos positivos a través de arctic-shift (#696) y un piso de relevancia para que una publicación viral fuera de tema no pueda secuestrar su resumen (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave API. Puntuaciones reales. Comentarios principales incluidos.
+Reddit.json API pública murió; el camino gratuito volvió más fuerte. RSS sin clave + scraping de shreddit (#457), descubrimiento de subreddit dedicado con conteos reales de votos positivos vía arctic-shift (#696), y un piso de relevancia para que una publicación viral fuera de tema no pueda secuestrar tu brief (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave API . Puntuaciones reales. Comentarios principales incluidos.
 
-### Los mejores comentarios en cada brief
+### Los mejores comentarios en cada informe
 
-Los comentarios ahora son una capa predeterminada en todas las fuentes: comentarios de Instagram con diversidad basada en clasificación, por lo que cinco tomas interesantes no provienen todas de una publicación (n.° 751), comentarios de YouTube más una copia de seguridad de la transcripción de ScrapeCreators para cuando yt-dlp se tache (n.° 637) y comentarios votados por la multitud ponderados en las mejores tomas para que las líneas más divertidas de la comunidad sobrevivan la puntuación (n.° 592, n.° 608).
+Los comentarios ahora son una capa predeterminada en todas las fuentes: comentarios de Instagram con diversidad basada en el ranking, así que cinco opiniones polémicas no provienen todas de una sola publicación (#751), YouTube comentarios más una copia de seguridad ScrapeCreators de transcripción para cuando YT-DLP se pone fuera (#637), y comentarios votados por el público ponderados en Best Takes para que las líneas más divertidas de la comunidad sobrevivan a la puntuación (#592, #608).
 
-### Un comando médico
+### Orden de un médico
 
-Solicite una verificación de estado y el médico ejecutará todas las fuentes y luego prescribe las soluciones exactas: qué clave falta, qué CLI está fuera de RUTA, qué cookie expiró (#753). Ya no tendrás que adivinar por qué X volvió a adelgazar.
+Pide un chequeo médico y el médico revisa todas las fuentes, luego prescribe soluciones exactas: qué clave falta, cuál CLI está desajustada PATH, qué cookie caducó (#753). No más adivinanzas por qué X salió floja.
 
-### Búsqueda X, reconstruida
+### X búsqueda, reconstruida
 
-El canal X recibió una revisión integral: carriles FROM y ACERCA de para que las publicaciones de una persona y la conversación sobre ellas se clasifiquen (n.° 610), desambiguación de subconsultas con reconocimiento de persona (n.° 611), base de autoría propia con clasificación de señales de interacción (n.° 613) y una única fuente X con conmutación automática por error de backend (n.° 622). Además de un `--diagnose` honesto que realmente prueba la autenticación (#609).
+La X pipeline recibió una renovación completa: carriles FROM y ABOUT, así que las publicaciones propias de una persona y la conversación sobre ambas se posicionan (#610), desambiguación de subconsultas conscientes de la persona (#611), puesta a tierra de autoría de primera mano con ranking de señal de interacción (#613), y una única fuente X con falla automática de backend (#622). Además, un `--diagnose` honesto que realmente sondea la autenticación (#609).
 
-### Más fuentes se unieron
+### Se sumaron más fuentes
 
-LinkedIn vía ScrapeCreators, con artículos de alta señal ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente para temas de ticker y cripto ([@wtiwana](https://github.com/wtiwana), #658). La perplejidad aumentó en los modos API directos y en la investigación profunda asíncrona ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn vía ScrapeCreators, con artículos como high signal ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente para temas de tickers y cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity creció directamente en modos API y async Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Endurecido por la comunidad
+### Endurecidos por la comunidad
 
-La ola de seguridad fue casi en su totalidad trabajo comunitario: correcciones de XSS almacenado en el renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies bloqueados, CI reforzado en la cadena de suministro con OpenSSF Scorecard y atestación de procedencia de compilación ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), escaneos de Semgrep y OSV-Scanner más una puerta de revisión de dependencia de relaciones públicas ([@23241a6749](https://github.com/23241a6749)), un piso de cobertura de prueba introducido al 60% y desde entonces elevado al 84% ([@gourab5139014](https://github.com/gourab5139014)) y un análisis de seguridad de Hermes eliminó todos los hallazgos CRÍTICOS (#768).
+La ola de seguridad consistía casi en su totalidad en trabajo comunitario: correcciones XSS almacenadas en el renderizador de HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies bloqueados, CI reforzado en cadena de suministro con OpenSSF Scorecard y atestación de procedencia de compilación ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), escaneos Semgrep y OSV-Scanner más una PR puerta de revisión de dependencias ([@23241a6749](https://github.com/23241a6749)), un piso de cobertura de pruebas introducido al 60% y desde entonces elevado al 84% ([@gourab5139014](https://github.com/gourab5139014)), y un escaneo de seguridad Hermes eliminado de todos los hallazgos CRÍTICOS (#768).
 
 ### Llega más lejos
 
-Lenguas hebreas y no latinas ([@dudyme](https://github.com/dudyme)). Tokenización compatible con CJK para fuentes chinas ([@An-idd](https://github.com/An-idd)). Una ola de compatibilidad con Windows. Extracción de cookies en toda la familia Chromium: Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)), además de fuentes de credenciales macOS Keychain y Linux pass(1). Revisión histórica de `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 con aprovisionamiento automático a través de uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Deltas de la lista de seguimiento entre ejecuciones.
+Hebreo y lenguas no latinas ([@dudyme](https://github.com/dudyme)). Tokenización consciente de CJKpara fuentes chinas ([@An-idd](https://github.com/An-idd)). Una ola de compatibilidad Windows . Extracción de cookies a lo largo de toda la familia Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - además de fuentes de credenciales macOS Keychain y Linux pass(1). `--as-of` revisión histórica ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionado automáticamente Python 3.12 vía uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Deltas de la lista de seguimiento entre ejecuciones.
 
-### Todavía en la caja de v3
+### Sigue en la caja de la v3
 
-Los fundamentos de la v3 todavía están aquí: el cerebro previo a la investigación que resuelve los identificadores, subreddits y hashtags correctos antes de que se active una única llamada API (creado por [@j-sperling](https://github.com/j-sperling)); Best Takes puntúa por humor y viralidad junto con relevancia; fusión de clústeres de fuentes cruzadas; comparaciones de un solo paso ("CLI vs MCP" en 3 minutos, no 12); comparaciones de `--competitors` descubiertas automáticamente; Modo persona de GitHub (`--github-user=steipete`); modo ELI5 ("eli5 activado" después de cualquier ejecución); y resúmenes HTML independientes y compartibles (`--emit=html`). Las perillas de configuración se encuentran en [CONFIGURATION.md](CONFIGURATION.md).
+Las bases de la v3 siguen aquí: el cerebro previo a la investigación que resuelve los handles, subreddits y hashtags correctos antes de que se active una sola llamada de API (creado por [@j-sperling](https://github.com/j-sperling)); Best Takes puntuación para humor y viralidad junto con relevancia; fusión de clústeres entre fuentes; comparaciones de un solo pase ("CLI vs MCP" en 3 minutos, no en 12); comparaciones `--competitors` descubiertas automáticamente; GitHub modo persona (`--github-user=steipete`); modo ELI5 ("eli5 activado" tras cualquier partida); y HTML briefs compartidos y autocontenidos (`--emit=html`). Los mandos de configuración están en [CONFIGURATION.md](CONFIGURATION.md).
 
-## Instalar
+## Instalación
 
-| Superficie | Instalar | Actualizaciones |
+| Superficie | Instalación | Actualizaciones |
 |---------|---------|---------|
-| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto a través del mercado, o `claude plugin update last30days@last30days-skill` |
-| **Grok** (CLI de compilación xAI) | `grok plugin marketplace add mvanhorn/last30days-skill` luego `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI o cualquiera de los más de 50 [hosts de Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Descargue `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y cárguelo a través de claude.ai > Personalizar > Habilidades > + > Crear habilidad > Cargar una habilidad | Volver a descargar y volver a subir |
-| **Claude Desktop** | [Descargue el `.mcpb` para su plataforma ](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrástrelo a Configuración > Extensiones | Vuelva a descargar y arrastre el nuevo paquete a |
+| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto a través del marketplace, o `claude plugin update last30days@last30days-skill` |
+| **Grok**( CLIde construcción xAI ) | `grok plugin marketplace add mvanhorn/last30days-skill` entonces `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLIo cualquiera de los 50+ [Agent Skills](https://agentskills.io) presentadores** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y sube a través de claude.ai > Personalizar > habilidades > + > Crear habilidades > Subir una habilidad | Volver a descargar y volver a subir |
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrastra a Configuración > Extensiones | Vuelve a descargar y arrastra el nuevo paquete |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recomendado)
@@ -169,46 +169,46 @@ Los fundamentos de la v3 todavía están aquí: el cerebro previo a la investiga
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recomendado porque el mercado de Claude Code maneja las actualizaciones por usted: la caché del complemento tiene versiones y se actualiza automáticamente cuando se publica una nueva versión. Ejecute `claude plugin update last30days@last30days-skill` para forzar una verificación.
+Recomendado porque el marketplace de Claude Code se encarga de las actualizaciones por ti: la caché del plugin está versionada y se actualiza automáticamente cuando se publica una nueva versión. Ejecuta `claude plugin update last30days@last30days-skill` para forzar una comprobación.
 
-Si prefiere utilizar la ruta de instalación de habilidades del agente en Claude Code, también es compatible:
+Si prefieres usar la ruta de instalación de agent-skills en Claude Code, eso también está soportado:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-El complemento nativo y la instalación `npx skills` pueden coexistir. Tenga en cuenta que Claude Code no realiza deduplicación entre métodos de instalación: si tiene activos tanto el complemento del mercado como la copia `npx skills`, `/last30days` mostrará dos entradas. Utilice un método de instalación por máquina.
+El plugin nativo y la instalación `npx skills` pueden coexistir. Ten en cuenta que Claude Code no se desduplica entre métodos de instalación: si tienes activas tanto el plugin del marketplace como la copia `npx skills` , `/last30days` mostrará dos entradas. Usa un método de instalación por máquina.
 
-### Grok (CLI de compilación xAI)
+### Grok ( CLIde la construcción xAI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) se instala los últimos 30 días como complemento nativo. La instalación directa rastrea el repositorio:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) se instala en dur30days como un plugin nativo. La instalación directa rastrea el repositorio:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-O agregue este repositorio como fuente del mercado, luego instálelo por el nombre del complemento:
+O añadir este repositorio como fuente del marketplace y luego instalar por nombre del plugin:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Agregue `--trust` para omitir la confirmación de instalación. Actualización con `grok plugin update last30days`. Grok también lee los manifiestos del Claude Code para comprobar la compatibilidad; el par nativo `.grok-plugin/` es el carril de primera clase (y a qué apunta un listado oficial [xAI Marketplace](https://github.com/xai-org/plugin-marketplace)). `npx skills add` sigue siendo una alternativa válida entre hosts.
+Añade `--trust` para saltarse la confirmación de instalación. Actualizar con `grok plugin update last30days`. Grok también lee los manifiestos de Claude Code para garantizar la compatibilidad; el par nativo de `.grok-plugin/` es el carril de primera clase (y lo que indica un listado oficial de [xAI marketplace](https://github.com/xai-org/plugin-marketplace) ). `npx skills add` sigue siendo un respaldo válido entre hosts.
 
-### Codex, Cursor, Copilot, Gemini CLI y otros hosts de Agent Skills
+### Codex, Cursor, Copilot, Gemini CLIy otros anfitriones Agent Skills
 
-Instale a través de la CLI abierta [Agent Skills](https://agentskills.io): admite más de 50 arneses, incluidos `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` y más (lista completa en el repositorio [vercel-labs/skills](https://github.com/vercel-labs/skills)).
+Instala a través del [Agent Skills](https://agentskills.io) CLI abierto — soporta 50+ arneses incluyendo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`y más (lista completa en el [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-El indicador `-g` (global) se instala en su directorio de usuarios para que la habilidad esté disponible en todos los proyectos. Sin `-g`, `npx skills` instala el proyecto localmente en `./.skills/` (comprometido con el repositorio). Para una herramienta de investigación del mundo, lo que desea es global.
+La bandera `-g` (global) se instala en tu directorio de usuario, por lo que la habilidad está disponible en todos los proyectos. Sin `-g`, `npx skills` instala el proyecto localmente en `./.skills/` (comprometido con el repositorio). Para una herramienta de investigación del mundo, lo que quieres es global.
 
-El escritorio Codex y otros hosts en modo carpeta pueden funcionar en carpetas normales, así como en repositorios Git. Antes de la primera investigación, solicite al agente anfitrión que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio de habilidades cargado; en un pago de origen, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Muestra el origen de la configuración, el plan de cookies del navegador, las escrituras planificadas, los comandos opcionales y la configuración del proyecto ignorada sin leer cookies, escribir archivos ni realizar investigaciones.
+Codex escritorio y otros hosts en modo carpeta pueden funcionar tanto en carpetas ordinarias como en repositorios Git. Antes de investigar primero, pide al agente host que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio skill cargado; en una comprobación de código, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Muestra el código fuente de configuración, el plan de cookies del navegador, las escrituras planificadas, los comandos opcionales y la configuración del proyecto ignorada sin leer cookies, escribir archivos ni ejecutar investigación.
 
-De forma predeterminada, esto se instala para cualquier arnés que detecte `npx skills`. Para apuntar a uno específico (o varios):
+Por defecto, esto se instala para el arnés que `npx skills` detecte. Para apuntar a uno específico (o varios):
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,57 +217,57 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Actualiza más tarde con:
+Actualización más adelante con:
 
 ```bash
 npx skills update last30days -g
 ```
 
-O actualice todo lo que ha instalado globalmente a través de `npx skills`:
+O actualiza todo lo que hayas instalado globalmente a través de `npx skills`:
 
 ```bash
 npx skills update -g
 ```
 
-Listar y eliminar con `npx skills list -g` y `npx skills remove last30days -g`.
+Lista y elimina con `npx skills list -g` y `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Descargue `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) desde la última versión
-2. Vaya a [claude.ai > Personalizar > Skills](https://claude.ai/customize/skills)
-3. Haga clic en el botón `+` en el panel Habilidades > haga clic en `Create skill` > `Upload a skill` y busque/solte el archivo en
+1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la última edición
+2. Ve a [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Haz clic en el botón `+` en el panel de Habilidades > haz clic en `Create skill` > `Upload a skill` y navega/suelta el archivo
 
-Habilite primero "Ejecución de código y creación de archivos" en Capacidades; las habilidades no se ejecutarán sin él.
+Activa primero "Ejecución de código y creación de archivos" en Capacidades — las habilidades no funcionarán sin ella.
 
 ### Claude Desktop
 
-Claude Desktop instala `/last30days` como servidor MCP a través de un paquete `.mcpb` (un paquete de protocolo de contexto modelo con un solo clic).
+Claude Desktop instala `/last30days` como servidor MCP mediante un paquete `.mcpb` (un paquete Model Context Protocol de un solo clic).
 
-1. Vaya a la [última versión](https://github.com/mvanhorn/last30days-skill/releases/latest) y descargue `.mcpb` para su plataforma:
-- macOS Apple Silicio: `last30days-pp-mcp-darwin-arm64.mcpb`
--Mac OS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
--Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abra Claude Desktop, vaya a Configuración > Extensiones y arrastre el archivo.
-3. Cuando se le solicite, pegue las claves API para las fuentes que desea habilitar. Cada campo es opcional: el motor pasa al modo solo web si los omite todos. Las claves se almacenan en el llavero de su sistema operativo.
-4. Reinicie Claude Desktop. Pídale a Claude que "investigue a Peter Steinberger" o cualquier tema y llamará a la herramienta `research`.
+1. Ve a la [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) y descarga el `.mcpb` para tu plataforma:
+   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Abre Claude Desktop, ve a Configuración > Extensiones y arrastra el archivo.
+3. Cuando te lo pidan, pega API claves para las fuentes que quieres activar. Cada campo es opcional: el motor se degrada a modo solo web si los saltas todos. Las claves se almacenan en el llavero de tu sistema operativo.
+4. Reinicia Claude Desktop. Pídele a Claude que "investigue a Peter Steinberger" o cualquier tema y llamará a la herramienta `research` .
 
-**Requisito de host:** Python 3.12+ en PATH. El paquete incluye el código fuente del motor pero utiliza su intérprete de Python local. Instalar desde [python.org](https://www.python.org/downloads/) en Windows; macOS y la mayoría de las distribuciones de Linux incluyen una versión compatible.
+**Requisito de host:** Python 3.12+ en PATH. El paquete incluye el código fuente del motor pero utiliza tu intérprete de Python local. Instala desde [python.org](https://www.python.org/downloads/) en Windows; macOS y la mayoría de Linux distribuciones envían una versión compatible.
 
-**Las claves no se sincronizan con la habilidad Código.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados por diseño. Si ya configuró `~/.config/last30days/.env` para la habilidad Código, volverá a ingresar las mismas claves aquí una vez.
+**Las teclas no se sincronizan con la habilidad Código.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados por diseño. Si ya configuraste `~/.config/last30days/.env` para la habilidad Código, volverás a introducir las mismas teclas aquí una vez.
 
-La compatibilidad con Windows se aplaza hasta que se resuelvan los puntos de entrada del manifiesto por plataforma; seguimiento en un número de seguimiento.
+Windows soporte se pospone hasta que se resuelvan los puntos de entrada del manifiesto por plataforma; se sigue en un número de seguimiento.
 
-### Garra Abierta
+### OpenClaw
 
 ```bash
 clawhub install last30days-official
 ```
 
-Para flujos de trabajo de acciones de X/Twitter fuera de la investigación de `/last30days`, como publicaciones
-tweets o respuestas, exportación de seguidores, manejo de medios, monitores y obsequios
-dibuja, usa [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como compañero
-Complemento OpenClaw. TweetClaw es mantenido por Xquik-dev y aparece solo como un
-ruta complementaria opcional, no una dependencia o respaldo de los últimos 30 días.
+Para X/Twitter acciones de trabajo fuera de la investigación `/last30days` , como publicar
+tuits o respuestas, exportación de seguidores, gestión de medios, monitores y sorteo
+Draws, usa a [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como compañero
+OpenClaw plugin. TweetClaw es mantenido por Xquik-dev y aparece solo como un
+Camino de compañero opcional, no una dependencia o endoso de Last30Days.
 
 ### Manual (desarrollador)
 
@@ -276,30 +276,30 @@ git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-El enlace simbólico mantiene la instalación sincronizada con su árbol de trabajo mientras edita, sin necesidad de volver a copiarlo. Para `claude.ai`, cree el archivo `.skill` desde el origen: `bash skills/last30days/scripts/build-skill.sh` produce `dist/last30days.skill`.
+El enlace simbólico mantiene la instalación sincronizada con tu árbol de trabajo mientras editas — no es necesario recopiar. Para `claude.ai`, compila el archivo `.skill` desde el código fuente: `bash skills/last30days/scripts/build-skill.sh` produce `dist/last30days.skill`.
 
-Reddit (con comentarios), Hacker News, Polymarket y GitHub funcionan de inmediato. Configuración cero. Ejecute `/last30days` una vez y el asistente de configuración desbloqueará más fuentes en 30 segundos, incluidas las CLI gratuitas de arXiv y Techmeme.
+Reddit (con comentarios), Hacker News, Polymarkety GitHub funcionan inmediatamente. Cero configuración. Ejecuta `/last30days` una vez y el asistente de configuración desbloquea más fuentes en 30 segundos, incluyendo la arXiv gratuita y la Techmeme CLIs.
 
 ## Trae tus propias llaves
 
-Estas plataformas no tienen relaciones entre sí. X no sabe lo que piensa Reddit. YouTube no ve TikTok. Pero puedes traer tus propias claves API y tokens de navegador y, de repente, tendrás acceso a todos ellos a la vez.
+Estas plataformas no tienen relaciones entre sí. X no sabe lo que Reddit piensa. YouTube no ve TikTok. Pero puedes traer tus propias claves de API y tokens de navegador, y de repente tienes acceso a todos a la vez.
 
-| Fuentes | Lo que necesitas | Costo |
+| Fuentes | Lo que necesitas | Coste |
 |---------|---------------|------|
 | Reddit (con comentarios) + HN + Polymarket + GitHub + StockTwits | Nada | Gratis |
-| arXiv + Techmeme | CLI gratuitos, autoinstalados mediante la configuración de primera ejecución | Gratis |
-| X/Twitter | Inicie sesión en x.com en cualquier navegador o configure `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratuitas; las claves son específicas del proveedor |
-| Youtube | `brew install yt-dlp` | Gratis |
-| Cielo azul | Contraseña de la aplicación de bsky.app | Gratis |
-| TikTok + Instagram + Hilos + Pinterest + LinkedIn + Comentarios de YouTube | Clave ScrapeCreators | 10.000 llamadas gratis, luego PAYG |
-| Xiaohongshu (ROJO) | Ejecute un complemento de navegador x-mcp conectado o un servicio `xiaohongshu-mcp` y opte por `--search xhs` por ejecución o `INCLUDE_SOURCES=xiaohongshu` en `.env`; Los últimos 30 días sondean automáticamente `http://localhost:18060` y luego `http://host.docker.internal:18060`, o use `XIAOHONGSHU_API_BASE` para una URL personalizada | Sin clave API de los últimos 30 días; depende del servicio de sesión de su navegador local |
-| DripStack (boletines financieros premium) | Optar por: `--search dripstack` por ejecución, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin llave; API de búsqueda pública gratuita |
-| Sonar de perplejidad / API de búsqueda / Investigación profunda | Clave de perplejidad o clave de OpenRouter como respaldo de Sonar | Paga sobre la marcha |
-| Búsqueda web | Tecla de búsqueda valiente | 2.000 consultas gratuitas/mes |
+| arXiv + Techmeme | Free CLIs, instalado automáticamente por la primera ejecución | Gratis |
+| X / Twitter | Inicia sesión en x.com en cualquier navegador, o configura `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratuitas; las claves son específicas de cada proveedor |
+| YouTube | `brew install yt-dlp` | Gratis |
+| Bluesky | Contraseña de la app de bsky.app | Gratis |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comentarios | ScrapeCreators clave | 10.000 llamadas gratis, luego PAYG |
+| Xiaohongshu (RED) | Ejecuta un plugin de navegador x-mcp o servicio `xiaohongshu-mcp` iniciado sesión y opta por `--search xhs` por partida o `INCLUDE_SOURCES=xiaohongshu` en `.env`; last30days auto-probes `http://localhost:18060` luego `http://host.docker.internal:18060`, o usa `XIAOHONGSHU_API_BASE` para una URL personalizada | No hay clave de API de últimos 30 días; depende del servicio local de sesiones de navegador |
+| DripStack (boletines financieros premium) | Opt-in: `--search dripstack` por partida, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin clave; búsqueda pública gratuita API |
+| Perplexity Sonar / API de búsqueda / Investigación profunda | Perplexity tecla, o clave OpenRouter como respaldo para Sonar | Paga según la acción |
+| Web búsqueda | Clave de búsqueda Brave | 2.000 consultas gratuitas al mes |
 
-### Llavero macOS (opcional)
+### macOS Keychain (opcional)
 
-En macOS, puede almacenar claves en el llavero del sistema en lugar de en un archivo `.env`. La habilidad los selecciona automáticamente como la fuente de menor prioridad: los archivos `.env` y el entorno de proceso aún ganan en caso de colisión.
+En macOS puedes almacenar claves en el Keychain del sistema en lugar de un archivo `.env` . La habilidad las detecta automáticamente como la fuente de menor prioridad — `.env` archivos y entorno de procesos siguen ganando en la colisión.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +313,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Los elementos se almacenan con el nombre de servicio `last30days-<KEY>` para el usuario actual. En plataformas que no son Darwin, el cargador no funciona, por lo que no hay ningún cambio de comportamiento para los usuarios de Linux/Windows.
+Los elementos se almacenan bajo `last30days-<KEY>` de nombre de servicio para el usuario actual. En plataformas no Darwin, el cargador es no-op, por lo que no hay cambio de comportamiento para usuarios de Linux/Windows .
 
-¿Ya tienes claves con diferentes nombres de servicios de llavero? Configure la asignación `LAST30DAYS_KEYCHAIN_ALIASES` no secreta descrita en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) en lugar de copiar secretos.
+¿Ya tienes claves bajo diferentes nombres de servicio Keychain ? Configura el mapeo de `LAST30DAYS_KEYCHAIN_ALIASES` no secreto descrito en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) en lugar de copiar secretos.
 
-Consulte [CONFIGURATION.md](CONFIGURATION.md) para obtener la matriz de claves completa por fuente, la prioridad del proveedor de razonamiento y la prioridad del backend de búsqueda web.
+Consulta [CONFIGURATION.md](CONFIGURATION.md) para la matriz completa de claves por fuente, prioridad del proveedor de razonamiento y prioridad del backend de búsqueda web.
 
 ## Configuración
 
 Dos cosas que probablemente querrás saber el primer día:
 
-**Donde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` tiene como valor predeterminado `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Anule estableciendo esa var env en cualquier ruta en su shell, o `--save-dir <path>` por ejecución. Utilice `--output <file>` cuando necesite el resultado renderizado en una ruta exacta, utilizando el formato seleccionado por `--emit`. Utilice `--save-suffix=<name>` para mantener separadas múltiples variaciones del mismo tema (por ejemplo, por cliente). Cada ejecución de `--save-dir` produce `<slug>-raw[-suffix].md`. Ejecute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar las escrituras planificadas antes de realizar una investigación.
+**Donde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` por defecto es `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Anula configurando esa variable ambiental a cualquier ruta de tu shell, o `--save-dir <path>` por partida. Usa `--output <file>` cuando necesites el resultado renderizado en una ruta exacta, usando el formato seleccionado por `--emit`. Usa `--save-suffix=<name>` para mantener separadas varias variaciones del mismo tema (por ejemplo, por cliente). Cada `--save-dir` ejecución produce `<slug>-raw[-suffix].md`. Ejecuta `python3 skills/last30days/scripts/last30days.py --preflight` para revisar las escrituras planificadas antes de una ejecución de investigación.
 
-**Salida estructurada para agentes y flujos de trabajo.** Solicite a `/last30days` un JSON legible por máquina para recibir el perfil de agente versionado y estable. Para uso directo del motor en scripts o desarrollo, ejecute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; agregue `--json-profile=raw` solo cuando necesite el volcado interno sin versión de `Report`. Consulte la [referencia del campo de exportación JSON y política de versiones](docs/reference/json-export.md).
+**Salida estructurada para agentes y flujos de trabajo.** Pide `/last30days` JSON legibles por máquina para recibir el perfil estable y versionado del agente. Para uso directo del motor en scripts o desarrollo, ejecuta `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; añade `--json-profile=raw` solo cuando necesites el volcado interno de `Report` sin versiones. Consulta el [JSON export field reference and versioning policy](docs/reference/json-export.md).
 
-**Descubrimiento sin temas.** Solicite a `/last30days what's trending in AI agents?` que obtenga un resumen de descubrimiento clasificado en lugar de investigar un tema que ya conoce; en un host de agente, esto ejecuta el protocolo de tres comandos evaluado por el host (el modelo nombra los temas, filtra la basura, califica el valor y escribe los ángulos del contenido). Para uso directo del motor en scripts o cron, ejecute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nombres de temas deterministas, sin ángulos); agregue `--emit=json` para el contrato de descubrimiento versionado. Discovery es mutuamente excluyente con un tema posicional y `--drill`.
+**Descubrimiento sin tema.** Pide a `/last30days what's trending in AI agents?` que consigas un resumen de descubrimiento clasificado en lugar de investigar un tema que ya conoces; en un agente anfitrión esto ejecuta el protocolo de tres comandos host-judged (el modelo nombra temas, filtra basura, puntua la dignidad y escribe los ángulos de contenido). Para uso directo del motor en scripts o cron, ejecuta `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nombres deterministas de temas, sin ángulos); añade `--emit=json` para el contrato de descubrimiento versionado. El descubrimiento es mutuamente excluyente con un tema posicional y `--drill`.
 
-**Monitoreo de tendencias entre ejecuciones.** El modo predeterminado produce una nueva instantánea de rebajas por ejecución. Para acumular hallazgos a lo largo del tiempo, agregue `--store` para persistir en una base de datos SQLite, luego use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con entrega opcional de Slack/webhook en nuevos hallazgos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios/semanales. El patrón de cadencia completo se encuentra en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Monitorización de tendencias entre ejecuciones.** El modo predeterminado produce una instantánea de descuento nueva por ejecución. Para acumular hallazgos a lo largo del tiempo, añade `--store` para que persistan en una base de datos SQLite, luego usa [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con entrega opcional de Slack / webhook en nuevos hallazgos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios o semanales. El patrón completo de cadencia está en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Una biblioteca de investigación a la que se puede suscribir.** Solicite a `/last30days` que cree el feed de su biblioteca o utilice `python3 skills/last30days/scripts/last30days.py library feed` directamente para secuencias de comandos y desarrollo. Convierte resúmenes guardados en `index.html`, un Atom `feed.xml` local y páginas breves legibles. Agregue `--publish` solo cuando desee alojar el índice HTML y las páginas breves; la publicación es explícita y pública de forma predeterminada. Para que se pueda suscribir la fuente Atom, aloje el directorio de salida generado en un host estático como GitHub Pages.
+**Una biblioteca de investigación suscribible.** Pídete `/last30days` que construya tu feed de biblioteca, o úsala `python3 skills/last30days/scripts/last30days.py library feed` directamente para scripting y desarrollo. Convierte los briefs guardados en `index.html`, un `feed.xml`local de Atom y páginas breves legibles. Añade `--publish` solo cuando quieras que el índice de HTML y las páginas breves estén alojadas; la publicación es explícita opt-in y pública por defecto. Para que el feed de Atom sea suscribible, aloja el directorio de salida generado en un host estático como GitHub Pages.
 
-**Busca todo lo que has investigado.** Pregúntale a `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para uso directo del motor, ejecute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda está fuera de línea y es determinista: indexa incrementalmente los mismos resúmenes guardados utilizados por el feed de la biblioteca, fusiona avistamientos de tiendas coincidentes por ejecución y agrupa los resultados por tema y fecha. Las tiradas nuevas también aparecen en una sección compacta **De su biblioteca** cuando investigaciones anteriores se superponen con el tema actual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para deshabilitar ese contexto pasivo.
+**Busca todo lo que has investigado.** Pregunta `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para uso directo del motor, ejecuta `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda es offline y determinista: indexa de forma incremental los mismos briefs guardados que usa el feed de la biblioteca, fusiona los avistamientos de la tienda correspondientes por ejecución y agrupa los resultados por tema y fecha. Las ejecuciones nuevas también muestran una sección compacta **Desde tu biblioteca** cuando investigaciones previas se solapan con el tema actual; configura `LAST30DAYS_LIBRARY_CONTEXT=off` para desactivar ese contexto pasivo.
 
-Los scripts de contenedor por cliente, los subreddits de pares de categorías personalizados y el canal beta experimental para personalizaciones en progreso también se documentan en [CONFIGURATION.md](CONFIGURATION.md).
+Los scripts wrapper por cliente, subreddits personalizados de categoría y el canal beta experimental para personalizaciones en proceso también están documentados en [CONFIGURATION.md](CONFIGURATION.md).
 
-## Escaparate: feeds de investigación de la comunidad
+## Showcase: feeds de investigación comunitaria
 
-¿Publicó una actualización recurrente de IA, una observación del mercado o una obsesión maravillosamente estrecha con los últimos 30 días? Comparta la URL de la biblioteca pública (o la URL de Atom después de alojar `feed.xml` en un host estático) en [el hilo de presentación de la comunidad](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds de la comunidad se vincularán aquí a medida que sus propietarios los envíen; Mientras tanto, el hilo es el punto de recogida.
+¿Has publicado una actualización recurrente de IA, un seguimiento de mercado o una obsesión maravillosamente limitada con los últimos 30 días? Comparte la URL de la biblioteca pública—o la URL de Atom después de alojarla `feed.xml` en un host estático—en [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds comunitarios estarán enlazados aquí a medida que sus propietarios los envíen; el hilo es el punto de recogida mientras tanto.
 
 ## Cómo funciona
 
-1. **Escribes un tema.** Persona, empresa, producto, tecnología, "X vs Y". Cualquier cosa.
-2. **El agente decide quién importa.** Encuentra X identificadores (incluidos los fundadores), repositorios de GitHub, subreddits, hashtags de TikTok y canales de YouTube. Para "Kanye West" conoce r/hiphopheads, @kanyewest y "bully review" en YouTube. Para "OpenClaw", resuelve openclaw/openclaw en GitHub y obtiene recuentos de estrellas en vivo.
-3. **Todas las fuentes buscadas en paralelo.** Expansión de consultas múltiples. Resultados puntuados por compromiso, relevancia y frescura.
-4. **La profundidad que nadie más tiene.** Transcripciones completas de YouTube de videos de reacciones. Principales comentarios de Reddit con recuentos de votos a favor. Subtítulos de TikTok. Cuotas de polimercado. No sólo títulos y enlaces.
-5. **La misma historia, fusionada.** Wireless Festival anunciado en Reddit, discutido en X, precios de las entradas en TikTok = un grupo, no tres artículos separados.
-6. **Sintetizado en un resumen.** Basado en datos específicos. Citado por fuente. Clasificados según lo que realmente interactúa con la gente. No "esto es lo que encontré". Es "esto es lo que importa".
-7. **Entonces se convierte en tu experto.** Después de una ejecución, tu sesión de Claude sabe todo lo que sabe la comunidad. Haga preguntas de seguimiento. Pídale que escriba indicaciones, redacte correos electrónicos, planifique viajes, diseñe sistemas, todo ello basado en lo que es real en este momento.
+1. **Escribes un tema.** Persona, empresa, producto, tecnología, "X vs Y." Cualquier cosa.
+2. **El agente decide quién importa.** Encuentra X cuentas (incluidos fundadores), repositorios de GitHub , subreddits TikTok hashtags YouTube canales. Para "Kanye West" conoce r/hiphopheads, @kanyewesty "bully review" en YouTube. Para "OpenClaw" resuelve openclaw/openclaw en GitHub y recoge recuentos de estrellas en directo.
+3. **Todas las fuentes buscadas en paralelo.** Expansión multiconsulta. Resultados puntuados por interacción, relevancia y frescura.
+4. **La profundidad que nadie más tiene.** Transcripciones completas YouTube de vídeos de reacción. Comentarios de Reddit con el recuento de votos positivos. TikTok pies de foto. Polymarket probabilidades. No solo títulos y enlaces.
+5. **Misma historia, fusionada.** El Festival Wireless anunciado el Reddit, se discutió en X, los precios de las entradas en TikTok = un grupo, no tres artículos separados.
+6. **Sintetizado en un solo informe.** Basado en datos específicos. Citado por fuente. Clasificado según lo que la gente realmente interactúa. No "esto es lo que encontré". Es "esto es lo que importa."
+7. **Entonces se convierte en tu experto.** Tras una sola partida, tu sesión Claude sabe todo lo que sabe la comunidad. Haz preguntas de seguimiento. Haz que escriba prompts, redacte correos electrónicos, planifique viajes, diseñe sistemas, todo basado en lo que es real ahora mismo.
 
 ## Lo que dice la gente
 
-> "Encontré una habilidad de Claude Code que investiga cualquier tema en Reddit, X, YouTube y HN de los últimos 30 días. Luego escribe las indicaciones por ti. He estado buscando manualmente en Reddit y X para investigar antes de cada contenido que escribo. Pestaña por pestaña. Hilo por hilo. Esa es la parte que lleva 90 minutos. Esto lo elimina". -@itsjasonai
+> "He encontrado una habilidad Claude Code que investiga cualquier tema en Reddit, X, YouTubey HN de los últimos 30 días. Luego escribe los prompts para ti. He estado buscando manualmente Reddit y X investigación antes de cada contenido que escribo. Pestaña por pestaña. Hilo por hilo. Esa es la parte que tarda 90 minutos. Esto lo elimina." -@itsjasonai
 
-> "Esta habilidad reemplazó todo mi flujo de trabajo de investigación. Le das un tema, busca en Reddit, X y la web lo que la gente realmente está hablando. No publicaciones de blogs antiguas. Conversaciones reales de los últimos 30 días". -@itswilsoncharles
+> "Esta habilidad reemplazó todo mi flujo de trabajo de investigación. Le das un tema, raspa Reddit, Xy la web para encontrar de qué la gente realmente habla. No de viejas entradas de blog. Conversaciones reales de los últimos 30 días." -@itswilsoncharles
 
-> "5 de los 10 repositorios de tendencia en GitHub hoy en día son herramientas de Claude. #1: mvanhorn/last30days-skill" -@yieldhunter95
+> "5 de los 10 repositorios más populares en GitHub hoy son herramientas Claude . #1: Mvanhorn/last30days-habilidad" -@yieldhunter95
 
 ## Código abierto
 
-Licencia MIT. Sin seguimiento. Sin análisis. Su investigación permanece en su máquina. Más de 2700 pruebas.
+Licencia del MIT. Sin rastreo. Sin análisis. Tu investigación permanece en tu máquina. 2.700+ pruebas.
 
-Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird suministrado para búsqueda X) y API ScrapeCreators. Arquitectura del motor v3 por [@j-sperling](https://github.com/j-sperling).
+Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird para X búsqueda) y ScrapeCreators API. arquitectura del motor v3 por [@j-sperling](https://github.com/j-sperling).
 
-Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para abrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para obtener la lista completa de contribuyentes de la comunidad y [CHANGELOG.md](CHANGELOG.md) para ver el historial de versiones.
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para abrir una PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para la lista completa de colaboradores de la comunidad y [CHANGELOG.md](CHANGELOG.md) para el historial de versiones.
 
-## Historia de las estrellas
+## Historia de Star
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,382 @@
+# /last30days
+
+[English](README.md) | Français | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+
+<p align="center">
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/mvanhorn/last30days-skill">
+    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
+  </a>
+  <br/>
+  <a href="https://trendshift.io/repositories/21997" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
+</p>
+
+**Un moteur de recherche dirigé par un agent IA et évalué par les votes positifs, les likes et l'argent réel - et non par les éditeurs.**
+
+Ce README suit le pipeline v3 actuel. La spécification de compétence d'exécution se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui est la source de vérité pour le dernier comportement de commande et de configuration.
+
+**Claude Code (recommandé — mises à jour automatiques via la place de marché) :**
+```
+/plugin marketplace add mvanhorn/last30days-skill
+/plugin install last30days
+```
+
+**Codex, Cursor, Copilot, Gemini CLI ou l'un des 50+ [Hôtes Agent Skills](https://agentskills.io) :**
+```
+npx skills add mvanhorn/last30days-skill -g
+```
+(`-g` s'installe globalement pour votre utilisateur, disponible dans tous les projets. Déposez-le dans la portée de chaque projet.)
+
+Plus d'options d'installation (claude.ai web, OpenClaw, manuel) dans la section [Install](#installation) ci-dessous.
+
+Zéro configuration. Reddit, HN, Polymarket et GitHub fonctionnent immédiatement. Exécutez-le une fois et l'assistant de configuration déverrouille X, YouTube, TikTok, arXiv, Techmeme et plus encore en 30 secondes.
+
+---
+
+Votes positifs sur Reddit. X aime. Transcriptions YouTube. Engagement sur TikTok. Cotes Polymarket soutenues par de l'argent réel et des informations privilégiées. Cela représente des millions de personnes qui votent chaque jour avec leur attention et leur portefeuille. /last30days recherche tout cela en parallèle, le note en fonction de ce avec quoi de vraies personnes interagissent réellement, et un juge d'agent IA le synthétise en un seul dossier.
+
+Google regroupe les éditeurs. /last30days recherche des personnes.
+
+Vous ne pouvez obtenir cette recherche nulle part ailleurs car aucune IA n’a accès à tout cela. La recherche Google ne touche pas les commentaires Reddit ou les publications X. ChatGPT a un accord avec Reddit mais ne peut pas rechercher X ou TikTok. Gemini a YouTube mais pas Reddit. Claude n'en possède aucun nativement. Chaque plateforme est un jardin clos avec sa propre API, ses propres tokens, sa propre authentification. Mais vous pouvez apporter vos propres clés et sessions de navigateur, et tout à coup, un agent IA peut toutes les rechercher en même temps, les comparer les unes aux autres et vous dire ce qui compte réellement.
+
+C'est le déverrouillage. Il n'y a pas de meilleur moteur de recherche. Une douzaine de plateformes déconnectées, pontées par un agent.
+
+```
+/last30days Peter Steinberger
+```
+
+Vous avez une réunion demain. Vous les recherchez sur Google. Vous obtenez leur LinkedIn à partir de 2023. /last30days vous montre ce qu'ils font réellement ce mois-ci : ils ont rejoint OpenAI pour travailler sur le Codex, luttent contre l'interdiction d'Anthropic sur les agents tiers, expédient 23 PR à un taux de fusion de 85 %, créent "LobsterOS" pour le contrôle des agents multi-appareils, et r/ClaudeCode a obtenu 569 votes positifs en débattant s'il est un héros ou "insupportable". Dispersé dans les publications X, les fils de discussion Reddit, les transcriptions YouTube et les commits GitHub. Rien de tout cela n'était sur Google.
+
+## Pourquoi cela existe
+
+Je l'ai construit pour suivre le rythme de l'IA. Tout change chaque jour et les nerds de Reddit et X sont toujours au top en premier. J'avais besoin de meilleures invites, et les données de formation étaient toujours en retard de plusieurs mois par rapport à ce que la communauté avait déjà compris.
+
+Mais cela s’est transformé en quelque chose de plus grand. Maintenant, je l'exécute avant un appel commercial pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion, pour lire les tweets récents et les transcriptions de podcasts de quelqu'un. Avant un voyage à Disney World pour savoir quels manèges sont fermés et ce que dit la communauté de Genie+. Avant de construire quoi que ce soit, je dois savoir quels problèmes les gens rencontrent réellement.
+
+Si vous rencontrez un PDG, avez-vous lu tous ses tweets et transcriptions YouTube des 30 derniers jours ? J'ai.
+
+## Sources, notées par le peuple
+
+| Source | Ce que les gens vous disent |
+|--------|--------------------------|
+| **Reddit** | La prise non filtrée. Meilleurs commentaires avec un nombre réel de votes positifs, gratuits, sans clé API. Les vraies opinions que Google enterre. |
+| **X / Twitter** | La prise chaude, le fil expert, la réaction cassante. Premier à savoir, premier à argumenter. |
+| **YouTube** | La plongée profonde de 45 minutes. Les transcriptions complètes ont recherché les 5 phrases citables qui comptent. |
+| **TikTok** | Le créateur touche 3,6 millions de personnes avec une prise que vous ne trouverez jamais sur Google. |
+| **Instagram Reels** | Le point de vue de l'influenceur avec des transcriptions de créations orales. Le signal de la culture visuelle. |
+| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les techniciens discutent réellement. |
+| **Polymarket** | Pas des avis. Chances. Soutenu par de l'argent réel. 96% de confiance sur les ventes d'albums. 4% sur une acquisition. |
+| **GitHub** | Pour les personnes : vitesse des relations publiques, meilleurs dépôts par stars, notes de version. Pour les sujets : problèmes et discussions. |
+| **Digg** | Groupes d'histoires sélectionnés à partir du classement AI 1000 de Digg (~ 1 000 comptes IA à signal élevé sur X), avec des citations en ligne attribuables (aucune authentification X requise). Activé automatiquement lorsque `digg-pp-cli` est sur PATH. |
+| **arXiv** | Les journaux derrière le battage médiatique. Nouvelle recherche dans la fenêtre, gratuite, sans clé API. Activé automatiquement lorsque `arxiv-pp-cli` est sur PATH (l'installation de première exécution l'installe). |
+| **Techmème** | La couche éditoriale d'actualités technologiques, fenêtrée sur vos 30 jours. Gratuit, sans clé API. Activé automatiquement lorsque `techmeme-pp-cli` est sur PATH (l'installation de première exécution l'installe). |
+| **LinkedIn** | Le signal professionnel. Publications et articles, avec des articles considérés comme un signal élevé. |
+| **StockTwits** | Sentiment des commerçants. S'active automatiquement lorsque votre sujet est un ticker ou une crypto. |
+| **Fils** | La couche de texte post-Twitter. Conversations de créateurs et de marques. |
+| **Pinterest** | Découverte visuelle. Épinglez, enregistrez et commentez les produits et les idées. |
+| **Xiaohongshu (ROUGE)** | Signaux de style de vie, de produit et de créateur chinois. Demandé explicitement avec `--search xhs` lorsqu'un plug-in de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` s'exécute localement. |
+| **Ciel bleu** | La couche sociale décentralisée. Publications du protocole AT issues de la migration post-Twitter. |
+| **Perplexité** | Synthèse Sonar mise à la terre, lignes brutes de l'API de recherche et recherche approfondie. |
+| **Internet** | La couverture éditoriale, les comparaisons de blogs. Un signal parmi tant d’autres, mais pas le seul. |
+
+Les contributeurs de la communauté continuent d’en ajouter. Truth Social et d’autres sources de niche sont dans le moteur et d’autres sont en route.
+
+Un fil de discussion Reddit avec 1 500 votes positifs est un signal plus fort qu’un article de blog que personne n’a lu. Un TikTok avec 3,6 millions de vues vous en dit plus sur ce qui est culturellement pertinent qu'un communiqué de presse. Les cotes du polymarché soutenues par un volume de 66 000 $ sont plus difficiles à contester que la supposition d'un expert.
+
+La synthèse est classée en fonction de ce avec quoi de vraies personnes se sont réellement engagées. Pertinence sociale, pas pertinence SEO.
+
+## Pourquoi les gens l'utilisent réellement
+
+**Avant une réunion.** `/last30days Peter Steinberger` - a rejoint l'équipe Codex d'OpenAI, luttant contre l'interdiction d'Anthropic sur les agents tiers, 23 PR ont fusionné à un taux de fusion de 85 % sur GitHub, créant LobsterOS pour le contrôle des agents multi-appareils. r/ClaudeCode : "Depuis la sortie d'OpenClaw, il était largement connu que si vous l'exécutiez via autre chose que l'API, vous finiriez par être banni" (227 votes positifs). Ce n'est pas sur LinkedIn.
+
+**Pour lire les signaux d'embauche.** `/last30days Listen Labs --hiring-signals` : les pages d'emplois et de carrières actuelles deviennent des preuves citées de changements d'orientation : embauche dans la sécurité de l'entreprise, la réussite des clients, l'infrastructure ou l'expansion des produits. Le rapport indique ce que l’embauche semble signaler, et non ce que la feuille de route prévoit.
+
+**Pour trouver le sujet avant qu'il n'atteigne son apogée.** Demandez à `/last30days what's exploding in AI agents?` et la compétence passe en mode découverte : le moteur balaie les listes de catégories Reddit, les fronts/meilleures histoires de Hacker News, le flux AI 1000 de Digg et X une fois authentifié ; votre agent juge les nominations (noms, filtrage des courriers indésirables, valeur du contenu) et rédige les angles des podcasts/articles X ; Ensuite, vous obtenez 5 à 10 sujets classés en fonction de la vitesse. Chaque résultat comprend des numéros multi-sources, une étiquette Momentum et un suivi `/last30days "<topic>"` prêt à l'emploi.
+
+**Quand quelque chose tombe.** `/last30days Kanye West` - Le Royaume-Uni a bloqué son visa, le Wireless Festival a été annulé, les sponsors ont fui. Mais BULLY a fait ses débuts au numéro 2 du Billboard. Fantano est revenu de son "Yay sabbatique" pour le revoir (653K vues). SoFi Homecoming a fait sortir Lauryn Hill et Travis Scott pour 44 chansons. Polymarket : "Est-ce que Kanye tweetera encore ?" 86% Oui. 23 fils de discussion Reddit, 17 vidéos YouTube, 86 000 votes positifs.
+
+**Pour comparer les outils.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Ce ne sont pas des concurrents, ce sont des couches." OpenClaw est l'exécuteur (351 000 étoiles GitHub, en direct), Hermes est le cerveau qui s'améliore automatiquement (31 000 étoiles), Paperclip est l'organigramme (49 000 étoiles). Le nombre d'étoiles est extrait en direct de l'API GitHub, et non d'articles de blog obsolètes. Table côte à côte avec architecture, mémoire, sécurité, le meilleur pour. Selon @IMJustinBrooke : "OpenClaw = Charmander, Hermes = Charizard."
+
+**Pour comprendre le monde.** `/last30days Iran vs USA` - Jour 38 de la guerre. La date limite fixée mardi par Trump pour que l'Iran rouvre le détroit d'Ormuz. Deux avions de guerre américains abattus. Pétrole à 126$/baril. L'AIE l'a qualifié de "plus grande rupture d'approvisionnement dans l'histoire du marché pétrolier mondial". Polymarket : cessez-le-feu d'ici le 31 décembre à 74 %. 27 publications X, 10 vidéos YouTube, 20 marchés de prédiction.
+
+**Avant un voyage.** `/last30days Universal Epic Universe` - Agrandissement déjà en construction. Permis « Projet 680 » déposé. Feu d'artifice confirmé par les infrastructures mais inopiné. Temps d'attente : Mine-Cart Madness en moyenne 148 minutes. Pas encore de laissez-passer annuel et les habitants sont frustrés. Les Stardust Racers seront rénovés jusqu'au 5 avril.
+
+**Pour apprendre quelque chose rapidement.** `/last30days Nano Banana Pro prompting` - Les invites structurées en JSON remplacent la soupe de balises. Le format imbriqué du @pictsbyai évite le « saignement des concepts ». Le flux de travail de modification en premier surpasse la régénération. Ensuite, il vous écrit une invite de production utilisant exactement ce que la communauté a dit fonctionner.
+
+## Quoi de neuf
+
+Depuis l'annonce de la v3.3 en mai, à partir de la v3.11.1 (juillet 2026) : 175 PR fusionnés - dont 122 provenant de 52 contributeurs de la communauté - dans 15 versions. C'est ce qui a atterri.
+
+### Première classe sur OpenAI Codex
+
+/last30days est désormais un plugin Codex natif avec une configuration guidée - pas un port, un citoyen de première classe. Les citations compatibles avec le moteur de rendu signifient que la sortie du Codex se lit comme un bref au lieu d'une soupe d'URL (#694), et que le même moteur fonctionne sur les hôtes Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw et plus de 50 Agent Skills. Manifeste du plugin Codex par [@rfoust](https://github.com/rfoust) (#686), correctif d'authentification Codex par [@tmchow](https://github.com/tmchow) (#698).
+
+### arXiv, Techmeme et Digg - gratuits, pas de clés API
+
+arXiv apporte les journaux derrière le battage médiatique et Techmeme apporte la couche d'actualités technologiques éditoriales - gratuite, sans clé, et la première configuration installe leurs CLI afin qu'elles s'activent automatiquement (#709). Les clusters d'histoires AI 1000 de Digg arrivent sans authentification X de la même manière : le programme d'installation installe la CLI Digg gratuite pour vous (#590). Trustpilot propose une option d'adhésion pour les recherches sur les marques grand public.
+
+### Free Reddit a augmenté ses scores réels et ses meilleurs commentaires
+
+L'API publique .json de Reddit est morte ; le libre chemin est revenu plus fort. RSS sans clé + scraping shreddit (#457), découverte de subreddit dédié avec un nombre réel de votes positifs via arctic-shift (#696) et un seuil de pertinence pour qu'une publication virale hors sujet ne puisse pas détourner votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Aucune clé API. De vrais scores. Principaux commentaires inclus.
+
+### Les meilleurs commentaires dans chaque brief
+
+Les commentaires sont désormais une couche par défaut entre les sources : commentaires Instagram avec une diversité basée sur le classement afin que cinq prises chaudes ne proviennent pas toutes d'une seule publication (#751), commentaires YouTube plus une sauvegarde de transcription ScrapeCreators pour le moment où yt-dlp est supprimé (#637), et les commentaires votés par la foule pondérés dans les meilleures prises afin que les lignes les plus drôles de la communauté survivent au score (#592, #608).
+
+### Une commande de médecin
+
+Demandez un bilan de santé et le médecin exécute chaque source, puis prescrit des correctifs exacts : quelle clé manque, quelle CLI est hors PATH, quel cookie a expiré (#753). Plus besoin de deviner pourquoi X est revenu mince.
+
+### Recherche X, reconstruite
+
+Le pipeline X a fait l'objet d'une refonte de fond : les voies FROM et ABOUT afin que les propres publications d'une personne et la conversation à leur sujet soient toutes deux classées (#610), la désambiguïsation des sous-requêtes sensibles à la personne (#611), la paternité de première partie avec classement des signaux d'interaction (#613) et une source X unique avec basculement automatique du backend (#622). Plus un honnête `--diagnose` qui sonde réellement l'authentification (#609).
+
+### Plus de sources jointes
+
+LinkedIn via ScrapeCreators, avec des articles comme signal fort ([@ravstr](https://github.com/ravstr), #702). StockTwits s'active automatiquement pour les sujets de ticker et de cryptographie ([@wtiwana](https://github.com/wtiwana), #658). Perplexity a développé les modes API directs et la recherche approfondie asynchrone ([@sk-holmes](https://github.com/sk-holmes), #629).
+
+### Endurci par la communauté
+
+La vague de sécurité était presque entièrement un travail communautaire : correctifs XSS stockés dans le moteur de rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI renforcés par la chaîne d'approvisionnement avec OpenSSF Scorecard et attestation de provenance de la construction ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), analyses Semgrep et OSV-Scanner ainsi qu'une porte d'examen des dépendances PR ([@23241a6749](https://github.com/23241a6749)), un plancher de couverture de test introduit à 60 % et augmenté depuis à 84 % ([@gourab5139014](https://github.com/gourab5139014)) et une analyse de sécurité Hermes effacée de toutes les découvertes CRITIQUES (#768).
+
+### Va plus loin
+
+Langues hébraïques et non latines ([@dudyme](https://github.com/dudyme)). Tokenisation compatible CJK pour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague de compatibilité Windows. Extraction de cookies dans toute la famille Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - ainsi que les sources d'informations d'identification macOS Keychain et Linux pass(1). Analyse historique `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 provisionné automatiquement via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages d'emploi d'une entreprise. Deltas de liste de surveillance entre les exécutions.
+
+### Toujours dans la boîte de la v3
+
+Les fondations de la v3 sont toujours là : le cerveau de pré-recherche qui résout les bons identifiants, sous-reddits et hashtags avant qu'un seul appel d'API ne se déclenche (construit par [@j-sperling](https://github.com/j-sperling)) ; Meilleurs scores pour l'humour et la viralité ainsi que la pertinence ; fusion de clusters multi-sources ; comparaisons en un seul passage (« CLI vs MCP » en 3 minutes, et non 12) ; comparaisons `--competitors` découvertes automatiquement ; Mode personne GitHub (`--github-user=steipete`) ; Mode ELI5 (« eli5 activé » après toute exécution) ; et des mémoires HTML autonomes et partageables (`--emit=html`). Les boutons de configuration se trouvent dans [CONFIGURATION.md](CONFIGURATION.md).
+
+## Installer
+
+| Surfaces | Installer | Mises à jour |
+|---------|---------|---------|
+| **Claude Code** (recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via Marketplace, ou `claude plugin update last30days@last30days-skill` |
+| **Grok** (CLI xAI Build) | `grok plugin marketplace add mvanhorn/last30days-skill` puis `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI ou l'un des 50+ [Hôtes Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et téléchargez via claude.ai > Personnaliser > Compétences > + > Créer une compétence > Télécharger une compétence | Re-télécharger et ré-uploader |
+| **Claude Desktop** | [Téléchargez le `.mcpb` pour votre plateforme](https://github.com/mvanhorn/last30days-skill/releases/latest) et faites-le glisser dans Paramètres > Extensions | Re-téléchargez et faites glisser le nouveau bundle dans |
+| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+
+### Claude Code (recommandé)
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+Recommandé car le marché Claude Code gère les mises à jour pour vous : le cache du plugin est versionné et s'actualise automatiquement lors de la publication d'une nouvelle version. Exécutez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
+
+Si vous préférez utiliser le chemin d'installation des compétences d'agent sur Claude Code, celui-ci est également pris en charge :
+
+```
+npx skills add mvanhorn/last30days-skill -g -a claude-code
+```
+
+Le plugin natif et l'installation `npx skills` peuvent coexister. Notez que Claude Code n'effectue pas de déduplication entre les méthodes d'installation : si le plugin Marketplace et la copie `npx skills` sont actifs, `/last30days` affichera deux entrées. Utilisez une méthode d'installation par machine.
+
+### Grok (CLI xAI Build)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installe last30days en tant que plugin natif. L'installation directe suit le référentiel :
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+Ou ajoutez ce dépôt en tant que source de marché, puis installez par nom de plugin :
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+Ajoutez `--trust` pour ignorer la confirmation d'installation. Mise à jour avec `grok plugin update last30days`. Grok lit également les manifestes du Claude Code pour vérifier leur compatibilité ; la paire native `.grok-plugin/` est la voie de première classe (et à quelle liste officielle [xAI Marketplace](https://github.com/xai-org/plugin-marketplace) pointe). `npx skills add` reste une solution de secours entre hôtes valide.
+
+### Codex, Cursor, Copilot, Gemini CLI et autres hôtes de compétences d'agent
+
+Installation via la CLI ouverte [Agent Skills](https://agentskills.io) — prend en charge plus de 50 harnais, notamment `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` et plus (liste complète sur le [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+
+```bash
+npx skills add mvanhorn/last30days-skill -g
+```
+
+L'indicateur `-g` (global) s'installe dans votre répertoire utilisateur afin que la compétence soit disponible dans tous les projets. Sans `-g`, `npx skills` installe le projet localement dans `./.skills/` (engagé avec le dépôt). Pour un outil de recherche sur le monde, vous voulez une approche globale.
+
+Le bureau Codex et d'autres hôtes en mode dossier peuvent fonctionner dans des dossiers ordinaires ainsi que dans les dépôts Git. Avant la première recherche, demandez à l'agent hôte d'exécuter le `scripts/last30days.py --preflight` fourni à partir du répertoire de compétences chargé ; dans une extraction de source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Il affiche la source de configuration, le plan des cookies du navigateur, les écritures planifiées, les commandes facultatives et la configuration du projet ignorée sans lire les cookies, écrire des fichiers ou exécuter des recherches.
+
+Par défaut, cela s'installe pour le faisceau détecté par `npx skills`. Pour en cibler un en particulier (ou plusieurs) :
+
+```bash
+npx skills add mvanhorn/last30days-skill -g -a codex
+npx skills add mvanhorn/last30days-skill -g -a cursor
+npx skills add mvanhorn/last30days-skill -g -a gemini-cli
+npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+```
+
+Mettre à jour plus tard avec :
+
+```bash
+npx skills update last30days -g
+```
+
+Ou mettez à jour tout ce que vous avez installé globalement via `npx skills` :
+
+```bash
+npx skills update -g
+```
+
+Répertoriez et supprimez avec `npx skills list -g` et `npx skills remove last30days -g`.
+
+### claude.ai (web)
+
+1. [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) à partir de la dernière version
+2. Accédez à [claude.ai > Personnaliser > Skills](https://claude.ai/customize/skills)
+3. Cliquez sur le bouton `+` dans le panneau Compétences > cliquez sur `Create skill` > `Upload a skill` et parcourez/déposez le fichier dans
+
+Activez d'abord « Exécution de code et création de fichiers » sous Fonctionnalités : les compétences ne fonctionneront pas sans cela.
+
+### Bureau Claude
+
+Claude Desktop installe `/last30days` en tant que serveur MCP via un bundle `.mcpb` (un package Model Context Protocol en un clic).
+
+1. Accédez à la [dernière version ](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` pour votre plateforme :
+- macOS Apple Silicon : `last30days-pp-mcp-darwin-arm64.mcpb`
+- macOS Intel : `last30days-pp-mcp-darwin-amd64.mcpb`
+-Linux x86_64 : `last30days-pp-mcp-linux-amd64.mcpb`
+2. Ouvrez Claude Desktop, accédez à Paramètres > Extensions et faites glisser le fichier.
+3. Lorsque vous y êtes invité, collez les clés API des sources que vous souhaitez activer. Chaque champ est facultatif : le moteur passe en mode Web uniquement si vous les ignorez tous. Les clés sont stockées dans le trousseau de votre système d’exploitation.
+4. Redémarrez Claude Desktop. Demandez à Claude de « rechercher Peter Steinberger » ou n'importe quel sujet et il appellera l'outil `research`.
+
+**Exigence d'hôte :** Python 3.12+ sur PATH. Le bundle fournit la source du moteur mais utilise votre interpréteur Python local. Installez depuis [python.org](https://www.python.org/downloads/) sous Windows ; macOS et la plupart des distributions Linux proposent une version compatible.
+
+**Les clés ne sont pas synchronisées avec la compétence Code.** Claude Desktop et Claude Code conservent des magasins d'informations d'identification distincts de par leur conception. Si vous avez déjà configuré `~/.config/last30days/.env` pour la compétence Code, vous saisirez à nouveau les mêmes clés ici une fois.
+
+La prise en charge de Windows est différée jusqu'à ce que les points d'entrée du manifeste par plate-forme soient réglés ; suivre dans un numéro de suivi.
+
+### OpenClaw
+
+```bash
+clawhub install last30days-official
+```
+
+Pour les flux de travail d'action X/Twitter en dehors de la recherche `/last30days`, tels que la publication
+tweets ou réponses, exportation de followers, gestion des médias, moniteurs et cadeaux
+tirages, utilisez [TweetClaw](https://github.com/Xquik-dev/tweetclaw) comme compagnon
+Plugin OpenClaw. TweetClaw est maintenu par Xquik-dev et est répertorié uniquement en tant que
+chemin compagnon facultatif, pas une dépendance ou une approbation des 30 derniers jours.
+
+### Manuel (développeur)
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill.git
+ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
+```
+
+Le lien symbolique maintient l'installation synchronisée avec votre arborescence de travail pendant que vous modifiez - aucune recopie n'est nécessaire. Pour `claude.ai`, créez le fichier `.skill` à partir de la source : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
+
+Reddit (avec commentaires), Hacker News, Polymarket et GitHub fonctionnent immédiatement. Zéro configuration. Exécutez `/last30days` une fois et l'assistant de configuration déverrouille plus de sources en 30 secondes, y compris les CLI gratuites arXiv et Techmeme.
+
+## Apportez vos propres clés
+
+Ces plateformes n'ont pas de relations entre elles. X ne sait pas ce que pense Reddit. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés API et jetons de navigateur, et du coup vous avez accès à tous en même temps.
+
+| Sources | Ce dont vous avez besoin | Coût |
+|---------|---------------|------|
+| Reddit (avec commentaires) + HN + Polymarket + GitHub + StockTwits | Rien | Gratuit |
+| arXiv + Techmeme | CLI gratuites, installées automatiquement lors de la première configuration | Gratuit |
+| X/Twitter | Connectez-vous à x.com dans n'importe quel navigateur ou définissez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies du navigateur sont gratuits ; les clés sont spécifiques au fournisseur |
+| YouTube | `brew install yt-dlp` | Gratuit |
+| Ciel bleu | Mot de passe de l'application de bsky.app | Gratuit |
+| TikTok + Instagram + Fils de discussion + Pinterest + LinkedIn + Commentaires YouTube | Clé ScrapeCreators | 10 000 appels gratuits, puis PAYG |
+| Xiaohongshu (ROUGE) | Exécutez un plug-in de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` et inscrivez-vous avec `--search xhs` par exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env` ; last30days sonde automatiquement `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilise `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Aucune clé API des 30 derniers jours ; dépend de votre service de session de navigateur local |
+| DripStack (newsletters financières premium) | Opt-in : `--search dripstack` par exécution, ou `INCLUDE_SOURCES=dripstack` dans `.env` | Pas de clé ; API de recherche publique gratuite |
+| Sonar Perplexity / API de recherche / Recherche approfondie | Clé Perplexité ou clé OpenRouter comme solution de secours Sonar | Payez au fur et à mesure |
+| Recherche sur le Web | Clé de recherche courageuse | 2 000 requêtes gratuites/mois |
+
+### Trousseau macOS (facultatif)
+
+Sur macOS, vous pouvez stocker les clés dans le trousseau système au lieu d'un fichier `.env`. La compétence les sélectionne automatiquement en tant que source de priorité la plus faible : les fichiers `.env` et l'environnement de processus gagnent toujours en cas de collision.
+
+```bash
+# Interactive setup — prompts for each known key, skip with empty input
+skills/last30days/scripts/setup-keychain.sh
+
+# Or store a single key by hand
+security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
+
+# Inspect / clean up
+skills/last30days/scripts/setup-keychain.sh --list
+skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
+```
+
+Les éléments sont stockés sous le nom de service `last30days-<KEY>` pour l'utilisateur actuel. Sur les plates-formes non Darwin, le chargeur ne fonctionne pas, il n'y a donc aucun changement de comportement pour les utilisateurs Linux/Windows.
+
+Vous disposez déjà de clés sous différents noms de service de trousseau ? Définissez le mappage non secret `LAST30DAYS_KEYCHAIN_ALIASES` décrit dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) au lieu de copier les secrets.
+
+Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète des clés par source, la priorité du fournisseur de raisonnement et la priorité du backend de recherche Web.
+
+## Configuration
+
+Deux choses que vous voudrez probablement savoir dès le premier jour :
+
+**Où les fichiers de recherche sont enregistrés.** `LAST30DAYS_MEMORY_DIR` est par défaut `~/Documents/Last30Days/` (Windows : `C:\Users\<you>\Documents\Last30Days\`). Remplacez en définissant cette variable d'environnement sur n'importe quel chemin de votre shell, ou `--save-dir <path>` par exécution. Utilisez `--output <file>` lorsque vous avez besoin du résultat rendu selon un chemin exact, en utilisant le format sélectionné par `--emit`. Utilisez `--save-suffix=<name>` pour séparer plusieurs variantes du même sujet (par exemple, par client). Chaque exécution de `--save-dir` produit `<slug>-raw[-suffix].md`. Exécutez `python3 skills/last30days/scripts/last30days.py --preflight` pour examiner les écritures planifiées avant une exécution de recherche.
+
+**Sortie structurée pour les agents et les flux de travail.** Demandez à `/last30days` un JSON lisible par machine pour recevoir le profil d'agent stable et versionné. Pour une utilisation directe du moteur dans les scripts ou le développement, exécutez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` ; ajoutez `--json-profile=raw` uniquement lorsque vous avez besoin du vidage interne `Report` non versionné. Consultez la [référence du champ d'exportation JSON et la politique de gestion des versions](docs/reference/json-export.md).
+
+**Découverte sans sujet.** Demandez à `/last30days what's trending in AI agents?` d'obtenir un dossier de découverte classé au lieu de rechercher un sujet que vous connaissez déjà. Sur un hôte d'agent, cela exécute le protocole d'évaluation de l'hôte à trois commandes (le modèle nomme les sujets, filtre les indésirables, note la valeur et écrit les angles du contenu). Pour une utilisation directe du moteur dans des scripts ou cron, exécutez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte s'exclut mutuellement avec un sujet positionnel et `--drill`.
+
+**Surveillance des tendances entre les exécutions.** Le mode par défaut produit un nouvel instantané de démarque par exécution. Pour accumuler les résultats au fil du temps, ajoutez `--store` pour persister dans une base de données SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec livraison Slack/webhook en option sur les nouveaux résultats) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour les résumés quotidiens/hebdomadaires. Le modèle de cadence complet se trouve dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+
+**Une bibliothèque de recherche avec abonnement.** Demandez à `/last30days` de créer votre flux de bibliothèque ou utilisez `python3 skills/last30days/scripts/last30days.py library feed` directement pour les scripts et le développement. Il transforme les mémoires enregistrés en `index.html`, en Atom `feed.xml` local et en pages brèves lisibles. Ajoutez `--publish` uniquement lorsque vous souhaitez héberger l'index HTML et les pages brèves ; la publication est explicite et publique par défaut. Pour rendre le flux Atom accessible, hébergez le répertoire de sortie généré sur un hôte statique tel que GitHub Pages.
+
+**Recherchez tout ce que vous avez recherché.** Demandez à `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour une utilisation directe du moteur, exécutez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe progressivement les mêmes résumés enregistrés que ceux utilisés par le flux de la bibliothèque, fusionne les observations de magasin correspondantes par exécution et regroupe les résultats par sujet et par date. De nouvelles analyses font également apparaître une section compacte **De votre bibliothèque** lorsque des recherches antérieures chevauchent le sujet actuel ; définissez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
+
+Les scripts wrapper par client, les sous-reddits de catégorie personnalisés et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
+
+## Showcase : flux de recherche communautaire
+
+Vous avez publié une mise à jour récurrente de l'IA, une surveillance du marché ou une obsession merveilleusement étroite pour les 30 derniers jours ? Partagez l'URL de la bibliothèque publique (ou l'URL Atom après avoir hébergé `feed.xml` sur un hôte statique) dans [le fil de discussion de la communauté ](https://github.com/mvanhorn/last30days-skill/issues/532). Les flux communautaires seront liés ici au fur et à mesure que leurs propriétaires les soumettront ; le fil est le point de collecte entre-temps.
+
+## Comment ça marche
+
+1. **Vous saisissez un sujet.** Personne, entreprise, produit, technologie, « X contre Y ». Rien.
+2. **L'agent décide qui compte.** Trouve X identifiants (y compris les fondateurs), les dépôts GitHub, les subreddits, les hashtags TikTok, les chaînes YouTube. Pour "Kanye West", il connaît r/hiphopheads, @kanyewest et "bully review" sur YouTube. Pour "OpenClaw", il résout openclaw/openclaw sur GitHub et récupère le nombre d'étoiles en direct.
+3. **Toutes les sources recherchées en parallèle.** Expansion multi-requêtes. Des résultats notés par engagement, pertinence, fraîcheur.
+4. **La profondeur que personne d'autre n'a.** Transcriptions YouTube complètes de vidéos de réaction. Meilleurs commentaires Reddit avec le nombre de votes positifs. Légendes TikTok. Cotes du polymarché. Pas seulement des titres et des liens.
+5. **Même histoire, fusionné.** Wireless Festival annoncé sur Reddit, discuté sur X, prix des billets sur TikTok = un cluster, pas trois éléments distincts.
+6. **Synthétisé en un seul mémoire.** Fondé sur des données spécifiques. Cité par la source. Classé en fonction de ce avec quoi les gens s'engagent réellement. Pas "voici ce que j'ai trouvé". C'est "voici ce qui compte".
+7. **Il devient alors votre expert.** Après une seule exécution, votre session Claude sait tout ce que la communauté sait. Posez des questions de suivi. Demandez-lui de rédiger des invites, de rédiger des e-mails, de planifier des voyages, de concevoir des systèmes - le tout fondé sur la réalité actuelle.
+
+## Ce que disent les gens
+
+> "J'ai trouvé une compétence Claude Code qui recherche n'importe quel sujet sur Reddit, X, YouTube et HN au cours des 30 derniers jours. Ensuite, j'écris les invites pour vous. J'ai effectué des recherches manuelles sur Reddit et X avant chaque élément de contenu que j'écris. Onglet par onglet. Fil par fil. C'est la partie qui prend 90 minutes. Cela l'élimine. " -@itsjasonai
+
+> "Cette compétence a remplacé l'ensemble de mon flux de travail de recherche. Vous lui donnez un sujet, elle supprime Reddit, X et le Web de ce dont les gens parlent réellement. Pas d'anciens articles de blog. De vraies conversations des 30 derniers jours." -@itswilsoncharles
+
+> "5 des 10 dépôts tendances sur GitHub aujourd'hui sont des outils Claude. #1 : mvanhorn/last30days-skill" -@yieldhunter95
+
+## Open source
+
+Licence MIT. Aucun suivi. Aucune analyse. Votre recherche reste sur votre machine. Plus de 2 700 tests.
+
+Construit avec Python 3.12+, yt-dlp, Node.js (client Bird fourni pour la recherche X) et l'API ScrapeCreators. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
+
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté et [CHANGELOG.md](CHANGELOG.md) pour l'historique des versions.
+
+## Historique des étoiles
+
+<a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+  </picture>
+</a>
+
+---
+
+**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)

--- a/README.fr.md
+++ b/README.fr.md
@@ -16,151 +16,151 @@
   </a>
 </p>
 
-**Un moteur de recherche dirigé par un agent IA et évalué par les votes positifs, les likes et l'argent réel - et non par les éditeurs.**
+**Un moteur de recherche dirigé par un agent IA, noté par des votes positifs, des likes et de l’argent réel - pas par des éditeurs.**
 
-Ce README suit le pipeline v3 actuel. La spécification de compétence d'exécution se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui est la source de vérité pour le dernier comportement de commande et de configuration.
+Ce README suit le pipeline v3 actuel. La spécification de compétence à l’exécution se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui est la source de vérité pour le comportement de commande et de configuration les plus récents.
 
-**Claude Code (recommandé — mises à jour automatiques via la place de marché) :**
+**Claude Code (recommandé — mises à jour automatiques via le marketplace):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI ou l'un des 50+ [Hôtes Agent Skills](https://agentskills.io) :**
+**Codex, Cursor, Copilot, Gemini CLI, ou n’importe lequel des 50+ [Agent Skills](https://agentskills.io) hôtes :**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` s'installe globalement pour votre utilisateur, disponible dans tous les projets. Déposez-le dans la portée de chaque projet.)
+(`-g` s’installe globalement pour votre utilisateur, disponible sur tous les projets. Réduisez-le à la portée par projet.)
 
-Plus d'options d'installation (claude.ai web, OpenClaw, manuel) dans la section [Install](#installation) ci-dessous.
+Plus d’options d’installation (claude.ai web, OpenClaw, manuel) dans la section [Install](#installation) ci-dessous.
 
-Zéro configuration. Reddit, HN, Polymarket et GitHub fonctionnent immédiatement. Exécutez-le une fois et l'assistant de configuration déverrouille X, YouTube, TikTok, arXiv, Techmeme et plus encore en 30 secondes.
+Zéro configuration. Reddit, HN, Polymarketet GitHub fonctionnent immédiatement. Lancez-le une fois et l’assistant de configuration débloque X, YouTube, TikTok, arXiv, Techmemeet plus encore en 30 secondes.
 
 ---
 
-Votes positifs sur Reddit. X aime. Transcriptions YouTube. Engagement sur TikTok. Cotes Polymarket soutenues par de l'argent réel et des informations privilégiées. Cela représente des millions de personnes qui votent chaque jour avec leur attention et leur portefeuille. /last30days recherche tout cela en parallèle, le note en fonction de ce avec quoi de vraies personnes interagissent réellement, et un juge d'agent IA le synthétise en un seul dossier.
+Reddit votes positifs. X likes. YouTube transcriptions. TikTok engagement. Polymarket probabilités soutenues par de l’argent réel et des informations privilégiées. Cela fait des millions de personnes votant chaque jour avec leur attention et leur portefeuille. /last30days recherche tout cela en parallèle, évalue selon ce avec quoi les vraies personnes interagissent réellement, et un juge IA synthétise tout en un seul mémoire.
 
-Google regroupe les éditeurs. /last30days recherche des personnes.
+Google agréga des éditeurs. /last30days recherche des gens.
 
-Vous ne pouvez obtenir cette recherche nulle part ailleurs car aucune IA n’a accès à tout cela. La recherche Google ne touche pas les commentaires Reddit ou les publications X. ChatGPT a un accord avec Reddit mais ne peut pas rechercher X ou TikTok. Gemini a YouTube mais pas Reddit. Claude n'en possède aucun nativement. Chaque plateforme est un jardin clos avec sa propre API, ses propres tokens, sa propre authentification. Mais vous pouvez apporter vos propres clés et sessions de navigateur, et tout à coup, un agent IA peut toutes les rechercher en même temps, les comparer les unes aux autres et vous dire ce qui compte réellement.
+Vous ne pouvez pas trouver cette recherche ailleurs car aucune IA unique n’a accès à tout. Google recherche ne touche ni Reddit commentaires ni X publications. ChatGPT a un accord avec Reddit mais ne peut pas rechercher X ni TikTok. Gemini a YouTube mais pas Reddit. Claude n’en a aucun d’eux nativement. Chaque plateforme est un jardin clos avec ses propres API, ses propres jetons, sa propre authentification. Mais vous pouvez apporter vos propres clés et sessions de navigateur, et soudain un agent IA peut toutes les rechercher en même temps, les évaluer entre elles et vous dire ce qui compte réellement.
 
-C'est le déverrouillage. Il n'y a pas de meilleur moteur de recherche. Une douzaine de plateformes déconnectées, pontées par un agent.
+C’est ça le déblocage. Pas un meilleur moteur de recherche. Une douzaine de plateformes déconnectées, pontées par un agent.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Vous avez une réunion demain. Vous les recherchez sur Google. Vous obtenez leur LinkedIn à partir de 2023. /last30days vous montre ce qu'ils font réellement ce mois-ci : ils ont rejoint OpenAI pour travailler sur le Codex, luttent contre l'interdiction d'Anthropic sur les agents tiers, expédient 23 PR à un taux de fusion de 85 %, créent "LobsterOS" pour le contrôle des agents multi-appareils, et r/ClaudeCode a obtenu 569 votes positifs en débattant s'il est un héros ou "insupportable". Dispersé dans les publications X, les fils de discussion Reddit, les transcriptions YouTube et les commits GitHub. Rien de tout cela n'était sur Google.
+Vous avez une réunion demain. Vous les Google . Vous obtenez leur LinkedIn de 2023. /last30days vous donne ce qu’ils font réellement ce mois-ci : rejoindre OpenAI pour travailler sur Codex, combattre l’interdiction d’Anthropic sur les agents tiers, expédier 23 PRs à un taux de fusion de 85 %, construire des «LobsterOS» pour le contrôle multi-appareils des agents, et r/ClaudeCode a obtenu 569 votes positifs pour débattre de savoir s’il est un héros ou « insupportable ». Dispersé dans X posts, Reddit fils, YouTube transcriptions et GitHub commits. Rien de tout cela n’était sur Google.
 
-## Pourquoi cela existe
+## Pourquoi cela existe-t-il
 
-Je l'ai construit pour suivre le rythme de l'IA. Tout change chaque jour et les nerds de Reddit et X sont toujours au top en premier. J'avais besoin de meilleures invites, et les données de formation étaient toujours en retard de plusieurs mois par rapport à ce que la communauté avait déjà compris.
+Je l’ai construit pour suivre le rythme de l’IA. Tout change chaque jour et les Reddit et X nerds sont toujours à l’affût en premier. J’avais besoin de meilleurs indices, et les données d’entraînement avaient toujours des mois de retard sur ce que la communauté avait déjà compris.
 
-Mais cela s’est transformé en quelque chose de plus grand. Maintenant, je l'exécute avant un appel commercial pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion, pour lire les tweets récents et les transcriptions de podcasts de quelqu'un. Avant un voyage à Disney World pour savoir quels manèges sont fermés et ce que dit la communauté de Genie+. Avant de construire quoi que ce soit, je dois savoir quels problèmes les gens rencontrent réellement.
+Mais cela s’est transformé en quelque chose de plus important. Maintenant, je le passe avant un appel commercial pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion pour lire les tweets récents et les transcriptions de podcasts de quelqu’un. Avant un Disney World voyage pour savoir quelles attractions sont fermées et ce que la communauté dit à propos de Genie+. Avant de construire quoi que ce soit pour savoir quels problèmes les gens rencontrent réellement.
 
-Si vous rencontrez un PDG, avez-vous lu tous ses tweets et transcriptions YouTube des 30 derniers jours ? J'ai.
+Si vous rencontrez un PDG, avez-vous lu tous ses tweets et YouTube transcriptions des 30 derniers jours ? Oui.
 
 ## Sources, notées par le peuple
 
-| Source | Ce que les gens vous disent |
+| Source | Ce que les gens te disent |
 |--------|--------------------------|
-| **Reddit** | La prise non filtrée. Meilleurs commentaires avec un nombre réel de votes positifs, gratuits, sans clé API. Les vraies opinions que Google enterre. |
-| **X / Twitter** | La prise chaude, le fil expert, la réaction cassante. Premier à savoir, premier à argumenter. |
-| **YouTube** | La plongée profonde de 45 minutes. Les transcriptions complètes ont recherché les 5 phrases citables qui comptent. |
-| **TikTok** | Le créateur touche 3,6 millions de personnes avec une prise que vous ne trouverez jamais sur Google. |
-| **Instagram Reels** | Le point de vue de l'influenceur avec des transcriptions de créations orales. Le signal de la culture visuelle. |
-| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les techniciens discutent réellement. |
-| **Polymarket** | Pas des avis. Chances. Soutenu par de l'argent réel. 96% de confiance sur les ventes d'albums. 4% sur une acquisition. |
-| **GitHub** | Pour les personnes : vitesse des relations publiques, meilleurs dépôts par stars, notes de version. Pour les sujets : problèmes et discussions. |
-| **Digg** | Groupes d'histoires sélectionnés à partir du classement AI 1000 de Digg (~ 1 000 comptes IA à signal élevé sur X), avec des citations en ligne attribuables (aucune authentification X requise). Activé automatiquement lorsque `digg-pp-cli` est sur PATH. |
-| **arXiv** | Les journaux derrière le battage médiatique. Nouvelle recherche dans la fenêtre, gratuite, sans clé API. Activé automatiquement lorsque `arxiv-pp-cli` est sur PATH (l'installation de première exécution l'installe). |
-| **Techmème** | La couche éditoriale d'actualités technologiques, fenêtrée sur vos 30 jours. Gratuit, sans clé API. Activé automatiquement lorsque `techmeme-pp-cli` est sur PATH (l'installation de première exécution l'installe). |
-| **LinkedIn** | Le signal professionnel. Publications et articles, avec des articles considérés comme un signal élevé. |
-| **StockTwits** | Sentiment des commerçants. S'active automatiquement lorsque votre sujet est un ticker ou une crypto. |
-| **Fils** | La couche de texte post-Twitter. Conversations de créateurs et de marques. |
-| **Pinterest** | Découverte visuelle. Épinglez, enregistrez et commentez les produits et les idées. |
-| **Xiaohongshu (ROUGE)** | Signaux de style de vie, de produit et de créateur chinois. Demandé explicitement avec `--search xhs` lorsqu'un plug-in de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` s'exécute localement. |
-| **Ciel bleu** | La couche sociale décentralisée. Publications du protocole AT issues de la migration post-Twitter. |
-| **Perplexité** | Synthèse Sonar mise à la terre, lignes brutes de l'API de recherche et recherche approfondie. |
-| **Internet** | La couverture éditoriale, les comparaisons de blogs. Un signal parmi tant d’autres, mais pas le seul. |
+| **Reddit** | L’avis non filtré. Meilleurs commentaires avec de vrais votes positifs, gratuits, sans API clé. Les vraies opinions que Google enterre. |
+| **X / Twitter** | L’opinion controversée, le fil narratif de l’expert, la réaction qui s’est brisée. Premier à savoir, premier à argumenter. |
+| **YouTube** | L’analyse approfondie de 45 minutes. Les transcriptions complètes ont été recherchées pour les 5 phrases citables qui comptent. |
+| **TikTok** | Le créateur atteint 3,6 millions de personnes avec une vision que vous ne trouverez jamais sur Google. |
+| **Instagram Reels** | La perspective de l’influenceur avec des transcriptions de spoken word. Le signal visuel de la culture. |
+| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les techniciens argumentent réellement. |
+| **Polymarket** | Pas des opinions. Des cotes. Soutenu par de l’argent réel. 96 % de confiance sur les ventes d’album. 4 % sur une acquisition. |
+| **GitHub** | Pour les gens : PR Velocity, Top Repos par étoiles, notes de release. Pour les sujets : problèmes et discussions. |
+| **Digg** | Clusters d’histoires sélectionnés à partir du classement AI 1000 de Digg(~1000 comptes IA high-signal sur X), avec des citations en ligne attribuables (sans authentification X requise). Autoactivé lorsque `digg-pp-cli` est activé PATH. |
+| **arXiv** | Les papiers derrière tout ce battage médiatique. Nouvelle recherche dans la fenêtre, gratuite, sans API de touche. Auto-activé quand `arxiv-pp-cli` est en PATH (la première configuration l’installe). |
+| **Techmeme** | La couche éditoriale tech-news, avec une fenêtre de date à 30 jours. Gratuit, sans clé API . Activé automatiquement quand `techmeme-pp-cli` est en PATH (la première configuration l’installe). |
+| **LinkedIn** | Le signal professionnel. Publications et articles, avec des éléments pondérés en haut du signal. |
+| **StockTwits** | Le sentiment du trader. S’active automatiquement lorsque votre sujet est un ticker ou une crypto. |
+| **Threads** | La couche texte post-Twitter. Conversations de créateurs et de marques. |
+| **Pinterest** | Découverte visuelle. Épinglez, sauvegardez et commente des produits et des idées. |
+| **Xiaohongshu (RED)** | Signaux de mode de vie, produit et créateur chinois. Demandé explicitement avec `--search xhs` lorsqu’un plugin ou un service `xiaohongshu-mcp` navigateur x-mcp connecté fonctionne localement. |
+| **Bluesky** | La couche sociale décentralisée. Les publications du protocole AT issues de la migration post-Twitter. |
+| **Perplexity** | Synthèse sonar au sol, lignes de API de recherche brute, et recherche profonde. |
+| **Web** | La couverture éditoriale, les comparaisons sur les blogs. Un signal parmi tant d’autres, pas le seul. |
 
-Les contributeurs de la communauté continuent d’en ajouter. Truth Social et d’autres sources de niche sont dans le moteur et d’autres sont en route.
+Les contributeurs de la communauté n’arrêtent pas d’en ajouter. Truth Social et d’autres sources de niche sont en cours avec d’autres en préparation.
 
-Un fil de discussion Reddit avec 1 500 votes positifs est un signal plus fort qu’un article de blog que personne n’a lu. Un TikTok avec 3,6 millions de vues vous en dit plus sur ce qui est culturellement pertinent qu'un communiqué de presse. Les cotes du polymarché soutenues par un volume de 66 000 $ sont plus difficiles à contester que la supposition d'un expert.
+Un fil de discussion Reddit avec 1 500 upvotes est un signal plus fort qu’un article de blog que personne n’a lu. Un TikTok avec 3,6 millions de vues en dit plus sur ce qui est culturellement pertinent qu’un communiqué de presse. Polymarket cotes soutenues par 66 000 $ de volume sont plus difficiles à contester qu’une supposition d’un commentateur.
 
-La synthèse est classée en fonction de ce avec quoi de vraies personnes se sont réellement engagées. Pertinence sociale, pas pertinence SEO.
+La synthèse se classe selon ce avec quoi les vraies personnes interagissent réellement. La pertinence sociale, pas SEO pertinence.
 
-## Pourquoi les gens l'utilisent réellement
+## À quoi servent réellement les gens
 
-**Avant une réunion.** `/last30days Peter Steinberger` - a rejoint l'équipe Codex d'OpenAI, luttant contre l'interdiction d'Anthropic sur les agents tiers, 23 PR ont fusionné à un taux de fusion de 85 % sur GitHub, créant LobsterOS pour le contrôle des agents multi-appareils. r/ClaudeCode : "Depuis la sortie d'OpenClaw, il était largement connu que si vous l'exécutiez via autre chose que l'API, vous finiriez par être banni" (227 votes positifs). Ce n'est pas sur LinkedIn.
+**Avant une réunion.** `/last30days Peter Steinberger` - a rejoint l’équipe Codex de OpenAI, luttant contre l’interdiction d’Anthropic sur les agents tiers, 23 PRs fusionnés avec un taux de fusion de 85 % sur GitHub, construisant LobsterOS pour le contrôle inter-appareils des agents. r/ClaudeCode : « Depuis la sortie de OpenClaw, il était largement connu que si vous le passiez par autre chose que le API, vous finiriez par être banni » (227 votes positifs). Ce n’est pas la faute de LinkedIn.
 
-**Pour lire les signaux d'embauche.** `/last30days Listen Labs --hiring-signals` : les pages d'emplois et de carrières actuelles deviennent des preuves citées de changements d'orientation : embauche dans la sécurité de l'entreprise, la réussite des clients, l'infrastructure ou l'expansion des produits. Le rapport indique ce que l’embauche semble signaler, et non ce que la feuille de route prévoit.
+**Pour lire les signaux d’embauche.** `/last30days Listen Labs --hiring-signals` - les pages actuelles d’emplois et de carrières deviennent des preuves citées de changements de focus : recrutement vers la sécurité d’entreprise, la réussite client, l’infrastructure ou l’expansion produit. Le rapport indique ce que le recrutement semble signifier, pas ce que la feuille de route présentera.
 
-**Pour trouver le sujet avant qu'il n'atteigne son apogée.** Demandez à `/last30days what's exploding in AI agents?` et la compétence passe en mode découverte : le moteur balaie les listes de catégories Reddit, les fronts/meilleures histoires de Hacker News, le flux AI 1000 de Digg et X une fois authentifié ; votre agent juge les nominations (noms, filtrage des courriers indésirables, valeur du contenu) et rédige les angles des podcasts/articles X ; Ensuite, vous obtenez 5 à 10 sujets classés en fonction de la vitesse. Chaque résultat comprend des numéros multi-sources, une étiquette Momentum et un suivi `/last30days "<topic>"` prêt à l'emploi.
+**Pour trouver le sujet avant qu’il ne soit au sommet.** Demandez `/last30days what's exploding in AI agents?` et la compétence passe en mode découverte : le moteur balaie Reddit listes de catégories, Hacker News les articles de première ligne/les meilleures histoires, le fil AI 1000 de Digg, et X lorsqu’authentifié ; votre agent juge les nominations (noms, filtrage des indésirables, qualité du contenu) et écrit des angles d’article pour podcast / X; puis vous obtenez 5 à 10 sujets classés en vélocité. Chaque résultat inclut des chiffres cross-source, une étiquette de momentum, et un `/last30days "<topic>"` suivi prêt à être publié.
 
-**Quand quelque chose tombe.** `/last30days Kanye West` - Le Royaume-Uni a bloqué son visa, le Wireless Festival a été annulé, les sponsors ont fui. Mais BULLY a fait ses débuts au numéro 2 du Billboard. Fantano est revenu de son "Yay sabbatique" pour le revoir (653K vues). SoFi Homecoming a fait sortir Lauryn Hill et Travis Scott pour 44 chansons. Polymarket : "Est-ce que Kanye tweetera encore ?" 86% Oui. 23 fils de discussion Reddit, 17 vidéos YouTube, 86 000 votes positifs.
+**Quand quelque chose tombe.** `/last30days Kanye West` - Le Royaume-Uni a bloqué son visa, le Wireless Festival annulé, les sponsors ont fui. Mais BULLY a débuté #2 sur Billboard. Fantano est revenu de son « Yay sabbatique » pour le critiquer (653 000 vues). SoFi Homecoming a fait venir Lauryn Hill et Travis Scott pour 44 chansons. Polymarket: « Kanye tweetera-t-il encore ? » 86 % Oui. 23 fils Reddit , 17 vidéos YouTube , 86 000 votes positifs.
 
-**Pour comparer les outils.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Ce ne sont pas des concurrents, ce sont des couches." OpenClaw est l'exécuteur (351 000 étoiles GitHub, en direct), Hermes est le cerveau qui s'améliore automatiquement (31 000 étoiles), Paperclip est l'organigramme (49 000 étoiles). Le nombre d'étoiles est extrait en direct de l'API GitHub, et non d'articles de blog obsolètes. Table côte à côte avec architecture, mémoire, sécurité, le meilleur pour. Selon @IMJustinBrooke : "OpenClaw = Charmander, Hermes = Charizard."
+**Pour comparer les outils.** `/last30days OpenClaw vs Hermes vs Paperclip` - « Ce ne sont pas des concurrents, ce sont des couches. » OpenClaw est l’exécuteur (351K GitHub étoiles, en direct), Hermès est le cerveau qui s’améliore lui-même (31K étoiles), Paperclip est l’organigramme (49K étoiles). Comptage d’étoiles extrait en direct depuis le GitHub API, pas des articles de blog obsolètes. Table côte à côte avec architecture, mémoire, sécurité, meilleur pour. Par @IMJustinBrooke: «OpenClaw = Salamèche, Hermès = Dracaufeu. »
 
-**Pour comprendre le monde.** `/last30days Iran vs USA` - Jour 38 de la guerre. La date limite fixée mardi par Trump pour que l'Iran rouvre le détroit d'Ormuz. Deux avions de guerre américains abattus. Pétrole à 126$/baril. L'AIE l'a qualifié de "plus grande rupture d'approvisionnement dans l'histoire du marché pétrolier mondial". Polymarket : cessez-le-feu d'ici le 31 décembre à 74 %. 27 publications X, 10 vidéos YouTube, 20 marchés de prédiction.
+**Pour comprendre le monde.** `/last30days Iran vs USA` - 38e jour de la guerre. La date limite de Trump mardi pour la réouverture du détroit d’Ormuz par l’Iran. Deux avions de guerre américains abattus. Le pétrole à 126 $ le baril. L’AIE a qualifié cela de « plus grande perturbation de l’approvisionnement de l’histoire du marché mondial du pétrole ». Polymarket: cessez-le-feu d’ici le 31 décembre à 74 %. 27 X posts, 10 vidéos YouTube , 20 marchés de prévision.
 
-**Avant un voyage.** `/last30days Universal Epic Universe` - Agrandissement déjà en construction. Permis « Projet 680 » déposé. Feu d'artifice confirmé par les infrastructures mais inopiné. Temps d'attente : Mine-Cart Madness en moyenne 148 minutes. Pas encore de laissez-passer annuel et les habitants sont frustrés. Les Stardust Racers seront rénovés jusqu'au 5 avril.
+**Avant un voyage.** `/last30days Universal Epic Universe` - Extension déjà en construction. Permis « Projet 680 » déposé. Feu d’artifice confirmé par l’infrastructure mais sans prévenir. Temps d’attente : Mine Wagon Madness en moyenne 148 minutes. Pas encore de pass annuel, et les habitants sont frustrés. Stardust Racers en rénovation jusqu’au 5 avril.
 
-**Pour apprendre quelque chose rapidement.** `/last30days Nano Banana Pro prompting` - Les invites structurées en JSON remplacent la soupe de balises. Le format imbriqué du @pictsbyai évite le « saignement des concepts ». Le flux de travail de modification en premier surpasse la régénération. Ensuite, il vous écrit une invite de production utilisant exactement ce que la communauté a dit fonctionner.
+**Pour apprendre quelque chose rapidement.** `/last30days Nano Banana Pro prompting` - JSONles prompts structurés remplacent la soupe de tags. Le format imbriqué de @pictsbyaiempêche le « concept saccade ». Le workflow d’édition d’abord vaut la régénération. Ensuite, il vous écrit une invite de production en utilisant exactement ce que la communauté a dit fonctionner.
 
 ## Quoi de neuf
 
-Depuis l'annonce de la v3.3 en mai, à partir de la v3.11.1 (juillet 2026) : 175 PR fusionnés - dont 122 provenant de 52 contributeurs de la communauté - dans 15 versions. C'est ce qui a atterri.
+Depuis l’annonce de la v3.3 en mai, à partir de la v3.11.1 (juillet 2026), 175 ont fusionné PRs - 122 d’entre eux issus de 52 contributeurs de la communauté - répartis sur 15 versions. C’est ce qui a été adopté.
 
 ### Première classe sur OpenAI Codex
 
-/last30days est désormais un plugin Codex natif avec une configuration guidée - pas un port, un citoyen de première classe. Les citations compatibles avec le moteur de rendu signifient que la sortie du Codex se lit comme un bref au lieu d'une soupe d'URL (#694), et que le même moteur fonctionne sur les hôtes Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw et plus de 50 Agent Skills. Manifeste du plugin Codex par [@rfoust](https://github.com/rfoust) (#686), correctif d'authentification Codex par [@tmchow](https://github.com/tmchow) (#698).
+/last30days est désormais un plugin Codex natif avec configuration guidée – pas un port, un citoyen de première classe. Les citations conscientes du rendu signifient que Codex sortie se lit comme un brief plutôt qu’un soup URL (#694), et le même moteur fonctionne sur Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawet 50+ hôtes Agent Skills . Codex manifeste du plugin par [@rfoust](https://github.com/rfoust) (#686), Codex correction d’authentification par [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmeme et Digg - gratuits, pas de clés API
+### arXiv, Techmemeet Digg - gratuit, sans API clés
 
-arXiv apporte les journaux derrière le battage médiatique et Techmeme apporte la couche d'actualités technologiques éditoriales - gratuite, sans clé, et la première configuration installe leurs CLI afin qu'elles s'activent automatiquement (#709). Les clusters d'histoires AI 1000 de Digg arrivent sans authentification X de la même manière : le programme d'installation installe la CLI Digg gratuite pour vous (#590). Trustpilot propose une option d'adhésion pour les recherches sur les marques grand public.
+arXiv apporte les journaux derrière le battage médiatique et Techmeme apporte la couche éditoriale-actualité technique - gratuit, zéro clé, et la configuration en première exécution installe leurs CLIpour qu’ils s’activent automatiquement (#709). Les clusters d’histoires IA 1000 de Diggarrivent sans authentification X de la même manière – setup installe le Digg CLI gratuit pour vous (#590). Trustpilot envoient l’option pour la recherche sur la marque grand public.
 
-### Free Reddit a augmenté ses scores réels et ses meilleurs commentaires
+### Les Reddit gratuits ont fait fructifier de vrais scores et ont fait grimper les commentaires
 
-L'API publique .json de Reddit est morte ; le libre chemin est revenu plus fort. RSS sans clé + scraping shreddit (#457), découverte de subreddit dédié avec un nombre réel de votes positifs via arctic-shift (#696) et un seuil de pertinence pour qu'une publication virale hors sujet ne puisse pas détourner votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Aucune clé API. De vrais scores. Principaux commentaires inclus.
+Redditpublic .json API est mort ; le chemin gratuit est revenu plus fort. RSS sans clé + scraping shreddit (#457), découverte de subreddit dédié avec de vrais décomptes de votes via arctic-shift (#696), et un plancher de pertinence pour qu’un post viral hors sujet ne puisse pas détourner votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Pas de clé API . Scores réels. Commentaires principaux inclus.
 
-### Les meilleurs commentaires dans chaque brief
+### Les meilleurs commentaires dans chaque mémoire
 
-Les commentaires sont désormais une couche par défaut entre les sources : commentaires Instagram avec une diversité basée sur le classement afin que cinq prises chaudes ne proviennent pas toutes d'une seule publication (#751), commentaires YouTube plus une sauvegarde de transcription ScrapeCreators pour le moment où yt-dlp est supprimé (#637), et les commentaires votés par la foule pondérés dans les meilleures prises afin que les lignes les plus drôles de la communauté survivent au score (#592, #608).
+Les commentaires sont désormais une couche par défaut entre les sources : les commentaires Instagram avec une diversité basée sur le classement, donc cinq opinions brûlantes ne proviennent pas toutes d’un même post (#751), YouTube commentaires plus une sauvegarde de ScrapeCreators transcription pour quand yt-dlp est éliminé (#637), et les commentaires votés par le public mis en Best Takes pour que les répliques les plus drôles de la communauté survivent au score (#592, #608).
 
-### Une commande de médecin
+### Commande un médecin
 
-Demandez un bilan de santé et le médecin exécute chaque source, puis prescrit des correctifs exacts : quelle clé manque, quelle CLI est hors PATH, quel cookie a expiré (#753). Plus besoin de deviner pourquoi X est revenu mince.
+Demandez un contrôle de santé et le médecin analyse toutes les sources, puis prescrit des solutions exactes - quelle clé manque, laquelle CLI est décalée PATH, quel cookie a expiré (#753). Plus de devinettes sur les raisons X sont revenues faibles.
 
-### Recherche X, reconstruite
+### X recherche, reconstruite
 
-Le pipeline X a fait l'objet d'une refonte de fond : les voies FROM et ABOUT afin que les propres publications d'une personne et la conversation à leur sujet soient toutes deux classées (#610), la désambiguïsation des sous-requêtes sensibles à la personne (#611), la paternité de première partie avec classement des signaux d'interaction (#613) et une source X unique avec basculement automatique du backend (#622). Plus un honnête `--diagnose` qui sonde réellement l'authentification (#609).
+Le pipeline X a bénéficié d’une refonte complète : les voies FROM et ABOUT pour que les posts d’une personne et la conversation à leur sujet soient tous deux classés (#610), désambiguïsation des sous-requêtes conscientes (#611), mise à la terre de l’auteur de première partie avec classement du signal d’interaction (#613), et une source X unique avec basculement automatique backend (#622). En plus d’un `--diagnose` honnête qui sonde réellement l’authentification (#609).
 
-### Plus de sources jointes
+### D’autres sources ont rejoint
 
-LinkedIn via ScrapeCreators, avec des articles comme signal fort ([@ravstr](https://github.com/ravstr), #702). StockTwits s'active automatiquement pour les sujets de ticker et de cryptographie ([@wtiwana](https://github.com/wtiwana), #658). Perplexity a développé les modes API directs et la recherche approfondie asynchrone ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn via ScrapeCreators, avec des articles comme signal élevé ([@ravstr](https://github.com/ravstr), #702). StockTwits s’active automatiquement pour les thèmes ticker et crypto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity développé en modes API directs et asynchrone Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
 
 ### Endurci par la communauté
 
-La vague de sécurité était presque entièrement un travail communautaire : correctifs XSS stockés dans le moteur de rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI renforcés par la chaîne d'approvisionnement avec OpenSSF Scorecard et attestation de provenance de la construction ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), analyses Semgrep et OSV-Scanner ainsi qu'une porte d'examen des dépendances PR ([@23241a6749](https://github.com/23241a6749)), un plancher de couverture de test introduit à 60 % et augmenté depuis à 84 % ([@gourab5139014](https://github.com/gourab5139014)) et une analyse de sécurité Hermes effacée de toutes les découvertes CRITIQUES (#768).
+La vague de sécurité consistait presque entièrement en travail communautaire : correctifs stocked-XSS dans le moteur de rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI renforcé par la chaîne d’approvisionnement avec OpenSSF Scorecard et attestation de provenance de compilation ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), scans Semgrep et OSV-Scanner plus une porte de contrôle de dépendance PR ([@23241a6749](https://github.com/23241a6749)), un plancher de couverture de test introduit à 60 % et depuis porté à 84 % ([@gourab5139014](https://github.com/gourab5139014)), et un scan de sécurité Hermes effacé de toutes les conclusions CRITIQUES (#768).
 
 ### Va plus loin
 
-Langues hébraïques et non latines ([@dudyme](https://github.com/dudyme)). Tokenisation compatible CJK pour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague de compatibilité Windows. Extraction de cookies dans toute la famille Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - ainsi que les sources d'informations d'identification macOS Keychain et Linux pass(1). Analyse historique `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 provisionné automatiquement via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages d'emploi d'une entreprise. Deltas de liste de surveillance entre les exécutions.
+Hébreu et langues non latines ([@dudyme](https://github.com/dudyme)). Tokenisation consciente CJKpour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague de compatibilité Windows . Extraction des cookies à travers toute la famille Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - plus macOS Keychain et Linux pass(1) sources de certification. `--as-of` rétrospection historique ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionnement automatique Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages d’emplois d’une entreprise. Deltas de la liste de surveillance entre les exécutions.
 
-### Toujours dans la boîte de la v3
+### Toujours dans la boîte depuis la v3
 
-Les fondations de la v3 sont toujours là : le cerveau de pré-recherche qui résout les bons identifiants, sous-reddits et hashtags avant qu'un seul appel d'API ne se déclenche (construit par [@j-sperling](https://github.com/j-sperling)) ; Meilleurs scores pour l'humour et la viralité ainsi que la pertinence ; fusion de clusters multi-sources ; comparaisons en un seul passage (« CLI vs MCP » en 3 minutes, et non 12) ; comparaisons `--competitors` découvertes automatiquement ; Mode personne GitHub (`--github-user=steipete`) ; Mode ELI5 (« eli5 activé » après toute exécution) ; et des mémoires HTML autonomes et partageables (`--emit=html`). Les boutons de configuration se trouvent dans [CONFIGURATION.md](CONFIGURATION.md).
+Les fondations de la v3 sont toujours là : le cerveau pré-recherche qui résout les bons pseudos, subreddits et hashtags avant qu’un seul appel de API ne se déclenche (construit par [@j-sperling](https://github.com/j-sperling)) ; Best Takes la notation pour l’humour et la viralité en plus de la pertinence ; la fusion de clusters multisources ; les comparaisons en un seul passage («CLI vs MCP» en 3 minutes, pas 12) ; la découverte automatique `--competitors` comparaisons ; GitHub mode personne (`--github-user=steipete`) ; ELI5 mode (« eli5 on » après chaque partie ; et des briefs HTML partageables et autonomes (`--emit=html`). Les boutons de configuration sont présents dans [CONFIGURATION.md](CONFIGURATION.md).
 
-## Installer
+## Installation
 
-| Surfaces | Installer | Mises à jour |
+| Surface | Installation | Mises à jour |
 |---------|---------|---------|
-| **Claude Code** (recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via Marketplace, ou `claude plugin update last30days@last30days-skill` |
-| **Grok** (CLI xAI Build) | `grok plugin marketplace add mvanhorn/last30days-skill` puis `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI ou l'un des 50+ [Hôtes Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et téléchargez via claude.ai > Personnaliser > Compétences > + > Créer une compétence > Télécharger une compétence | Re-télécharger et ré-uploader |
-| **Claude Desktop** | [Téléchargez le `.mcpb` pour votre plateforme](https://github.com/mvanhorn/last30days-skill/releases/latest) et faites-le glisser dans Paramètres > Extensions | Re-téléchargez et faites glisser le nouveau bundle dans |
+| **Claude Code**(recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via le marché, ou `claude plugin update last30days@last30days-skill` |
+| **Grok**(Build xAI CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` alors `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI, ou n’importe lequel des 50+ [Agent Skills](https://agentskills.io) hôtes** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(toile) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et téléverser via claude.ai > Personnaliser > compétences > + > Créer une compétence > Télécharger une compétence | Téléchargez et ré-téléchargez |
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) et glisser dans Paramètres > Extensions | Retéléchargez et faites glisser le nouveau bundle |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recommandé)
@@ -169,46 +169,46 @@ Les fondations de la v3 sont toujours là : le cerveau de pré-recherche qui r�
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recommandé car le marché Claude Code gère les mises à jour pour vous : le cache du plugin est versionné et s'actualise automatiquement lors de la publication d'une nouvelle version. Exécutez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
+Recommandé car le marché Claude Code gère les mises à jour pour vous — le cache des plugins est versionné et se rafraîchit automatiquement lorsqu’une nouvelle version est publiée. Lancez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
 
-Si vous préférez utiliser le chemin d'installation des compétences d'agent sur Claude Code, celui-ci est également pris en charge :
+Si vous préférez utiliser le chemin d’installation des compétences agent-skills sur Claude Code, c’est aussi pris en charge :
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-Le plugin natif et l'installation `npx skills` peuvent coexister. Notez que Claude Code n'effectue pas de déduplication entre les méthodes d'installation : si le plugin Marketplace et la copie `npx skills` sont actifs, `/last30days` affichera deux entrées. Utilisez une méthode d'installation par machine.
+Le plugin natif et l’installation `npx skills` peuvent coexister. Notez que Claude Code ne déduppe pas entre les méthodes d’installation : si vous avez activé à la fois le plugin marketplace et la copie `npx skills` , `/last30days` affichera deux entrées. Utilisez une méthode d’installation par machine.
 
-### Grok (CLI xAI Build)
+### Grok ( CLIde construction xAI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installe last30days en tant que plugin natif. L'installation directe suit le référentiel :
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) s’installe en dur30days en tant que plugin natif. L’installation directe suit le dépôt :
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Ou ajoutez ce dépôt en tant que source de marché, puis installez par nom de plugin :
+Ou ajoutez ce dépôt comme source marketplace, puis installez par nom de plugin :
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Ajoutez `--trust` pour ignorer la confirmation d'installation. Mise à jour avec `grok plugin update last30days`. Grok lit également les manifestes du Claude Code pour vérifier leur compatibilité ; la paire native `.grok-plugin/` est la voie de première classe (et à quelle liste officielle [xAI Marketplace](https://github.com/xai-org/plugin-marketplace) pointe). `npx skills add` reste une solution de secours entre hôtes valide.
+Ajouter `--trust` pour sauter la confirmation d’installation. Mettre à jour avec `grok plugin update last30days`. Grok lit aussi les manifestes Claude Code pour la compatibilité ; la paire native `.grok-plugin/` est la voie de première classe (et ce à quoi indique une liste officielle [xAI marketplace](https://github.com/xai-org/plugin-marketplace) ). `npx skills add` reste une solution de secours valide entre hôtes.
 
-### Codex, Cursor, Copilot, Gemini CLI et autres hôtes de compétences d'agent
+### Codex, Cursor, Copilot, Gemini CLI, et autres hôtes Agent Skills
 
-Installation via la CLI ouverte [Agent Skills](https://agentskills.io) — prend en charge plus de 50 harnais, notamment `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` et plus (liste complète sur le [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Installation via l’open [Agent Skills](https://agentskills.io) CLI — prend en charge 50+ harnais incluant `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`et plus encore (liste complète sur le [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-L'indicateur `-g` (global) s'installe dans votre répertoire utilisateur afin que la compétence soit disponible dans tous les projets. Sans `-g`, `npx skills` installe le projet localement dans `./.skills/` (engagé avec le dépôt). Pour un outil de recherche sur le monde, vous voulez une approche globale.
+Le drapeau `-g` (global) s’installe dans votre répertoire utilisateur, donc la compétence est disponible sur tous les projets. Sans `-g`, `npx skills` installe localement dans `./.skills/` (engagé avec le dépôt). Pour un outil de recherche du monde, global, c’est ce qu’il vous faut.
 
-Le bureau Codex et d'autres hôtes en mode dossier peuvent fonctionner dans des dossiers ordinaires ainsi que dans les dépôts Git. Avant la première recherche, demandez à l'agent hôte d'exécuter le `scripts/last30days.py --preflight` fourni à partir du répertoire de compétences chargé ; dans une extraction de source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Il affiche la source de configuration, le plan des cookies du navigateur, les écritures planifiées, les commandes facultatives et la configuration du projet ignorée sans lire les cookies, écrire des fichiers ou exécuter des recherches.
+Codex hôtes de bureau et autres en mode dossier peuvent fonctionner dans des dossiers ordinaires ainsi que dans des dépôts Git. Avant de faire une première recherche, demandez à l’agent hôte d’exécuter les `scripts/last30days.py --preflight` fournis depuis le répertoire skill chargé ; lors d’une vérification de source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Elle affiche la source de configuration, le plan de cookies-navigateur, les écritures planifiées, les commandes optionnelles et la configuration du projet ignorée sans lire les cookies, écrire des fichiers ou lancer de recherche.
 
-Par défaut, cela s'installe pour le faisceau détecté par `npx skills`. Pour en cibler un en particulier (ou plusieurs) :
+Par défaut, cela s’installe pour le faisceau `npx skills` détecte. Pour cibler un ou plusieurs :
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Mettre à jour plus tard avec :
+Mise à jour plus tard avec :
 
 ```bash
 npx skills update last30days -g
 ```
 
-Ou mettez à jour tout ce que vous avez installé globalement via `npx skills` :
+Ou mettez à jour tout ce que vous avez installé globalement via `npx skills`:
 
 ```bash
 npx skills update -g
 ```
 
-Répertoriez et supprimez avec `npx skills list -g` et `npx skills remove last30days -g`.
+Listez et supprimez avec `npx skills list -g` et `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) à partir de la dernière version
-2. Accédez à [claude.ai > Personnaliser > Skills](https://claude.ai/customize/skills)
-3. Cliquez sur le bouton `+` dans le panneau Compétences > cliquez sur `Create skill` > `Upload a skill` et parcourez/déposez le fichier dans
+1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la dernière sortie
+2. Va à [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Cliquez sur le bouton `+` dans le panneau Compétences > cliquez sur `Create skill` > `Upload a skill` et parcourez/déposez le fichier
 
-Activez d'abord « Exécution de code et création de fichiers » sous Fonctionnalités : les compétences ne fonctionneront pas sans cela.
+Activez d’abord « Exécution de code et création de fichiers » sous Capacités — les compétences ne s’exécuteront pas sans cela.
 
-### Bureau Claude
+### Claude Desktop
 
 Claude Desktop installe `/last30days` en tant que serveur MCP via un bundle `.mcpb` (un package Model Context Protocol en un clic).
 
-1. Accédez à la [dernière version ](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` pour votre plateforme :
-- macOS Apple Silicon : `last30days-pp-mcp-darwin-arm64.mcpb`
-- macOS Intel : `last30days-pp-mcp-darwin-amd64.mcpb`
--Linux x86_64 : `last30days-pp-mcp-linux-amd64.mcpb`
-2. Ouvrez Claude Desktop, accédez à Paramètres > Extensions et faites glisser le fichier.
-3. Lorsque vous y êtes invité, collez les clés API des sources que vous souhaitez activer. Chaque champ est facultatif : le moteur passe en mode Web uniquement si vous les ignorez tous. Les clés sont stockées dans le trousseau de votre système d’exploitation.
-4. Redémarrez Claude Desktop. Demandez à Claude de « rechercher Peter Steinberger » ou n'importe quel sujet et il appellera l'outil `research`.
+1. Allez sur le [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` pour votre plateforme :
+   - macOS Apple Silicon : `last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOS Intel : `last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linux x86_64 : `last30days-pp-mcp-linux-amd64.mcpb`
+2. Ouvre Claude Desktop, va dans Paramètres > Extensions, et fais glisser le fichier dedans.
+3. Lorsqu’on vous le demande, collez API clés pour les sources que vous souhaitez activer. Chaque champ est optionnel — le moteur passe au mode web uniquement si vous les sautez tous. Les clés sont stockées dans votre trousseau d’OS.
+4. Redémarrez Claude Desktop. Demandez- Claude de « rechercher Peter Steinberger » ou n’importe quel sujet, et cela appellera l’outil `research` .
 
-**Exigence d'hôte :** Python 3.12+ sur PATH. Le bundle fournit la source du moteur mais utilise votre interpréteur Python local. Installez depuis [python.org](https://www.python.org/downloads/) sous Windows ; macOS et la plupart des distributions Linux proposent une version compatible.
+**Exigence de l’hôte :** Python 3.12+ sur PATH. Le bundle envoie la source moteur mais utilise votre interprète Python local. Installez depuis [python.org](https://www.python.org/downloads/) sur Windows; macOS et la plupart des distributions Linux livrent une version compatible.
 
-**Les clés ne sont pas synchronisées avec la compétence Code.** Claude Desktop et Claude Code conservent des magasins d'informations d'identification distincts de par leur conception. Si vous avez déjà configuré `~/.config/last30days/.env` pour la compétence Code, vous saisirez à nouveau les mêmes clés ici une fois.
+**Les clés ne se synchronisent pas avec la compétence Code.** Claude Desktop et Claude Code maintiennent des magasins d’identifiants séparés par conception. Si vous avez déjà configuré `~/.config/last30days/.env` pour la compétence Code, vous saisirez à nouveau les mêmes clés ici une fois.
 
-La prise en charge de Windows est différée jusqu'à ce que les points d'entrée du manifeste par plate-forme soient réglés ; suivre dans un numéro de suivi.
+Windows support est différé jusqu’à ce que les points d’entrée des manifestes par plateforme soient réglés ; suivre un problème de suivi.
 
 ### OpenClaw
 
@@ -263,11 +263,11 @@ La prise en charge de Windows est différée jusqu'à ce que les points d'entré
 clawhub install last30days-official
 ```
 
-Pour les flux de travail d'action X/Twitter en dehors de la recherche `/last30days`, tels que la publication
-tweets ou réponses, exportation de followers, gestion des médias, moniteurs et cadeaux
-tirages, utilisez [TweetClaw](https://github.com/Xquik-dev/tweetclaw) comme compagnon
-Plugin OpenClaw. TweetClaw est maintenu par Xquik-dev et est répertorié uniquement en tant que
-chemin compagnon facultatif, pas une dépendance ou une approbation des 30 derniers jours.
+Pour Xflux d’action /Twitter en dehors de la recherche `/last30days` , comme la publication
+tweets ou réponses, exportation d’abonnés, gestion des médias, surveillance et concours
+pioche, utilise [TweetClaw](https://github.com/Xquik-dev/tweetclaw) comme compagnon
+OpenClaw plugin. TweetClaw est maintenu par Xquik-dev et n’est listé que comme un
+Chemin de compagnon optionnel, pas une dépendance ou une endosse de Last30Days.
 
 ### Manuel (développeur)
 
@@ -276,30 +276,30 @@ git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-Le lien symbolique maintient l'installation synchronisée avec votre arborescence de travail pendant que vous modifiez - aucune recopie n'est nécessaire. Pour `claude.ai`, créez le fichier `.skill` à partir de la source : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
+Le lien sym maintient l’installation synchronisée avec votre arbre de travail pendant la modification — pas besoin de recopier. Pour `claude.ai`, construisez le fichier `.skill` à partir de la source : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
 
-Reddit (avec commentaires), Hacker News, Polymarket et GitHub fonctionnent immédiatement. Zéro configuration. Exécutez `/last30days` une fois et l'assistant de configuration déverrouille plus de sources en 30 secondes, y compris les CLI gratuites arXiv et Techmeme.
+Reddit (avec commentaires), Hacker News, Polymarketet GitHub fonctionnent immédiatement. Zéro configuration. Lancez- `/last30days` une fois et l’assistant de configuration débloque plus de sources en 30 secondes, y compris les arXiv gratuits et les Techmeme CLIs.
 
 ## Apportez vos propres clés
 
-Ces plateformes n'ont pas de relations entre elles. X ne sait pas ce que pense Reddit. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés API et jetons de navigateur, et du coup vous avez accès à tous en même temps.
+Ces plateformes n’ont pas de relations entre elles. X ne sait pas ce que Reddit pense. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés de API et jetons navigateur, et soudainement vous avez accès à tout en même temps.
 
-| Sources | Ce dont vous avez besoin | Coût |
+| Sources | Ce dont tu as besoin | Coût |
 |---------|---------------|------|
 | Reddit (avec commentaires) + HN + Polymarket + GitHub + StockTwits | Rien | Gratuit |
-| arXiv + Techmeme | CLI gratuites, installées automatiquement lors de la première configuration | Gratuit |
-| X/Twitter | Connectez-vous à x.com dans n'importe quel navigateur ou définissez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies du navigateur sont gratuits ; les clés sont spécifiques au fournisseur |
+| arXiv + Techmeme | Free CLIs, installé automatiquement par la première exécution | Gratuit |
+| X / Twitter | Connectez-vous à x.com dans n’importe quel navigateur, ou configurez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies du navigateur sont gratuits ; les clés sont spécifiques à chaque fournisseur |
 | YouTube | `brew install yt-dlp` | Gratuit |
-| Ciel bleu | Mot de passe de l'application de bsky.app | Gratuit |
-| TikTok + Instagram + Fils de discussion + Pinterest + LinkedIn + Commentaires YouTube | Clé ScrapeCreators | 10 000 appels gratuits, puis PAYG |
-| Xiaohongshu (ROUGE) | Exécutez un plug-in de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` et inscrivez-vous avec `--search xhs` par exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env` ; last30days sonde automatiquement `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilise `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Aucune clé API des 30 derniers jours ; dépend de votre service de session de navigateur local |
-| DripStack (newsletters financières premium) | Opt-in : `--search dripstack` par exécution, ou `INCLUDE_SOURCES=dripstack` dans `.env` | Pas de clé ; API de recherche publique gratuite |
-| Sonar Perplexity / API de recherche / Recherche approfondie | Clé Perplexité ou clé OpenRouter comme solution de secours Sonar | Payez au fur et à mesure |
-| Recherche sur le Web | Clé de recherche courageuse | 2 000 requêtes gratuites/mois |
+| Bluesky | Mot de passe de l’application depuis bsky.app | Gratuit |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube commentaires | ScrapeCreators clé | 10 000 appels gratuits, puis PAYG |
+| Xiaohongshu (RED) | Exécutez un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` et optez pour `--search xhs` par exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env`; last30days s’auto-sonde `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilisez `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Pas de clé de API des derniers 30 jours ; cela dépend de votre service local de session de navigateur |
+| DripStack (newsletters financières premium) | Opt-in : `--search dripstack` par partie, ou `INCLUDE_SOURCES=dripstack` en `.env` | Pas de clé ; recherche publique gratuite API |
+| Perplexity Sonar / API de recherche / Recherche approfondie | Perplexity clé, ou clé OpenRouter comme solution de secours Sonar | Payez au fur et à mesure |
+| Web recherche | Clé de recherche Brave | 2 000 requêtes gratuites par mois |
 
-### Trousseau macOS (facultatif)
+### macOS Keychain (optionnel)
 
-Sur macOS, vous pouvez stocker les clés dans le trousseau système au lieu d'un fichier `.env`. La compétence les sélectionne automatiquement en tant que source de priorité la plus faible : les fichiers `.env` et l'environnement de processus gagnent toujours en cas de collision.
+Sur macOS , vous pouvez stocker les clés dans le Keychain système au lieu d’un fichier `.env` . La compétence les détecte automatiquement comme source de priorité la plus basse — `.env` fichiers et environnement de processus l’emportent toujours en cas de collision.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +313,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Les éléments sont stockés sous le nom de service `last30days-<KEY>` pour l'utilisateur actuel. Sur les plates-formes non Darwin, le chargeur ne fonctionne pas, il n'y a donc aucun changement de comportement pour les utilisateurs Linux/Windows.
+Les éléments sont stockés sous le nom de service `last30days-<KEY>` pour l’utilisateur actuel. Sur les plateformes non-Darwin, le chargeur est un no-op, donc il n’y a pas de changement de comportement pour les utilisateurs Linux/Windows .
 
-Vous disposez déjà de clés sous différents noms de service de trousseau ? Définissez le mappage non secret `LAST30DAYS_KEYCHAIN_ALIASES` décrit dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) au lieu de copier les secrets.
+Avez-vous déjà des clés sous différents noms de service Keychain ? Définissez la `LAST30DAYS_KEYCHAIN_ALIASES` non secrète décrite dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) au lieu de copier les secrets.
 
-Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète des clés par source, la priorité du fournisseur de raisonnement et la priorité du backend de recherche Web.
+Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète de clés par source, la priorité du fournisseur de raisonnement et la priorité backend de recherche web.
 
 ## Configuration
 
-Deux choses que vous voudrez probablement savoir dès le premier jour :
+Deux choses que vous voudrez probablement savoir dès le premier jour :
 
-**Où les fichiers de recherche sont enregistrés.** `LAST30DAYS_MEMORY_DIR` est par défaut `~/Documents/Last30Days/` (Windows : `C:\Users\<you>\Documents\Last30Days\`). Remplacez en définissant cette variable d'environnement sur n'importe quel chemin de votre shell, ou `--save-dir <path>` par exécution. Utilisez `--output <file>` lorsque vous avez besoin du résultat rendu selon un chemin exact, en utilisant le format sélectionné par `--emit`. Utilisez `--save-suffix=<name>` pour séparer plusieurs variantes du même sujet (par exemple, par client). Chaque exécution de `--save-dir` produit `<slug>-raw[-suffix].md`. Exécutez `python3 skills/last30days/scripts/last30days.py --preflight` pour examiner les écritures planifiées avant une exécution de recherche.
+**Où les fichiers de recherche sont sauvegardés.** `LAST30DAYS_MEMORY_DIR` par défaut est `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Remplaça en définissant cette variable d’environnement sur n’importe quel chemin dans ton shell, ou `--save-dir <path>` par exécution. Utilise `--output <file>` lorsque tu as besoin que le résultat affiché soit sur un chemin exact, en utilisant le format choisi par `--emit`. Utilise `--save-suffix=<name>` pour séparer plusieurs variantes du même sujet (par exemple par client). Chaque exécution `--save-dir` produit `<slug>-raw[-suffix].md`. Exécute `python3 skills/last30days/scripts/last30days.py --preflight` pour revoir les écritures prévues avant une exécution de recherche.
 
-**Sortie structurée pour les agents et les flux de travail.** Demandez à `/last30days` un JSON lisible par machine pour recevoir le profil d'agent stable et versionné. Pour une utilisation directe du moteur dans les scripts ou le développement, exécutez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` ; ajoutez `--json-profile=raw` uniquement lorsque vous avez besoin du vidage interne `Report` non versionné. Consultez la [référence du champ d'exportation JSON et la politique de gestion des versions](docs/reference/json-export.md).
+**Sortie structurée pour les agents et les flux de travail.** Demandez `/last30days` JSON lisibles par machine pour recevoir le profil d’agent stable et versionné. Pour une utilisation directe du moteur dans les scripts ou le développement, exécutez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; ajoutez `--json-profile=raw` uniquement lorsque vous avez besoin du vidage interne de `Report` non versionné. Voir le [JSON export field reference and versioning policy](docs/reference/json-export.md).
 
-**Découverte sans sujet.** Demandez à `/last30days what's trending in AI agents?` d'obtenir un dossier de découverte classé au lieu de rechercher un sujet que vous connaissez déjà. Sur un hôte d'agent, cela exécute le protocole d'évaluation de l'hôte à trois commandes (le modèle nomme les sujets, filtre les indésirables, note la valeur et écrit les angles du contenu). Pour une utilisation directe du moteur dans des scripts ou cron, exécutez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte s'exclut mutuellement avec un sujet positionnel et `--drill`.
+**Découverte sans sujet.** Demandez- `/last30days what's trending in AI agents?` d’obtenir un brief de découverte classé au lieu de rechercher un sujet déjà connu – sur un agent hôte, cela exécute le protocole à trois commandes hôte-jugé (le modèle nomme les sujets, filtre les indésirables, note la valeur et écrit les angles de contenu). Pour une utilisation directe du moteur dans des scripts ou des crons, exécutez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte est mutuellement exclusive avec un sujet positionnel et `--drill`.
 
-**Surveillance des tendances entre les exécutions.** Le mode par défaut produit un nouvel instantané de démarque par exécution. Pour accumuler les résultats au fil du temps, ajoutez `--store` pour persister dans une base de données SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec livraison Slack/webhook en option sur les nouveaux résultats) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour les résumés quotidiens/hebdomadaires. Le modèle de cadence complet se trouve dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Surveillance des tendances entre les exécutions.** Le mode par défaut produit un instantané de remarques fraîchement par exécution. Pour accumuler les résultats au fil du temps, ajoutez `--store` pour persister dans une base SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec une livraison optionnelle par Slack / webhook sur les nouvelles découvertes) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour les digestes quotidiens / hebdomadaires. Le schéma de cadence complet est dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Une bibliothèque de recherche avec abonnement.** Demandez à `/last30days` de créer votre flux de bibliothèque ou utilisez `python3 skills/last30days/scripts/last30days.py library feed` directement pour les scripts et le développement. Il transforme les mémoires enregistrés en `index.html`, en Atom `feed.xml` local et en pages brèves lisibles. Ajoutez `--publish` uniquement lorsque vous souhaitez héberger l'index HTML et les pages brèves ; la publication est explicite et publique par défaut. Pour rendre le flux Atom accessible, hébergez le répertoire de sortie généré sur un hôte statique tel que GitHub Pages.
+**Une bibliothèque de recherche abonnée.** Demandez- `/last30days` de construire votre fil d’actualité de bibliothèque, ou utilisez- `python3 skills/last30days/scripts/last30days.py library feed` directement pour le script et le développement. Cela transforme les briefs sauvegardés en `index.html`, un `feed.xml`Atom local et des pages brèves lisibles. Ajoutez `--publish` uniquement lorsque vous souhaitez que l’index HTML et les pages de briefs soient hébergés ; la publication est explicitement volontaire et publique par défaut. Pour rendre le flux Atom abonné, hébergez le répertoire de sortie généré sur un hôte statique tel que GitHub Pages.
 
-**Recherchez tout ce que vous avez recherché.** Demandez à `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour une utilisation directe du moteur, exécutez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe progressivement les mêmes résumés enregistrés que ceux utilisés par le flux de la bibliothèque, fusionne les observations de magasin correspondantes par exécution et regroupe les résultats par sujet et par date. De nouvelles analyses font également apparaître une section compacte **De votre bibliothèque** lorsque des recherches antérieures chevauchent le sujet actuel ; définissez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
+**Recherchez tout ce que vous avez recherché.** Demandez `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour une utilisation directe du moteur, exécutez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe progressivement les mêmes briefs sauvegardés utilisés par le fil de la bibliothèque, fusionne les observations correspondantes à chaque exécution, et regroupe les résultats par sujet et date. Les nouvelles sessions font également apparaître une section compacte **Depuis votre bibliothèque** lorsque des recherches antérieures chevauchent le sujet actuel ; réglez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
 
-Les scripts wrapper par client, les sous-reddits de catégorie personnalisés et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
+Des scripts wrapper par client, des subreddits personnalisés par catégories peer et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
 
-## Showcase : flux de recherche communautaire
+## Vitrine : flux de recherche communautaires
 
-Vous avez publié une mise à jour récurrente de l'IA, une surveillance du marché ou une obsession merveilleusement étroite pour les 30 derniers jours ? Partagez l'URL de la bibliothèque publique (ou l'URL Atom après avoir hébergé `feed.xml` sur un hôte statique) dans [le fil de discussion de la communauté ](https://github.com/mvanhorn/last30days-skill/issues/532). Les flux communautaires seront liés ici au fur et à mesure que leurs propriétaires les soumettront ; le fil est le point de collecte entre-temps.
+Publié une mise à jour récurrente de l’IA, une surveillance du marché, ou une obsession merveilleusement étroite pour les dernier30 jours ? Partagez l’URL de la bibliothèque publique — ou l’URL Atom après `feed.xml` hébergé sur un hébergeur statique — dans [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Les fils communautaires seront liés ici au fur et à mesure que leurs propriétaires les soumettent ; le fil de discussion sert de point de collecte en attendant.
 
-## Comment ça marche
+## Comment ça fonctionne
 
-1. **Vous saisissez un sujet.** Personne, entreprise, produit, technologie, « X contre Y ». Rien.
-2. **L'agent décide qui compte.** Trouve X identifiants (y compris les fondateurs), les dépôts GitHub, les subreddits, les hashtags TikTok, les chaînes YouTube. Pour "Kanye West", il connaît r/hiphopheads, @kanyewest et "bully review" sur YouTube. Pour "OpenClaw", il résout openclaw/openclaw sur GitHub et récupère le nombre d'étoiles en direct.
-3. **Toutes les sources recherchées en parallèle.** Expansion multi-requêtes. Des résultats notés par engagement, pertinence, fraîcheur.
-4. **La profondeur que personne d'autre n'a.** Transcriptions YouTube complètes de vidéos de réaction. Meilleurs commentaires Reddit avec le nombre de votes positifs. Légendes TikTok. Cotes du polymarché. Pas seulement des titres et des liens.
-5. **Même histoire, fusionné.** Wireless Festival annoncé sur Reddit, discuté sur X, prix des billets sur TikTok = un cluster, pas trois éléments distincts.
-6. **Synthétisé en un seul mémoire.** Fondé sur des données spécifiques. Cité par la source. Classé en fonction de ce avec quoi les gens s'engagent réellement. Pas "voici ce que j'ai trouvé". C'est "voici ce qui compte".
-7. **Il devient alors votre expert.** Après une seule exécution, votre session Claude sait tout ce que la communauté sait. Posez des questions de suivi. Demandez-lui de rédiger des invites, de rédiger des e-mails, de planifier des voyages, de concevoir des systèmes - le tout fondé sur la réalité actuelle.
+1. **Tu tapes un sujet.** Personne, entreprise, produit, technologie, «X vs Y. » N’importe quoi.
+2. **L’agent décide qui compte.** Trouve X pseudos (y compris les fondateurs), GitHub dépôts, subreddits, hashtags TikTok YouTube chaînes. Pour « Kanye West », il connaît r/hiphopheads, @kanyewest, et « bully review » sur YouTube. Pour «OpenClaw», il résout openclaw/openclaw sur GitHub et récupère les comptes d’étoiles en direct.
+3. **Toutes les sources recherchées en parallèle.** Extension multi-requêtes. Résultats notés par engagement, pertinence, fraîcheur.
+4. **La profondeur que personne d’autre n’a.** Transcriptions complètes YouTube des vidéos de réactions. Meilleurs Reddit commentaires avec le nombre de votes positifs. TikTok légendes. Polymarket chances. Pas seulement les titres et les liens.
+5. **Même histoire, fusionnée.** Wireless Festival annoncé le Reddit, discuté sur X, prix des billets sur TikTok = un cluster, pas trois articles séparés.
+6. **Synthétisé en un seul mémoire.** Fondé sur des données spécifiques. Cité par source. Classée selon ce avec quoi les gens interagissent réellement. Pas « voici ce que j’ai trouvé ». C’est « voici ce qui compte ».
+7. **Puis il devient votre expert.** Après une seule partie, votre Claude session sait tout ce que la communauté sait. Posez des questions de suivi. Faites-lui écrire des suggestions, rédiger des e-mails, planifier des voyages, créer des systèmes d’architecture – tout cela ancré dans ce qui est réel en ce moment.
 
-## Ce que disent les gens
+## Ce que les gens disent
 
-> "J'ai trouvé une compétence Claude Code qui recherche n'importe quel sujet sur Reddit, X, YouTube et HN au cours des 30 derniers jours. Ensuite, j'écris les invites pour vous. J'ai effectué des recherches manuelles sur Reddit et X avant chaque élément de contenu que j'écris. Onglet par onglet. Fil par fil. C'est la partie qui prend 90 minutes. Cela l'élimine. " -@itsjasonai
+> « J’ai trouvé une compétence Claude Code qui recherche n’importe quel sujet à travers Reddit, X, YouTubeet HN des 30 derniers jours. Ensuite, il écrit les consignes pour vous. J’ai cherché manuellement Reddit et X recherches avant chaque contenu que j’écris. Onglet par onglet. Fil par fil. C’est la partie qui prend 90 minutes. Ça l’élimine. » -@itsjasonai
 
-> "Cette compétence a remplacé l'ensemble de mon flux de travail de recherche. Vous lui donnez un sujet, elle supprime Reddit, X et le Web de ce dont les gens parlent réellement. Pas d'anciens articles de blog. De vraies conversations des 30 derniers jours." -@itswilsoncharles
+> « Cette compétence a remplacé tout mon flux de recherche. Tu lui donnes un sujet, ça gratte Reddit, X, et le web pour trouver ce dont les gens parlent vraiment. Pas de vieux articles de blog. De vraies conversations des 30 derniers jours. » -@itswilsoncharles
 
-> "5 des 10 dépôts tendances sur GitHub aujourd'hui sont des outils Claude. #1 : mvanhorn/last30days-skill" -@yieldhunter95
+> « 5 des 10 dépôts tendance sur GitHub aujourd’hui sont Claude outils. #1 : Mvanhorn/last30days- compétence » -@yieldhunter95
 
 ## Open source
 
-Licence MIT. Aucun suivi. Aucune analyse. Votre recherche reste sur votre machine. Plus de 2 700 tests.
+Licence MIT. Pas de suivi. Pas d’analyses. Votre recherche reste sur votre machine. 2 700+ tests.
 
-Construit avec Python 3.12+, yt-dlp, Node.js (client Bird fourni pour la recherche X) et l'API ScrapeCreators. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
+Construit avec Python architecture du moteur v3.12+, yt-dlp, Node.js (client Bird fourni pour X recherche), et ScrapeCreators API. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
 
-Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté et [CHANGELOG.md](CHANGELOG.md) pour l'historique des versions.
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté, et [CHANGELOG.md](CHANGELOG.md) pour l’historique des versions.
 
-## Historique des étoiles
+## Histoire de Star
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,382 @@
+# /last30days
+
+[English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | 日本語 | [简体中文](README.zh-CN.md)
+
+<p align="center">
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/mvanhorn/last30days-skill">
+    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
+  </a>
+  <br/>
+  <a href="https://trendshift.io/repositories/21997" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
+</p>
+
+**AIエージェント主導の検索エンジンは、upvotes, likes, 実際のお金によって得点 - エディタではありません。**
+
+このREADME は、現在の v3 パイプラインを追跡します。 ランタイムスキルのスペックは、[skills/last30days/SKILL.md](skills/last30days/SKILL.md), これは、最新のコマンドとセットアップの動作のための真実のソースです。.
+
+**Claude Code(推奨 — マーケットプレイスによる自動更新):**
+```
+/plugin marketplace add mvanhorn/last30days-skill
+/plugin install last30days
+```
+
+**Codex, Cursor, Copilot, Gemini CLI50以上のもの[Agent Skills](https://agentskills.io)ホスト:**
+```
+npx skills add mvanhorn/last30days-skill -g
+```
+(`-g`すべてのプロジェクトで利用できる、ユーザーのグローバルにインストールします。 プロジェクトごとのスコープにドロップします。
+
+その他のインストールオプション (claude.ai web,OpenClaw、マニュアル)[Install](#インストール)以下のセクション。
+
+ゼロコンフィグReddit、HN、PolymarketとGitHubすぐに働く。 一度実行し、セットアップウィザードがXのロックを解除します。YouTube, TikTok, arXiv, Techmeme30秒以上。
+
+---
+
+Redditアップボット。 Xは好きです。YouTubeトランスクリプト。TikTokエンゲージメント。Polymarket実際のお金とインサイダー情報によって裏付けられたオッズ。 それは、毎日、自分の注意と財布に投票する万人の人々です。/last30days実質の人々が実際に何を従事しているか、そしてAIの代理店がそれを1つの短いに合成することを判断することによってそれを並列で捜します。
+
+Googleエディタを集計します。/last30days人を検索します。
+
+単一のAIがすべてにアクセスできないため、他の場所でこの検索を取得することはできません。Google検索は触れませんRedditコメントやX投稿。ChatGPTお問い合わせRedditしかし、Xを検索することはできませんTikTok. ジェミニは持っていますYouTubeしかし、そうではありませんReddit. Claudeそれらをネイティブに持っていません。 各プラットフォームは、独自のウォールガーデンですAPI、独自のトークン、独自のauth。 しかし、自分の鍵やブラウザのセッションを持参し、突然、AIエージェントは一度にすべて検索でき、お互いにスコアをつけ、実際に何かを伝えることができます。
+
+これはロック解除です。 より良い検索エンジンではありません。 エージェントが橋渡しするダース接続プラットフォーム。
+
+```
+/last30days Peter Steinberger
+```
+
+明日は会いましょう。 お問い合わせGoogleお問い合わせ 自分を手に入れるLinkedInから 2023./last30days彼らが実際にこの月をやっていることをあなたに与えます: 参加OpenAIお問い合わせCodex, サードパーティの代理店でAnthropicの禁止を戦う, 発送 23PRs85%の合併率で、建物 "LobsterOS"クロスデバイスエージェント制御、r/Claudeコードヒット 569 彼がヒーローか「不十分」かどうかを逆転させるアップボット. Xの投稿に散らばるRedditスレッド,YouTubeトランスクリプトとGitHubコミット。 何もなかったGoogle.
+
+## なぜこれが存在するのか
+
+人工知能に追いつくために構築しました。 日々変化する変化や、Redditそして、X の nerds は、最初にその上に常にあります。 私はより良いプロンプトを必要とし、トレーニングデータは、コミュニティがすでに把握していたものの後ろに常に数か月後にありました。
+
+しかし、それは何かを大きく変えました。 今、私はビジネスについての最後の30日真実を知るために販売コールの前にそれを実行します。 ミーティングの前に、誰かの最近のツイートとポッドキャストのトランスクリプトを読んでください。 前のページへDisney Worldどの乗車が閉鎖されているか、コミュニティが何を言うかを知るための旅行Genie+. 人が実際にどんな問題を抱えているかを知るために何かを造る前に.
+
+社長に会うなら、すべてのツイートを読んでください。YouTube過去30日間の成績証明書? お問い合わせ
+
+## 人によって得たソース
+
+|ソース|人々があなたを教えてくれるもの|
+|--------|--------------------------|
+| **Reddit** |ろ過されていないテイク。 実際の上書きカウント、無料、なしのトップコメントAPIキー。 実際の意見は?Googleブリス。|
+|*X / Twitter**|ホットテイク、エキスパートスレッド、ブレイク反応。 最初に知るために、最初に主張する。|
+| **YouTube** |深夜45分ダイブ 問題の5つの引用語句を検索した完全なトランスクリプト。|
+| **TikTok** |クリエーターが3.6Mの人々を連れて行くと、あなたは決して見つけることができませんGoogle. |
+| **Instagram Reels** |単語のトランスクリプトによるインフルエンサーの視点。 視覚文化信号。|
+| **Hacker News** |開発者のコンセンサス。 825 ポイント, 899コメント. 技術的な人が実際に議論する場所。|
+| **Polymarket** |コメントはありません。 オッズ。 実質のお金によって支えられる。 アルバム販売に関する96%の自信 取得の4%。|
+| **GitHub** |人のために:PR星、リリースノートによる速度、トップリpos。 トピック:問題と議論。|
+| **Digg** |キュレーションストーリー クラスターからDigg'AI 1000 のリーダーボード (~1000 の High-signal AI アカウントが X に帰属します)。 自動使用可能時`digg-pp-cli`お問い合わせPATH. |
+| **arXiv** |ハイプの背後にある紙。 窓の新しい研究、自由、いいえAPIキー。 自動使用可能時`arxiv-pp-cli`お問い合わせPATH(初回設定でインストール)|
+| **Techmeme** |tech-newsの編集層、30日間に渡る日付。 無料, いいえAPIキー。 自動使用可能時`techmeme-pp-cli`お問い合わせPATH(初回設定でインストール)|
+| **LinkedIn** |専門の信号。 高い信号として重くされる記事および記事。|
+| **StockTwits** |トレーダーの感情。 トピックがティッカーや暗号であるときに自動アクティブ化します。|
+| **Threads** |投稿Twitterテキストレイヤー。 クリエイターやブランドとの会話|
+| **Pinterest** |視覚的な発見。 ピン、保存、製品やアイデアに関するコメント。|
+| **Xiaohongshu (RED)** |中国のライフスタイル、製品、クリエイターの信号。 リクエストを明示的に`--search xhs`ロギングインx-mcpブラウザプラグインまたは`xiaohongshu-mcp`現地でサービスを展開しています。|
+| **Bluesky** |分散型社会層。 ポストTwitterの移行からプロトコル投稿。|
+|**性能**|地上のソナーの統合、未加工調査API行、深層研究|
+|**ウェブ**|編集カバレッジ、ブログの比較。 1つの信号だけではありません。|
+
+コミュニティコントリビューターが増え続ける。Truth Socialそして他のニッチの源は方法のより多くのエンジンにあります。
+
+ツイートReddit1,500のアップボットでスレッドは、誰も読んでいないブログ投稿よりも強い信号です。 ツイートTikTok3.6M ビューでは、プレスリリースよりも文化的に関連しているものについて詳しく説明します。Polymarketボリュームの$66Kでバックされたオッズは、punditの推測よりも議論するのは困難です。
+
+実際に従事している現実の人々によって合成のランク。 社会的関連性、ないSEO関連する。
+
+## 実際に使用している人
+
+**会議のため。**`/last30days Peter Steinberger`- 参加OpenAIお問い合わせCodexチーム, サードパーティのエージェントでAnthropicの禁止を戦う, 23PRs85%の合併率で合併GitHub, 建物LobsterOSクロスデバイスエージェント制御用 ログインClaudeコード: "以来OpenClawリリースされて、他のものを通してそれを実行すると広く知られていましたAPI最終的に禁止されたつもりだった」(227 投票)。 そうではありませんLinkedIn.
+
+**採用信号を読むため**`/last30days Listen Labs --hiring-signals`- 現在のジョブとキャリアページは、フォーカスシフトの証拠を引用する:企業のセキュリティ、顧客の成功、インフラストラクチャ、または製品拡張に採用します。 レポートは、配線が信号に表示されること、ロードマップが出荷するものではありません。
+
+**ピーク前のトピックを見つける。** お問い合わせ`/last30days what's exploding in AI agents?`そして発見モードへの技術スイッチ:エンジンの渦Redditカテゴリ リスト,Hacker Newsフロント/ベストストーリーDigg'AI 1000 フィードと X 認証時。エージェントは、指名(名前、ジャンクフィルタリング、コンテンツワース)を判断し、ポッドキャスト/ X 粒子の角度を記述します。その後、5-10の速度でランクされたトピックを取得します。 すべての結果には、クロスソース番号、勢いラベル、および準備が整ったものが含まれます。`/last30days "<topic>"`フォローアップ。
+
+**何かが落ちるとき。**`/last30days Kanye West`- 英国は、彼のビザをブロックしました, ワイヤレスフェスティバルはキャンセルしました, スポンサーは逃げました. しかし、BULLYはビルボードで2位デビューしました。 ファンタノが「ヤ・サバティカル」から戻って、それを見直しました (653K ビュー). SoFi Homecomingは、ローレン・ヒルとトラビス・スコットを44曲引き出す。Polymarket: 「カニエのつぶやきが再びか?」 86% はい。 23Redditスレッド, 17YouTubeビデオ、86K の upvotes。
+
+**ツールを比較する。**`/last30days OpenClaw vs Hermes vs Paperclip`- 「競合他社ではなく、レイヤーです。」OpenClawエクセプター (351K)GitHub星, ライブ), エルメスは、自己即興脳です (31K星), ペーパークリップは、orgのチャートです (49K星). スターカウントは、からライブを引っ張りましたGitHub APIブログ投稿を stale しない。 アーキテクチャ、メモリ、セキュリティ、最高のサイドバイサイドテーブル。 パープル@IMJustinBrooke: "OpenClaw= チャーマーダー、ヘルメス = チャリザード。
+
+**世界を理解する。**`/last30days Iran vs USA`- 戦争38日目。 イランがホルムズの海峡を再開するためのトランプの火曜日の期限。 米国戦車2隻がダウン。 $126/バレルのオイル。 IEAは「世界油市場史における最大の供給破壊」と呼びました。Polymarket: 12月31日(火)74%で消火。 27 Xの投稿、10YouTubeビデオ、20の予測市場。
+
+**旅行の前に。**`/last30days Universal Epic Universe`- 既に工事中の拡張。 "Project 680" はファイルを許可します。 インフラで確認した花火大会だが、発表されていない。 待ち時間:Mine-Cart Madness 平均 148 分. 年間パスはなく、ローカルは不満です。 スターダストレーサーは4月5日までの改装のためにダウンします。
+
+**早く何かを学ぶため**`/last30days Nano Banana Pro prompting` - JSON-structedプロンプトはタグスープを置き換えています。@pictsbyai's のネストされたフォーマットは「出血を受け入れる」を防ぎます。 ワークフローを編集するワークフローは、再生を破ります。 その後、コミュニティが何を語ったかを正確に使用して生産のプロンプトを書きます。
+
+## 新着情報
+
+5月のv3.3発表以来、v3.11.1(7月2026)として:175合併PRs- 52のコミュニティコントリビューターの122 - 15回のリリースで。 これは、着陸したものです。
+
+### ファーストクラスOpenAI Codex
+
+/last30daysネイティブCodexガイド付きセットアップ付きプラグイン - ポートではなく、一流の市民。 Renderer-awareの引用は意味しますCodex出力は URL のスープ(#694)の代りに短いように読み、同じエンジンは動きますClaude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw, と 50+Agent Skillsホスト。Codexプラグインマニフェストによる[@rfoust](https://github.com/rfoust) (#686), Codexauthの修正による[@tmchow](https://github.com/tmchow) (#698).
+
+### arXiv, TechmemeとDigg- 無料、なしAPIキーキー
+
+arXivハイプの背後にある紙を持参し、Techmeme編集技術ニュースレイヤー - 無料、ゼロキー、および最初の実行セットアップがインストールされますCLIs なので、自動的に起動します (#709).Digg'AI 1000ストーリークラスターは、同じ方法でXのauthなしで到着 - セットアップは無料でインストールしますDigg CLIあなたのため(#590)。Trustpilot消費者ブランドのリサーチのためにオプトインを出荷します。
+
+### 無料Reddit実際のスコアとトップコメントの増加
+
+Reddit'sパブリック .jsonAPI死亡した; フリーパスがより強く戻ってきました。 キーレスRSS +シュレッディットスクレイピング(#457)、アークティックシフト(#696)を介して実質的なアップボットカウントと専用のサブレッドディットディスカバリー、および関連するフロアなので、ウイルスオフトピックポストがあなたのブリーフをハイジャックすることはできません(#488、おかげで[@rzachsmith](https://github.com/rzachsmith))。 いいえ。APIキー。 実際のスコア。 トップコメントが含まれています。
+
+### すべての簡単なコメントで最高のコメント
+
+コメントは現在、ソースを渡るデフォルトでレイヤーです。 ランクベースのダイバーシティでインスタグラムのコメントで、5つのホットが1つの投稿から来ることはありません(#751)、YouTubeコメントとコメントScrapeCreatorsyt-dlp が起動したときにトランスクリプトのバックアップ(#637)、およびクラウド投票されたコメントが重なったときBest Takesコミュニティの最も楽しいラインは、スコアリング(#592、#608)を存続させます。
+
+### 1人の医者の命令
+
+健康チェックを要求し、医師はすべてのソースを実行し、その後、キーが欠落している正確な修正を処方します。CLIオフPATH, クッキーが期限切れ (#753). Xが薄くなってきた理由はこれ以上推測しません。
+
+### X検索、再構築
+
+Xのパイプラインは、地上のオーバーホールを持っています: からとAboutレーンので、人の自身の投稿とそれらについての会話は、両方のランク(#610)、人身のサブクエリの議論(#611)、インタラクション・シグナル・ランキング(#613)、および自動バックエンド・フェイルオーバー(#622)で1つのXソース。 プラス正直`--diagnose`実際にプローブオース (#609).
+
+### より多くのソースが加わりました
+
+LinkedInお問い合わせScrapeCreators、高い信号として記事を使って()[@ravstr](https://github.com/ravstr), #702). StockTwitsティッカーと暗号トピックの自動アクティブ化 ()[@wtiwana](https://github.com/wtiwana), #658). 複雑さは直接育ちましたAPIモードと非同期深層研究()[@sk-holmes](https://github.com/sk-holmes), #629).
+
+### コミュニティによって硬化
+
+セキュリティ波は、ほぼ完全にコミュニティの作業でした。保存されたXSSは、HTMLレンダー ()[@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars))、ロックダウンクッキーの臨時雇用者ファイル、OpenSSFのスコアカードが付いている供給鎖堅くされたCIおよび作成の証明()[@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909))、SemgrepおよびOSV-ScannerのスキャンおよびaPR依存症レビューゲート()[@23241a6749](https://github.com/23241a6749))、60%で導入されたテスト カバーの床および84%に上げられたので()[@gourab5139014](https://github.com/gourab5139014))、およびすべてのCRITICALの発見(#768)でクリアされたヘルメスのセキュリティスキャン。
+
+### さらなる回復
+
+ヘブライ語と非ラテン語 (Hebrew)[@dudyme](https://github.com/dudyme)). CJK中国のソースのための -aware のトークン化 ([@An-idd](https://github.com/An-idd)). AWindows互換性の波。 フルクロム家族を渡るクッキー抽出 - ブレイブ、エッジ、ヴィヴァルディ、オペラ、アーク(Arc)[@andrey-esipov](https://github.com/andrey-esipov)) - プラスmacOS Keychainそして、Linuxpass(1) 認証情報。`--as-of`歴史の振り返り ([@chiyi-creator](https://github.com/chiyi-creator))。自動約束されるPython3.12 ビア uv (uv)[@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals`会社の求人ページを読んでください。 実行中のウォッチリストのデルタ。
+
+### それでもv3から箱の中に
+
+v3 の基礎はすべてここにあります: 単一の前に正しいハンドル、subreddits、およびハッシュタグを解決する事前調査の脳API火を呼ぶ(によって造られる)[@j-sperling](https://github.com/j-sperling)); Best Takesユーモアと死亡率の上昇、クロスソースクラスターマージ、シングルパス比較(以下「比較」)CLI対決MCP" 3 分ではなく 12 で。自動検出`--competitors`比較;GitHub人モード (`--github-user=steipete`); ELI5任意の実行後のモード(「eli5 on」)。 共有可能で、自己完結HTML簡略化(簡略化)`--emit=html`)。 構成ノブは住んでいます[CONFIGURATION.md](CONFIGURATION.md).
+
+## インストール
+
+|ステンレス|インストール|アップデート|
+|---------|---------|---------|
+| **Claude Code** (推奨)| `/plugin marketplace add mvanhorn/last30days-skill` |市場を経由して自動車、または`claude plugin update last30days@last30days-skill` |
+| **Grok** (xAIビルド)CLI) | `grok plugin marketplace add mvanhorn/last30days-skill`それから`grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI50以上のもの[Agent Skills](https://agentskills.io)ホスト**| `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+|**claude.ai** (web)| [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)claude.ai > カスタマイズ > スキル > + > スキルを作成する > スキルをアップロード|再ダウンロードおよび再アップロード|
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest)設定にドラッグします。 > エクステンション|再ダウンロードと新しいバンドルをドラッグ|
+| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+
+### Claude Code(推奨)
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+おすすめの理由Claude Codeマーケットプレースは、新しいリリース公開時にプラグインキャッシュがバージョンアップされ、自動修正されます。 ログイン`claude plugin update last30days@last30days-skill`チェックを強制する。
+
+エージェント・スキル・インストール・パスを使わなければClaude Code、それはまた支えられます:
+
+```
+npx skills add mvanhorn/last30days-skill -g -a claude-code
+```
+
+ネイティブプラグインと`npx skills`インストールは共存できます。 注意:Claude Codeインストール方法を渡ってdedupeしません: 両方のマーケットプレースプラグインと`npx skills`アクティブなコピー,`/last30days`2つのエントリが表示されます。 機械ごとの1つの取付け方法を使用して下さい。
+
+### Grok(xAIビルド)CLI)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) ネイティブプラグインとしてLast30daysをインストールします。 直接インストールはリポジトリを追跡します。
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+または、このリポジトリをマーケットプレースソースとして追加し、プラグイン名でインストールします。
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+追加する`--trust`インストール確認をスキップします。 更新情報`grok plugin update last30days`. Grokまた読みますClaude Code互換性のためのマニフェスト; ネイティブ`.grok-plugin/`ペアは、ファーストクラスの車線(および公式のもの)です[xAI marketplace](https://github.com/xai-org/plugin-marketplace)リストポイント`npx skills add`有効なクロスホストフォールバックのまま。
+
+### Codex, Cursor, Copilot, Gemini CLIその他Agent Skillsホスト
+
+オープンでインストールする[Agent Skills](https://agentskills.io) CLI— 50以上のハーネスに対応`codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`、および多く(完全なリスト)[vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+
+```bash
+npx skills add mvanhorn/last30days-skill -g
+```
+
+ふりがな`-g`(グローバル) フラグはユーザーディレクトリにインストールされ、すべてのプロジェクトでスキルが利用できます。 なし`-g`, `npx skills`project-locally をインストール`./.skills/`(レポに同封) リサーチ・ザ・ワールド・ツールのグローバルは、あなたが望むものです。
+
+Codexデスクトップや他のフォルダモードホストは、通常のフォルダだけでなく、Gitリポジトリで動作することができます。 最初の研究の前に、ホストエージェントにバンドルされた実行を依頼`scripts/last30days.py --preflight`読み込まれたスキルディレクトリから。 ソースチェックアウトでは、同等のコマンドは`python3 skills/last30days/scripts/last30days.py --preflight`. 設定ソース、ブラウザ・クッキー・プラン、計画書、オプションのコマンド、および無視されたプロジェクト・コンフィグは、クッキー、書き込みファイル、または研究を実行せずに表示します。
+
+デフォルトでは、このインストールはどのハーネスにも使用できます。`npx skills`検出します。 特定のもの(または複数の)をターゲットにするには
+
+```bash
+npx skills add mvanhorn/last30days-skill -g -a codex
+npx skills add mvanhorn/last30days-skill -g -a cursor
+npx skills add mvanhorn/last30days-skill -g -a gemini-cli
+npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+```
+
+後で更新して下さい:
+
+```bash
+npx skills update last30days -g
+```
+
+またはグローバルにインストールされているすべての更新を`npx skills`:
+
+```bash
+npx skills update -g
+```
+
+リストと削除`npx skills list -g`そして、`npx skills remove last30days -g`.
+
+### claude.ai (web)
+
+1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)最新のリリースから
+2. お問い合わせ[claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. クリックします。`+`スキルパネルのボタン > クリック`Create skill` > `Upload a skill`ファイルの閲覧/ドロップ
+
+機能の最初の「コード実行とファイル作成」を有効にする — スキルはそれなしで実行しません。
+
+### Claude Desktop
+
+Claude Desktopインストール`/last30days`としてMCPサーバ経由で`.mcpb`バンドル(モデルコンテキストプロトコルパッケージをワンクリック)。
+
+1. お問い合わせ[latest release](https://github.com/mvanhorn/last30days-skill/releases/latest)ダウンロード`.mcpb`あなたのプラットフォームのために:
+   - macOSアップルシリコン:`last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOSインテル:`last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linuxx86 64:`last30days-pp-mcp-linux-amd64.mcpb`
+2. オープンClaude Desktop設定 > 拡張子、ファイルをドラッグします。
+3. プロンプトが表示されたら、貼り付けAPI有効にしたいソースのキー。 すべてのフィールドはオプションです。すべてのフィールドをスキップすると、エンジンはWeb専用のモードに劣化します。 鍵はOSキーホルダーに保存されます。
+4. リスタートClaude Desktop. お問い合わせClaude"Research Peter Steinberger" または任意のトピックに、それは呼び出します`research`ツール。
+
+**ホストの条件:**Python3.12+ にPATH. バンドルはエンジンのソースを出荷しますが、ローカルを使用するPython通訳者。 インストールから[python.org](https://www.python.org/downloads/)お問い合わせWindows; macOSそして最も多くLinuxdistrosは互換性のあるバージョンを出荷します。
+
+**キーはコードスキルと同期しません。**Claude Desktopそして、Claude Codeデザインで独立したクレデンシャルストアを維持します。 既に設定されている場合`~/.config/last30days/.env`コードスキルについては、ここで同じキーを再入力します。
+
+Windowsパープラットフォームのマニフェストエントリ ポイントがソートされるまでサポートが拒否されます。フォローアップの問題で追跡します。
+
+### OpenClaw
+
+```bash
+clawhub install last30days-official
+```
+
+外部のX/Twitterアクションワークフローの場合`/last30days`研究、投稿など
+ツイートや返信、フォロワーエクスポート、メディア処理、モニター、プレゼント
+引くこと、使用[TweetClaw](https://github.com/Xquik-dev/tweetclaw)仲間として
+OpenClawプラグイン。TweetClawXquik-dev によって維持され、としてだけリストされます
+オプションのコンパニオンパス、Last30daysの依存性または支持ではありません。
+
+### マニュアル(デベロッパー)
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill.git
+ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
+```
+
+symlink は、作業ツリーと同期して、必要な再コピーが不要になります。 お問い合わせ`claude.ai`, ビルド`.skill`ソースからファイル:`bash skills/last30days/scripts/build-skill.sh`プロデュース`dist/last30days.skill`.
+
+Reddit(コメントあり)Hacker News, PolymarketとGitHubすぐに働く。 ゼロ構成。 ログイン`/last30days`セットアップウィザードは、30秒でより多くのソースをアンロックします。arXivそして、Techmeme CLIお問い合わせ
+
+## 自分の鍵を持参
+
+これらのプラットフォームは互いに関係を持たない。 Xは何を知らないReddit考えます。YouTube見えないTikTok。しかし、あなた自身を持参することができますAPIキーとブラウザトークン、そして突然、あなたは一度にそれらすべてにアクセスしている。
+
+|ソース|必要なもの|コスト|
+|---------|---------------|------|
+| Reddit(コメントあり) + HN +Polymarket + GitHub + StockTwits |コメントはありません。|無料|
+| arXiv + Techmeme |無料CLIs, 初回設定で自動インストール|無料|
+|X / Twitterの|任意のブラウザでx.comにログインするか、または設定`XQUIK_API_KEY` / `XAI_API_KEY` |ブラウザのクッキーは無料です。キーはプロバイダ固有のものです。|
+| YouTube | `brew install yt-dlp` |無料|
+| Bluesky |bsky.appからのアプリパスワード|無料|
+| TikTok+ インスタグラム +Threads + Pinterest + LinkedIn + YouTubeコメント| ScrapeCreatorsキーキー|10,000 の自由な呼出し、それから PAYG|
+| Xiaohongshu (RED) |ログインx-mcpブラウザプラグインを実行するか、`xiaohongshu-mcp`サービスおよびオプトイン`--search xhs`実行または`INCLUDE_SOURCES=xiaohongshu`お問い合わせ`.env`; last30days 自動プローブ`http://localhost:18060`それから`http://host.docker.internal:18060`、または使用して下さい`XIAOHONGSHU_API_BASE`カスタムURLの場合|残り30日APIキー;ローカルブラウザセッションサービスに依存します|
+|DripStack(プレミアムファイナンシャルニュースレター)|オプトイン:`--search dripstack`実行中、または`INCLUDE_SOURCES=dripstack`お問い合わせ`.env` |いいえキー;無料公開検索API |
+|パープレクシティソナー/検索API/ ディープリサーチ|パープレックスキー、またはSonarフォールバックとしてOpenRouterキー|あなたが行くように支払う|
+|ウェブ検索|ブレイブ検索キー|2,000 無料の問い合わせ/月|
+
+### macOS Keychain(オプション)
+
+お問い合わせmacOSシステムにキーを貯えることができますKeychain代わりに`.env`ファイル。 スキルは、最低優先ソースとして自動的にピックアップします。`.env`ファイルとプロセス環境が衝突しても勝ちます。
+
+```bash
+# Interactive setup — prompts for each known key, skip with empty input
+skills/last30days/scripts/setup-keychain.sh
+
+# Or store a single key by hand
+security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
+
+# Inspect / clean up
+skills/last30days/scripts/setup-keychain.sh --list
+skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
+```
+
+アイテムはサービス名の下に保存されます`last30days-<KEY>`現在のユーザの場合。 非ダーウィンプラットフォームでは、ローダーはノップなので、振る舞いは変化しません。Linux/Windowsユーザー。
+
+すでに異なるキーを持っているKeychainサービス名? 非秘密の設定`LAST30DAYS_KEYCHAIN_ALIASES`記載されているマッピング[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items)秘密をコピーする代わりに。
+
+お問い合わせ[CONFIGURATION.md](CONFIGURATION.md)完全なパーソースキーマトリクス、推論プロバイダー優先、Web-search バックエンド優先順位。
+
+## コンテンツ
+
+一日中知っておきたい2つのこと:
+
+**研究ファイルが保存されます。**`LAST30DAYS_MEMORY_DIR`デフォルトは`~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`)。 シェル内の任意のパスに var を env する設定、または`--save-dir <path>`実行ごとに。 使用条件`--output <file>`レンダリングされた結果を正確なパスで必要とするとき、選択したフォーマットを使用して`--emit`. 使用`--save-suffix=<name>`同じトピックの複数のバリエーションを別々に保つ(例えば、クライアントごとに)。 詳しくはこちら`--save-dir`実行生成`<slug>-raw[-suffix].md`. 実行`python3 skills/last30days/scripts/last30days.py --preflight`研究の実行前に計画書を見直します。
+
+**エージェントとワークフローの厳しい出力** お問い合わせ`/last30days`機械読みやすいのためJSON安定した、バージョンアップされたエージェントプロファイルを受け取るため。 スクリプトや開発でエンジンを直接使用する場合、実行`python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`;追加`--json-profile=raw`変換されていない内部が必要なときだけ`Report`ダンプ。 詳細はこちら[JSON export field reference and versioning policy](docs/reference/json-export.md).
+
+**トピックなしの発見。** お問い合わせ`/last30days what's trending in AI agents?`すでに知っているトピックを調べる代わりにランクされた発見の簡単な取得 - エージェントホストでは、これは3つのコマンドホスト判断プロトコル(モデル名トピック、ジャンクフィルタ、スコアの適性、およびコンテンツの角度)を実行します。 スクリプトや cron で直接エンジンを使用するには、`python3 skills/last30days/scripts/last30days.py --discover "AI agents"`(一ショット: 決定的なトピック名、角度なし); 追加`--emit=json`バージョン化された発見契約のため。 ディスカバリーは、位置情報と位置情報で相互に排他的です`--drill`.
+
+**走行中の監視を追跡する。** デフォルトモードでは、実行ごとに新しいマークダウンスナップショットが生成されます。 時間をかけて発見を蓄積するために、追加`--store`SQLiteデータベースに永続する[`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py)スケジュールされた操業のために(新しい発見の任意Slack/webhook配達と)[`scripts/briefing.py`](skills/last30days/scripts/briefing.py)毎日/毎週の消化のために。 フル・アカデミー・パターンは[CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+
+**サブスクライブ可能な研究ライブラリ** お問い合わせ`/last30days`ライブラリフィードの構築、または使用`python3 skills/last30days/scripts/last30days.py library feed`スクリプトや開発に直接。 保存されたブリーフをオンにします`index.html`ローカル原子`feed.xml`, 読みやすい簡単なページ. 追加する`--publish`あなたが望むときだけHTML公開は、デフォルトで明示的にオプトインし、公開されます。 Atom フィードをサブスクライブ可能にするには、生成された出力ディレクトリを static ホストにホストします。GitHubサイトマップ
+
+**調査したすべてのものを検索します。** お問い合わせ`/last30days search my library for MCP servers`または`/last30days have I researched MCP servers before?`. 直接エンジンの使用のために、操業して下さい`python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. 検索はオフラインで決定的です: ライブラリフィードによって使用される同じ保存されたブリーフをインクリメンタルにインデックス化し、パーランストアの視覚化とグループの結果をトピックと日付でマージします。 フレッシュランは、現在のトピックをオーバーラップする前の研究では、ライブラリ**セクションから、コンパクトに面しています。`LAST30DAYS_LIBRARY_CONTEXT=off`パッシブコンテキストを無効にします。
+
+Per-client wrapper スクリプト、カスタムカテゴリ-peer subreddits 、および in-progress のカスタマイズのための実験的なベータ チャネルも文書化されます[CONFIGURATION.md](CONFIGURATION.md).
+
+## ショーケース:コミュニティリサーチフィード
+
+過去30日間の再カーリングAIアップデート、マーケットウォッチ、または素晴らしい狭い obsession を公開しましたか? 公開ライブラリ URL または Atom URL をホスティング後に共有する`feed.xml`静的なホストに[the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). コミュニティフィードは、所有者がそれらを提出するようにここにリンクされます。 スレッドは、その間のコレクションポイントです。
+
+## 作品紹介
+
+1. **トピックを入力します。** 人、会社、製品、技術、X対Y。 お問い合わせ
+2. **代理人は誰が重要であるかを解決します。** Xハンドル(創始者を含む)を見つけ、GitHubリポジトリ、サブreddits、TikTokハッシュタグYouTubeチャンネル. 「Kanye West」では、r/hiphopheadsを知っています。@kanyewest, と "bully review" 上のYouTube. のために "OpenClaw「openclaw/openclawを解決する」GitHubライブスターカウントをフェッチします。
+3. **すべてのソースは並列で検索します。** 多品種の拡大。 エンゲージメント、関連性、鮮度で得た結果
+4. **奥深さの誰も持っていません。** スタッフYouTube反応ビデオからのトランスクリプト。 トップページRedditアップ投票数のコメント。TikTokキャプション。Polymarketオッズ。 タイトルやリンクだけではありません。
+5. **サメストーリー、マージ。** ワイヤレスフェスティバルが発表されましたReddit, Xで議論, チケットの価格TikTok= 1つのクラスター、3つの独立した項目ではなく。
+6. **1つに合成** 特定のデータに基づいた。 ソースによって引用される。 実際に参加する人々によってランク付けされる。 「自分が見つけたもの」ではない。 「こんなこと」です。
+7. **専門医になる。** 実行後、Claudeセッションは、コミュニティが知っているすべてのことを知っています。 フォローアップの質問をしてください。 プロンプト、メールのドラフト、計画旅行、アーキテクトシステム - 今のところ何が本物にすべて基づかせていました。
+
+## 人が言うこと
+
+> 「私は見つけましたClaude Codeあらゆるトピックを研究するスキルReddit、 X、YouTube過去30日間のHNとHN。 それからあなたのためのプロンプトを書きます。 私は手動で検索してきたRedditそしてXは、私が書いたすべてのコンテンツの前に研究のために。 タブでタブします。 糸による糸。 90分かかる部分です。 これはそれを排除します。」 -@itsjasonai
+
+> 「この1つのスキルは、研究ワークフロー全体を置き換えました。 あなたはそれをトピックを与える、それはスクレイピングReddit、X、そして実際に話している人のためのウェブ。 古いブログ投稿はありません。 過去30日間のリアルタイム会話。 -@itswilsoncharles
+
+> 「10のトレンドレポの5」GitHub今日はClaudeツール。 #1: マバンホーン/last30days-スキル -@yieldhunter95
+
+## オープンソース
+
+MITライセンス 追跡無し。 分析なし。 あなたの研究はあなたの機械にとどまります。 2,700以上のテスト
+
+組み込みPython3.12+、yt-dlp、Node.js(ベンダー)BirdX検索のクライアントScrapeCreators API. v3エンジンアーキテクチャ[@j-sperling](https://github.com/j-sperling).
+
+お問い合わせ[CONTRIBUTING.md](CONTRIBUTING.md)開くPR, [CONTRIBUTORS.md](CONTRIBUTORS.md)コミュニティコントリビューターの完全なリストのために、[CHANGELOG.md](CHANGELOG.md)バージョン履歴のため。
+
+## 星の歴史
+
+<a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+  </picture>
+</a>
+
+---
+
+**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,199 +16,199 @@
   </a>
 </p>
 
-**AIエージェント主導の検索エンジンは、upvotes, likes, 実際のお金によって得点 - エディタではありません。**
+**編集者ではなく、アップボート、いいね、リアルマネーで評価されるAIエージェント主導の検索エンジン。**
 
-このREADME は、現在の v3 パイプラインを追跡します。 ランタイムスキルのスペックは、[skills/last30days/SKILL.md](skills/last30days/SKILL.md), これは、最新のコマンドとセットアップの動作のための真実のソースです。.
+このREADMEは現在のv3パイプラインを追跡しています。ランタイムスキル仕様は [skills/last30days/SKILL.md](skills/last30days/SKILL.md)に存在し、これが最新のコマンドおよびセットアップ動作の真実の源です。
 
-**Claude Code(推奨 — マーケットプレイスによる自動更新):**
+**Claude Code (推奨 — マーケットプレイス経由の自動更新):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI50以上のもの[Agent Skills](https://agentskills.io)ホスト:**
+**Codex、 Cursor、 Copilot、 Gemini CLI、または50+ [Agent Skills](https://agentskills.io) ホストのいずれか:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g`すべてのプロジェクトで利用できる、ユーザーのグローバルにインストールします。 プロジェクトごとのスコープにドロップします。
+(`-g` ユーザーのグローバルにインストールされ、すべてのプロジェクトで利用可能です。プロジェクトごとにスコープに切り替えてください。)
 
-その他のインストールオプション (claude.ai web,OpenClaw、マニュアル)[Install](#インストール)以下のセクション。
+claude.ai ウェブ、 OpenClaw、マニュアルなどのインストールオプションは下の [Install](#設置) セクションにあります。
 
-ゼロコンフィグReddit、HN、PolymarketとGitHubすぐに働く。 一度実行し、セットアップウィザードがXのロックを解除します。YouTube, TikTok, arXiv, Techmeme30秒以上。
+設定はゼロです。 Reddit、HN、 Polymarket、 GitHub はすぐに動作します。一度実行すると、セットアップウィザードが30秒で X、 YouTube、 TikTok、 arXiv、 Techmemeなどをアンロックします。
 
 ---
 
-Redditアップボット。 Xは好きです。YouTubeトランスクリプト。TikTokエンゲージメント。Polymarket実際のお金とインサイダー情報によって裏付けられたオッズ。 それは、毎日、自分の注意と財布に投票する万人の人々です。/last30days実質の人々が実際に何を従事しているか、そしてAIの代理店がそれを1つの短いに合成することを判断することによってそれを並列で捜します。
+Reddit アップボート。 X いいね。トランスクリプト YouTube 。関与 TikTok 。実際のお金と内部情報に裏付けられた Polymarket オッズ。毎日何百万人もの人々が自分の注意と財布を使って投票しているのです。 /last30days それらすべてを並行して検索し、実際に人々が関わっているもので評価し、AIエージェントの審査員がそれを一つのブリーフにまとめます。
 
-Googleエディタを集計します。/last30days人を検索します。
+Google 編集者を集約します。 /last30days 人を検索します。
 
-単一のAIがすべてにアクセスできないため、他の場所でこの検索を取得することはできません。Google検索は触れませんRedditコメントやX投稿。ChatGPTお問い合わせRedditしかし、Xを検索することはできませんTikTok. ジェミニは持っていますYouTubeしかし、そうではありませんReddit. Claudeそれらをネイティブに持っていません。 各プラットフォームは、独自のウォールガーデンですAPI、独自のトークン、独自のauth。 しかし、自分の鍵やブラウザのセッションを持参し、突然、AIエージェントは一度にすべて検索でき、お互いにスコアをつけ、実際に何かを伝えることができます。
+この検索は他のどこでも得られません。なぜなら、単一のAIがすべてにアクセスできるわけではないからです。Google検索はコメントやX投稿Reddit触れません。ChatGPTRedditと契約していますが、XやTikTokは検索できません。GeminiはYouTubeはありますが、Redditはありません。Claudeはネイティブにそれらのどれも持っていません。各プラットフォームは独自のAPI、トークン、認証を持つ囲い庭園のようなものです。しかし、自分のキーやブラウザセッションを持ち込めば、AIエージェントがそれらを一度に検索し、互いにスコアリングし、何が本当に重要かを教えてくれます。
 
-これはロック解除です。 より良い検索エンジンではありません。 エージェントが橋渡しするダース接続プラットフォーム。
+それがアンロックだ。これ以上の検索エンジンは一つもない。12の切り離されたプラットフォームがエージェントでつながっている。
 
 ```
 /last30days Peter Steinberger
 ```
 
-明日は会いましょう。 お問い合わせGoogleお問い合わせ 自分を手に入れるLinkedInから 2023./last30days彼らが実際にこの月をやっていることをあなたに与えます: 参加OpenAIお問い合わせCodex, サードパーティの代理店でAnthropicの禁止を戦う, 発送 23PRs85%の合併率で、建物 "LobsterOS"クロスデバイスエージェント制御、r/Claudeコードヒット 569 彼がヒーローか「不十分」かどうかを逆転させるアップボット. Xの投稿に散らばるRedditスレッド,YouTubeトランスクリプトとGitHubコミット。 何もなかったGoogle.
+明日会議がある。彼らをGoogle。2023年の彼らのLinkedInを手に入れる。/last30days今月実際にやっていることを教えてくれます:Codexに関わるためにOpenAIに参加し、Anthropicのサードパーティエージェント禁止に反対し、23PRsを85%のマージ率で出荷し、クロスデバイスエージェント制御のための「LobsterOS」を構築し、r/Claudeコードでは彼がヒーローか「耐え難い」かで569のアップボートを獲得しました。X投稿、Redditスレッド、YouTubeのトランスクリプト、そしてGitHubコミットに散らばっています。どれも入っていなかったGoogle。
 
 ## なぜこれが存在するのか
 
-人工知能に追いつくために構築しました。 日々変化する変化や、Redditそして、X の nerds は、最初にその上に常にあります。 私はより良いプロンプトを必要とし、トレーニングデータは、コミュニティがすでに把握していたものの後ろに常に数か月後にありました。
+AIに追いつくために作りました。すべてが日々変わり、 Reddit や X オタクたちが常に最初に対応しています。より良いプロンプトが必要で、トレーニングデータはコミュニティがすでに把握しているものより常に数ヶ月遅れていました。
 
-しかし、それは何かを大きく変えました。 今、私はビジネスについての最後の30日真実を知るために販売コールの前にそれを実行します。 ミーティングの前に、誰かの最近のツイートとポッドキャストのトランスクリプトを読んでください。 前のページへDisney Worldどの乗車が閉鎖されているか、コミュニティが何を言うかを知るための旅行Genie+. 人が実際にどんな問題を抱えているかを知るために何かを造る前に.
+しかし、それはもっと大きなものに発展しました。今では営業電話の前に、ビジネスの過去30日間の真実を知るために使っています。会議の前に誰かの最近のツイートやポッドキャストの書き起こしを読む前に。 Disney World 旅行の前に、どのライドが閉鎖されているか、コミュニティが Genie+について何を言っているかを知るために。何かを作る前に、人々が実際にどんな問題に直面しているのかを知るために。
 
-社長に会うなら、すべてのツイートを読んでください。YouTube過去30日間の成績証明書? お問い合わせ
+CEOと会う場合、過去30日間のツイートや議事録 YouTube 全部読んだ?読んだよ。
 
-## 人によって得たソース
+## 情報源は人々によって評価されました
 
-|ソース|人々があなたを教えてくれるもの|
+| 出典 | 人々の言うこと |
 |--------|--------------------------|
-| **Reddit** |ろ過されていないテイク。 実際の上書きカウント、無料、なしのトップコメントAPIキー。 実際の意見は?Googleブリス。|
-|*X / Twitter**|ホットテイク、エキスパートスレッド、ブレイク反応。 最初に知るために、最初に主張する。|
-| **YouTube** |深夜45分ダイブ 問題の5つの引用語句を検索した完全なトランスクリプト。|
-| **TikTok** |クリエーターが3.6Mの人々を連れて行くと、あなたは決して見つけることができませんGoogle. |
-| **Instagram Reels** |単語のトランスクリプトによるインフルエンサーの視点。 視覚文化信号。|
-| **Hacker News** |開発者のコンセンサス。 825 ポイント, 899コメント. 技術的な人が実際に議論する場所。|
-| **Polymarket** |コメントはありません。 オッズ。 実質のお金によって支えられる。 アルバム販売に関する96%の自信 取得の4%。|
-| **GitHub** |人のために:PR星、リリースノートによる速度、トップリpos。 トピック:問題と議論。|
-| **Digg** |キュレーションストーリー クラスターからDigg'AI 1000 のリーダーボード (~1000 の High-signal AI アカウントが X に帰属します)。 自動使用可能時`digg-pp-cli`お問い合わせPATH. |
-| **arXiv** |ハイプの背後にある紙。 窓の新しい研究、自由、いいえAPIキー。 自動使用可能時`arxiv-pp-cli`お問い合わせPATH(初回設定でインストール)|
-| **Techmeme** |tech-newsの編集層、30日間に渡る日付。 無料, いいえAPIキー。 自動使用可能時`techmeme-pp-cli`お問い合わせPATH(初回設定でインストール)|
-| **LinkedIn** |専門の信号。 高い信号として重くされる記事および記事。|
-| **StockTwits** |トレーダーの感情。 トピックがティッカーや暗号であるときに自動アクティブ化します。|
-| **Threads** |投稿Twitterテキストレイヤー。 クリエイターやブランドとの会話|
-| **Pinterest** |視覚的な発見。 ピン、保存、製品やアイデアに関するコメント。|
-| **Xiaohongshu (RED)** |中国のライフスタイル、製品、クリエイターの信号。 リクエストを明示的に`--search xhs`ロギングインx-mcpブラウザプラグインまたは`xiaohongshu-mcp`現地でサービスを展開しています。|
-| **Bluesky** |分散型社会層。 ポストTwitterの移行からプロトコル投稿。|
-|**性能**|地上のソナーの統合、未加工調査API行、深層研究|
-|**ウェブ**|編集カバレッジ、ブログの比較。 1つの信号だけではありません。|
+| **Reddit** | フィルターなしの意見。実際にアップボート数がつくトップコメント、無料、 API キーなし。 Google が埋めている本当の意見。 |
+| **X / Twitter** | 熱い意見、専門家のスレッド、そして激しい反応。最初に知り、最初に議論する。 |
+| **YouTube** | 45分間の深掘り。重要な引用可能な5文の全文を検索しました。 |
+| **TikTok** | クリエイターは360万人にリーチし、 Googleでは決して得られないような視点を持っています。 |
+| **Instagram Reels** | スポークンワードの書き起こしによるインフルエンサーの視点。ビジュアルカルチャーのシグナル。 |
+| **Hacker News** | 開発者の合意。825ポイント、899件のコメント。技術者たちが実際に議論している場面。 |
+| **Polymarket** | 意見じゃない。確率だ。本物の資金に裏付けられている。アルバム売上に96%の信頼。買収に4%の信頼。 |
+| **GitHub** | 人向けに: PR Velocity、スターによるトップリポジトリ、リリースノート。トピック:問題や議論。 |
+| **Digg** | DiggのAI 1000リーダーボード(Xで約1000のハイシグナルAIアカウント)からキュレーションされたストーリークラスターで、帰属可能なインライン引用付き(X認証不要)。`digg-pp-cli`がPATHオン時は自動有効化。 |
+| **arXiv** | 話題の裏にある論文。ウィンドウに新しいリサーチが表示され、無料、APIキーなし。PATH`arxiv-pp-cli`中は自動有効化(初回セットアップでインストール)。 |
+| **Techmeme** | テックニュース編集レイヤーで、30日以内の日付ウィンドウが表示されます。無料で API キーなし。 `techmeme-pp-cli` が PATH 上にあると自動で有効化されます(初回セットアップでインストールされます)。 |
+| **LinkedIn** | プロフェッショナルシグナル。投稿や記事、記事は高シグナルとして重み付けされています。 |
+| **StockTwits** | トレーダーのセンチメント。トピックがティッカーや暗号通貨の場合、自動で活性化されます。 |
+| **Threads** | Twitter後のテキスト層。クリエイターやブランドからの会話。 |
+| **Pinterest** | ビジュアルディスカバリー。製品やアイデアをピン、保存、コメント。 |
+| **Xiaohongshu (RED)** | 中国のライフスタイル、製品、クリエイターのシグナル。ログイン済みのx-mcpブラウザプラグインや`xiaohongshu-mcp`サービスがローカルで動作している場合、`--search xhs`に明示的にリクエストされます。 |
+| **Bluesky** | 分散型ソーシャルレイヤー。ATプロトコルはTwitter移行後の投稿です。 |
+| **Perplexity** | グラウンデッドソナー合成、生のサーチ API ロウ、そしてディープリサーチ。 |
+| **Web** | 編集報道やブログの比較。多くの兆候の一つであり、唯一のものではありません。 |
 
-コミュニティコントリビューターが増え続ける。Truth Socialそして他のニッチの源は方法のより多くのエンジンにあります。
+コミュニティの貢献者たちが次々と追加しています。 Truth Social やその他のニッチなソースもエンジンに含まれており、今後も追加予定です。
 
-ツイートReddit1,500のアップボットでスレッドは、誰も読んでいないブログ投稿よりも強い信号です。 ツイートTikTok3.6M ビューでは、プレスリリースよりも文化的に関連しているものについて詳しく説明します。Polymarketボリュームの$66Kでバックされたオッズは、punditの推測よりも議論するのは困難です。
+1,500アップボートの Reddit スレッドは、誰も読まないブログ記事よりも強いシグナルです。360万回の閲覧数を持つ TikTok は、プレスリリースよりも文化的に重要なことをよく伝えます。66,000ドルのボリュームに裏付けられた Polymarket 確率は、評論家の推測よりも議論しにくいです。
 
-実際に従事している現実の人々によって合成のランク。 社会的関連性、ないSEO関連する。
+総合は、実際の人々が実際に関わったものに基づいてランク付けされます。社会的関連性であり、 SEO 関連性ではありません。
 
-## 実際に使用している人
+## 実際に人々が使う用途
 
-**会議のため。**`/last30days Peter Steinberger`- 参加OpenAIお問い合わせCodexチーム, サードパーティのエージェントでAnthropicの禁止を戦う, 23PRs85%の合併率で合併GitHub, 建物LobsterOSクロスデバイスエージェント制御用 ログインClaudeコード: "以来OpenClawリリースされて、他のものを通してそれを実行すると広く知られていましたAPI最終的に禁止されたつもりだった」(227 投票)。 そうではありませんLinkedIn.
+**会議前に。** `/last30days Peter Steinberger` - OpenAIの Codex チームに加わり、Anthropicのサードパーティエージェント禁止に反対し、23 PRs が85%の合併率で GitHubに統合され、デバイス間エージェント制御のための統合 LobsterOS を構築しました。r/ClaudeCode:「 OpenClaw リリース以来、 API以外の手段で処理するといずれBANされるというのは広く知られていました」(227アップボート)。これは LinkedInではありません。
 
-**採用信号を読むため**`/last30days Listen Labs --hiring-signals`- 現在のジョブとキャリアページは、フォーカスシフトの証拠を引用する:企業のセキュリティ、顧客の成功、インフラストラクチャ、または製品拡張に採用します。 レポートは、配線が信号に表示されること、ロードマップが出荷するものではありません。
+**採用シグナルを読み取るため。** `/last30days Listen Labs --hiring-signals` - 現在の求人やキャリアページは、企業のセキュリティ、カスタマーサクセス、インフラ、製品拡大など、焦点の変化の証拠として引用されます。レポートは採用が示唆しているように見えるものを述べており、ロードマップが何を提供するかを示しています。
 
-**ピーク前のトピックを見つける。** お問い合わせ`/last30days what's exploding in AI agents?`そして発見モードへの技術スイッチ:エンジンの渦Redditカテゴリ リスト,Hacker Newsフロント/ベストストーリーDigg'AI 1000 フィードと X 認証時。エージェントは、指名(名前、ジャンクフィルタリング、コンテンツワース)を判断し、ポッドキャスト/ X 粒子の角度を記述します。その後、5-10の速度でランクされたトピックを取得します。 すべての結果には、クロスソース番号、勢いラベル、および準備が整ったものが含まれます。`/last30days "<topic>"`フォローアップ。
+**ピーク前にトピックを見つけるために。** `/last30days what's exploding in AI agents?`に尋ねるとスキルは発見モードに切り替わります:エンジンはカテゴリーリストReddit、表出し/ベストストーリー、DiggのAI 1000フィード、認証時にXHacker Newsします。エージェントがノミネーション(名前、ジャンクフィルタリング、コンテンツの価値度)を審査し、ポッドキャストやX記事の角度を書きます。その後、5〜10件のVelocityランクのトピックが得られます。すべての結果にはクロスソースの数値、モメンタムラベル、そしてすぐに実行可能な`/last30days "<topic>"`フォローアップが含まれています。
 
-**何かが落ちるとき。**`/last30days Kanye West`- 英国は、彼のビザをブロックしました, ワイヤレスフェスティバルはキャンセルしました, スポンサーは逃げました. しかし、BULLYはビルボードで2位デビューしました。 ファンタノが「ヤ・サバティカル」から戻って、それを見直しました (653K ビュー). SoFi Homecomingは、ローレン・ヒルとトラビス・スコットを44曲引き出す。Polymarket: 「カニエのつぶやきが再びか?」 86% はい。 23Redditスレッド, 17YouTubeビデオ、86K の upvotes。
+**何かが落ちるとき。** `/last30days Kanye West` - イギリスは彼のビザをブロックし、ワイヤレスフェスティバルは中止、スポンサーは逃げた。しかしBULLYはビルボードで#2をデビューさせた。ファンタノは「イェイ・サバティカル」から戻ってレビューを続けた(65万3千回)。SoFi Homecomingはローリン・ヒルとトラヴィス・スコットを招き、44曲を披露した。 Polymarket:「カニエはまたツイートするのか?」86%はイエス。23件の Reddit スレッド、17本の YouTube 動画、8万6千件のアップボート。
 
-**ツールを比較する。**`/last30days OpenClaw vs Hermes vs Paperclip`- 「競合他社ではなく、レイヤーです。」OpenClawエクセプター (351K)GitHub星, ライブ), エルメスは、自己即興脳です (31K星), ペーパークリップは、orgのチャートです (49K星). スターカウントは、からライブを引っ張りましたGitHub APIブログ投稿を stale しない。 アーキテクチャ、メモリ、セキュリティ、最高のサイドバイサイドテーブル。 パープル@IMJustinBrooke: "OpenClaw= チャーマーダー、ヘルメス = チャリザード。
+**ツールを比較するため。** `/last30days OpenClaw vs Hermes vs Paperclip` - 「これらは競合ではなく層だ。」 OpenClaw は執行者(351, GitHub 0星、ライブ)、ヘルメスは自己改善の脳(31,0星)、ペーパークリップは組織図(49,000星)。星の数はライブで取得されたもので、古びたブログ投稿ではなく GitHub APIから抽出される。建築、メモリ、セキュリティを備えた並列テーブル、ベストフォース。 @IMJustinBrookeによると:「OpenClaw =ヒトカゲ、ヘルメス=リザードン。」
 
-**世界を理解する。**`/last30days Iran vs USA`- 戦争38日目。 イランがホルムズの海峡を再開するためのトランプの火曜日の期限。 米国戦車2隻がダウン。 $126/バレルのオイル。 IEAは「世界油市場史における最大の供給破壊」と呼びました。Polymarket: 12月31日(火)74%で消火。 27 Xの投稿、10YouTubeビデオ、20の予測市場。
+**世界を理解するために。** `/last30days Iran vs USA` - 戦争38日目。トランプ大統領がイランにホルムズ海峡を再開させる火曜日の期限を掲げた。米軍機2機が撃墜された。石油は1バレルあたり126ドル。IEAはこれを「世界石油市場史上最大の供給混乱」と呼んだ。 Polymarket:12月31日までに停戦が74%で達成。27件の X 投稿、10本の YouTube 動画、20の予測市場。
 
-**旅行の前に。**`/last30days Universal Epic Universe`- 既に工事中の拡張。 "Project 680" はファイルを許可します。 インフラで確認した花火大会だが、発表されていない。 待ち時間:Mine-Cart Madness 平均 148 分. 年間パスはなく、ローカルは不満です。 スターダストレーサーは4月5日までの改装のためにダウンします。
+**旅行の前に。** `/last30days Universal Epic Universe` - 拡張工事がすでに進行中。「プロジェクト680」許可申請済み。インフラで花火大会が確認されたが、予告なし。待ち時間:鉱山カートの狂気、平均148分。まだ年間パスはなく、地元の人々は不満を抱いている。スターダストレーサーズは4月5日まで改装中。
 
-**早く何かを学ぶため**`/last30days Nano Banana Pro prompting` - JSON-structedプロンプトはタグスープを置き換えています。@pictsbyai's のネストされたフォーマットは「出血を受け入れる」を防ぎます。 ワークフローを編集するワークフローは、再生を破ります。 その後、コミュニティが何を語ったかを正確に使用して生産のプロンプトを書きます。
+**何かを素早く学ぶために。** `/last30days Nano Banana Pro prompting` - JSON構造化プロンプトがタグスープに取って代わっています。 @pictsbyaiのネスト形式は「コンセプトの漏れ」を防ぎます。編集優先のワークフローは再生よりも優れています。そしてコミュニティが「うまくいく」と言った方法で、まさに本番プロンプトを書いてくれます。
 
-## 新着情報
+## 新しいこと
 
-5月のv3.3発表以来、v3.11.1(7月2026)として:175合併PRs- 52のコミュニティコントリビューターの122 - 15回のリリースで。 これは、着陸したものです。
+5月のv3.3発表以降、v3.11.1(2026年7月)時点で、175件の統合 PRs 、そのうち122件は52人のコミュニティ貢献者から15のリリースにわたり統合されました。これが実現したものです。
 
-### ファーストクラスOpenAI Codex
+### ファーストクラス OpenAI Codex
 
-/last30daysネイティブCodexガイド付きセットアップ付きプラグイン - ポートではなく、一流の市民。 Renderer-awareの引用は意味しますCodex出力は URL のスープ(#694)の代りに短いように読み、同じエンジンは動きますClaude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw, と 50+Agent Skillsホスト。Codexプラグインマニフェストによる[@rfoust](https://github.com/rfoust) (#686), Codexauthの修正による[@tmchow](https://github.com/tmchow) (#698).
+/last30days現在はネイティブの Codex プラグインで、ガイド付きセットアップが可能で、ポートではなく一流の市民です。レンダラー対応の引用により、Codex出力はURLスープではなくブリーフのように読み取れます(#694)、同じエンジンはClaude Code、Cursor、Copilot、Gemini CLI、Claude Desktop、OpenClaw、50+ Agent Skillsホストで動作します。プラグインマニフェストCodex[@rfoust](https://github.com/rfoust)(#686)、認証修正は[@tmchow](https://github.com/tmchow)(#698)によってCodexされています。
 
-### arXiv, TechmemeとDigg- 無料、なしAPIキーキー
+### arXiv、 Techmeme、 Digg - 無料、 API キーなし
 
-arXivハイプの背後にある紙を持参し、Techmeme編集技術ニュースレイヤー - 無料、ゼロキー、および最初の実行セットアップがインストールされますCLIs なので、自動的に起動します (#709).Digg'AI 1000ストーリークラスターは、同じ方法でXのauthなしで到着 - セットアップは無料でインストールしますDigg CLIあなたのため(#590)。Trustpilot消費者ブランドのリサーチのためにオプトインを出荷します。
+arXiv 新聞を宣伝の後ろに引き込み、 Techmeme は編集技術ニュース層をもたらします。無料、ゼロキー、初回セットアップが CLIをインストールして自動的に有効化します(#709)。 DiggのAI 1000ストーリークラスターも同様の方法で X 認証なしに届きます。セットアップが無料 Digg CLI をインストールしてくれます(#590)。 Trustpilot 消費者ブランドリサーチのオプトインを出荷します。
 
-### 無料Reddit実際のスコアとトップコメントの増加
+### 無料 Reddit は実際のスコアとトップコメントを増やしました
 
-Reddit'sパブリック .jsonAPI死亡した; フリーパスがより強く戻ってきました。 キーレスRSS +シュレッディットスクレイピング(#457)、アークティックシフト(#696)を介して実質的なアップボットカウントと専用のサブレッドディットディスカバリー、および関連するフロアなので、ウイルスオフトピックポストがあなたのブリーフをハイジャックすることはできません(#488、おかげで[@rzachsmith](https://github.com/rzachsmith))。 いいえ。APIキー。 実際のスコア。 トップコメントが含まれています。
+Redditの公開.json API は死んだ。フリーパスはより強く復活した。キーレスRSS+シュレディットスクレイピング(#457)、arctic-shiftによる本当のアップボート数を持つ専用サブレディット発見(#696)、そしてバイラルなオフトピック投稿がブリーフを乗っ取らない関連性フロア(#488、ありがとう [@rzachsmith](https://github.com/rzachsmith)))。キーは API なし。リアルスコア。トップコメントも含まれている。
 
-### すべての簡単なコメントで最高のコメント
+### すべてのブリーフに最高のコメントが
 
-コメントは現在、ソースを渡るデフォルトでレイヤーです。 ランクベースのダイバーシティでインスタグラムのコメントで、5つのホットが1つの投稿から来ることはありません(#751)、YouTubeコメントとコメントScrapeCreatorsyt-dlp が起動したときにトランスクリプトのバックアップ(#637)、およびクラウド投票されたコメントが重なったときBest Takesコミュニティの最も楽しいラインは、スコアリング(#592、#608)を存続させます。
+コメントは現在、ソース全体でデフォルトレイヤーとなっています。Instagramのコメントはランクベースの多様性で、5つのホットテイクが1つの投稿からすべて出てこないようにしています(#751)、 YouTube コメントと ScrapeCreators のトランスクリプトバックアップ(#637)、そしてコミュニティの最も面白いセリフがスコアリングに残るようにクラウド投票によるコメントは Best Takes に重み付けされています(#592、#608)。
 
-### 1人の医者の命令
+### 1人のドクター指令
 
-健康チェックを要求し、医師はすべてのソースを実行し、その後、キーが欠落している正確な修正を処方します。CLIオフPATH, クッキーが期限切れ (#753). Xが薄くなってきた理由はこれ以上推測しません。
+健康診断を依頼すれば、医師はあらゆる情報源を調べ、どのキーが欠けているか、どの CLI が PATHか、どのクッキーが期限切れか(#753)と正確な修正を処方します。なぜ X が薄くなったのか、もう推測する必要はありません。
 
-### X検索、再構築
+### X 捜索、再建
 
-Xのパイプラインは、地上のオーバーホールを持っています: からとAboutレーンので、人の自身の投稿とそれらについての会話は、両方のランク(#610)、人身のサブクエリの議論(#611)、インタラクション・シグナル・ランキング(#613)、および自動バックエンド・フェイルオーバー(#622)で1つのXソース。 プラス正直`--diagnose`実際にプローブオース (#609).
+Xパイプラインは一から刷新されました。FROMレーンとABOUTレーンが導入され、本人の投稿とそれに関する会話が両方にランク付けされる(#610)、パーソンウェアなサブクエリの曖昧さ回避(#611)、インタラクション・シグナルランキングによるファーストパーティ著作権のグラウンディング(#613)、そして自動バックエンドフェイルオーバーを備えた単一のXソース(#622)。さらに、認証を実際にプローブする正直な`--diagnose`(#609)。
 
-### より多くのソースが加わりました
+### さらに多くの情報源が加わりました
 
-LinkedInお問い合わせScrapeCreators、高い信号として記事を使って()[@ravstr](https://github.com/ravstr), #702). StockTwitsティッカーと暗号トピックの自動アクティブ化 ()[@wtiwana](https://github.com/wtiwana), #658). 複雑さは直接育ちましたAPIモードと非同期深層研究()[@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedInScrapeCreatorsを通じて、高信号の記事([@ravstr](https://github.com/ravstr)、#702)を掲載しています。StockTwitsティッカーや暗号通貨のトピックに対して自動でアクティベートされます([@wtiwana](https://github.com/wtiwana)、#658)。PerplexityダイレクトAPIモードと非同期のディープリサーチ([@sk-holmes](https://github.com/sk-holmes)、#629)を拡大しました。
 
-### コミュニティによって硬化
+### コミュニティによって鍛えられる
 
-セキュリティ波は、ほぼ完全にコミュニティの作業でした。保存されたXSSは、HTMLレンダー ()[@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars))、ロックダウンクッキーの臨時雇用者ファイル、OpenSSFのスコアカードが付いている供給鎖堅くされたCIおよび作成の証明()[@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909))、SemgrepおよびOSV-ScannerのスキャンおよびaPR依存症レビューゲート()[@23241a6749](https://github.com/23241a6749))、60%で導入されたテスト カバーの床および84%に上げられたので()[@gourab5139014](https://github.com/gourab5139014))、およびすべてのCRITICALの発見(#768)でクリアされたヘルメスのセキュリティスキャン。
+セキュリティの波はほぼ完全にコミュニティの作業によるものでした。 HTML レンダラーのストアドXSS修正([@iliaal](https://github.com/iliaal)、 [@aaronjmars](https://github.com/aaronjmars))、ロックダウンされたクッキー一時ファイル、OpenSSFスコアカードとビルドの出所証明([@shaanmajid](https://github.com/shaanmajid)、 [@hammadxcm](https://github.com/hammadxcm)、 [@aniruddh909](https://github.com/aniruddh909))を用いたサプライチェーン強化CI、SemgrepおよびOSV-Scannerスキャン、 PR 依存関係レビューゲート([@23241a6749](https://github.com/23241a6749))、60%で導入され現在84%に引き上げられたテストカバレッジの最低限([@gourab5139014](https://github.com/gourab5139014))、そしてすべての重要な発見を除去したHermesのセキュリティスキャン(#768)。
 
-### さらなる回復
+### さらに遠くへ
 
-ヘブライ語と非ラテン語 (Hebrew)[@dudyme](https://github.com/dudyme)). CJK中国のソースのための -aware のトークン化 ([@An-idd](https://github.com/An-idd)). AWindows互換性の波。 フルクロム家族を渡るクッキー抽出 - ブレイブ、エッジ、ヴィヴァルディ、オペラ、アーク(Arc)[@andrey-esipov](https://github.com/andrey-esipov)) - プラスmacOS Keychainそして、Linuxpass(1) 認証情報。`--as-of`歴史の振り返り ([@chiyi-creator](https://github.com/chiyi-creator))。自動約束されるPython3.12 ビア uv (uv)[@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals`会社の求人ページを読んでください。 実行中のウォッチリストのデルタ。
+ヘブライ語および非ラテン語([@dudyme](https://github.com/dudyme))。CJK中国語ソースの認識トークン化([@An-idd](https://github.com/An-idd))。Windows互換性の波。Chromiumファミリー全体(Brave、Edge、Vivaldi、Opera、Arc([@andrey-esipov](https://github.com/andrey-esipov))にわたるクッキー抽出、さらに認証情報ソースmacOS Keychainとpass(1)Linux。`--as-of`過去の遡及([@chiyi-creator](https://github.com/chiyi-creator))。uv([@buntysomroy](https://github.com/buntysomroy))を経由Python3.12で自動プロビジョニング。`--hiring-signals`企業の求人ページを読むためのもの。実行間のウォッチリストの差。
 
-### それでもv3から箱の中に
+### まだv3のまま箱の中です
 
-v3 の基礎はすべてここにあります: 単一の前に正しいハンドル、subreddits、およびハッシュタグを解決する事前調査の脳API火を呼ぶ(によって造られる)[@j-sperling](https://github.com/j-sperling)); Best Takesユーモアと死亡率の上昇、クロスソースクラスターマージ、シングルパス比較(以下「比較」)CLI対決MCP" 3 分ではなく 12 で。自動検出`--competitors`比較;GitHub人モード (`--github-user=steipete`); ELI5任意の実行後のモード(「eli5 on」)。 共有可能で、自己完結HTML簡略化(簡略化)`--emit=html`)。 構成ノブは住んでいます[CONFIGURATION.md](CONFIGURATION.md).
+v3の基盤はすべてまだ存在しています:単一の API コールが発信する前に適切なハンドルネーム、サブレディット、ハッシュタグを解析する事前研究の脳( [@j-sperling](https://github.com/j-sperling)が構築);ユーモアやバイラル性の Best Takes スコアリングと関連性を並行して評価するもの;ソース間のクラスター統合;シングルパス比較(「CLI vs MCP」を3分で行う、12分ではなく;自動発見 `--competitors` 比較; GitHub パーソンモード(`--github-user=steipete`); ELI5 モード("実行後に"eli5オン");そして共有可能で自己完結型の HTML ブリーフ(`--emit=html`)。設定ノブは [CONFIGURATION.md](CONFIGURATION.md)に存在します。
 
-## インストール
+## 設置
 
-|ステンレス|インストール|アップデート|
+| 表面 | 設置 | アップデート |
 |---------|---------|---------|
-| **Claude Code** (推奨)| `/plugin marketplace add mvanhorn/last30days-skill` |市場を経由して自動車、または`claude plugin update last30days@last30days-skill` |
-| **Grok** (xAIビルド)CLI) | `grok plugin marketplace add mvanhorn/last30days-skill`それから`grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI50以上のもの[Agent Skills](https://agentskills.io)ホスト**| `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-|**claude.ai** (web)| [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)claude.ai > カスタマイズ > スキル > + > スキルを作成する > スキルをアップロード|再ダウンロードおよび再アップロード|
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest)設定にドラッグします。 > エクステンション|再ダウンロードと新しいバンドルをドラッグ|
+| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイスを通じた自動車保険、または `claude plugin update last30days@last30days-skill` |
+| **Grok**(xAIビルド CLI) | `grok plugin marketplace add mvanhorn/last30days-skill``grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex、 Cursor、 Copilot、 Gemini CLI、または50+のホストのいずれか [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(ウェブ) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) ・アップロード claude.ai > カスタマイズ > スキル > + > スキル作成 > スキルをアップロード | 再ダウンロードと再アップロード |
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) して設定>拡張機能にドラッグします | 新しいバンドルを再ダウンロードしてドラッグしてください |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
-### Claude Code(推奨)
+### Claude Code (推奨)
 
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-おすすめの理由Claude Codeマーケットプレースは、新しいリリース公開時にプラグインキャッシュがバージョンアップされ、自動修正されます。 ログイン`claude plugin update last30days@last30days-skill`チェックを強制する。
+おすすめです。なぜなら Claude Code マーケットプレイスがアップデートを代行してくれるからです。プラグインキャッシュはバージョン管理されており、新しいリリースが公開されると自動的にリフレッシュされます。 `claude plugin update last30days@last30days-skill` を実行してチェックを強制してください。
 
-エージェント・スキル・インストール・パスを使わなければClaude Code、それはまた支えられます:
+Claude Codeでエージェントスキルインストールパスを使いたい場合は、こちらもサポートしています:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-ネイティブプラグインと`npx skills`インストールは共存できます。 注意:Claude Codeインストール方法を渡ってdedupeしません: 両方のマーケットプレースプラグインと`npx skills`アクティブなコピー,`/last30days`2つのエントリが表示されます。 機械ごとの1つの取付け方法を使用して下さい。
+ネイティブプラグインと `npx skills` インストールは共存可能です。 Claude Code インストール方法間での重複除去はしないことに注意してください。マーケットプレイスプラグインと `npx skills` コピーの両方が有効 `/last30days` 、2つのエントリが表示されます。1台のマシンごとに1つのインストール方法を使いましょう。
 
-### Grok(xAIビルド)CLI)
+### Grok (xAIビルド CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) ネイティブプラグインとしてLast30daysをインストールします。 直接インストールはリポジトリを追跡します。
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`)インストールはネイティブプラグインとして30日間有効です。直接インストールはリポジトリを追跡します:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-または、このリポジトリをマーケットプレースソースとして追加し、プラグイン名でインストールします。
+または、このリポジトリをマーケットプレイスのソースとして追加し、プラグイン名でインストールする方法もあります:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-追加する`--trust`インストール確認をスキップします。 更新情報`grok plugin update last30days`. Grokまた読みますClaude Code互換性のためのマニフェスト; ネイティブ`.grok-plugin/`ペアは、ファーストクラスの車線(および公式のもの)です[xAI marketplace](https://github.com/xai-org/plugin-marketplace)リストポイント`npx skills add`有効なクロスホストフォールバックのまま。
+インストール確認をスキップするために `--trust` を追加してください。 `grok plugin update last30days`でアップデートします。 Grok 互換性のために Claude Code マニフェストも読みます。ネイティブ `.grok-plugin/` ペアがファーストクラスレーン(公式 [xAI marketplace](https://github.com/xai-org/plugin-marketplace) リストが示している通りです)。 `npx skills add` 有効なクロスホストのフォールバックとして機能しています。
 
-### Codex, Cursor, Copilot, Gemini CLIその他Agent Skillsホスト
+### Codex、 Cursor、 Copilot、 Gemini CLI、その他の Agent Skills ホスト
 
-オープンでインストールする[Agent Skills](https://agentskills.io) CLI— 50以上のハーネスに対応`codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`、および多く(完全なリスト)[vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+オープン [Agent Skills](https://agentskills.io) CLI 経由でインストール — `codex`、 `cursor`、 `github-copilot`、 `gemini-cli`、 `claude-code`、 `windsurf`、 `cline`、 `continue`、 `roo`、 `aider-desk`、 `opencode`、 `goose`など50+ハーネスに対応しています( [vercel-labs/skills repo](https://github.com/vercel-labs/skills)に全リスト)。
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-ふりがな`-g`(グローバル) フラグはユーザーディレクトリにインストールされ、すべてのプロジェクトでスキルが利用できます。 なし`-g`, `npx skills`project-locally をインストール`./.skills/`(レポに同封) リサーチ・ザ・ワールド・ツールのグローバルは、あなたが望むものです。
+`-g`(グローバル)フラグはユーザーディレクトリにインストールされるため、スキルはすべてのプロジェクトで利用可能です。`-g`がなければ、`npx skills`プロジェクトローカルに`./.skills/`にインストールします(リポジトリとコミットしています)。世界を調査するツールとしては、グローバルが最適です。
 
-Codexデスクトップや他のフォルダモードホストは、通常のフォルダだけでなく、Gitリポジトリで動作することができます。 最初の研究の前に、ホストエージェントにバンドルされた実行を依頼`scripts/last30days.py --preflight`読み込まれたスキルディレクトリから。 ソースチェックアウトでは、同等のコマンドは`python3 skills/last30days/scripts/last30days.py --preflight`. 設定ソース、ブラウザ・クッキー・プラン、計画書、オプションのコマンド、および無視されたプロジェクト・コンフィグは、クッキー、書き込みファイル、または研究を実行せずに表示します。
+Codex デスクトップやその他のフォルダモードのホストは、通常のフォルダでもGitリポジトリでも動作します。最初の調査を行う前に、ホストエージェントにロードされたスキルディレクトリからバンドルされた `scripts/last30days.py --preflight` を実行するよう依頼してください。ソースチェックアウトでは、同等のコマンドは `python3 skills/last30days/scripts/last30days.py --preflight`です。これは設定ソース、ブラウザクッキー計画、計画された書き込み、オプションコマンド、無視されたプロジェクト設定をクッキーの読み取り、書き込み、リサーチを行わずに表示されます。
 
-デフォルトでは、このインストールはどのハーネスにも使用できます。`npx skills`検出します。 特定のもの(または複数の)をターゲットにするには
+デフォルトでは、 `npx skills` 検出したハーネスに対してこの仕組みがインストールされます。特定のハーネス(または複数)をターゲットにするには:
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-後で更新して下さい:
+後日更新:
 
 ```bash
 npx skills update last30days -g
 ```
 
-またはグローバルにインストールされているすべての更新を`npx skills`:
+または、 `npx skills`を通じてグローバルにインストールしたすべてのものを更新してください:
 
 ```bash
 npx skills update -g
 ```
 
-リストと削除`npx skills list -g`そして、`npx skills remove last30days -g`.
+リストして `npx skills list -g` と `npx skills remove last30days -g`で削除してください。
 
-### claude.ai (web)
+### claude.ai(ウェブ)
 
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)最新のリリースから
-2. お問い合わせ[claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. クリックします。`+`スキルパネルのボタン > クリック`Create skill` > `Upload a skill`ファイルの閲覧/ドロップ
+1. 最新リリースからの[Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)
+2. [claude.ai > Customize > Skills](https://claude.ai/customize/skills)に行って
+3. スキルパネルの `+` ボタンをクリックし> `Create skill` > `Upload a skill` をクリックしてファイルを閲覧・ドロップしてください
 
-機能の最初の「コード実行とファイル作成」を有効にする — スキルはそれなしで実行しません。
+まずは「Capabilities」で「コード実行とファイル作成」を有効にしてください。スキルはそれなしでは動作しません。
 
 ### Claude Desktop
 
-Claude Desktopインストール`/last30days`としてMCPサーバ経由で`.mcpb`バンドル(モデルコンテキストプロトコルパッケージをワンクリック)。
+Claude Desktop`.mcpb`バンドル(ワンクリックのModel Context Protocolパッケージ)を通じて`/last30days`をMCPサーバーとしてインストールします。
 
-1. お問い合わせ[latest release](https://github.com/mvanhorn/last30days-skill/releases/latest)ダウンロード`.mcpb`あなたのプラットフォームのために:
-   - macOSアップルシリコン:`last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOSインテル:`last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linuxx86 64:`last30days-pp-mcp-linux-amd64.mcpb`
-2. オープンClaude Desktop設定 > 拡張子、ファイルをドラッグします。
-3. プロンプトが表示されたら、貼り付けAPI有効にしたいソースのキー。 すべてのフィールドはオプションです。すべてのフィールドをスキップすると、エンジンはWeb専用のモードに劣化します。 鍵はOSキーホルダーに保存されます。
-4. リスタートClaude Desktop. お問い合わせClaude"Research Peter Steinberger" または任意のトピックに、それは呼び出します`research`ツール。
+1. [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest)にアクセスし、あなたのプラットフォームの`.mcpb`をダウンロードしてください:
+   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOS インテル: `last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Claude Desktopを開き、拡張機能>設定に行き、ファイルをドラッグします。
+3. 促されたら、有効にしたいソースのキーを API 貼り付けます。すべてのフィールドは任意で、すべてスキップするとエンジンはウェブ専用モードに劣化します。キーはOSのキーチェーンに保存されます。
+4. Claude Desktopを再起動してください。Claudeに「ピーター・スタインバーガーを調べて」など、どのトピックでも「リサーチ」と頼むと、`research`ツールを呼び出します。
 
-**ホストの条件:**Python3.12+ にPATH. バンドルはエンジンのソースを出荷しますが、ローカルを使用するPython通訳者。 インストールから[python.org](https://www.python.org/downloads/)お問い合わせWindows; macOSそして最も多くLinuxdistrosは互換性のあるバージョンを出荷します。
+**ホスト要件:** PATHPython 3.12+。バンドルはエンジンソースを出荷しますが、ローカルのPythonインタプリタを使用します。Windows[python.org](https://www.python.org/downloads/)からインストールしてください;macOSおよびほとんどのLinuxディストリビューションは互換性のあるバージョンを出荷します。
 
-**キーはコードスキルと同期しません。**Claude Desktopそして、Claude Codeデザインで独立したクレデンシャルストアを維持します。 既に設定されている場合`~/.config/last30days/.env`コードスキルについては、ここで同じキーを再入力します。
+**キーはコードスキルと同期しません。** Claude Desktop と Claude Code は設計上別々の認証情報ストアを維持しています。コードスキルですでに `~/.config/last30days/.env` を設定している場合、同じキーをここで一度再入力します。
 
-Windowsパープラットフォームのマニフェストエントリ ポイントがソートされるまでサポートが拒否されます。フォローアップの問題で追跡します。
+Windows サポートはプラットフォームごとのマニフェストエントリポイントが解決されるまで延期されます。追跡はフォローアップの問題で行われます。
 
 ### OpenClaw
 
@@ -263,43 +263,43 @@ Windowsパープラットフォームのマニフェストエントリ ポイン
 clawhub install last30days-official
 ```
 
-外部のX/Twitterアクションワークフローの場合`/last30days`研究、投稿など
-ツイートや返信、フォロワーエクスポート、メディア処理、モニター、プレゼント
-引くこと、使用[TweetClaw](https://github.com/Xquik-dev/tweetclaw)仲間として
-OpenClawプラグイン。TweetClawXquik-dev によって維持され、としてだけリストされます
-オプションのコンパニオンパス、Last30daysの依存性または支持ではありません。
+X/Twitter のアクションワークフロー、例えば`/last30days`研究以外の作業、例えば投稿
+ツイートや返信、フォロワーのエクスポート、メディアの管理、モニター、プレゼント企画
+ドローを使い、 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) を仲間として使う
+OpenClaw プラグインです。 TweetClaw はXquik-devによって管理されており、
+オプションの伴侶パスであり、最後の30日間の依存や承認ではありません。
 
-### マニュアル(デベロッパー)
+### マニュアル(開発者)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-symlink は、作業ツリーと同期して、必要な再コピーが不要になります。 お問い合わせ`claude.ai`, ビルド`.skill`ソースからファイル:`bash skills/last30days/scripts/build-skill.sh`プロデュース`dist/last30days.skill`.
+シンムリンクは編集中にインストールを作業ツリーと同期させ、再コピーは不要です。 `claude.ai`はソースから `.skill` ファイルをビルドします。 `bash skills/last30days/scripts/build-skill.sh` `dist/last30days.skill`を生成します。
 
-Reddit(コメントあり)Hacker News, PolymarketとGitHubすぐに働く。 ゼロ構成。 ログイン`/last30days`セットアップウィザードは、30秒でより多くのソースをアンロックします。arXivそして、Techmeme CLIお問い合わせ
+Reddit (コメント付き)、 Hacker News、 Polymarket、 GitHub が即座に動作します。設定はゼロです。一度 `/last30days` 実行すると、セットアップウィザードが30秒でさらに多くのソースをアンロックし、無料の arXiv や Techmeme CLIsも含まれます。
 
-## 自分の鍵を持参
+## 自分の鍵を持ってきてください
 
-これらのプラットフォームは互いに関係を持たない。 Xは何を知らないReddit考えます。YouTube見えないTikTok。しかし、あなた自身を持参することができますAPIキーとブラウザトークン、そして突然、あなたは一度にそれらすべてにアクセスしている。
+これらのプラットフォーム同士には関係性がありません。 X は Reddit がどう思っているか分かりません。 YouTube はそれを見 TikTok。しかし、自分の API キーやブラウザトークンを持っていけば、突然それらすべてに一度にアクセスできるようになります。
 
-|ソース|必要なもの|コスト|
+| 出典 | 必要なもの | 費用 |
 |---------|---------------|------|
-| Reddit(コメントあり) + HN +Polymarket + GitHub + StockTwits |コメントはありません。|無料|
-| arXiv + Techmeme |無料CLIs, 初回設定で自動インストール|無料|
-|X / Twitterの|任意のブラウザでx.comにログインするか、または設定`XQUIK_API_KEY` / `XAI_API_KEY` |ブラウザのクッキーは無料です。キーはプロバイダ固有のものです。|
-| YouTube | `brew install yt-dlp` |無料|
-| Bluesky |bsky.appからのアプリパスワード|無料|
-| TikTok+ インスタグラム +Threads + Pinterest + LinkedIn + YouTubeコメント| ScrapeCreatorsキーキー|10,000 の自由な呼出し、それから PAYG|
-| Xiaohongshu (RED) |ログインx-mcpブラウザプラグインを実行するか、`xiaohongshu-mcp`サービスおよびオプトイン`--search xhs`実行または`INCLUDE_SOURCES=xiaohongshu`お問い合わせ`.env`; last30days 自動プローブ`http://localhost:18060`それから`http://host.docker.internal:18060`、または使用して下さい`XIAOHONGSHU_API_BASE`カスタムURLの場合|残り30日APIキー;ローカルブラウザセッションサービスに依存します|
-|DripStack(プレミアムファイナンシャルニュースレター)|オプトイン:`--search dripstack`実行中、または`INCLUDE_SOURCES=dripstack`お問い合わせ`.env` |いいえキー;無料公開検索API |
-|パープレクシティソナー/検索API/ ディープリサーチ|パープレックスキー、またはSonarフォールバックとしてOpenRouterキー|あなたが行くように支払う|
-|ウェブ検索|ブレイブ検索キー|2,000 無料の問い合わせ/月|
+| Reddit (コメント付き)+ HN + Polymarket + GitHub + StockTwits | 何も | 無料 |
+| arXiv + Techmeme | 初開セットアップで自動インストールされる無料CLI | 無料 |
+| X / Twitter | どのブラウザでも x.com にログインするか、`XQUIK_API_KEY`/`XAI_API_KEY`設定してください。 | ブラウザクッキーは無料です。キーはプロバイダーごとに異なります |
+| YouTube | `brew install yt-dlp` | 無料 |
+| Bluesky | アプリパスワードは bsky.app から | 無料 |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube コメント | ScrapeCreators キー | 1万件の無料通話、そしてPAYG |
+| Xiaohongshu (RED) | ログインしたx-mcpブラウザプラグインや`xiaohongshu-mcp`サービスを実行し、`.env`で`--search xhs`の`INCLUDE_SOURCES=xiaohongshu`でオプトインしてください;最後に30日の自動プローブ`http://localhost:18060`、その後`http://host.docker.internal:18060`、またはカスタムURLとして`XIAOHONGSHU_API_BASE`を使う | last30daysの API キーはありません。ローカルのブラウザセッションサービスによります |
+| DripStack(プレミアム金融ニュースレター) | オプトイン:1回のランに`--search dripstack`、または`INCLUDE_SOURCES=dripstack``.env` | 鍵なし;無料の公開検索 API |
+| Perplexity ソナー / 捜索 API / 深層調査 | Perplexity キー、またはOpenRouterキーをSonarのフォールバックとして使います | 使い分ずつ支払ってください |
+| Web 検索 | Brave Searchキー | 月間2,000件の無料クエリ |
 
-### macOS Keychain(オプション)
+### macOS Keychain (任意)
 
-お問い合わせmacOSシステムにキーを貯えることができますKeychain代わりに`.env`ファイル。 スキルは、最低優先ソースとして自動的にピックアップします。`.env`ファイルとプロセス環境が衝突しても勝ちます。
+macOSでは、`.env`ファイルではなくシステムKeychainにキーを保存できます。スキルは自動的にキーを最も優先度の低いソースとして取得します。`.env`ファイルやプロセス環境は衝突時に依然として優勢です。
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +313,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-アイテムはサービス名の下に保存されます`last30days-<KEY>`現在のユーザの場合。 非ダーウィンプラットフォームでは、ローダーはノップなので、振る舞いは変化しません。Linux/Windowsユーザー。
+アイテムは現在のユーザーのためにサービス名 `last30days-<KEY>` に保存されます。ダーウィン以外のプラットフォームではローダーはノーオペレーターであるため、 Linux/Windows ユーザーの挙動変更はありません。
 
-すでに異なるキーを持っているKeychainサービス名? 非秘密の設定`LAST30DAYS_KEYCHAIN_ALIASES`記載されているマッピング[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items)秘密をコピーする代わりに。
+すでに異なるKeychainサービス名でキーを持っていますか?秘密をコピーする代わりに、[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items)で説明された非秘密の`LAST30DAYS_KEYCHAIN_ALIASES`マッピングを設定しましょう。
 
-お問い合わせ[CONFIGURATION.md](CONFIGURATION.md)完全なパーソースキーマトリクス、推論プロバイダー優先、Web-search バックエンド優先順位。
+ソースごとの鍵マトリックス、推論提供者の優先順位、ウェブ検索のバックエンド優先度については、詳細 [CONFIGURATION.md](CONFIGURATION.md) を参照してください。
 
-## コンテンツ
+## 構成
 
-一日中知っておきたい2つのこと:
+初日に知っておくべきことが2つあります:
 
-**研究ファイルが保存されます。**`LAST30DAYS_MEMORY_DIR`デフォルトは`~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`)。 シェル内の任意のパスに var を env する設定、または`--save-dir <path>`実行ごとに。 使用条件`--output <file>`レンダリングされた結果を正確なパスで必要とするとき、選択したフォーマットを使用して`--emit`. 使用`--save-suffix=<name>`同じトピックの複数のバリエーションを別々に保つ(例えば、クライアントごとに)。 詳しくはこちら`--save-dir`実行生成`<slug>-raw[-suffix].md`. 実行`python3 skills/last30days/scripts/last30days.py --preflight`研究の実行前に計画書を見直します。
+**研究ファイルが保存される場所。** `LAST30DAYS_MEMORY_DIR`デフォルトは`~/Documents/Last30Days/`(Windows: `C:\Users\<you>\Documents\Last30Days\`)。そのenv varをシェル内の任意のパスに設定し、または1回の実行ごとに`--save-dir <path>`設定してオーバーライドしてください。正確なパスでレンダリング結果が必要な場合は、`--emit`が選択したフォーマットで`--output <file>`を使います。`--save-suffix=<name>`を使って同じトピックの複数のバリエーションを別々に管理してください(例:クライアントごと)。各`--save-dir`実行は`<slug>-raw[-suffix].md`を生成します。研究実行前に計画された書き込みを確認するために`python3 skills/last30days/scripts/last30days.py --preflight`実行してください。
 
-**エージェントとワークフローの厳しい出力** お問い合わせ`/last30days`機械読みやすいのためJSON安定した、バージョンアップされたエージェントプロファイルを受け取るため。 スクリプトや開発でエンジンを直接使用する場合、実行`python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`;追加`--json-profile=raw`変換されていない内部が必要なときだけ`Report`ダンプ。 詳細はこちら[JSON export field reference and versioning policy](docs/reference/json-export.md).
+**エージェントおよびワークフロー向けの構造化出力。** 安定したバージョン管理されたエージェントプロファイルを受け取るための機械可読JSONを`/last30days`に求めてください。スクリプトや開発で直接エンジンを使う場合は、`python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`実行してください;バージョンのない内部`Report`ダンプが必要な時のみ`--json-profile=raw`追加してください。[JSON export field reference and versioning policy](docs/reference/json-export.md)を参照してください。
 
-**トピックなしの発見。** お問い合わせ`/last30days what's trending in AI agents?`すでに知っているトピックを調べる代わりにランクされた発見の簡単な取得 - エージェントホストでは、これは3つのコマンドホスト判断プロトコル(モデル名トピック、ジャンクフィルタ、スコアの適性、およびコンテンツの角度)を実行します。 スクリプトや cron で直接エンジンを使用するには、`python3 skills/last30days/scripts/last30days.py --discover "AI agents"`(一ショット: 決定的なトピック名、角度なし); 追加`--emit=json`バージョン化された発見契約のため。 ディスカバリーは、位置情報と位置情報で相互に排他的です`--drill`.
+**トピックレスディスカバリー。** 既知のトピックを調べる代わりにランク付けされたディスカバリーブリーフを取得 `/last30days what's trending in AI agents?` を求めてください。エージェントホストでは、3コマンドのホストジャッジドプロトコルを実行します(モデルがトピック名、ジャンクをフィルタリングし、価値をスコアリングし、コンテンツの角度を書きます)。スクリプトやクロンで直接エンジンで使う場合は、 `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` を実行します(ワンショット:決定的なトピック名、アングルなし);バージョン付きディスカバリー契約のために、 `--emit=json` を追加します。ディスカバリーはポジショントピックと相互排他的であり、 `--drill`。
 
-**走行中の監視を追跡する。** デフォルトモードでは、実行ごとに新しいマークダウンスナップショットが生成されます。 時間をかけて発見を蓄積するために、追加`--store`SQLiteデータベースに永続する[`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py)スケジュールされた操業のために(新しい発見の任意Slack/webhook配達と)[`scripts/briefing.py`](skills/last30days/scripts/briefing.py)毎日/毎週の消化のために。 フル・アカデミー・パターンは[CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**実行をまたぐ傾向監視。** デフォルトモードでは1回の実行ごとに新しいマークダウンスナップショットが生成されます。時間をかけて発見を蓄積するには、SQLiteデータベースに永続化する `--store` を追加し、スケジュールされた実行には [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) (新しい発見にはオプションでSlackやwebhookの配信も可能)、日次・週次ダイジェストには日次 [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) を使います。完全なカデンスパターンは [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings)にあります。
 
-**サブスクライブ可能な研究ライブラリ** お問い合わせ`/last30days`ライブラリフィードの構築、または使用`python3 skills/last30days/scripts/last30days.py library feed`スクリプトや開発に直接。 保存されたブリーフをオンにします`index.html`ローカル原子`feed.xml`, 読みやすい簡単なページ. 追加する`--publish`あなたが望むときだけHTML公開は、デフォルトで明示的にオプトインし、公開されます。 Atom フィードをサブスクライブ可能にするには、生成された出力ディレクトリを static ホストにホストします。GitHubサイトマップ
+**購読可能な研究図書館です。** `/last30days`に図書館フィードを作成してもらうか、スクリプト作成や開発に直接使う`python3 skills/last30days/scripts/last30days.py library feed`をください。保存されたブリーフを`index.html`、ローカルのAtom `feed.xml`、読みやすいブリーフページに変換します。HTMLインデックスやブリーフページをホストしたい場合にのみ追加`--publish`;公開は明示的にオプトインし、デフォルトで公開されます。Atomフィードを購読可能にするには、生成された出力ディレクトリをGitHub Pagesのような静的ホストでホストしてください。
 
-**調査したすべてのものを検索します。** お問い合わせ`/last30days search my library for MCP servers`または`/last30days have I researched MCP servers before?`. 直接エンジンの使用のために、操業して下さい`python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. 検索はオフラインで決定的です: ライブラリフィードによって使用される同じ保存されたブリーフをインクリメンタルにインデックス化し、パーランストアの視覚化とグループの結果をトピックと日付でマージします。 フレッシュランは、現在のトピックをオーバーラップする前の研究では、ライブラリ**セクションから、コンパクトに面しています。`LAST30DAYS_LIBRARY_CONTEXT=off`パッシブコンテキストを無効にします。
+**調べたものをすべて検索してください。** `/last30days search my library for MCP servers` または質問 `/last30days have I researched MCP servers before?`。直接エンジン使用の場合は `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`を実行します。検索はオフラインかつ決定論的です。図書館フィードで使われる同じ保存ブリーフを段階的にインデックス化し、各ランごとに一致する店舗の目撃情報を統合し、トピックや日付で結果をグループ化します。新規の検索では、先行研究が現在のトピックと重複する場合、コンパクトな**あなたの図書館から**セクションが表示されます。その受動的なコンテキストを無効に `LAST30DAYS_LIBRARY_CONTEXT=off` 設定してください。
 
-Per-client wrapper スクリプト、カスタムカテゴリ-peer subreddits 、および in-progress のカスタマイズのための実験的なベータ チャネルも文書化されます[CONFIGURATION.md](CONFIGURATION.md).
+クライアントごとのラッパースクリプト、カスタムカテゴリピアサブレディット、進行中のカスタマイズのための実験的ベータチャンネルも [CONFIGURATION.md](CONFIGURATION.md)でドキュメント化されています。
 
-## ショーケース:コミュニティリサーチフィード
+## 紹介:コミュニティリサーチフィード
 
-過去30日間の再カーリングAIアップデート、マーケットウォッチ、または素晴らしい狭い obsession を公開しましたか? 公開ライブラリ URL または Atom URL をホスティング後に共有する`feed.xml`静的なホストに[the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). コミュニティフィードは、所有者がそれらを提出するようにここにリンクされます。 スレッドは、その間のコレクションポイントです。
+定期的なAIアップデート、市場観察、またはlast30daysへの非常に狭い執着を公開した?公共図書館のURL、または静的ホストで `feed.xml` ホスティングした後のAtomのURLを共有 [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532)。コミュニティフィードは所有者が投稿する際にここにリンクされます。スレッドがその間、収集の拠点となっています。
 
-## 作品紹介
+## 仕組み
 
-1. **トピックを入力します。** 人、会社、製品、技術、X対Y。 お問い合わせ
-2. **代理人は誰が重要であるかを解決します。** Xハンドル(創始者を含む)を見つけ、GitHubリポジトリ、サブreddits、TikTokハッシュタグYouTubeチャンネル. 「Kanye West」では、r/hiphopheadsを知っています。@kanyewest, と "bully review" 上のYouTube. のために "OpenClaw「openclaw/openclawを解決する」GitHubライブスターカウントをフェッチします。
-3. **すべてのソースは並列で検索します。** 多品種の拡大。 エンゲージメント、関連性、鮮度で得た結果
-4. **奥深さの誰も持っていません。** スタッフYouTube反応ビデオからのトランスクリプト。 トップページRedditアップ投票数のコメント。TikTokキャプション。Polymarketオッズ。 タイトルやリンクだけではありません。
-5. **サメストーリー、マージ。** ワイヤレスフェスティバルが発表されましたReddit, Xで議論, チケットの価格TikTok= 1つのクラスター、3つの独立した項目ではなく。
-6. **1つに合成** 特定のデータに基づいた。 ソースによって引用される。 実際に参加する人々によってランク付けされる。 「自分が見つけたもの」ではない。 「こんなこと」です。
-7. **専門医になる。** 実行後、Claudeセッションは、コミュニティが知っているすべてのことを知っています。 フォローアップの質問をしてください。 プロンプト、メールのドラフト、計画旅行、アーキテクトシステム - 今のところ何が本物にすべて基づかせていました。
+1. **トピックをタイプします。** 人物、会社、製品、技術、「X vs Y」何でもいい。
+2. **エージェントが重要な人物を決定します。** Xハンドル(創業者を含む)、リポジトリ、サブレディット、TikTokハッシュタグ、YouTubeチャンネルGitHubを見つけます。「Kanye West」についてはr/hiphopheads、@kanyewest、そしてYouTubeの「bully review」を知っています。「OpenClaw」ではopenclaw/openclawをGitHubで解決し、ライブのスター数を取得します。
+3. **すべてのソースを並行検索。** 複数クエリの拡張。結果はエンゲージメント、関連性、新鮮度で評価されます。
+4. **他の誰にもない深み。**リアクション動画の全 YouTube トランスクリプト。アップボート数を含むトップ Reddit コメント。 TikTok キャプション。 Polymarket 確率。タイトルやリンクだけじゃない。
+5. **同じ話、統合済み。**ワイヤレスフェスティバルは Reddit日に発表され、 Xで議論、 TikTok のチケット価格は3つの別々の項目ではなく1つのクラスターです。
+6. **まとめて一つのブリーフにまとめた。** 具体的なデータに根ざしている。出典ごとに引用。人々が実際に関わるもので順位付け。「これが私の発見だ」ではなく「これが重要なことだ」ということだ。
+7. **そうすればあなたの専門家になります。** 一度の実行で、あなたの Claude セッションはコミュニティが知っているすべてを知っています。フォローアップの質問をしてください。プロンプトを書かせ、メールを下書きし、旅行計画を立て、アーキテクトシステムを計画し、すべて今の現実に基づいています。
 
-## 人が言うこと
+## 人々が言っていること
 
-> 「私は見つけましたClaude Codeあらゆるトピックを研究するスキルReddit、 X、YouTube過去30日間のHNとHN。 それからあなたのためのプロンプトを書きます。 私は手動で検索してきたRedditそしてXは、私が書いたすべてのコンテンツの前に研究のために。 タブでタブします。 糸による糸。 90分かかる部分です。 これはそれを排除します。」 -@itsjasonai
+> 「過去30日間の44Reddit、X、YouTube、HNのあらゆるトピックを調べるClaude Codeスキルを見つけました。そして、あなたのためにプロンプトを書きます。私は毎回のコンテンツを書く前に、RedditやXを手動で調査しています。タブごとに。スレッドごとに。そこが90分かかる部分です。これでその部分はなくなります。」-@itsjasonai
 
-> 「この1つのスキルは、研究ワークフロー全体を置き換えました。 あなたはそれをトピックを与える、それはスクレイピングReddit、X、そして実際に話している人のためのウェブ。 古いブログ投稿はありません。 過去30日間のリアルタイム会話。 -@itswilsoncharles
+> 「この一つのスキルが、私の研究ワークフロー全体を置き換えました。トピックを与えると、実際に人々が話していることを Reddit、 X、ウェブからスクレイピングします。古いブログ記事ではありません。過去30日間の本当の会話です。」-@itswilsoncharles
 
-> 「10のトレンドレポの5」GitHub今日はClaudeツール。 #1: マバンホーン/last30days-スキル -@yieldhunter95
+> 「今日 GitHub でトレンド入りしている10のリポジトリのうち5つは Claude ツールです。#1:Mvanhorn/last30days-スキル」 -@yieldhunter95
 
 ## オープンソース
 
-MITライセンス 追跡無し。 分析なし。 あなたの研究はあなたの機械にとどまります。 2,700以上のテスト
+MITライセンス。追跡なし。分析なし。研究はあなたのマシンに残る。2,700+テスト。
 
-組み込みPython3.12+、yt-dlp、Node.js(ベンダー)BirdX検索のクライアントScrapeCreators API. v3エンジンアーキテクチャ[@j-sperling](https://github.com/j-sperling).
+Python 3.12+、yt-dlp、Node.js(X検索用にベンダーBirdクライアント)、およびScrapeCreators API[@j-sperling](https://github.com/j-sperling)によるv3エンジンアーキテクチャで構築されています。
 
-お問い合わせ[CONTRIBUTING.md](CONTRIBUTING.md)開くPR, [CONTRIBUTORS.md](CONTRIBUTORS.md)コミュニティコントリビューターの完全なリストのために、[CHANGELOG.md](CHANGELOG.md)バージョン履歴のため。
+PRを開くには[CONTRIBUTING.md](CONTRIBUTING.md)、コミュニティ貢献者の全リストは「[CONTRIBUTORS.md](CONTRIBUTORS.md)」、バージョン履歴は「[CHANGELOG.md](CHANGELOG.md)」を参照してください。
 
-## 星の歴史
+## スターの歴史
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.ja.md
+++ b/README.ja.md
@@ -156,7 +156,7 @@ v3の基盤はすべてまだ存在しています:単一の API コールが発
 
 | 表面 | 設置 | アップデート |
 |---------|---------|---------|
-| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイスを通じた自動車保険、または `claude plugin update last30days@last30days-skill` |
+| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイス経由で自動更新、または `claude plugin update last30days@last30days-skill` |
 | **Grok**(xAIビルド CLI) | `grok plugin marketplace add mvanhorn/last30days-skill``grok plugin install last30days` | `grok plugin update last30days` |
 | **Codex、 Cursor、 Copilot、 Gemini CLI、または50+のホストのいずれか [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
 | **claude.ai**(ウェブ) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) ・アップロード claude.ai > カスタマイズ > スキル > + > スキル作成 > スキルをアップロード | 再ダウンロードと再アップロード |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # /last30days
 
-English | [简体中文](README.zh-CN.md)
+English | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 <p align="center">
   <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -156,7 +156,7 @@ As bases da v3 ainda estão todas aqui: o cérebro pré-pesquisa que resolve os 
 
 | Superfície | Instalação | Atualizações |
 |---------|---------|---------|
-| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automóvel via marketplace, ou `claude plugin update last30days@last30days-skill` |
+| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Atualização automática via marketplace ou `claude plugin update last30days@last30days-skill` |
 | **Grok**(Build xAI CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` então `grok plugin install last30days` | `grok plugin update last30days` |
 | **Codex, Cursor, Copilot, Gemini CLIou qualquer um dos 50+ [Agent Skills](https://agentskills.io) apresentadores** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
 | **claude.ai**(web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e envie via claude.ai > Personalizar > Habilidades > + > Criar habilidades > Enviar uma habilidade | Rebaixe e refaça o upload |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -16,9 +16,9 @@
   </a>
 </p>
 
-**Um mecanismo de pesquisa liderado por agentes de IA pontuado por votos positivos, curtidas e dinheiro real - não por editores.**
+**Um mecanismo de busca liderado por agentes de IA, pontuado por votos positivos, curtidas e dinheiro real - não por editores.**
 
-Este README rastreia o pipeline v3 atual. A especificação de habilidade de tempo de execução reside em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a fonte da verdade para o comando e comportamento de configuração mais recentes.
+Este README acompanha o pipeline v3 atual. A especificação de habilidade em tempo de execução está em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a fonte de verdade para o comportamento mais recente de comandos e configurações.
 
 **Claude Code (recomendado — atualizações automáticas via marketplace):**
 ```
@@ -26,141 +26,141 @@ Este README rastreia o pipeline v3 atual. A especificação de habilidade de tem
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI ou qualquer um dos mais de 50 [hosts do Agent Skills](https://agentskills.io):**
+**Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ [Agent Skills](https://agentskills.io) apresentadores:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` é instalado globalmente para seu usuário, disponível em todos os projetos. Coloque-o no escopo por projeto.)
+(`-g` instala globalmente para seu usuário, disponível em todos os projetos. Coloque para o escopo por projeto.)
 
 Mais opções de instalação (claude.ai web, OpenClaw, manual) na seção [Install](#instalação) abaixo.
 
-Configuração zero. Reddit, HN, Polymarket e GitHub funcionam imediatamente. Execute-o uma vez e o assistente de configuração desbloqueia X, YouTube, TikTok, arXiv, Techmeme e muito mais em 30 segundos.
+Zero configuração. Reddit, HN, Polymarkete GitHub funcionam imediatamente. Execute uma vez e o assistente de configuração desbloqueia X, YouTube, TikTok, arXiv, Techmemee mais em 30 segundos.
 
 ---
 
-Votos positivos do Reddit. X gosta. Transcrições do YouTube. Engajamento do TikTok. Probabilidades do Polymarket apoiadas por dinheiro real e informações privilegiadas. São milhões de pessoas votando com sua atenção e suas carteiras todos os dias. /last30days pesquisa tudo em paralelo, pontua de acordo com o que as pessoas reais realmente interagem e um juiz agente de IA sintetiza tudo em um resumo.
+Reddit votos positivos. X gostos. YouTube transcrições. TikTok engajamento. Polymarket probabilidades respaldadas por dinheiro real e informações privilegiadas. São milhões de pessoas votando com sua atenção e carteiras todos os dias. /last30days pesquisa tudo em paralelo, pontua pelo que pessoas reais realmente envolvem, e um juiz agente de IA sintetiza tudo em um único recurso.
 
-O Google agrega editores. /last30days pesquisa pessoas.
+Google agrega editores. /last30days pesquisa pessoas.
 
-Você não pode obter essa pesquisa em nenhum outro lugar porque nenhuma IA tem acesso a tudo isso. A pesquisa do Google não aborda comentários do Reddit ou postagens X. ChatGPT tem acordo com Reddit, mas não consegue pesquisar X ou TikTok. Gemini tem YouTube, mas não Reddit. Claude não tem nenhum deles nativamente. Cada plataforma é um jardim murado com sua própria API, seus próprios tokens, sua própria autenticação. Mas você pode trazer suas próprias chaves e sessões do navegador e, de repente, um agente de IA pode pesquisar todas elas de uma vez, compará-las entre si e dizer o que realmente importa.
+Você não pode encontrar essa busca em nenhum outro lugar porque nenhuma IA única tem acesso a tudo. Google busca não mexe Reddit comentários ou X postagens. ChatGPT tem um acordo com Reddit , mas não pode pesquisar X ou TikTok. Gemini tem YouTube , mas não Reddit. Claude não tem nenhuma delas nativamente. Cada plataforma é um jardim murado com seu próprio API, seus próprios tokens, sua própria autenticação. Mas você pode trazer suas próprias chaves e sessões de navegador, e de repente um agente de IA pode pesquisar todas de uma vez, pontuá-las entre si e dizer o que realmente importa.
 
-Esse é o desbloqueio. Nenhum mecanismo de pesquisa melhor. Uma dúzia de plataformas desconectadas, interligadas por um agente.
+Esse é o desbloqueio. Não há um motor de busca melhor. Uma dúzia de plataformas desconectadas, conectadas por um agente.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Você tem uma reunião amanhã. Você os pesquisa no Google. Você obtém o LinkedIn de 2023. /last30days mostra o que eles realmente estão fazendo este mês: juntou-se à OpenAI para trabalhar no Codex, lutando contra a proibição da Anthropic de agentes terceirizados, enviando 23 PRs com taxa de mesclagem de 85%, construindo "LobsterOS" para controle de agente entre dispositivos e r/ClaudeCode atingiu 569 votos positivos debatendo se ele é um herói ou "insuportável". Espalhados por postagens X, tópicos do Reddit, transcrições do YouTube e commits do GitHub. Nada disso estava no Google.
+Você tem uma reunião amanhã. Você Google eles. Você recebe o LinkedIn deles de 2023. /last30days te dá o que eles realmente estão fazendo este mês: entrou na OpenAI para trabalhar em Codex, lutou contra a proibição da Anthropic sobre agentes terceirizados, enviou 23 PRs com 85% de taxa de fusão, construiu "LobsterOS" para controle de agentes entre dispositivos, e o código r/Claudeatingiu 569 votos positivos debatendo se ele é um herói ou "insuportável". Espalhados por X postagens, Reddit tópicos, transcrições YouTube e GitHub commits. Nada disso estava no Google.
 
 ## Por que isso existe
 
-Eu o construí para acompanhar a IA. Tudo muda todos os dias e os nerds do Reddit e do X estão sempre por dentro disso. Eu precisava de instruções melhores, e os dados de treinamento estavam sempre meses atrás do que a comunidade já havia descoberto.
+Eu o construí para acompanhar a IA. Tudo muda todo dia e os nerds Reddit e X sempre estão por dentro primeiro. Eu precisava de prompts melhores, e os dados de treinamento sempre estavam meses atrás do que a comunidade já havia descoberto.
 
-Mas isso se transformou em algo maior. Agora eu o executo antes de uma ligação de vendas para saber a verdade dos últimos 30 dias sobre um negócio. Antes de uma reunião, para ler os tweets recentes e as transcrições de podcast de alguém. Antes de uma viagem à Disney World para saber quais atrações estão fechadas e o que a comunidade diz sobre o Genie+. Antes de construir qualquer coisa, quero saber quais problemas as pessoas estão realmente enfrentando.
+Mas virou algo maior. Agora eu faço isso antes de uma ligação de vendas para saber a verdade dos últimos 30 dias sobre um negócio. Antes de uma reunião para ler os tweets recentes e transcrições de podcasts de alguém. Antes de uma Disney World viagem para saber quais brinquedos estão fechados e o que a comunidade diz sobre Genie+. Antes de construir qualquer coisa para saber quais problemas as pessoas realmente estão enfrentando.
 
-Se você estiver se reunindo com um CEO, leu todos os tweets e transcrições do YouTube dos últimos 30 dias? Eu tenho.
+Se você está se reunindo com um CEO, já leu todos os tweets e transcrições de YouTube dos últimos 30 dias? Leu.
 
 ## Fontes, pontuadas pelo povo
 
-| Fonte | O que as pessoas dizem para você |
+| Fonte | O que as pessoas te dizem |
 |--------|--------------------------|
-| **Reddit** | A tomada não filtrada. Principais comentários com contagens reais de votos positivos, gratuitos e sem chave de API. As verdadeiras opiniões que o Google enterra. |
-| **X/Twitter** | A tomada quente, o tópico especializado, a reação de ruptura. Primeiro a saber, primeiro a discutir. |
-| **YouTube** | O mergulho profundo de 45 minutos. As transcrições completas procuraram as 5 frases citáveis ​​​​que importam. |
-| **TikTok** | O criador alcançando 3,6 milhões de pessoas com um take que você nunca encontrará no Google. |
-| **Instagram Reels** | A perspectiva do influenciador com transcrições de palavras faladas. O sinal da cultura visual. |
-| **Notícias sobre hackers** | O consenso do desenvolvedor. 825 pontos, 899 comentários. Onde os técnicos realmente discutem. |
-| **Polymarket** | Não opiniões. Chances. Apoiado em dinheiro real. 96% de confiança nas vendas de álbuns. 4% em uma aquisição. |
-| **GitHub** | Para pessoas: velocidade de relações públicas, principais repositórios por estrelas, notas de lançamento. Para tópicos: questões e discussões. |
-| **Digg** | Clusters de histórias selecionados da tabela de classificação AI 1000 do Digg (cerca de 1.000 contas de IA de alto sinal no X), com cotações inline atribuíveis (sem necessidade de autenticação X). Ativado automaticamente quando `digg-pp-cli` está em PATH. |
-| **arXiv** | Os jornais por trás do hype. Nova pesquisa na janela, gratuita, sem chave de API. Ativado automaticamente quando `arxiv-pp-cli` está em PATH (a configuração na primeira execução o instala). |
-| **Tecmeme** | A camada editorial de notícias de tecnologia, com janela de data de 30 dias. Gratuito, sem chave de API. Ativado automaticamente quando `techmeme-pp-cli` está em PATH (a configuração na primeira execução o instala). |
-| **LinkedIn** | O sinal profissional. Postagens e artigos, com artigos considerados de alto sinal. |
-| **StockTwits** | Sentimento do comerciante. Ativa automaticamente quando o seu tópico é um ticker ou criptografia. |
-| **Tópicos** | A camada de texto pós-Twitter. Conversas de criadores e marcas. |
-| **Pinterest** | Descoberta visual. Pins, salvamentos e comentários sobre produtos e ideias. |
-| **Xiaohongshu (VERMELHO)** | Sinais de estilo de vida, produto e criador chineses. Solicitado explicitamente com `--search xhs` quando um plug-in de navegador x-mcp conectado ou serviço `xiaohongshu-mcp` está sendo executado localmente. |
-| **Céu Azul** | A camada social descentralizada. Postagens do Protocolo AT da migração pós-Twitter. |
-| **Perplexidade** | Síntese do Grounded Sonar, linhas brutas da API de pesquisa e pesquisa profunda. |
-| **Web** | A cobertura editorial, as comparações do blog. Um sinal entre muitos, não o único. |
+| **Reddit** | A opinião sem filtros. Comentários no topo com contagens reais de votos, gratuito, sem API chave. As opiniões reais que Google enterram. |
+| **X / Twitter** | A opinião polêmica, o fio do especialista, a reação de quebra. Primeiro a saber, primeiro a discutir. |
+| **YouTube** | O mergulho profundo de 45 minutos. Transcrições completas buscadas pelas 5 frases citáveis que importam. |
+| **TikTok** | O criador alcançando 3,6 milhões de pessoas com uma opinião que você nunca encontrará sobre Google. |
+| **Instagram Reels** | A perspectiva do influenciador com transcrições de spoken word. O sinal cultural visual. |
+| **Hacker News** | O consenso dos desenvolvedores. 825 pontos, 899 comentários. Onde pessoas técnicas realmente discutem. |
+| **Polymarket** | Não opiniões. Probabilidades. Garantido por dinheiro real. 96% de confiança nas vendas do álbum. 4% em uma aquisição. |
+| **GitHub** | Para as pessoas: PR Velocity, top repos por estrelas, notas de release. Para tópicos: questões e discussões. |
+| **Digg** | Clusters de histórias selecionados do ranking AI 1000 da Digg(~1000 contas de IA de alta sinalização no X), com citações inline atribuíbles (sem necessidade de autenticação X ). Autoativado quando `digg-pp-cli` está ativado PATH. |
+| **arXiv** | Os papéis por trás do hype. Nova pesquisa na janela, gratuita, sem chave API . Ativado automaticamente quando `arxiv-pp-cli` está no PATH (a primeira configuração instala). |
+| **Techmeme** | A camada editorial de notícias tecnológicas, datada para seus 30 dias. Grátis, sem chave API . Ativada automaticamente quando `techmeme-pp-cli` está no PATH (a primeira execução instala). |
+| **LinkedIn** | O sinal profissional. Posts e artigos, com artigos ponderados como sinal alto. |
+| **StockTwits** | Sentimento do trader. Ativa-se automaticamente quando seu tema é um ticker ou criptomoeda. |
+| **Threads** | A camada de texto pós-Twitter. Conversas de criadores e marcas. |
+| **Pinterest** | Descoberta visual. Fixe, salve e comente sobre produtos e ideias. |
+| **Xiaohongshu (RED)** | Sinais de estilo de vida, produto e criador chineses. Solicitado explicitamente com `--search xhs` quando um plugin ou serviço de `xiaohongshu-mcp` do navegador x-mcp logado está rodando localmente. |
+| **Bluesky** | A camada social descentralizada. Postagens do Protocolo AT da migração pós-Twitter. |
+| **Perplexity** | Síntese de Sonar no Solo, Busca API Linhas brutas e Pesquisa Profunda. |
+| **Web** | A cobertura editorial, as comparações com blogs. Um sinal entre muitos, não o único. |
 
-Os contribuidores da comunidade continuam adicionando mais. Truth Social e outras fontes de nicho estão no motor com mais a caminho.
+Colaboradores da comunidade continuam adicionando mais. Truth Social e outras fontes de nicho estão no motor com mais a caminho.
 
-Um tópico do Reddit com 1.500 votos positivos é um sinal mais forte do que uma postagem de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações conta mais sobre o que é culturalmente relevante do que um comunicado à imprensa. As probabilidades do Polymarket apoiadas por um volume de US$ 66 mil são mais difíceis de argumentar do que a suposição de um especialista.
+Um tópico Reddit com 1.500 votos positivos é um sinal mais forte do que um post de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações diz mais sobre o que é culturalmente relevante do que um comunicado à imprensa. Polymarket probabilidades apoiadas em $66 mil em volume são mais difíceis de contestar do que um palpite de um comentarista.
 
-A síntese classifica aquilo com que as pessoas reais realmente se engajaram. Relevância social, não relevância de SEO.
+A síntese é classificada pelo que as pessoas reais realmente se envolveram. Relevância social, não SEO relevância.
 
-## Para que as pessoas realmente o usam
+## Para que as pessoas realmente usam
 
-**Antes de uma reunião.** `/last30days Peter Steinberger` - juntou-se à equipe Codex da OpenAI, lutando contra a proibição da Anthropic de agentes terceirizados, 23 PRs se fundiram a uma taxa de mesclagem de 85% no GitHub, construindo o LobsterOS para controle de agente entre dispositivos. r/ClaudeCode: "Desde o lançamento do OpenClaw, era amplamente conhecido que se você executá-lo por meio de qualquer coisa que não fosse a API, você acabaria sendo banido" (227 votos positivos). Isso não está no LinkedIn.
+**Antes de uma reunião.** `/last30days Peter Steinberger` - juntou-se à equipe Codex da OpenAI, lutando contra a proibição da Anthropic de agentes terceiros, 23 PRs fundiu com 85% de taxa de fusão na GitHub, construindo LobsterOS para controle de agentes entre dispositivos. Código r/Claude: "Desde OpenClaw lançado, era amplamente conhecido que, se você rodasse por qualquer coisa que não fosse a API, acabaria sendo banido" (227 votos positivos). Isso não é culpa LinkedIn.
 
-**Para ler os sinais de contratação.** `/last30days Listen Labs --hiring-signals` - as páginas atuais de empregos e carreiras tornam-se evidências citadas de mudanças de foco: contratação para segurança empresarial, sucesso do cliente, infraestrutura ou expansão de produtos. O relatório diz o que a contratação parece sinalizar, e não o que o roteiro irá fornecer.
+**Para ler sinais de contratação.** `/last30days Listen Labs --hiring-signals` - as páginas atuais de empregos e carreiras passam a ser evidências citadas para mudanças de foco: contratações para segurança empresarial, sucesso do cliente, infraestrutura ou expansão de produtos. O relatório diz o que a contratação parece sinalizar, não o que o roteiro irá trazer.
 
-**Para encontrar o tópico antes que ele atinja o pico.** Pergunte a `/last30days what's exploding in AI agents?` e a habilidade muda para o modo de descoberta: o mecanismo varre as listagens de categorias do Reddit, as principais/melhores histórias do Hacker News, o feed AI 1000 do Digg e X quando autenticado; seu agente julga as nomeações (nomes, filtragem de lixo eletrônico, valor do conteúdo) e escreve ângulos de podcast/artigo X; então você obtém de 5 a 10 tópicos classificados por velocidade. Cada resultado inclui números de fontes cruzadas, um rótulo de impulso e um acompanhamento `/last30days "<topic>"` pronto para execução.
+**Para encontrar o tema antes que ele atinja o auge.** Pergunte `/last30days what's exploding in AI agents?` e a habilidade muda para o modo descoberta: o motor varre Reddit listagens de categorias, Hacker News primeiras histórias/melhores, o feed AI 1000 da Digge X quando autenticado; seu agente avalia as indicações (nomes, filtragem de lixo, qualidade de conteúdo) e escreve podcast / X- ângulos de artigo; depois você recebe de 5 a 10 tópicos classificados por velocidade. Cada resultado inclui números de fontes cruzadas, um rótulo de momentum e um `/last30days "<topic>"` de acompanhamento pronto para rodar.
 
-**Quando algo cai.** `/last30days Kanye West` - O Reino Unido bloqueou seu visto, o Wireless Festival foi cancelado, os patrocinadores fugiram. Mas BULLY estreou em segundo lugar na Billboard. Fantano voltou de seu "Yay sabático" para revisá-lo (653 mil visualizações). SoFi Homecoming trouxe Lauryn Hill e Travis Scott para 44 músicas. Polymarket: "Kanye vai twittar de novo?" 86% Sim. 23 tópicos do Reddit, 17 vídeos do YouTube, 86 mil votos positivos.
+**Quando algo cai.** `/last30days Kanye West` - O Reino Unido bloqueou seu visto, o Festival Wireless cancelou, os patrocinadores fugiram. Mas BULLY estreou em #2 na Billboard. Fantano voltou do seu "Yay sabático" para resenhar (653 mil visualizações). O SoFi Homecoming trouxe Lauryn Hill e Travis Scott para 44 músicas. Polymarket: "Será que Kanye vai tuitar de novo?" 86% Sim. 23 tópicos Reddit , 17 vídeos YouTube , 86 mil votos positivos.
 
-**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Estes não são concorrentes, são camadas." OpenClaw é o executor (351 mil estrelas do GitHub, ao vivo), Hermes é o cérebro que se aprimora (31 mil estrelas), Paperclip é o organograma (49 mil estrelas). Contagens de estrelas extraídas ao vivo da API do GitHub, e não de postagens de blog obsoletas. Tabela lado a lado com arquitetura, memória, segurança, best-for. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
+**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Esses não são concorrentes, são camadas." OpenClaw é o executor (351K GitHub estrelas, ao vivo), Hermes é o cérebro autoaperfeiçoador (31K estrelas), Paperclip é o organigrama (49K estrelas). Contagens de estrelas puxadas ao vivo do GitHub API, não posts de blog sem graça. Mesa lado a lado com arquitetura, memória, segurança, o melhor para. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
 
-**Para entender o mundo.** `/last30days Iran vs USA` - Dia 38 da guerra. O prazo de terça-feira de Trump para o Irã reabrir o Estreito de Ormuz. Dois aviões de guerra dos EUA abatidos. Petróleo a US$ 126/barril. A AIE chamou-a de “a maior interrupção no fornecimento na história do mercado global de petróleo”. Polymarket: cessar-fogo até 31 de dezembro em 74%. 27 postagens X, 10 vídeos no YouTube, 20 mercados de previsão.
+**Para entender o mundo.** `/last30days Iran vs USA` - Dia 38 da guerra. O prazo de terça-feira de Trump para o Irã reabrir o Estreito de Ormuz. Dois aviões de guerra americanos abatidos. Petróleo a $126/barril. A IEA chamou isso de "a maior interrupção do fornecimento na história do mercado global de petróleo." Polymarket: cessar-fogo até 31 de dezembro com 74%. 27 X postagens, 10 vídeos YouTube , 20 mercados de previsão.
 
-**Antes de uma viagem.** `/last30days Universal Epic Universe` - Ampliação já em construção. Licença do "Projeto 680" arquivada. Espetáculo de fogos de artifício confirmado pela infraestrutura, mas sem aviso prévio. Tempos de espera: Mine-Cart Madness com média de 148 minutos. Ainda não há passe anual e os moradores locais estão frustrados. Stardust Racers será reformado até 5 de abril.
+**Antes de uma viagem.** `/last30days Universal Epic Universe` - Expansão já em construção. Permissão "Projeto 680" solicitada. Show de fogos de artifício confirmado pela infraestrutura, mas sem aviso. Tempos de espera: Loucura de Carrinhos de Mina com média de 148 minutos. Ainda sem passe anual, e os moradores locais estão frustrados. Stardust Racers em reforma até 5 de abril.
 
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - Prompts estruturados em JSON estão substituindo a sopa de tags. O formato aninhado do @pictsbyai evita "sangramento de conceito". O fluxo de trabalho que prioriza a edição supera a regeneração. Em seguida, ele escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - JSONprompts estruturados estão substituindo o tag soup. O formato aninhado do @pictsbyaiimpede o "conceito de sangrar". O fluxo de trabalho editado primeiro vence regeneração. Depois, ele escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
 
-## O que há de novo
+## Novidades
 
-Desde o anúncio da v3.3 em maio, até a v3.11.1 (julho de 2026): 175 PRs mesclados - 122 deles de 52 colaboradores da comunidade - em 15 versões. Isto é o que pousou.
+Desde o anúncio da v3.3 em maio, a partir da v3.11.1 (julho de 2026): 175 PRs se fundiram – 122 deles de 52 colaboradores da comunidade – em 15 lançamentos. Foi isso que apareceu.
 
 ### Primeira classe no OpenAI Codex
 
-/last30days agora é um plugin nativo do Codex com configuração guiada - não uma porta, um cidadão de primeira classe. Citações com reconhecimento de renderizador significam que a saída do Codex é lida como um resumo em vez de uma sopa de URL (# 694), e o mesmo mecanismo é executado em hosts Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw e mais de 50 Agent Skills. Manifesto do plugin Codex por [@rfoust](https://github.com/rfoust) (#686), correção de autenticação do Codex por [@tmchow](https://github.com/tmchow) (#698).
+/last30days agora é um plugin nativo de Codex com configuração guiada – não é uma porta, é um cidadão de primeira classe. Citações conscientes do renderizador fazem com que Codex saída seja lida como um brief em vez de um soup de URL (#694), e o mesmo motor roda em Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawe 50+ hosts Agent Skills . Codex manifesto de plugin por [@rfoust](https://github.com/rfoust) (#686), Codex correção de autenticação por [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmeme e Digg - gratuitos, sem chaves de API
+### arXiv, Techmemee Digg - grátis, sem chaves API
 
-arXiv traz os documentos por trás do hype e Techmeme traz a camada editorial de notícias técnicas - grátis, sem chaves e com configuração de primeira execução que instala suas CLIs para que sejam ativadas automaticamente (# 709). Os clusters de histórias AI 1000 do Digg chegam sem autenticação X da mesma maneira - a configuração instala a CLI gratuita do Digg para você (#590). A Trustpilot oferece opt-in para pesquisas de marcas de consumo.
+arXiv traz os jornais por trás do hype e Techmeme traz a camada editorial de notícias tecnológicas - grátis, zero chaves, e o setup de primeira execução instala seus CLIs para que sejam ativados automaticamente (#709). Clusters de histórias AI 1000 do Diggchegam sem X autenticação da mesma forma – setup instala o Digg CLI gratuito para você (#590). Trustpilot envia opt-in para pesquisa de marcas de consumo.
 
-### Reddit gratuito aumentou pontuações reais e comentários principais
+### O Reddit gratuito aumentou as pontuações reais e os principais comentários
 
-A API .json pública do Reddit morreu; o caminho livre voltou mais forte. Keyless RSS + scraping de Shreddit (#457), descoberta de subreddit dedicado com contagens reais de votos positivos via Arctic-Shift (#696) e um piso de relevância para que uma postagem viral fora do tópico não possa sequestrar seu briefing (#488, obrigado [@rzachsmith](https://github.com/rzachsmith)). Nenhuma chave de API. Pontuações reais. Principais comentários incluídos.
+Reddit.json API público morreu; o caminho gratuito voltou mais forte. RSS sem chave + scraping do shreddit (#457), descoberta de subreddit dedicado com contagens reais de votos positivos via arctic-shift (#696), e um piso de relevância para que um post viral fora do tema não possa sequestrar seu briefing (#488, obrigado [@rzachsmith](https://github.com/rzachsmith)). Sem chave API . Pontuações reais. Comentários principais incluídos.
 
 ### Os melhores comentários em cada briefing
 
-Os comentários agora são uma camada padrão em todas as fontes: comentários do Instagram com diversidade baseada em classificação para que cinco tomadas interessantes não venham todas de uma postagem (# 751), comentários do YouTube mais um backup de transcrição do ScrapeCreators para quando yt-dlp for eliminado (# 637) e comentários votados pelo público ponderados em Melhores tomadas para que as falas mais engraçadas da comunidade sobrevivam à pontuação (# 592, # 608).
+Os comentários agora são uma camada padrão em várias fontes: comentários no Instagram com diversidade baseada em ranking, então cinco opiniões polémicas não vêm todas de um único post (#751), comentários YouTube mais um backup de transcrição ScrapeCreators para quando o YT-DLP falha (#637), e comentários votados pelo público ponderados em Best Takes para que as falas mais engraçadas da comunidade sobrevivam à pontuação (#592, #608).
 
-### Um comando médico
+### Comando de um médico
 
-Solicite uma verificação de integridade e o médico executará todas as fontes e, em seguida, prescreverá as correções exatas - qual chave está faltando, qual CLI está fora do PATH, qual cookie expirou (#753). Chega de adivinhar por que X voltou magro.
+Peça um exame de saúde e o médico verifica todas as fontes, depois prescreve soluções exatas – qual chave está faltando, qual CLI está errada PATH, qual cookie expirou (#753). Chega de adivinhar por que X voltou magra.
 
-### Pesquisa X, reconstruída
+### X busca, reconstruída
 
-O pipeline X passou por uma revisão completa: pistas FROM e ABOUT para que as próprias postagens de uma pessoa e a conversa sobre elas sejam classificadas (nº 610), desambiguação de subconsulta com reconhecimento de pessoa (nº 611), base de autoria primária com classificação de sinal de interação (nº 613) e uma única fonte X com failover de back-end automático (nº 622). Além de um `--diagnose` honesto que realmente testa a autenticação (# 609).
+O pipeline X passou por uma reformulação de raiz: faixas FROM e ABOUT para que as próprias postagens e a conversa sobre elas sejam classificadas (#610), desambiguação de subquery consciente da pessoa (#611), aterramento de autoria de primeira parte com ranking de sinal de interação (#613), e uma única fonte X com failover automático de backend (#622). Além de um `--diagnose` honesto que realmente sonda a autenticação (#609).
 
-### Mais fontes unidas
+### Mais fontes se juntaram
 
-LinkedIn via ScrapeCreators, com artigos de alto sinal ([@ravstr](https://github.com/ravstr), #702). StockTwits é ativado automaticamente para tópicos de ticker e criptografia ([@wtiwana](https://github.com/wtiwana), #658). A Perplexity aumentou os modos API diretos e Deep Research assíncrona ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn via ScrapeCreators, com artigos como high signal ([@ravstr](https://github.com/ravstr), #702). StockTwits ativa-se automaticamente para tópicos de ticker e cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity cresceu diretamente em modos API e Deep Research assíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Fortalecido pela comunidade
+### Endurecidos pela comunidade
 
-A onda de segurança foi quase inteiramente trabalho comunitário: correções de XSS armazenado no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookie bloqueados, CI reforçado para cadeia de suprimentos com OpenSSF Scorecard e atestado de proveniência de construção ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), verificações Semgrep e OSV-Scanner, além de uma porta de revisão de dependência de PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de teste introduzido em 60% e desde então aumentado para 84% ([@gourab5139014](https://github.com/gourab5139014)) e uma verificação de segurança Hermes limpa de todas as descobertas CRÍTICAS (#768).
+A onda de segurança foi quase inteiramente trabalho comunitário: correções armazenadas em XSS no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookies bloqueados, CI reforçado na cadeia de suprimentos com OpenSSF Scorecard e atestação de proveniência de compilações ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), varreduras Semgrep e OSV-Scanner além de uma porta de revisão de dependência PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de testes introduzido a 60% e desde então elevado para 84% ([@gourab5139014](https://github.com/gourab5139014)), e uma varredura de segurança Hermes limpa de todas as descobertas CRÍTICAS (#768).
 
 ### Alcança mais longe
 
-Idiomas hebraico e não latino ([@dudyme](https://github.com/dudyme)). Tokenização compatível com CJK para fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade do Windows. Extração de cookies em toda a família Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - além de fontes de credenciais macOS Keychain e Linux pass(1). Lookback histórico de `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 provisionado automaticamente via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leitura das páginas de empregos de uma empresa. Deltas da lista de observação entre execuções.
+Hebraico e línguas não latinas ([@dudyme](https://github.com/dudyme)). Tokenização consciente de CJKpara fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade Windows . Extração de cookies em toda a família Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - além de fontes de credenciais macOS Keychain e Linux pass(1). `--as-of` retrospecto histórico ([@chiyi-creator](https://github.com/chiyi-creator)). Provisão automática Python 3.12 via UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leitura das páginas de empregos de uma empresa. Deltas da lista de observação entre as execuções.
 
-### Ainda na caixa da v3
+### Ainda está na caixa da v3
 
-As bases da v3 ainda estão aqui: o cérebro de pré-pesquisa que resolve os identificadores, subreddits e hashtags corretos antes que uma única chamada de API seja disparada (construída por [@j-sperling](https://github.com/j-sperling)); Best Takes pontua em humor e viralidade junto com relevância; fusão de cluster de origem cruzada; comparações de passagem única (“CLI vs MCP” em 3 minutos, não 12); comparações `--competitors` descobertas automaticamente; Modo pessoal do GitHub (`--github-user=steipete`); Modo ELI5 (“eli5 on” após qualquer execução); e resumos HTML independentes e compartilháveis ​​(`--emit=html`). Os botões de configuração ficam em [CONFIGURATION.md](CONFIGURATION.md).
+As bases da v3 ainda estão todas aqui: o cérebro pré-pesquisa que resolve os handles, subreddits e hashtags corretos antes de uma única chamada API ser lançada (criado por [@j-sperling](https://github.com/j-sperling)); Best Takes pontuação para humor e viralidade junto com relevância; fusão de clusters entre fontes; comparações em passagem única ("CLI vs MCP" em 3 minutos, não 12); comparações `--competitors` descobertas automaticamente; modo pessoa GitHub (`--github-user=steipete`); modo ELI5 ("eli5 ligado" após qualquer execução); e briefs HTML compartilháveis e autônomos (`--emit=html`). Knobs de configuração vivem em [CONFIGURATION.md](CONFIGURATION.md).
 
-## Instalar
+## Instalação
 
-| Superfície | Instalar | Atualizações |
+| Superfície | Instalação | Atualizações |
 |---------|---------|---------|
-| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automático via marketplace ou `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` e depois `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI ou qualquer um dos mais de 50 [hosts do Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e carregue via claude.ai > Personalizar > Habilidades > + > Criar habilidade > Carregar uma habilidade | Baixe novamente e carregue novamente |
-| **Claude Desktop** | [Baixe o `.mcpb` para sua plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Configurações > Extensões | Baixe novamente e arraste o novo pacote para |
+| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automóvel via marketplace, ou `claude plugin update last30days@last30days-skill` |
+| **Grok**(Build xAI CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` então `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLIou qualquer um dos 50+ [Agent Skills](https://agentskills.io) apresentadores** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e envie via claude.ai > Personalizar > Habilidades > + > Criar habilidades > Enviar uma habilidade | Rebaixe e refaça o upload |
+| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Configurações > Extensões | Baixe novamente e arraste o novo pacote |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recomendado)
@@ -169,46 +169,46 @@ As bases da v3 ainda estão aqui: o cérebro de pré-pesquisa que resolve os ide
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recomendado porque o mercado Claude Code cuida das atualizações para você – o cache do plug-in é versionado e atualizado automaticamente quando uma nova versão é publicada. Execute `claude plugin update last30days@last30days-skill` para forçar uma verificação.
+Recomendado porque o marketplace Claude Code gerencia as atualizações para você — o cache do plugin é versionado e atualiza automaticamente quando uma nova versão é lançada. Execute `claude plugin update last30days@last30days-skill` para forçar uma verificação.
 
-Se você preferir usar o caminho de instalação de habilidades do agente no Claude Code, isso também é compatível:
+Se preferir usar o caminho de instalação de agentes-skills no Claude Code, isso também é suportado:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-O plugin nativo e a instalação do `npx skills` podem coexistir. Observe que o Claude Code não desduplica os métodos de instalação: se você tiver o plugin do Marketplace e a cópia `npx skills` ativos, `/last30days` mostrará duas entradas. Use um método de instalação por máquina.
+O plugin nativo e a instalação `npx skills` podem coexistir. Note que Claude Code não desduplica entre métodos de instalação: se você tiver tanto o plugin do marketplace quanto a cópia `npx skills` ativados, `/last30days` mostrará duas entradas. Use um método de instalação por máquina.
 
-### Grok (xAI Build CLI)
+### Grok (Build xAI CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala last30days como um plugin nativo. A instalação direta rastreia o repositório:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala o last30days como um plugin nativo. A instalação direta acompanha o repositório:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Ou adicione este repositório como fonte do marketplace e instale pelo nome do plugin:
+Ou adicione esse repositório como uma fonte do marketplace e depois instale pelo nome do plugin:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Adicione `--trust` para ignorar a confirmação de instalação. Atualize com `grok plugin update last30days`. Grok também lê os manifestos do Claude Code para compatibilidade; o par nativo `.grok-plugin/` é a faixa de primeira classe (e para onde aponta uma listagem oficial [xAI marketplace](https://github.com/xai-org/plugin-marketplace)). `npx skills add` continua sendo um substituto válido entre hosts.
+Adicione `--trust` para pular a confirmação da instalação. Atualize com `grok plugin update last30days`. Grok também lê os manifestos Claude Code para compatibilidade; o par nativo de `.grok-plugin/` é a linha de primeira classe (e o que uma listagem oficial [xAI marketplace](https://github.com/xai-org/plugin-marketplace) indica). `npx skills add` permanece um recurso válido entre hosts.
 
-### Codex, Cursor, Copilot, Gemini CLI e outros hosts de Agent Skills
+### Codex, Cursor, Copilot, Gemini CLIe outros Agent Skills hospedeiros
 
-Instale por meio da CLI aberta [Agent Skills](https://agentskills.io) – suporta mais de 50 chicotes, incluindo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` e mais (lista completa no [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Instale via [Agent Skills](https://agentskills.io) CLI aberto — suporta 50+ chicotes incluindo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`e mais (lista completa no [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-O sinalizador `-g` (global) é instalado em seu diretório de usuário para que a habilidade esteja disponível em todos os projetos. Sem `-g`, `npx skills` instala o projeto localmente em `./.skills/` (confirmado com o repositório). Para uma ferramenta de pesquisa do mundo, global é o que você deseja.
+A flag `-g` (global) se instala no seu diretório de usuário, então a habilidade está disponível em todos os projetos. Sem `-g`, `npx skills` instala o projeto localmente no `./.skills/` (comprometido com o repositório). Para uma ferramenta de pesquisa no mundo, global é o que você quer.
 
-O desktop Codex e outros hosts em modo de pasta podem funcionar em pastas comuns, bem como em repositórios Git. Antes da primeira pesquisa, peça ao agente host para executar o `scripts/last30days.py --preflight` incluído no diretório de habilidades carregado; em uma verificação de origem, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra a fonte de configuração, o plano de cookies do navegador, gravações planejadas, comandos opcionais e configuração de projeto ignorado sem ler cookies, gravar arquivos ou executar pesquisas.
+Codex servidores desktop e outros hosts em modo pasta podem funcionar tanto em pastas comuns quanto em repositórios Git. Antes de pesquisar, peça ao agente host para executar o `scripts/last30days.py --preflight` incluído do diretório de skill carregado; em uma verificação de código-fonte, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra a fonte de configuração, plano de cookies do navegador, escritas planejadas, comandos opcionais e configuração ignorada do projeto sem ler cookies, gravar arquivos ou rodar pesquisas.
 
-Por padrão, isso é instalado para qualquer chicote que o `npx skills` detectar. Para atingir um específico (ou vários):
+Por padrão, isso é instalado para o chicote que `npx skills` detectar. Para direcionar um específico (ou vários):
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,13 +217,13 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Atualize mais tarde com:
+Atualização depois com:
 
 ```bash
 npx skills update last30days -g
 ```
 
-Ou atualize tudo o que você instalou globalmente via `npx skills`:
+Ou atualize tudo que você instalou globalmente via `npx skills`:
 
 ```bash
 npx skills update -g
@@ -233,29 +233,29 @@ Liste e remova com `npx skills list -g` e `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) da versão mais recente
-2. Vá para [claude.ai > Personalizar > Skills](https://claude.ai/customize/skills)
-3. Clique no botão `+` no painel Habilidades > clique em `Create skill` > `Upload a skill` e navegue/solte o arquivo
+1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) do lançamento mais recente
+2. Vá para [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Clique no botão `+` no painel de Habilidades > clique em `Create skill` > `Upload a skill` e navegue/coloque o arquivo em
 
-Habilite "Execução de código e criação de arquivo" em Recursos primeiro - as habilidades não serão executadas sem ele.
+Ative "Execução de código e criação de arquivo" primeiro em Capacidades — as habilidades não funcionam sem isso.
 
 ### Claude Desktop
 
-Claude Desktop instala `/last30days` como um servidor MCP por meio de um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
+Claude Desktop instala `/last30days` como um servidor MCP via um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
 
-1. Vá para [lançamento mais recente](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` para sua plataforma:
-- macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-- macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
--Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abra o Claude Desktop, vá para Configurações > Extensões e arraste o arquivo.
-3. Quando solicitado, cole as chaves de API das fontes que deseja ativar. Cada campo é opcional – o mecanismo passa para o modo somente web se você ignorar todos eles. As chaves são armazenadas nas chaves do seu sistema operacional.
-4. Reinicie o Claude Desktop. Peça ao Claude para “pesquisar Peter Steinberger” ou qualquer assunto e ele chamará a ferramenta `research`.
+1. Vá até o [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` para sua plataforma:
+   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Abra Claude Desktop, vá em Configurações > Extensões e arraste o arquivo.
+3. Quando solicitado, cole API chaves para as fontes que deseja ativar. Cada campo é opcional — o motor se degrada para modo apenas web se você pular todos. As chaves são armazenadas no chaveiro do seu sistema operacional.
+4. Reinicie Claude Desktop. Peça para Claude "pesquisar Peter Steinberger" ou qualquer outro tema e ele chamará a ferramenta de `research` .
 
-**Requisito de host:** Python 3.12+ em PATH. O pacote inclui o código-fonte do mecanismo, mas usa seu interpretador Python local. Instale em [python.org](https://www.python.org/downloads/) no Windows; O macOS e a maioria das distribuições Linux fornecem uma versão compatível.
+**Requisito de host:** Python 3.12+ no PATH. O pacote envia a fonte do motor, mas usa seu interpretador local de Python . Instale a partir do [python.org](https://www.python.org/downloads/) no Windows; macOS e a maioria das distros Linux enviam uma versão compatível.
 
-**As chaves não são sincronizadas com a habilidade Código.** Claude Desktop e Claude Code mantêm armazenamentos de credenciais separados por design. Se você já configurou `~/.config/last30days/.env` para a habilidade Código, você inserirá novamente as mesmas chaves aqui uma vez.
+**As chaves não sincronizam com a habilidade Code.** Claude Desktop e Claude Code mantêm armazenamentos de credenciais separados por design. Se você já configurou `~/.config/last30days/.env` para a habilidade Code, vai digitar as mesmas chaves aqui uma vez novamente.
 
-O suporte do Windows é adiado até que os pontos de entrada do manifesto por plataforma sejam resolvidos; acompanhar em uma edição de acompanhamento.
+Windows suporte é adiado até que os pontos de entrada do manifesto por plataforma sejam resolvidos; acompanhe uma edição de acompanhamento.
 
 ### OpenClaw
 
@@ -263,11 +263,11 @@ O suporte do Windows é adiado até que os pontos de entrada do manifesto por pl
 clawhub install last30days-official
 ```
 
-Para fluxos de trabalho de ação X/Twitter fora da pesquisa `/last30days`, como postagem
-tweets ou respostas, exportação de seguidores, manipulação de mídia, monitores e brindes
-desenha, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como companheiro
-Plug-in OpenClaw. TweetClaw é mantido pela Xquik-dev e está listado apenas como um
-caminho complementar opcional, não uma dependência ou endosso de últimos 30 dias.
+Para Xfluxos de trabalho de ação no /Twitter fora da pesquisa `/last30days` , como postar
+Tweets ou respostas, exportação de seguidores, gerenciamento de mídia, monitores e sorteios
+Draws, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como companheiro
+OpenClaw plugin. TweetClaw é mantido pelo Xquik-dev e é listado apenas como um
+Caminho de companheiro opcional, não uma dependência ou endosso de Last30days.
 
 ### Manual (desenvolvedor)
 
@@ -276,30 +276,30 @@ git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-O link simbólico mantém a instalação sincronizada com sua árvore de trabalho enquanto você edita - não é necessária nova cópia. Para `claude.ai`, crie o arquivo `.skill` a partir da origem: `bash skills/last30days/scripts/build-skill.sh` produz `dist/last30days.skill`.
+O symlink mantém a instalação sincronizada com sua árvore de trabalho enquanto você edita — não é necessário re-copiar. Para `claude.ai`, construa o arquivo `.skill` a partir da fonte: `bash skills/last30days/scripts/build-skill.sh` produz `dist/last30days.skill`.
 
-Reddit (com comentários), Hacker News, Polymarket e GitHub funcionam imediatamente. Configuração nula. Execute `/last30days` uma vez e o assistente de configuração desbloqueia mais fontes em 30 segundos, incluindo as CLIs gratuitas arXiv e Techmeme.
+Reddit (com comentários), Hacker News, Polymarkete GitHub funcionam imediatamente. Configuração zero. Execute `/last30days` uma vez e o assistente de configuração desbloqueia mais fontes em 30 segundos, incluindo o arXiv gratuito e Techmeme CLIs.
 
 ## Traga suas próprias chaves
 
-Essas plataformas não se relacionam entre si. X não sabe o que o Reddit pensa. O YouTube não vê o TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador e, de repente, terá acesso a todos eles de uma vez.
+Essas plataformas não têm relações entre si. X não sabe o que Reddit pensa. YouTube não vê TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador, e de repente tem acesso a todos ao mesmo tempo.
 
 | Fontes | O que você precisa | Custo |
 |---------|---------------|------|
 | Reddit (com comentários) + HN + Polymarket + GitHub + StockTwits | Nada | Grátis |
-| arXiv + Techmeme | CLIs gratuitas, instaladas automaticamente pela configuração inicial | Grátis |
-| X/Twitter | Faça login em x.com em qualquer navegador ou defina `XQUIK_API_KEY` / `XAI_API_KEY` | Os cookies do navegador são gratuitos; as chaves são específicas do provedor |
+| arXiv + Techmeme | Free CLIs, instalado automaticamente pela primeira vez | Grátis |
+| X / Twitter | Faça login em x.com em qualquer navegador, ou configure `XQUIK_API_KEY` / `XAI_API_KEY` | Cookies do navegador são gratuitos; as chaves são específicas do provedor |
 | YouTube | `brew install yt-dlp` | Grátis |
-| Céu Azul | Senha do aplicativo de bsky.app | Grátis |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentários no YouTube | Chave ScrapeCreators | 10.000 chamadas gratuitas e PAYG |
-| Xiaohongshu (VERMELHO) | Execute um plug-in de navegador x-mcp conectado ou serviço `xiaohongshu-mcp` e opte por `--search xhs` por execução ou `INCLUDE_SOURCES=xiaohongshu` em `.env`; last30days sonda automaticamente `http://localhost:18060` e depois `http://host.docker.internal:18060` ou use `XIAOHONGSHU_API_BASE` para um URL personalizado | Nenhuma chave de API dos últimos 30 dias; depende do serviço de sessão do navegador local |
-| DripStack (boletins financeiros premium) | Aceitação: `--search dripstack` por execução ou `INCLUDE_SOURCES=dripstack` em `.env` | Sem chave; API de pesquisa pública gratuita |
-| Sonar Perplexity / API de pesquisa / Pesquisa profunda | Chave de perplexidade ou chave OpenRouter como substituto do Sonar | Pague conforme usar |
-| Pesquisa na web | Chave de pesquisa corajosa | 2.000 consultas gratuitas/mês |
+| Bluesky | Senha do aplicativo do bsky.app | Grátis |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comentários | ScrapeCreators chave | 10.000 chamadas grátis, depois PAYG |
+| Xiaohongshu (RED) | Execute um plugin de navegador x-mcp logado ou serviço `xiaohongshu-mcp` e opte por `--search xhs` por execução ou `INCLUDE_SOURCES=xiaohongshu` no `.env`; last30days auto-sonda `http://localhost:18060` depois `http://host.docker.internal:18060`, ou use `XIAOHONGSHU_API_BASE` para uma URL personalizada | Sem chave de API de últimos 30 dias; depende do seu serviço local de sessão de navegador |
+| DripStack (boletins financeiros premium) | Opt-in: `--search dripstack` por tentativa, ou `INCLUDE_SOURCES=dripstack` em `.env` | Sem chave; busca pública gratuita API |
+| Perplexity Sonar / API de busca / Pesquisa Profunda | Perplexity chave, ou chave OpenRouter como recurso de replio do Sonar | Pague conforme a vida |
+| Web busca | Chave Brave Search | 2.000 consultas gratuitas/mês |
 
-### Chaveiro macOS (opcional)
+### macOS Keychain (opcional)
 
-No macOS, você pode armazenar chaves nas chaves do sistema em vez de um arquivo `.env`. A habilidade os seleciona automaticamente como a fonte de menor prioridade – os arquivos `.env` e o ambiente do processo ainda vencem na colisão.
+No macOS você pode armazenar chaves no Keychain do sistema em vez de um arquivo `.env` . A habilidade as detecta automaticamente como a fonte de menor prioridade — `.env` arquivos e o ambiente de processos ainda vencem em colisão.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +313,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Os itens são armazenados sob o nome de serviço `last30days-<KEY>` para o usuário atual. Em plataformas não Darwin, o carregador não funciona, portanto não há mudança de comportamento para usuários de Linux/Windows.
+Os itens são armazenados sob `last30days-<KEY>` de nome de serviço para o usuário atual. Em plataformas que não são Darwin, o loader é um no-op, então não há mudança de comportamento para usuários Linux/Windows .
 
-Já possui chaves com nomes de serviço de chaveiro diferentes? Defina o mapeamento `LAST30DAYS_KEYCHAIN_ALIASES` não secreto descrito em [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) em vez de copiar segredos.
+Já tem chaves sob nomes de serviço Keychain diferentes? Defina o mapeamento de `LAST30DAYS_KEYCHAIN_ALIASES` não secreto descrito no [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) em vez de copiar segredos.
 
-Consulte [CONFIGURATION.md](CONFIGURATION.md) para obter a matriz de chaves completa por fonte, prioridade do provedor de raciocínio e prioridade de back-end de pesquisa na web.
+Veja [CONFIGURATION.md](CONFIGURATION.md) para a matriz completa de chaves por fonte, prioridade do provedor de raciocínio e prioridade backend de busca web.
 
 ## Configuração
 
 Duas coisas que você provavelmente vai querer saber no primeiro dia:
 
-**Onde os arquivos de pesquisa são salvos.** O padrão de `LAST30DAYS_MEMORY_DIR` é `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Substitua definindo esse env var para qualquer caminho em seu shell ou `--save-dir <path>` por execução. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, usando o formato selecionado por `--emit`. Use `--save-suffix=<name>` para manter separadas diversas variações do mesmo tópico (por exemplo, por cliente). Cada execução de `--save-dir` produz `<slug>-raw[-suffix].md`. Execute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar as gravações planejadas antes de uma execução de pesquisa.
+**Onde os arquivos de pesquisa são salvos.** `LAST30DAYS_MEMORY_DIR` padrão é `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Sobrescreva definindo essa var ambientalmente para qualquer caminho no seu shell, ou `--save-dir <path>` por execução. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, usando o formato selecionado por `--emit`. Use `--save-suffix=<name>` para manter múltiplas variações do mesmo tópico separadas (por exemplo, por cliente). Cada execução `--save-dir` produz `<slug>-raw[-suffix].md`. Execute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar as escritas planejadas antes de uma execução de pesquisa.
 
-**Saída estruturada para agentes e fluxos de trabalho.** Solicite ao `/last30days` JSON legível por máquina para receber o perfil de agente estável e com versão. Para uso direto do mecanismo em scripts ou desenvolvimento, execute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; adicione `--json-profile=raw` somente quando precisar do dump `Report` interno não versionado. Consulte a [referência do campo de exportação JSON e política de controle de versão](docs/reference/json-export.md).
+**Saída estruturada para agentes e fluxos de trabalho.** Peça `/last30days` JSON legíveis por máquina para receber o perfil estável e versionado do agente. Para uso direto do motor em scripts ou desenvolvimento, execute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; adicione `--json-profile=raw` apenas quando precisar do despejo interno de `Report` sem versão. Veja o [JSON export field reference and versioning policy](docs/reference/json-export.md).
 
-**Descoberta sem tópico.** Peça ao `/last30days what's trending in AI agents?` para obter um resumo de descoberta classificado em vez de pesquisar um tópico que você já conhece - em um host de agente, isso executa o protocolo julgado por host de três comandos (o modelo nomeia tópicos, filtra lixo, pontua valor e escreve os ângulos de conteúdo). Para uso direto do mecanismo em scripts ou cron, execute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nomes de tópicos determinísticos, sem ângulos); adicione `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um tópico posicional e `--drill`.
+**Descoberta sem tópico.** Peça `/last30days what's trending in AI agents?` para obter um briefing de descoberta ranqueado em vez de pesquisar um tema que você já conhece – em um host agente, isso executa o protocolo de três comandos avaliados pelo host (o modelo nomeia tópicos, filtra lixo, avalia a dignidade e escreve os ângulos de conteúdo). Para uso direto do motor em scripts ou cron, execute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nomes determinísticos de tópicos, sem ângulos); adicione `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um tópico posicional e `--drill`.
 
-**Monitoramento de tendências entre execuções.** O modo padrão produz um novo instantâneo de redução por execução. Para acumular descobertas ao longo do tempo, adicione `--store` para persistir em um banco de dados SQLite e, em seguida, use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com entrega opcional de Slack/webhook em novas descobertas) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resumos diários/semanais. O padrão de cadência completo está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Monitoramento de tendências entre execuções.** O modo padrão produz um novo snapshot de markdown por execução. Para acumular descobertas ao longo do tempo, adicione `--store` para persistir em um banco de dados SQLite, depois use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com entrega opcional por Slack / webhook em novas descobertas) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para digestos diários/semanais. O padrão completo de cadência está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Uma biblioteca de pesquisa que pode ser assinada.** Peça ao `/last30days` para criar o feed da sua biblioteca ou use `python3 skills/last30days/scripts/last30days.py library feed` diretamente para scripts e desenvolvimento. Ele transforma resumos salvos em `index.html`, um Atom local `feed.xml` e páginas de resumos legíveis. Adicione `--publish` somente quando desejar que o índice HTML e as páginas resumidas sejam hospedados; a publicação é de aceitação explícita e pública por padrão. Para tornar o feed Atom subscrito, hospede o diretório de saída gerado em um host estático, como GitHub Pages.
+**Uma biblioteca de pesquisa para assinantes.** Peça `/last30days` para construir seu feed de biblioteca, ou use- `python3 skills/last30days/scripts/last30days.py library feed` diretamente para scripts e desenvolvimento. Ele transforma briefs salvos em `index.html`, um `feed.xml`local do Atom e páginas breves legíveis. Adicione `--publish` apenas quando quiser que o índice HTML e as páginas de resumos sejam hospedados; a publicação é explícita com opt-in e pública por padrão. Para tornar o feed do Atom assinável, hospede o diretório de saída gerado em um host estático, como GitHub Pages.
 
-**Pesquise tudo o que você pesquisou.** Pergunte a `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para uso direto do motor, execute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A pesquisa é off-line e determinística: ela indexa de forma incremental os mesmos resumos salvos usados ​​pelo feed da biblioteca, mescla as visualizações de lojas correspondentes por execução e agrupa os resultados por tópico e data. Novas versões também aparecem em uma seção compacta **Da sua biblioteca** quando pesquisas anteriores se sobrepõem ao tópico atual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para desabilitar esse contexto passivo.
+**Pesquise tudo o que você pesquisou.** Pergunte `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para uso direto do motor, execute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A busca é offline e determinística: ela indexa incrementalmente os mesmos briefs salvos usados pelo feed da biblioteca, mescla os avistamentos correspondentes a cada rodada da loja e agrupa os resultados por tópico e data. Execuções novas também apresentam uma seção compacta **Da sua biblioteca** quando pesquisas anteriores sobrepõem ao tema atual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para desabilitar esse contexto passivo.
 
-Scripts de wrapper por cliente, subreddits de categoria personalizada e o canal beta experimental para personalizações em andamento também estão documentados em [CONFIGURATION.md](CONFIGURATION.md).
+Scripts wrapper por cliente, subreddits personalizados de categorias peer e o canal beta experimental para personalizações em andamento também são documentados em [CONFIGURATION.md](CONFIGURATION.md).
 
-## Showcase: feeds de pesquisa da comunidade
+## Vitrine: feeds de pesquisa comunitária
 
-Publicou uma atualização recorrente de IA, observação do mercado ou uma obsessão maravilhosamente restrita com os últimos 30 dias? Compartilhe o URL da biblioteca pública — ou o URL Atom após hospedar `feed.xml` em um host estático — no [thread de demonstração da comunidade](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade serão vinculados aqui à medida que seus proprietários os enviarem; o tópico é o ponto de coleta enquanto isso.
+Publicou uma atualização recorrente de IA, observação de mercado ou uma obsessão maravilhosamente restrita com os últimos 30 dias? Compartilhe a URL da biblioteca pública — ou a URL do Atom após hospedar `feed.xml` em um host estático — em [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade estarão linkados aqui conforme seus proprietários os enviarem; o tópico é o ponto de coleta enquanto isso.
 
 ## Como funciona
 
-1. **Você digita um tópico.** Pessoa, empresa, produto, tecnologia, "X vs Y". Qualquer coisa.
-2. **O agente decide quem é importante.** Encontra X identificadores (incluindo fundadores), repositórios GitHub, subreddits, hashtags TikTok, canais do YouTube. Para "Kanye West" conhece r/hiphopheads, @kanyewest e "bully review" no YouTube. Para "OpenClaw", ele resolve openclaw/openclaw no GitHub e busca contagens de estrelas ao vivo.
-3. **Todas as fontes pesquisadas em paralelo.** Expansão multiconsulta. Resultados pontuados por engajamento, relevância, atualização.
-4. **A profundidade que ninguém mais tem.** Transcrições completas do YouTube de vídeos de reação. Principais comentários do Reddit com contagens de votos positivos. Legendas do TikTok. Probabilidades de polimercado. Não apenas títulos e links.
-5. **Mesma história, mesclada.** Wireless Festival anunciado no Reddit, discutido no X, preços dos ingressos no TikTok = um cluster, não três itens separados.
-6. **Sintetizado em um resumo.** Baseado em dados específicos. Citado pela fonte. Classificado de acordo com o que as pessoas realmente interagem. Não "aqui está o que encontrei". É "aqui está o que importa".
-7. **Então ele se torna seu especialista.** Após uma execução, sua sessão com Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Faça-o escrever avisos, redigir e-mails, planejar viagens, arquitetar sistemas - tudo baseado no que é real no momento.
+1. **Você digita um tópico.** Pessoa, empresa, produto, tecnologia, "X vs Y." Qualquer coisa.
+2. **O agente resolve quem importa.** Encontra X usuários (incluindo fundadores), repositórios GitHub , subreddits TikTok hashtags YouTube canais. Para "Kanye West", ele conhece r/hiphopheads, @kanyeweste "bully review" no YouTube. Para "OpenClaw", resolve openclaw/openclaw no GitHub e busca contagens de estrelas ao vivo.
+3. **Todas as fontes buscadas em paralelo.** Expansão multi-consulta. Resultados avaliados por engajamento, relevância e frescura.
+4. **A profundidade que ninguém mais tem.** Transcrições YouTube completas de vídeos de reação. Comentários Reddit principais com contagem de votos positivos. TikTok legendas. Polymarket probabilidades. Não só títulos e links.
+5. **Mesma história, fundida.** O Wireless Festival anunciou em Reddit, discutido no X, preços dos ingressos em TikTok = um cluster, não três itens separados.
+6. **Sintetizado em um único resumo.** Baseado em dados específicos. Citado por fonte. Classificado pelo que as pessoas realmente se envolvem. Não "aqui está o que eu encontrei." É "aqui está o que importa."
+7. **Então ele se torna seu especialista.** Após uma única tentativa, sua sessão Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Faça com que ele escreva prompts, relabore e-mails, planeje viagens, arquitetede sistemas – tudo baseado no que é real agora.
 
 ## O que as pessoas estão dizendo
 
-> "Encontrei uma habilidade do Claude Code que pesquisa qualquer tópico no Reddit, X, YouTube e HN dos últimos 30 dias. Em seguida, escreve as instruções para você. Tenho pesquisado manualmente no Reddit e no X antes de cada conteúdo que escrevo. Guia por guia. Tópico por tópico. Essa é a parte que leva 90 minutos. Isso a elimina." -@itsjasonai
+> "Encontrei uma habilidade Claude Code que pesquisa qualquer tema em Reddit, X, YouTubee HN dos últimos 30 dias. Depois escreve os prompts para você. Tenho pesquisado manualmente Reddit e X pesquisas antes de cada conteúdo que escrevo. Aba por aba. Thread por thread. Essa é a parte que leva 90 minutos. Isso elimina isso." -@itsjasonai
 
-> "Essa habilidade substituiu todo o meu fluxo de trabalho de pesquisa. Você dá um tópico a ele, ele vasculha o Reddit, o X e a web para saber o que as pessoas estão realmente falando. Não são postagens antigas de blog. Conversas reais dos últimos 30 dias." -@itswilsoncharles
+> "Essa habilidade substituiu todo o meu fluxo de trabalho de pesquisa. Você dá um tema, ele raspa Reddit, X, e a web para encontrar o que as pessoas realmente estão falando. Não posts antigos de blog. Conversas reais dos últimos 30 dias." -@itswilsoncharles
 
-> "5 dos 10 repositórios populares no GitHub hoje são ferramentas Claude. #1: mvanhorn/last30days-skill" -@yieldhunter95
+> "5 dos 10 repositórios em alta no GitHub hoje são Claude ferramentas. #1: Mvanhorn/last30days- habilidade" -@yieldhunter95
 
 ## Código aberto
 
-Licença do MIT. Sem rastreamento. Sem análises. Sua pesquisa permanece em sua máquina. Mais de 2.700 testes.
+Licença do MIT. Sem rastreamento. Sem análises. Sua pesquisa fica na sua máquina. 2.700+ testes.
 
-Construído com Python 3.12+, yt-dlp, Node.js (cliente Bird vendido para pesquisa X) e API ScrapeCreators. arquitetura do mecanismo v3 por [@j-sperling](https://github.com/j-sperling).
+Construído com Python 3.12+, YT-DLP, Node.js (cliente Bird fornecido para X busca) e ScrapeCreators API. arquitetura do motor v3 pela [@j-sperling](https://github.com/j-sperling).
 
-Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para abrir um PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para obter a lista completa de contribuidores da comunidade e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
+Veja [CONTRIBUTING.md](CONTRIBUTING.md) para abrir uma PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para a lista completa de colaboradores da comunidade e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
 
-## História da estrela
+## História da Star
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,382 @@
+# /last30days
+
+[English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | Português (Brasil) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+
+<p align="center">
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/mvanhorn/last30days-skill">
+    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
+  </a>
+  <br/>
+  <a href="https://trendshift.io/repositories/21997" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
+</p>
+
+**Um mecanismo de pesquisa liderado por agentes de IA pontuado por votos positivos, curtidas e dinheiro real - não por editores.**
+
+Este README rastreia o pipeline v3 atual. A especificação de habilidade de tempo de execução reside em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a fonte da verdade para o comando e comportamento de configuração mais recentes.
+
+**Claude Code (recomendado — atualizações automáticas via marketplace):**
+```
+/plugin marketplace add mvanhorn/last30days-skill
+/plugin install last30days
+```
+
+**Codex, Cursor, Copilot, Gemini CLI ou qualquer um dos mais de 50 [hosts do Agent Skills](https://agentskills.io):**
+```
+npx skills add mvanhorn/last30days-skill -g
+```
+(`-g` é instalado globalmente para seu usuário, disponível em todos os projetos. Coloque-o no escopo por projeto.)
+
+Mais opções de instalação (claude.ai web, OpenClaw, manual) na seção [Install](#instalação) abaixo.
+
+Configuração zero. Reddit, HN, Polymarket e GitHub funcionam imediatamente. Execute-o uma vez e o assistente de configuração desbloqueia X, YouTube, TikTok, arXiv, Techmeme e muito mais em 30 segundos.
+
+---
+
+Votos positivos do Reddit. X gosta. Transcrições do YouTube. Engajamento do TikTok. Probabilidades do Polymarket apoiadas por dinheiro real e informações privilegiadas. São milhões de pessoas votando com sua atenção e suas carteiras todos os dias. /last30days pesquisa tudo em paralelo, pontua de acordo com o que as pessoas reais realmente interagem e um juiz agente de IA sintetiza tudo em um resumo.
+
+O Google agrega editores. /last30days pesquisa pessoas.
+
+Você não pode obter essa pesquisa em nenhum outro lugar porque nenhuma IA tem acesso a tudo isso. A pesquisa do Google não aborda comentários do Reddit ou postagens X. ChatGPT tem acordo com Reddit, mas não consegue pesquisar X ou TikTok. Gemini tem YouTube, mas não Reddit. Claude não tem nenhum deles nativamente. Cada plataforma é um jardim murado com sua própria API, seus próprios tokens, sua própria autenticação. Mas você pode trazer suas próprias chaves e sessões do navegador e, de repente, um agente de IA pode pesquisar todas elas de uma vez, compará-las entre si e dizer o que realmente importa.
+
+Esse é o desbloqueio. Nenhum mecanismo de pesquisa melhor. Uma dúzia de plataformas desconectadas, interligadas por um agente.
+
+```
+/last30days Peter Steinberger
+```
+
+Você tem uma reunião amanhã. Você os pesquisa no Google. Você obtém o LinkedIn de 2023. /last30days mostra o que eles realmente estão fazendo este mês: juntou-se à OpenAI para trabalhar no Codex, lutando contra a proibição da Anthropic de agentes terceirizados, enviando 23 PRs com taxa de mesclagem de 85%, construindo "LobsterOS" para controle de agente entre dispositivos e r/ClaudeCode atingiu 569 votos positivos debatendo se ele é um herói ou "insuportável". Espalhados por postagens X, tópicos do Reddit, transcrições do YouTube e commits do GitHub. Nada disso estava no Google.
+
+## Por que isso existe
+
+Eu o construí para acompanhar a IA. Tudo muda todos os dias e os nerds do Reddit e do X estão sempre por dentro disso. Eu precisava de instruções melhores, e os dados de treinamento estavam sempre meses atrás do que a comunidade já havia descoberto.
+
+Mas isso se transformou em algo maior. Agora eu o executo antes de uma ligação de vendas para saber a verdade dos últimos 30 dias sobre um negócio. Antes de uma reunião, para ler os tweets recentes e as transcrições de podcast de alguém. Antes de uma viagem à Disney World para saber quais atrações estão fechadas e o que a comunidade diz sobre o Genie+. Antes de construir qualquer coisa, quero saber quais problemas as pessoas estão realmente enfrentando.
+
+Se você estiver se reunindo com um CEO, leu todos os tweets e transcrições do YouTube dos últimos 30 dias? Eu tenho.
+
+## Fontes, pontuadas pelo povo
+
+| Fonte | O que as pessoas dizem para você |
+|--------|--------------------------|
+| **Reddit** | A tomada não filtrada. Principais comentários com contagens reais de votos positivos, gratuitos e sem chave de API. As verdadeiras opiniões que o Google enterra. |
+| **X/Twitter** | A tomada quente, o tópico especializado, a reação de ruptura. Primeiro a saber, primeiro a discutir. |
+| **YouTube** | O mergulho profundo de 45 minutos. As transcrições completas procuraram as 5 frases citáveis ​​​​que importam. |
+| **TikTok** | O criador alcançando 3,6 milhões de pessoas com um take que você nunca encontrará no Google. |
+| **Instagram Reels** | A perspectiva do influenciador com transcrições de palavras faladas. O sinal da cultura visual. |
+| **Notícias sobre hackers** | O consenso do desenvolvedor. 825 pontos, 899 comentários. Onde os técnicos realmente discutem. |
+| **Polymarket** | Não opiniões. Chances. Apoiado em dinheiro real. 96% de confiança nas vendas de álbuns. 4% em uma aquisição. |
+| **GitHub** | Para pessoas: velocidade de relações públicas, principais repositórios por estrelas, notas de lançamento. Para tópicos: questões e discussões. |
+| **Digg** | Clusters de histórias selecionados da tabela de classificação AI 1000 do Digg (cerca de 1.000 contas de IA de alto sinal no X), com cotações inline atribuíveis (sem necessidade de autenticação X). Ativado automaticamente quando `digg-pp-cli` está em PATH. |
+| **arXiv** | Os jornais por trás do hype. Nova pesquisa na janela, gratuita, sem chave de API. Ativado automaticamente quando `arxiv-pp-cli` está em PATH (a configuração na primeira execução o instala). |
+| **Tecmeme** | A camada editorial de notícias de tecnologia, com janela de data de 30 dias. Gratuito, sem chave de API. Ativado automaticamente quando `techmeme-pp-cli` está em PATH (a configuração na primeira execução o instala). |
+| **LinkedIn** | O sinal profissional. Postagens e artigos, com artigos considerados de alto sinal. |
+| **StockTwits** | Sentimento do comerciante. Ativa automaticamente quando o seu tópico é um ticker ou criptografia. |
+| **Tópicos** | A camada de texto pós-Twitter. Conversas de criadores e marcas. |
+| **Pinterest** | Descoberta visual. Pins, salvamentos e comentários sobre produtos e ideias. |
+| **Xiaohongshu (VERMELHO)** | Sinais de estilo de vida, produto e criador chineses. Solicitado explicitamente com `--search xhs` quando um plug-in de navegador x-mcp conectado ou serviço `xiaohongshu-mcp` está sendo executado localmente. |
+| **Céu Azul** | A camada social descentralizada. Postagens do Protocolo AT da migração pós-Twitter. |
+| **Perplexidade** | Síntese do Grounded Sonar, linhas brutas da API de pesquisa e pesquisa profunda. |
+| **Web** | A cobertura editorial, as comparações do blog. Um sinal entre muitos, não o único. |
+
+Os contribuidores da comunidade continuam adicionando mais. Truth Social e outras fontes de nicho estão no motor com mais a caminho.
+
+Um tópico do Reddit com 1.500 votos positivos é um sinal mais forte do que uma postagem de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações conta mais sobre o que é culturalmente relevante do que um comunicado à imprensa. As probabilidades do Polymarket apoiadas por um volume de US$ 66 mil são mais difíceis de argumentar do que a suposição de um especialista.
+
+A síntese classifica aquilo com que as pessoas reais realmente se engajaram. Relevância social, não relevância de SEO.
+
+## Para que as pessoas realmente o usam
+
+**Antes de uma reunião.** `/last30days Peter Steinberger` - juntou-se à equipe Codex da OpenAI, lutando contra a proibição da Anthropic de agentes terceirizados, 23 PRs se fundiram a uma taxa de mesclagem de 85% no GitHub, construindo o LobsterOS para controle de agente entre dispositivos. r/ClaudeCode: "Desde o lançamento do OpenClaw, era amplamente conhecido que se você executá-lo por meio de qualquer coisa que não fosse a API, você acabaria sendo banido" (227 votos positivos). Isso não está no LinkedIn.
+
+**Para ler os sinais de contratação.** `/last30days Listen Labs --hiring-signals` - as páginas atuais de empregos e carreiras tornam-se evidências citadas de mudanças de foco: contratação para segurança empresarial, sucesso do cliente, infraestrutura ou expansão de produtos. O relatório diz o que a contratação parece sinalizar, e não o que o roteiro irá fornecer.
+
+**Para encontrar o tópico antes que ele atinja o pico.** Pergunte a `/last30days what's exploding in AI agents?` e a habilidade muda para o modo de descoberta: o mecanismo varre as listagens de categorias do Reddit, as principais/melhores histórias do Hacker News, o feed AI 1000 do Digg e X quando autenticado; seu agente julga as nomeações (nomes, filtragem de lixo eletrônico, valor do conteúdo) e escreve ângulos de podcast/artigo X; então você obtém de 5 a 10 tópicos classificados por velocidade. Cada resultado inclui números de fontes cruzadas, um rótulo de impulso e um acompanhamento `/last30days "<topic>"` pronto para execução.
+
+**Quando algo cai.** `/last30days Kanye West` - O Reino Unido bloqueou seu visto, o Wireless Festival foi cancelado, os patrocinadores fugiram. Mas BULLY estreou em segundo lugar na Billboard. Fantano voltou de seu "Yay sabático" para revisá-lo (653 mil visualizações). SoFi Homecoming trouxe Lauryn Hill e Travis Scott para 44 músicas. Polymarket: "Kanye vai twittar de novo?" 86% Sim. 23 tópicos do Reddit, 17 vídeos do YouTube, 86 mil votos positivos.
+
+**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Estes não são concorrentes, são camadas." OpenClaw é o executor (351 mil estrelas do GitHub, ao vivo), Hermes é o cérebro que se aprimora (31 mil estrelas), Paperclip é o organograma (49 mil estrelas). Contagens de estrelas extraídas ao vivo da API do GitHub, e não de postagens de blog obsoletas. Tabela lado a lado com arquitetura, memória, segurança, best-for. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
+
+**Para entender o mundo.** `/last30days Iran vs USA` - Dia 38 da guerra. O prazo de terça-feira de Trump para o Irã reabrir o Estreito de Ormuz. Dois aviões de guerra dos EUA abatidos. Petróleo a US$ 126/barril. A AIE chamou-a de “a maior interrupção no fornecimento na história do mercado global de petróleo”. Polymarket: cessar-fogo até 31 de dezembro em 74%. 27 postagens X, 10 vídeos no YouTube, 20 mercados de previsão.
+
+**Antes de uma viagem.** `/last30days Universal Epic Universe` - Ampliação já em construção. Licença do "Projeto 680" arquivada. Espetáculo de fogos de artifício confirmado pela infraestrutura, mas sem aviso prévio. Tempos de espera: Mine-Cart Madness com média de 148 minutos. Ainda não há passe anual e os moradores locais estão frustrados. Stardust Racers será reformado até 5 de abril.
+
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - Prompts estruturados em JSON estão substituindo a sopa de tags. O formato aninhado do @pictsbyai evita "sangramento de conceito". O fluxo de trabalho que prioriza a edição supera a regeneração. Em seguida, ele escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
+
+## O que há de novo
+
+Desde o anúncio da v3.3 em maio, até a v3.11.1 (julho de 2026): 175 PRs mesclados - 122 deles de 52 colaboradores da comunidade - em 15 versões. Isto é o que pousou.
+
+### Primeira classe no OpenAI Codex
+
+/last30days agora é um plugin nativo do Codex com configuração guiada - não uma porta, um cidadão de primeira classe. Citações com reconhecimento de renderizador significam que a saída do Codex é lida como um resumo em vez de uma sopa de URL (# 694), e o mesmo mecanismo é executado em hosts Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw e mais de 50 Agent Skills. Manifesto do plugin Codex por [@rfoust](https://github.com/rfoust) (#686), correção de autenticação do Codex por [@tmchow](https://github.com/tmchow) (#698).
+
+### arXiv, Techmeme e Digg - gratuitos, sem chaves de API
+
+arXiv traz os documentos por trás do hype e Techmeme traz a camada editorial de notícias técnicas - grátis, sem chaves e com configuração de primeira execução que instala suas CLIs para que sejam ativadas automaticamente (# 709). Os clusters de histórias AI 1000 do Digg chegam sem autenticação X da mesma maneira - a configuração instala a CLI gratuita do Digg para você (#590). A Trustpilot oferece opt-in para pesquisas de marcas de consumo.
+
+### Reddit gratuito aumentou pontuações reais e comentários principais
+
+A API .json pública do Reddit morreu; o caminho livre voltou mais forte. Keyless RSS + scraping de Shreddit (#457), descoberta de subreddit dedicado com contagens reais de votos positivos via Arctic-Shift (#696) e um piso de relevância para que uma postagem viral fora do tópico não possa sequestrar seu briefing (#488, obrigado [@rzachsmith](https://github.com/rzachsmith)). Nenhuma chave de API. Pontuações reais. Principais comentários incluídos.
+
+### Os melhores comentários em cada briefing
+
+Os comentários agora são uma camada padrão em todas as fontes: comentários do Instagram com diversidade baseada em classificação para que cinco tomadas interessantes não venham todas de uma postagem (# 751), comentários do YouTube mais um backup de transcrição do ScrapeCreators para quando yt-dlp for eliminado (# 637) e comentários votados pelo público ponderados em Melhores tomadas para que as falas mais engraçadas da comunidade sobrevivam à pontuação (# 592, # 608).
+
+### Um comando médico
+
+Solicite uma verificação de integridade e o médico executará todas as fontes e, em seguida, prescreverá as correções exatas - qual chave está faltando, qual CLI está fora do PATH, qual cookie expirou (#753). Chega de adivinhar por que X voltou magro.
+
+### Pesquisa X, reconstruída
+
+O pipeline X passou por uma revisão completa: pistas FROM e ABOUT para que as próprias postagens de uma pessoa e a conversa sobre elas sejam classificadas (nº 610), desambiguação de subconsulta com reconhecimento de pessoa (nº 611), base de autoria primária com classificação de sinal de interação (nº 613) e uma única fonte X com failover de back-end automático (nº 622). Além de um `--diagnose` honesto que realmente testa a autenticação (# 609).
+
+### Mais fontes unidas
+
+LinkedIn via ScrapeCreators, com artigos de alto sinal ([@ravstr](https://github.com/ravstr), #702). StockTwits é ativado automaticamente para tópicos de ticker e criptografia ([@wtiwana](https://github.com/wtiwana), #658). A Perplexity aumentou os modos API diretos e Deep Research assíncrona ([@sk-holmes](https://github.com/sk-holmes), #629).
+
+### Fortalecido pela comunidade
+
+A onda de segurança foi quase inteiramente trabalho comunitário: correções de XSS armazenado no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookie bloqueados, CI reforçado para cadeia de suprimentos com OpenSSF Scorecard e atestado de proveniência de construção ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), verificações Semgrep e OSV-Scanner, além de uma porta de revisão de dependência de PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de teste introduzido em 60% e desde então aumentado para 84% ([@gourab5139014](https://github.com/gourab5139014)) e uma verificação de segurança Hermes limpa de todas as descobertas CRÍTICAS (#768).
+
+### Alcança mais longe
+
+Idiomas hebraico e não latino ([@dudyme](https://github.com/dudyme)). Tokenização compatível com CJK para fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade do Windows. Extração de cookies em toda a família Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - além de fontes de credenciais macOS Keychain e Linux pass(1). Lookback histórico de `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Python 3.12 provisionado automaticamente via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leitura das páginas de empregos de uma empresa. Deltas da lista de observação entre execuções.
+
+### Ainda na caixa da v3
+
+As bases da v3 ainda estão aqui: o cérebro de pré-pesquisa que resolve os identificadores, subreddits e hashtags corretos antes que uma única chamada de API seja disparada (construída por [@j-sperling](https://github.com/j-sperling)); Best Takes pontua em humor e viralidade junto com relevância; fusão de cluster de origem cruzada; comparações de passagem única (“CLI vs MCP” em 3 minutos, não 12); comparações `--competitors` descobertas automaticamente; Modo pessoal do GitHub (`--github-user=steipete`); Modo ELI5 (“eli5 on” após qualquer execução); e resumos HTML independentes e compartilháveis ​​(`--emit=html`). Os botões de configuração ficam em [CONFIGURATION.md](CONFIGURATION.md).
+
+## Instalar
+
+| Superfície | Instalar | Atualizações |
+|---------|---------|---------|
+| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automático via marketplace ou `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` e depois `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI ou qualquer um dos mais de 50 [hosts do Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e carregue via claude.ai > Personalizar > Habilidades > + > Criar habilidade > Carregar uma habilidade | Baixe novamente e carregue novamente |
+| **Claude Desktop** | [Baixe o `.mcpb` para sua plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Configurações > Extensões | Baixe novamente e arraste o novo pacote para |
+| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
+
+### Claude Code (recomendado)
+
+```
+/plugin marketplace add mvanhorn/last30days-skill
+```
+
+Recomendado porque o mercado Claude Code cuida das atualizações para você – o cache do plug-in é versionado e atualizado automaticamente quando uma nova versão é publicada. Execute `claude plugin update last30days@last30days-skill` para forçar uma verificação.
+
+Se você preferir usar o caminho de instalação de habilidades do agente no Claude Code, isso também é compatível:
+
+```
+npx skills add mvanhorn/last30days-skill -g -a claude-code
+```
+
+O plugin nativo e a instalação do `npx skills` podem coexistir. Observe que o Claude Code não desduplica os métodos de instalação: se você tiver o plugin do Marketplace e a cópia `npx skills` ativos, `/last30days` mostrará duas entradas. Use um método de instalação por máquina.
+
+### Grok (xAI Build CLI)
+
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala last30days como um plugin nativo. A instalação direta rastreia o repositório:
+
+```bash
+grok plugin install mvanhorn/last30days-skill
+```
+
+Ou adicione este repositório como fonte do marketplace e instale pelo nome do plugin:
+
+```bash
+grok plugin marketplace add mvanhorn/last30days-skill
+grok plugin install last30days
+```
+
+Adicione `--trust` para ignorar a confirmação de instalação. Atualize com `grok plugin update last30days`. Grok também lê os manifestos do Claude Code para compatibilidade; o par nativo `.grok-plugin/` é a faixa de primeira classe (e para onde aponta uma listagem oficial [xAI marketplace](https://github.com/xai-org/plugin-marketplace)). `npx skills add` continua sendo um substituto válido entre hosts.
+
+### Codex, Cursor, Copilot, Gemini CLI e outros hosts de Agent Skills
+
+Instale por meio da CLI aberta [Agent Skills](https://agentskills.io) – suporta mais de 50 chicotes, incluindo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` e mais (lista completa no [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+
+```bash
+npx skills add mvanhorn/last30days-skill -g
+```
+
+O sinalizador `-g` (global) é instalado em seu diretório de usuário para que a habilidade esteja disponível em todos os projetos. Sem `-g`, `npx skills` instala o projeto localmente em `./.skills/` (confirmado com o repositório). Para uma ferramenta de pesquisa do mundo, global é o que você deseja.
+
+O desktop Codex e outros hosts em modo de pasta podem funcionar em pastas comuns, bem como em repositórios Git. Antes da primeira pesquisa, peça ao agente host para executar o `scripts/last30days.py --preflight` incluído no diretório de habilidades carregado; em uma verificação de origem, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra a fonte de configuração, o plano de cookies do navegador, gravações planejadas, comandos opcionais e configuração de projeto ignorado sem ler cookies, gravar arquivos ou executar pesquisas.
+
+Por padrão, isso é instalado para qualquer chicote que o `npx skills` detectar. Para atingir um específico (ou vários):
+
+```bash
+npx skills add mvanhorn/last30days-skill -g -a codex
+npx skills add mvanhorn/last30days-skill -g -a cursor
+npx skills add mvanhorn/last30days-skill -g -a gemini-cli
+npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+```
+
+Atualize mais tarde com:
+
+```bash
+npx skills update last30days -g
+```
+
+Ou atualize tudo o que você instalou globalmente via `npx skills`:
+
+```bash
+npx skills update -g
+```
+
+Liste e remova com `npx skills list -g` e `npx skills remove last30days -g`.
+
+### claude.ai (web)
+
+1. [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) da versão mais recente
+2. Vá para [claude.ai > Personalizar > Skills](https://claude.ai/customize/skills)
+3. Clique no botão `+` no painel Habilidades > clique em `Create skill` > `Upload a skill` e navegue/solte o arquivo
+
+Habilite "Execução de código e criação de arquivo" em Recursos primeiro - as habilidades não serão executadas sem ele.
+
+### Claude Desktop
+
+Claude Desktop instala `/last30days` como um servidor MCP por meio de um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
+
+1. Vá para [lançamento mais recente](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` para sua plataforma:
+- macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
+- macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
+-Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
+2. Abra o Claude Desktop, vá para Configurações > Extensões e arraste o arquivo.
+3. Quando solicitado, cole as chaves de API das fontes que deseja ativar. Cada campo é opcional – o mecanismo passa para o modo somente web se você ignorar todos eles. As chaves são armazenadas nas chaves do seu sistema operacional.
+4. Reinicie o Claude Desktop. Peça ao Claude para “pesquisar Peter Steinberger” ou qualquer assunto e ele chamará a ferramenta `research`.
+
+**Requisito de host:** Python 3.12+ em PATH. O pacote inclui o código-fonte do mecanismo, mas usa seu interpretador Python local. Instale em [python.org](https://www.python.org/downloads/) no Windows; O macOS e a maioria das distribuições Linux fornecem uma versão compatível.
+
+**As chaves não são sincronizadas com a habilidade Código.** Claude Desktop e Claude Code mantêm armazenamentos de credenciais separados por design. Se você já configurou `~/.config/last30days/.env` para a habilidade Código, você inserirá novamente as mesmas chaves aqui uma vez.
+
+O suporte do Windows é adiado até que os pontos de entrada do manifesto por plataforma sejam resolvidos; acompanhar em uma edição de acompanhamento.
+
+### OpenClaw
+
+```bash
+clawhub install last30days-official
+```
+
+Para fluxos de trabalho de ação X/Twitter fora da pesquisa `/last30days`, como postagem
+tweets ou respostas, exportação de seguidores, manipulação de mídia, monitores e brindes
+desenha, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como companheiro
+Plug-in OpenClaw. TweetClaw é mantido pela Xquik-dev e está listado apenas como um
+caminho complementar opcional, não uma dependência ou endosso de últimos 30 dias.
+
+### Manual (desenvolvedor)
+
+```bash
+git clone https://github.com/mvanhorn/last30days-skill.git
+ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
+```
+
+O link simbólico mantém a instalação sincronizada com sua árvore de trabalho enquanto você edita - não é necessária nova cópia. Para `claude.ai`, crie o arquivo `.skill` a partir da origem: `bash skills/last30days/scripts/build-skill.sh` produz `dist/last30days.skill`.
+
+Reddit (com comentários), Hacker News, Polymarket e GitHub funcionam imediatamente. Configuração nula. Execute `/last30days` uma vez e o assistente de configuração desbloqueia mais fontes em 30 segundos, incluindo as CLIs gratuitas arXiv e Techmeme.
+
+## Traga suas próprias chaves
+
+Essas plataformas não se relacionam entre si. X não sabe o que o Reddit pensa. O YouTube não vê o TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador e, de repente, terá acesso a todos eles de uma vez.
+
+| Fontes | O que você precisa | Custo |
+|---------|---------------|------|
+| Reddit (com comentários) + HN + Polymarket + GitHub + StockTwits | Nada | Grátis |
+| arXiv + Techmeme | CLIs gratuitas, instaladas automaticamente pela configuração inicial | Grátis |
+| X/Twitter | Faça login em x.com em qualquer navegador ou defina `XQUIK_API_KEY` / `XAI_API_KEY` | Os cookies do navegador são gratuitos; as chaves são específicas do provedor |
+| YouTube | `brew install yt-dlp` | Grátis |
+| Céu Azul | Senha do aplicativo de bsky.app | Grátis |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentários no YouTube | Chave ScrapeCreators | 10.000 chamadas gratuitas e PAYG |
+| Xiaohongshu (VERMELHO) | Execute um plug-in de navegador x-mcp conectado ou serviço `xiaohongshu-mcp` e opte por `--search xhs` por execução ou `INCLUDE_SOURCES=xiaohongshu` em `.env`; last30days sonda automaticamente `http://localhost:18060` e depois `http://host.docker.internal:18060` ou use `XIAOHONGSHU_API_BASE` para um URL personalizado | Nenhuma chave de API dos últimos 30 dias; depende do serviço de sessão do navegador local |
+| DripStack (boletins financeiros premium) | Aceitação: `--search dripstack` por execução ou `INCLUDE_SOURCES=dripstack` em `.env` | Sem chave; API de pesquisa pública gratuita |
+| Sonar Perplexity / API de pesquisa / Pesquisa profunda | Chave de perplexidade ou chave OpenRouter como substituto do Sonar | Pague conforme usar |
+| Pesquisa na web | Chave de pesquisa corajosa | 2.000 consultas gratuitas/mês |
+
+### Chaveiro macOS (opcional)
+
+No macOS, você pode armazenar chaves nas chaves do sistema em vez de um arquivo `.env`. A habilidade os seleciona automaticamente como a fonte de menor prioridade – os arquivos `.env` e o ambiente do processo ainda vencem na colisão.
+
+```bash
+# Interactive setup — prompts for each known key, skip with empty input
+skills/last30days/scripts/setup-keychain.sh
+
+# Or store a single key by hand
+security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
+
+# Inspect / clean up
+skills/last30days/scripts/setup-keychain.sh --list
+skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
+```
+
+Os itens são armazenados sob o nome de serviço `last30days-<KEY>` para o usuário atual. Em plataformas não Darwin, o carregador não funciona, portanto não há mudança de comportamento para usuários de Linux/Windows.
+
+Já possui chaves com nomes de serviço de chaveiro diferentes? Defina o mapeamento `LAST30DAYS_KEYCHAIN_ALIASES` não secreto descrito em [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) em vez de copiar segredos.
+
+Consulte [CONFIGURATION.md](CONFIGURATION.md) para obter a matriz de chaves completa por fonte, prioridade do provedor de raciocínio e prioridade de back-end de pesquisa na web.
+
+## Configuração
+
+Duas coisas que você provavelmente vai querer saber no primeiro dia:
+
+**Onde os arquivos de pesquisa são salvos.** O padrão de `LAST30DAYS_MEMORY_DIR` é `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Substitua definindo esse env var para qualquer caminho em seu shell ou `--save-dir <path>` por execução. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, usando o formato selecionado por `--emit`. Use `--save-suffix=<name>` para manter separadas diversas variações do mesmo tópico (por exemplo, por cliente). Cada execução de `--save-dir` produz `<slug>-raw[-suffix].md`. Execute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar as gravações planejadas antes de uma execução de pesquisa.
+
+**Saída estruturada para agentes e fluxos de trabalho.** Solicite ao `/last30days` JSON legível por máquina para receber o perfil de agente estável e com versão. Para uso direto do mecanismo em scripts ou desenvolvimento, execute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; adicione `--json-profile=raw` somente quando precisar do dump `Report` interno não versionado. Consulte a [referência do campo de exportação JSON e política de controle de versão](docs/reference/json-export.md).
+
+**Descoberta sem tópico.** Peça ao `/last30days what's trending in AI agents?` para obter um resumo de descoberta classificado em vez de pesquisar um tópico que você já conhece - em um host de agente, isso executa o protocolo julgado por host de três comandos (o modelo nomeia tópicos, filtra lixo, pontua valor e escreve os ângulos de conteúdo). Para uso direto do mecanismo em scripts ou cron, execute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nomes de tópicos determinísticos, sem ângulos); adicione `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um tópico posicional e `--drill`.
+
+**Monitoramento de tendências entre execuções.** O modo padrão produz um novo instantâneo de redução por execução. Para acumular descobertas ao longo do tempo, adicione `--store` para persistir em um banco de dados SQLite e, em seguida, use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com entrega opcional de Slack/webhook em novas descobertas) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resumos diários/semanais. O padrão de cadência completo está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+
+**Uma biblioteca de pesquisa que pode ser assinada.** Peça ao `/last30days` para criar o feed da sua biblioteca ou use `python3 skills/last30days/scripts/last30days.py library feed` diretamente para scripts e desenvolvimento. Ele transforma resumos salvos em `index.html`, um Atom local `feed.xml` e páginas de resumos legíveis. Adicione `--publish` somente quando desejar que o índice HTML e as páginas resumidas sejam hospedados; a publicação é de aceitação explícita e pública por padrão. Para tornar o feed Atom subscrito, hospede o diretório de saída gerado em um host estático, como GitHub Pages.
+
+**Pesquise tudo o que você pesquisou.** Pergunte a `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para uso direto do motor, execute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A pesquisa é off-line e determinística: ela indexa de forma incremental os mesmos resumos salvos usados ​​pelo feed da biblioteca, mescla as visualizações de lojas correspondentes por execução e agrupa os resultados por tópico e data. Novas versões também aparecem em uma seção compacta **Da sua biblioteca** quando pesquisas anteriores se sobrepõem ao tópico atual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para desabilitar esse contexto passivo.
+
+Scripts de wrapper por cliente, subreddits de categoria personalizada e o canal beta experimental para personalizações em andamento também estão documentados em [CONFIGURATION.md](CONFIGURATION.md).
+
+## Showcase: feeds de pesquisa da comunidade
+
+Publicou uma atualização recorrente de IA, observação do mercado ou uma obsessão maravilhosamente restrita com os últimos 30 dias? Compartilhe o URL da biblioteca pública — ou o URL Atom após hospedar `feed.xml` em um host estático — no [thread de demonstração da comunidade](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade serão vinculados aqui à medida que seus proprietários os enviarem; o tópico é o ponto de coleta enquanto isso.
+
+## Como funciona
+
+1. **Você digita um tópico.** Pessoa, empresa, produto, tecnologia, "X vs Y". Qualquer coisa.
+2. **O agente decide quem é importante.** Encontra X identificadores (incluindo fundadores), repositórios GitHub, subreddits, hashtags TikTok, canais do YouTube. Para "Kanye West" conhece r/hiphopheads, @kanyewest e "bully review" no YouTube. Para "OpenClaw", ele resolve openclaw/openclaw no GitHub e busca contagens de estrelas ao vivo.
+3. **Todas as fontes pesquisadas em paralelo.** Expansão multiconsulta. Resultados pontuados por engajamento, relevância, atualização.
+4. **A profundidade que ninguém mais tem.** Transcrições completas do YouTube de vídeos de reação. Principais comentários do Reddit com contagens de votos positivos. Legendas do TikTok. Probabilidades de polimercado. Não apenas títulos e links.
+5. **Mesma história, mesclada.** Wireless Festival anunciado no Reddit, discutido no X, preços dos ingressos no TikTok = um cluster, não três itens separados.
+6. **Sintetizado em um resumo.** Baseado em dados específicos. Citado pela fonte. Classificado de acordo com o que as pessoas realmente interagem. Não "aqui está o que encontrei". É "aqui está o que importa".
+7. **Então ele se torna seu especialista.** Após uma execução, sua sessão com Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Faça-o escrever avisos, redigir e-mails, planejar viagens, arquitetar sistemas - tudo baseado no que é real no momento.
+
+## O que as pessoas estão dizendo
+
+> "Encontrei uma habilidade do Claude Code que pesquisa qualquer tópico no Reddit, X, YouTube e HN dos últimos 30 dias. Em seguida, escreve as instruções para você. Tenho pesquisado manualmente no Reddit e no X antes de cada conteúdo que escrevo. Guia por guia. Tópico por tópico. Essa é a parte que leva 90 minutos. Isso a elimina." -@itsjasonai
+
+> "Essa habilidade substituiu todo o meu fluxo de trabalho de pesquisa. Você dá um tópico a ele, ele vasculha o Reddit, o X e a web para saber o que as pessoas estão realmente falando. Não são postagens antigas de blog. Conversas reais dos últimos 30 dias." -@itswilsoncharles
+
+> "5 dos 10 repositórios populares no GitHub hoje são ferramentas Claude. #1: mvanhorn/last30days-skill" -@yieldhunter95
+
+## Código aberto
+
+Licença do MIT. Sem rastreamento. Sem análises. Sua pesquisa permanece em sua máquina. Mais de 2.700 testes.
+
+Construído com Python 3.12+, yt-dlp, Node.js (cliente Bird vendido para pesquisa X) e API ScrapeCreators. arquitetura do mecanismo v3 por [@j-sperling](https://github.com/j-sperling).
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para abrir um PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para obter a lista completa de contribuidores da comunidade e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
+
+## História da estrela
+
+<a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mvanhorn/last30days-skill&type=Date" />
+  </picture>
+</a>
+
+---
+
+**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # /last30days
 
-[English](README.md) | 简体中文
+[English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | 简体中文
 
 <p align="center">
   <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days——由 AI 智能体驱动、搜索真实用户而非编辑内容的搜索引擎" />

--- a/tests/test_readme_translations.py
+++ b/tests/test_readme_translations.py
@@ -1,0 +1,69 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+READMES = {
+    "English": ROOT / "README.md",
+    "Français": ROOT / "README.fr.md",
+    "Deutsch": ROOT / "README.de.md",
+    "Español": ROOT / "README.es.md",
+    "Português (Brasil)": ROOT / "README.pt-BR.md",
+    "日本語": ROOT / "README.ja.md",
+    "简体中文": ROOT / "README.zh-CN.md",
+}
+def _navigation(current: str) -> str:
+    return " | ".join(
+        label if label == current else f"[{label}]({path.name})"
+        for label, path in READMES.items()
+    )
+
+
+def _code_blocks(text: str) -> list[str]:
+    return re.findall(r"```[^\n]*\n(.*?)```", text, flags=re.DOTALL)
+
+
+def _code_commands(text: str) -> list[str]:
+    return [
+        line
+        for block in _code_blocks(text)
+        for line in block.splitlines()
+        if line and not line.lstrip().startswith("#")
+    ]
+
+
+def _relative_link_targets(text: str) -> set[str]:
+    destinations = re.findall(r"\]\(([^)]+)\)", text)
+    return {
+        destination.split("#", 1)[0]
+        for destination in destinations
+        if destination
+        and not destination.startswith(("#", "http://", "https://", "mailto:"))
+    }
+
+
+def test_readme_translations_preserve_structure_and_commands() -> None:
+    english = READMES["English"].read_text(encoding="utf-8")
+    expected_code_commands = _code_commands(english)
+    expected_code_fences = english.count("```")
+    expected_table_rows = sum(line.startswith("|") for line in english.splitlines())
+    expected_ordered_items = len(re.findall(r"^\d+\. ", english, flags=re.MULTILINE))
+
+    for label, path in READMES.items():
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        assert lines[0] == "# /last30days"
+        assert lines[2] == _navigation(label)
+        assert text.count("```") == expected_code_fences
+        assert _code_commands(text) == expected_code_commands
+        assert sum(line.startswith("|") for line in lines) == expected_table_rows
+        assert len(re.findall(r"^\d+\. ", text, flags=re.MULTILINE)) == expected_ordered_items
+        assert not re.search(r"(?:ZXQ|XXQ|ZZQ|ZZZ)\d", text)
+        assert not re.search(r"^＃", text, flags=re.MULTILINE)
+        assert not re.search(r"\]\([^)]+\)\]", text)
+
+
+def test_readme_translation_relative_links_exist() -> None:
+    for path in READMES.values():
+        for target in _relative_link_targets(path.read_text(encoding="utf-8")):
+            assert (ROOT / target).exists(), f"{path.name}: missing relative link target {target}"

--- a/tests/test_readme_translations.py
+++ b/tests/test_readme_translations.py
@@ -12,6 +12,8 @@ READMES = {
     "日本語": ROOT / "README.ja.md",
     "简体中文": ROOT / "README.zh-CN.md",
 }
+
+
 def _navigation(current: str) -> str:
     return " | ".join(
         label if label == current else f"[{label}]({path.name})"
@@ -42,11 +44,22 @@ def _relative_link_targets(text: str) -> set[str]:
     }
 
 
+def _external_link_targets(text: str) -> set[str]:
+    return {
+        destination
+        for destination in re.findall(r"\]\(([^)]+)\)", text)
+        if destination.startswith(("http://", "https://"))
+    }
+
+
 def test_readme_translations_preserve_structure_and_commands() -> None:
     english = READMES["English"].read_text(encoding="utf-8")
     expected_code_commands = _code_commands(english)
     expected_code_fences = english.count("```")
-    expected_table_rows = sum(line.startswith("|") for line in english.splitlines())
+    expected_external_links = _external_link_targets(english)
+    expected_table_structure = [
+        line.count("|") for line in english.splitlines() if line.startswith("|")
+    ]
     expected_ordered_items = len(re.findall(r"^\d+\. ", english, flags=re.MULTILINE))
 
     for label, path in READMES.items():
@@ -56,7 +69,10 @@ def test_readme_translations_preserve_structure_and_commands() -> None:
         assert lines[2] == _navigation(label)
         assert text.count("```") == expected_code_fences
         assert _code_commands(text) == expected_code_commands
-        assert sum(line.startswith("|") for line in lines) == expected_table_rows
+        assert _external_link_targets(text) == expected_external_links
+        assert [line.count("|") for line in lines if line.startswith("|")] == (
+            expected_table_structure
+        )
         assert len(re.findall(r"^\d+\. ", text, flags=re.MULTILINE)) == expected_ordered_items
         assert not re.search(r"(?:ZXQ|XXQ|ZZQ|ZZZ)\d", text)
         assert not re.search(r"^＃", text, flags=re.MULTILINE)

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -74,7 +74,11 @@ class TestVersionConsistency(unittest.TestCase):
                     "LAST30DAYS_MEMORY_DIR" in line
                     and (
                         "defaults to" in line
-                        or "默认" in line
+                        or (
+                            path.parent == ROOT
+                            and path.name.startswith("README.")
+                            and path.name.endswith(".md")
+                        )
                         or "${LAST30DAYS_MEMORY_DIR:-$HOME/Documents/Last30Days}" in line
                     )
                 )


### PR DESCRIPTION
## Summary

French, German, Spanish, Brazilian Portuguese, and Japanese readers can now use complete localized project documentation alongside the existing English and Simplified Chinese READMEs. Reciprocal language navigation and synchronization guidance keep the English source canonical, while contract tests protect commands, tables, links, and document structure from localization drift.

## Testing

- [x] `uv run pytest` — 3,530 passed, 5 skipped, 41 subtests passed
- [x] `uv run pytest -q tests/test_readme_translations.py tests/test_version_consistency.py tests/test_doc_security_contract.py tests/test_env_doc_contract.py tests/test_changelog_workflow.py`
- [x] `git diff --check`

## Changelog

- [ ] Added a changelog fragment
- [x] Skip changelog — documentation localization only

## Agent disclosure

### AI review

Codex drafted and reviewed the translations against the English README section by section. The review checked reciprocal navigation, preserved commands and flags, code fences, table structure, relative and external links, product terminology, and accidental placeholder corruption. Contract tests now enforce those invariants across every localized README.

### Security

N/A. Documentation-only change; no input handling, command execution, authentication, dependencies, or secrets are modified.

## Notes

`README.md` remains canonical. `AGENTS.md` now requires substantive English README changes to be reflected across every localized README.

The translations were machine-drafted and structurally reviewed; native-speaker refinement remains welcome.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

N/A
