### PR TITLE
fix: accept an API root in *_BASE_URL overrides

### DIFF
--- a/changelog.d/+base-url-api-root.fixed.md
+++ b/changelog.d/+base-url-api-root.fixed.md
@@ -1,0 +1,1 @@
+`OPENAI_BASE_URL`, `XAI_BASE_URL`, and `OPENROUTER_BASE_URL` now accept an API root (`https://host/v1`) in addition to a full endpoint URL. Values copied from a provider's setup guide previously POSTed to the API root and failed.

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -26,6 +26,34 @@ OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 OPENROUTER_DEFAULT = "google/gemini-3.1-flash-lite-preview"
 
 
+_ENDPOINT_PATHS = {
+    OPENAI_RESPONSES_URL: "/responses",
+    XAI_RESPONSES_URL: "/responses",
+    OPENROUTER_URL: "/chat/completions",
+}
+
+
+def resolve_endpoint(env_var: str, default_url: str) -> str:
+    """Resolve a ``*_BASE_URL`` override into a full endpoint URL.
+
+    By the convention every OpenAI-compatible provider documents, ``*_BASE_URL``
+    names the API root (``https://host/v1``) and the client appends the endpoint
+    path. This module historically required the full endpoint URL instead, so a
+    value copied from a provider's setup guide POSTed to the API root and failed.
+
+    Accept both forms: an API root gets the endpoint path appended, and a value
+    that already ends with the endpoint path is used unchanged.
+    """
+    override = os.environ.get(env_var, "").strip()
+    if not override:
+        return default_url
+    override = override.rstrip("/")
+    path = _ENDPOINT_PATHS[default_url]
+    if override.endswith(path):
+        return override
+    return override + path
+
+
 class ReasoningClient:
     """Shared interface for planner and rerank providers."""
 
@@ -119,7 +147,7 @@ class OpenAIClient(ReasoningClient):
             "temperature": 0,
         }
         response = http.post(
-            os.environ.get("OPENAI_BASE_URL", OPENAI_RESPONSES_URL),
+            resolve_endpoint("OPENAI_BASE_URL", OPENAI_RESPONSES_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.token}",
@@ -150,7 +178,7 @@ class XAIClient(ReasoningClient):
             "input": [{"role": "user", "content": prompt}],
         }
         response = http.post(
-            os.environ.get("XAI_BASE_URL", XAI_RESPONSES_URL),
+            resolve_endpoint("XAI_BASE_URL", XAI_RESPONSES_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.api_key}",
@@ -182,7 +210,7 @@ class OpenRouterClient(ReasoningClient):
             "temperature": 0,
         }
         response = http.post(
-            os.environ.get("OPENROUTER_BASE_URL", OPENROUTER_URL),
+            resolve_endpoint("OPENROUTER_BASE_URL", OPENROUTER_URL),
             payload,
             headers={
                 "Authorization": f"Bearer {self.api_key}",

--- a/tests/test_providers_v3.py
+++ b/tests/test_providers_v3.py
@@ -1,5 +1,7 @@
 import json
+import os
 import unittest
+from unittest import mock
 from typing import get_args
 
 from lib import env
@@ -137,3 +139,57 @@ class TestExtractGeminiText(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ResolveEndpointTests(unittest.TestCase):
+    """``*_BASE_URL`` accepts an API root as well as a full endpoint URL."""
+
+    def _resolve(self, value, env_var="OPENAI_BASE_URL", default=None):
+        default = default or providers.OPENAI_RESPONSES_URL
+        patched = {} if value is None else {env_var: value}
+        with mock.patch.dict(os.environ, patched, clear=True):
+            return providers.resolve_endpoint(env_var, default)
+
+    def test_unset_uses_default_endpoint(self):
+        self.assertEqual(providers.OPENAI_RESPONSES_URL, self._resolve(None))
+
+    def test_blank_value_uses_default_endpoint(self):
+        self.assertEqual(providers.OPENAI_RESPONSES_URL, self._resolve("   "))
+
+    def test_api_root_gets_endpoint_path_appended(self):
+        self.assertEqual(
+            "https://example.test/v1/responses",
+            self._resolve("https://example.test/v1"),
+        )
+
+    def test_trailing_slash_is_normalised(self):
+        self.assertEqual(
+            "https://example.test/v1/responses",
+            self._resolve("https://example.test/v1/"),
+        )
+
+    def test_full_endpoint_url_is_preserved(self):
+        self.assertEqual(
+            "https://example.test/v1/responses",
+            self._resolve("https://example.test/v1/responses"),
+        )
+
+    def test_openrouter_uses_chat_completions_path(self):
+        self.assertEqual(
+            "https://example.test/api/v1/chat/completions",
+            self._resolve(
+                "https://example.test/api/v1",
+                env_var="OPENROUTER_BASE_URL",
+                default=providers.OPENROUTER_URL,
+            ),
+        )
+
+    def test_openrouter_full_endpoint_url_is_preserved(self):
+        self.assertEqual(
+            "https://example.test/api/v1/chat/completions",
+            self._resolve(
+                "https://example.test/api/v1/chat/completions",
+                env_var="OPENROUTER_BASE_URL",
+                default=providers.OPENROUTER_URL,
+            ),
+        )


### PR DESCRIPTION
## Summary

`OPENAI_BASE_URL`, `XAI_BASE_URL`, and `OPENROUTER_BASE_URL` were used as full endpoint URLs, but by the convention every OpenAI-compatible provider documents these name the API root (`https://host/v1`) and the client appends the endpoint path. A value copied from a provider's setup guide POSTed to the API root and failed. `resolve_endpoint` now accepts either form.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Added `ResolveEndpointTests` to `tests/test_providers_v3.py` — 7 cases covering unset, blank, API root, trailing slash, full endpoint URL (the previous behaviour), and the OpenRouter `/chat/completions` path. The 30 existing tests in that file still pass.

## Changelog

- [x] Added `changelog.d/+base-url-api-root.fixed.md` (type: `fixed`)
- [ ] Skip changelog — chore/internal only

## Agent disclosure

### AI review

Written with Claude Code (Opus 5). Risks checked: backwards compatibility for anyone already setting the full endpoint URL (covered by a test), trailing-slash and empty-string handling, and whether these three call sites are the only readers of the variables — `lib/env.py:504` and `lib/permission_preflight.py:12` pass them through without interpreting them, and `last30days.py:2406` re-exports them into `os.environ`, so no other behaviour changes.

### Security

N/A — no change to auth, secrets, command execution, or path handling. These variables were already user-controlled and are still only used as a request URL.

## Notes

The mapping lives in `_ENDPOINT_PATHS`, keyed by the default URL, so a new client needs its endpoint path registered there alongside its default constant.

### Relationship to this change

- [ ] None
- [x] Yes — disclosure: I work at WorldRouter (WorldClaw), an OpenAI-compatible inference provider. This PR does not add, name, or route to WorldRouter — it fixes the generic environment-variable contract. Our users hit this failure, which is how I found it.

## Related issues

N/A
