### PR TITLE
docs: correct meaning-changing errors in the localized READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -16,151 +16,151 @@
   </a>
 </p>
 
-**Eine von KI-Agenten geführte Suchmaschine, bewertet durch Upvotes, Likes und echtes Geld – nicht durch Redakteure.**
+**Eine von einem KI-Agenten gesteuerte Suchmaschine, die nach Upvotes, Likes und echtem Geld gewichtet – nicht nach Redaktionen.**
 
-Dieses README verfolgt die aktuelle v3-Pipeline. Die Runtime-Skill-Spezifikation befindet sich in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), was die Quelle der Wahrheit für das neueste Befehls- und Setup-Verhalten ist.
+Dieses README beschreibt die aktuelle v3-Pipeline. Die Laufzeitspezifikation der Skill liegt in [skills/last30days/SKILL.md](skills/last30days/SKILL.md) und ist maßgeblich für das aktuelle Verhalten von Befehlen und Setup.
 
-**Claude Code (empfohlen — automatische Aktualisierungen über den Marktplatz):**
+**Claude Code (empfohlen – automatische Updates über den Marketplace):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI, oder einer von 50+ [Agent Skills](https://agentskills.io) Hosts:**
+**Codex, Cursor, Copilot, Gemini CLI oder einer von 50+ [Agent Skills](https://agentskills.io)-Hosts:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` installiert sich global für deinen Nutzer und ist in allen Projekten verfügbar. Setze es in den Umfang pro Projekt.)
+(`-g` installiert global für deinen Benutzer, also in allen Projekten verfügbar. Lass das Flag weg, wenn du die Installation auf ein Projekt beschränken willst.)
 
-Weitere Installationsoptionen (claude.ai Web, OpenClaw, Handbuch) im folgenden Abschnitt [Install](#installation) .
+Weitere Installationswege (claude.ai im Browser, OpenClaw, manuell) findest du unten im Abschnitt [Installation](#installation).
 
-Null Konfiguration. Reddit, HN, Polymarketund GitHub funktionieren sofort. Führe es einmal aus und der Setup-Wizard schaltet X, YouTube, TikTok, arXiv, Techmemeund mehr in 30 Sekunden frei.
+Null Konfiguration. Reddit, HN, Polymarket und GitHub funktionieren sofort. Führe die Skill einmal aus, und der Setup-Assistent schaltet X, YouTube, TikTok, arXiv, Techmeme und mehr in 30 Sekunden frei.
 
 ---
 
-Reddit Upvotes. X Likes. YouTube Transkripte. TikTok Engagement. Polymarket Chancen, die durch echtes Geld und Insiderinformationen gestützt sind. Das sind Millionen von Menschen, die jeden Tag mit Aufmerksamkeit und Geldbörse abstimmen. /last30days durchsucht alles parallel, bewertet es nach dem, worauf echte Menschen tatsächlich interagieren, und ein KI-Agenten-Richter fasst es zu einem Briefing zusammen.
+Upvotes von Reddit. Likes von X. YouTube-Transkripte. TikTok-Engagement. Polymarket-Quoten, gedeckt durch echtes Geld und Insiderwissen. Das sind Millionen Menschen, die jeden Tag mit ihrer Aufmerksamkeit und ihrem Geldbeutel abstimmen. /last30days durchsucht all das parallel, gewichtet nach dem, womit echte Menschen tatsächlich interagieren, und ein KI-Agent fasst es als Juror zu einem einzigen Briefing zusammen.
 
-Google aggregiert Redakteure. /last30days sucht nach Leuten.
+Google aggregiert Redaktionen. /last30days durchsucht Menschen.
 
-Du kannst diese Suche nirgendwo anders bekommen, weil keine einzelne KI Zugriff auf alles hat. Google Suche berührt Reddit Kommentare oder X Beiträge nicht. ChatGPT hat einen Deal mit Reddit , kann aber nicht X oder TikToksuchen. Gemini hat YouTube , aber nicht Reddit. Claude hat keine davon nativ. Jede Plattform ist ein abgeschotteter Garten mit eigenem API, eigenen Tokens, eigener Authentifizierung. Aber du kannst deine eigenen Schlüssel und Browsersitzungen mitbringen, und plötzlich kann ein KI-Agent alle gleichzeitig durchsuchen, sie gegeneinander bewerten und dir sagen, was wirklich zählt.
+Diese Suche bekommst du nirgendwo sonst, weil keine einzelne KI Zugriff auf alles hat. Google erfasst weder Reddit-Kommentare noch X-Beiträge. ChatGPT hat einen Deal mit Reddit, kann aber weder X noch TikTok durchsuchen. Gemini hat YouTube, aber kein Reddit. Claude hat nichts davon nativ. Jede Plattform ist ein abgeschotteter Garten mit eigener API, eigenen Tokens, eigener Authentifizierung. Aber du kannst deine eigenen Schlüssel und Browser-Sessions mitbringen – und plötzlich durchsucht ein KI-Agent alle gleichzeitig, wägt sie gegeneinander ab und sagt dir, was wirklich zählt.
 
-Das ist die Entsperrung. Keine bessere Suchmaschine. Ein Dutzend getrennte Plattformen, von einem Agenten überbrückt.
+Das ist der eigentliche Durchbruch. Keine bessere Suchmaschine, sondern ein Dutzend getrennter Plattformen, die ein Agent miteinander verbindet.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Du hast morgen ein Meeting. Du Google sie. Du bekommst ihre LinkedIn von 2023. /last30days zeigt dir, was sie diesen Monat tatsächlich machen: OpenAI beigetreten, um an Codexzu arbeiten, gegen Anthropic's Verbot von Drittanbieteragenten zu kämpfen, 23 PRs mit 85 % Merge Rate ausgeliefert, "LobsterOS" für geräteübergreifende Agentensteuerung gebaut und r/ClaudeCode erreichte 569 Upvotes, in denen diskutiert wurde, ob er ein Held oder "unerträglich" ist. Über X Beiträge verteilt, Reddit Threads, YouTube Transkripte und GitHub Commits. Nichts davon war auf Google.
+Du hast morgen ein Meeting. Du googelst die Person. Du bekommst ihr LinkedIn-Profil von 2023. /last30days zeigt dir, was sie diesen Monat wirklich macht: bei OpenAI eingestiegen, um an Codex zu arbeiten, kämpft gegen Anthropics Verbot von Drittanbieter-Agenten, hat 23 PRs mit 85 % Merge-Rate geliefert, baut „LobsterOS“ für geräteübergreifende Agentensteuerung – und ein Thread in r/ClaudeCode kam auf 569 Upvotes bei der Frage, ob sie ein Held oder „unerträglich“ ist. Verteilt über X-Beiträge, Reddit-Threads, YouTube-Transkripte und GitHub-Commits. Nichts davon stand bei Google.
 
-## Warum das existiert
+## Warum es das gibt
 
-Ich habe es gebaut, um mit KI Schritt zu halten. Alles ändert sich jeden Tag und die Reddit und X Nerds sind immer zuerst dran. Ich brauchte bessere Prompts, und die Trainingsdaten lagen immer Monate hinter dem, was die Community bereits herausgefunden hatte.
+Ich habe es gebaut, um bei KI Schritt zu halten. Alles ändert sich täglich, und die Nerds auf Reddit und X wissen es immer zuerst. Ich brauchte bessere Prompts, und die Trainingsdaten lagen immer Monate hinter dem, was die Community längst herausgefunden hatte.
 
-Aber daraus wurde etwas Größeres. Jetzt führe ich es vor einem Verkaufsgespräch durch, um die Wahrheit der letzten 30 Tage über ein Unternehmen zu erfahren. Vor einem Meeting, um die aktuellen Tweets und Podcast-Transkripte von jemandem zu lesen. Vor einer Disney World Reise, um zu wissen, welche Fahrgeschäfte geschlossen sind und was die Community über Genie+sagt. Bevor ich etwas entwickle, um zu wissen, auf welche Probleme die Leute tatsächlich stoßen.
+Daraus wurde etwas Größeres. Heute lasse ich es vor einem Sales-Call laufen, um die Wahrheit der letzten 30 Tage über ein Unternehmen zu kennen. Vor einem Meeting, um die aktuellen Tweets und Podcast-Transkripte meines Gegenübers zu lesen. Vor einer Reise nach Disney World, um zu wissen, welche Attraktionen geschlossen sind und was die Community über Genie+ sagt. Bevor ich irgendetwas baue, um zu wissen, an welchen Problemen die Leute wirklich hängen.
 
-Wenn du dich mit einem CEO triffst, hast du alle Tweets und YouTube Transkripte der letzten 30 Tage gelesen? Ja, habe ich.
+Wenn du dich mit einem CEO triffst: Hast du alle Tweets und YouTube-Transkripte der letzten 30 Tage gelesen? Ich schon.
 
-## Quellen, von den Leuten bewertet
+## Quellen, gewichtet von den Menschen
 
-| Quelle | Was die Leute dir sagen. |
+| Quelle | Was dir die Menschen sagen |
 |--------|--------------------------|
-| **Reddit** | Die ungefilterte Sichtweise. Top-Kommentare mit echten Upvote-Zählen, kostenlos, kein API Schlüssel. Die echten Meinungen, die Google vergräbt. |
-| **X / Twitter** | Die heiße Meinung, der Experten-Thread, die Bruchreaktion. Zuerst weiß er, streitet zuerst. |
-| **YouTube** | Der 45-minütige Tieftauchgang. Vollständige Transkripte, gesucht nach den 5 zitierfähigen Sätzen, die zählen. |
-| **TikTok** | Der Creator erreicht 3,6 Millionen Leute mit einer Einnahme, die du auf Googlenie finden wirst. |
-| **Instagram Reels** | Die Influencer-Perspektive mit gesprochenen Transkripten. Das visuelle Kultursignal. |
-| **Hacker News** | Der Konsens der Entwickler. 825 Punkte, 899 Kommentare. Wo Techniker tatsächlich streiten. |
-| **Polymarket** | Nicht Meinungen. Chancen. Gedeckt durch echtes Geld. 96% Vertrauen bei Albumverkäufen. 4% bei einer Übernahme. |
-| **GitHub** | Für Personen: PR Geschwindigkeit, Top-Repos nach Sternen, Veröffentlichungshinweise. Für Themen: Themen und Diskussionen. |
-| **Digg** | Kuratierte Story-Cluster aus der AI 1000-Bestenliste von Digg(~1000 High-Signal-KI-Konten auf X), mit zuschreibbaren Inline-Quotes (keine X Authentifizierung erforderlich). Automatisch aktiviert, wenn `digg-pp-cli` auf PATHist. |
-| **arXiv** | Die Papiere hinter dem Hype. Neue Forschung im Fenster, kostenlos, kein API Schlüssel. Automatisch aktiviert, wenn `arxiv-pp-cli` PATH aktiviert ist (Erstlauf-Setup installiert es). |
-| **Techmeme** | Die Tech-News-Redaktionsebene, datumsabhängig auf deine 30 Tage. Kostenlos, kein API Schlüssel. Automatisch aktiviert, wenn `techmeme-pp-cli` PATH aktiviert ist (Erstlauf-Setup installiert es). |
-| **LinkedIn** | Das professionelle Signal. Beiträge und Artikel, wobei Artikel als High Signal gewichtet sind. |
-| **StockTwits** | Händler-Gefühl. Aktiviert sich automatisch, wenn Ihr Thema ein Ticker oder eine Krypto-Karte ist. |
-| **Threads** | Die Post-Twitter-Textebene. Gespräche von Schöpfern und Marken. |
-| **Pinterest** | Visuelle Entdeckung. Pins, Speicherstände und Kommentare zu Produkten und Ideen. |
-| **Xiaohongshu (RED)** | Chinesischer Lebensstil, Produkt und Creator-Signale. Explizit angefordert mit `--search xhs` , wenn ein eingeloggtes x-mcp-Browser-Plugin oder `xiaohongshu-mcp` Dienst lokal läuft. |
-| **Bluesky** | Die dezentrale soziale Schicht. AT Protocol-Beiträge aus der Post-Twitter-Migration. |
-| **Perplexity** | Geerdete Sonar-Synthese, rohe Suche API Reihen und Tiefe Forschung. |
-| **Web** | Die redaktionelle Berichterstattung, die Blogvergleiche. Ein Signal von vielen, nicht das einzige. |
+| **Reddit** | Die ungefilterte Meinung. Top-Kommentare mit echten Upvote-Zahlen, kostenlos, ohne API-Schlüssel. Die echten Meinungen, die Google vergräbt. |
+| **X / Twitter** | Die spontane Einschätzung, der Experten-Thread, die erste Reaktion auf eine Eilmeldung. Zuerst informiert, zuerst am Streiten. |
+| **YouTube** | Die 45-minütige Tiefenanalyse. Vollständige Transkripte, durchsucht nach den 5 zitierfähigen Sätzen, auf die es ankommt. |
+| **TikTok** | Der Creator, der 3,6 Millionen Menschen mit einer Sichtweise erreicht, die du bei Google nie findest. |
+| **Instagram Reels** | Die Perspektive der Influencer, inklusive Transkript des Gesprochenen. Das Signal der visuellen Kultur. |
+| **Hacker News** | Der Konsens der Entwickler. 825 Punkte, 899 Kommentare. Wo technische Leute wirklich streiten. |
+| **Polymarket** | Keine Meinungen. Quoten. Gedeckt durch echtes Geld. 96 % Wahrscheinlichkeit bei Albumverkäufen. 4 % bei einer Übernahme. |
+| **GitHub** | Für Personen: PR-Tempo, Top-Repos nach Sternen, Release Notes. Für Themen: Issues und Discussions. |
+| **Digg** | Kuratierte Story-Cluster aus Diggs AI-1000-Leaderboard (rund 1000 KI-Accounts mit hohem Signal auf X), mit zuordenbaren Inline-Zitaten und ganz ohne X-Authentifizierung. Wird automatisch aktiv, sobald `digg-pp-cli` im PATH liegt. |
+| **arXiv** | Die Fachartikel hinter dem Hype. Neue Forschung im Zeitfenster, kostenlos, ohne API-Schlüssel. Wird automatisch aktiv, sobald `arxiv-pp-cli` im PATH liegt (das Erst-Setup installiert es). |
+| **Techmeme** | Die redaktionelle Ebene der Tech-News, begrenzt auf dein 30-Tage-Fenster. Kostenlos, ohne API-Schlüssel. Wird automatisch aktiv, sobald `techmeme-pp-cli` im PATH liegt (das Erst-Setup installiert es). |
+| **LinkedIn** | Das berufliche Signal. Beiträge und Artikel, wobei Artikel als starkes Signal gewichtet werden. |
+| **StockTwits** | Die Stimmung der Trader. Aktiviert sich automatisch, wenn dein Thema ein Ticker oder eine Kryptowährung ist. |
+| **Threads** | Die Textebene nach Twitter. Gespräche von Creators und Marken. |
+| **Pinterest** | Visuelle Entdeckung. Pins, gespeicherte Beiträge und Kommentare zu Produkten und Ideen. |
+| **Xiaohongshu (RED)** | Chinesische Signale zu Lifestyle, Produkten und Creators. Wird ausdrücklich mit `--search xhs` angefordert, wenn lokal ein eingeloggtes x-mcp-Browser-Plugin oder ein `xiaohongshu-mcp`-Dienst läuft. |
+| **Bluesky** | Die dezentrale soziale Ebene. AT-Protocol-Beiträge aus der Abwanderung nach Twitter. |
+| **Perplexity** | Belegte Sonar-Synthese, Rohtreffer der Search API und Deep Research. |
+| **Web** | Die redaktionelle Berichterstattung, die Blog-Vergleiche. Ein Signal von vielen, nicht das einzige. |
 
-Community-Mitwirkende fügen immer mehr hinzu. Truth Social und andere Nischenquellen sind in der Engine, weitere sind unterwegs.
+Die Community steuert laufend weitere bei. Truth Social und andere Nischenquellen stecken bereits in der Engine, weitere folgen.
 
-Ein Reddit Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blogbeitrag, den niemand gelesen hat. Ein TikTok mit 3,6 Millionen Aufrufen sagt mehr darüber aus, was kulturell relevant ist, als eine Pressemitteilung. Polymarket Quoten mit 66.000 Dollar Volumen sind schwerer zu bestreiten als die Vermutung eines Experten.
+Ein Reddit-Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blogbeitrag, den niemand gelesen hat. Ein TikTok mit 3,6 Millionen Aufrufen sagt mehr darüber aus, was kulturell relevant ist, als jede Pressemitteilung. Polymarket-Quoten mit 66.000 $ Handelsvolumen dahinter lassen sich schwerer wegdiskutieren als die Vermutung eines Kommentators.
 
-Die Synthese rangiert nach dem, womit echte Menschen tatsächlich beschäftigt waren. Soziale Relevanz, nicht SEO Relevanz.
+Die Synthese sortiert nach dem, womit echte Menschen tatsächlich interagiert haben. Soziale Relevanz, nicht SEO-Relevanz.
 
-## Wofür die Leute es tatsächlich nutzen
+## Wofür die Leute es wirklich nutzen
 
-**Vor einem Meeting.** `/last30days Peter Steinberger` – bin dem Codex-Team von OpenAIbeigetreten und habe gegen Anthropics Verbot von Drittanbieteragenten gekämpft, 23 PRs mit einer Fusionsrate von 85 % auf GitHubfusioniert und LobsterOS für geräteübergreifende Agentensteuerung gebaut. r/ClaudeCode: "Seit OpenClaw veröffentlicht wurde, war allgemein bekannt, dass man, wenn man es über etwas anderes als das APIlaufen lässt, irgendwann gebannt wird" (227 Upvotes). Das liegt nicht an LinkedIn.
+**Vor einem Meeting.** `/last30days Peter Steinberger` – beim Codex-Team von OpenAI eingestiegen, kämpft gegen Anthropics Verbot von Drittanbieter-Agenten, 23 PRs mit 85 % Merge-Rate auf GitHub gemergt, baut LobsterOS für geräteübergreifende Agentensteuerung. r/ClaudeCode: „Seit OpenClaw erschienen ist, war allgemein bekannt: Wer es über etwas anderes als die API laufen lässt, fliegt irgendwann raus“ (227 Upvotes). Das steht so nicht auf LinkedIn.
 
-**Um Einstellungssignale zu lesen.** `/last30days Listen Labs --hiring-signals` – aktuelle Job- und Karriereseiten werden zu zitierten Belegen für Fokusverschiebungen: Einstellungen in Unternehmenssicherheit, Kundenerfolg, Infrastruktur oder Produktexpansion. Der Bericht sagt, was die Einstellung zu signalisieren scheint, nicht was die Roadmap liefern wird.
+**Um Hiring-Signale zu lesen.** `/last30days Listen Labs --hiring-signals` – aktuelle Stellenanzeigen und Karriereseiten werden zu zitierten Belegen für Schwerpunktverschiebungen: Einstellungen in Enterprise Security, Customer Success, Infrastruktur oder Produktausbau. Der Bericht sagt, was das Hiring zu signalisieren scheint, nicht was die Roadmap liefern wird.
 
-**Um das Thema zu finden, bevor es seinen Höhepunkt erreicht.** Frag `/last30days what's exploding in AI agents?` und die Fähigkeit wechselt in den Discovery-Modus: Die Engine durchsucht Reddit Kategorienlisten, Hacker News Front-/Best-Stories, den AI 1000-Feed von Diggund X bei Authentifizierung; dein Agent bewertet die Nominierungen (Namen, Junk-Filtering, Inhaltswertigkeit) und schreibt Podcast-/ X-Artikel-Winkel; dann bekommst du 5–10 Velocity-bewertete Themen. Jedes Ergebnis enthält Querseitennummern, ein Momentum-Label und eine startklare `/last30days "<topic>"` Folge.
+**Um ein Thema vor seinem Höhepunkt zu finden.** Frag `/last30days what's exploding in AI agents?`, und die Skill wechselt in den Discovery-Modus: Die Engine durchkämmt Reddit-Kategorielisten, die Front- und Best-Stories von Hacker News, Diggs AI-1000-Feed und X, sofern du authentifiziert bist. Dein Agent bewertet die Vorschläge (Namen, Müllfilterung, inhaltliche Relevanz) und schreibt Podcast- und X-Artikel-Ansätze. Am Ende bekommst du 5 bis 10 nach Velocity sortierte Themen. Jedes Ergebnis enthält quellenübergreifende Zahlen, ein Momentum-Label und einen startklaren Folgebefehl `/last30days "<topic>"`.
 
-**Wenn etwas fällt.** `/last30days Kanye West` - UK blockierte sein Visum, das Wireless Festival wurde gestrichen, Sponsoren flohen. Aber BULLY debütierte auf #2 bei Billboard. Fantano kam von seinem "Yay Sabbatical" zurück, um es zu rezensieren (653.000 Aufrufe). SoFi Homecoming brachte Lauryn Hill und Travis Scott für 44 Songs heraus. Polymarket: "Wird Kanye wieder twittern?" 86% Ja. 23 Reddit Threads, 17 YouTube Videos, 86.000 Upvotes.
+**Wenn etwas erscheint.** `/last30days Kanye West` – Großbritannien hat sein Visum blockiert, das Wireless Festival wurde abgesagt, die Sponsoren sind abgesprungen. Aber BULLY stieg auf Platz 2 der Billboard-Charts ein. Fantano kam aus seinem „Yay sabbatical“ zurück, um es zu rezensieren (653.000 Aufrufe). Beim SoFi Homecoming holte er Lauryn Hill und Travis Scott für 44 Songs auf die Bühne. Polymarket: „Wird Kanye wieder twittern?“ 86 % Ja. 23 Reddit-Threads, 17 YouTube-Videos, 86.000 Upvotes.
 
-**Um Werkzeuge zu vergleichen.** `/last30days OpenClaw vs Hermes vs Paperclip` – "Das sind keine Konkurrenten, das sind Schichten." OpenClaw ist der Testamentsvollstrecker (351.000 GitHub Sterne, live), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Sternzählungen werden live aus dem GitHub APIgezogen, nicht veraltete Blogbeiträge. Nebeneinander-Tabelle mit Architektur, Speicher, Sicherheit, Best-for. Laut @IMJustinBrooke: "OpenClaw = Glurak, Hermes = Glurak."
+**Um Tools zu vergleichen.** `/last30days OpenClaw vs Hermes vs Paperclip` – „Das sind keine Konkurrenten, das sind Schichten.“ OpenClaw ist die ausführende Ebene (351.000 GitHub-Sterne, produktiv), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Die Sternzahlen kommen live aus der GitHub-API, nicht aus veralteten Blogbeiträgen. Vergleichstabelle mit Architektur, Speicher, Sicherheit und idealem Einsatzzweck. Laut @IMJustinBrooke: „OpenClaw = Glumanda, Hermes = Glurak.“
 
-**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Deadline am Dienstag für Iran, die Straße von Hormus wieder zu öffnen. Zwei US-Kampfflugzeuge abgeschossen. Öl zu 126 Dollar pro Barrel. Die IEA bezeichnete es als "die größte Versorgungsstörung in der Geschichte des globalen Ölmarktes." Polymarket: Waffenstillstand bis zum 31. Dezember bei 74%. 27 X Beiträge, 10 YouTube Videos, 20 Prognosemärkte.
+**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Ultimatum bis Dienstag, damit der Iran die Straße von Hormus wieder öffnet. Zwei US-Kampfjets abgeschossen. Öl bei 126 $ pro Barrel. Die IEA nannte es „die größte Versorgungsstörung in der Geschichte des globalen Ölmarkts“. Polymarket: Waffenstillstand bis zum 31. Dezember bei 74 %. 27 X-Beiträge, 10 YouTube-Videos, 20 Prognosemärkte.
 
-**Vor einer Reise.** `/last30days Universal Epic Universe` - Erweiterung bereits im Bau. "Projekt 680"-Genehmigung eingereicht. Feuerwerksshow von der Infrastruktur bestätigt, aber unangekündigt. Wartezeiten: Mine-Cart Madness dauert durchschnittlich 148 Minuten. Noch keine Jahreskarte, und die Einheimischen sind frustriert. Stardust Racers sind bis zum 5. April zur Renovierung eingestellt.
+**Vor einer Reise.** `/last30days Universal Epic Universe` – die Erweiterung ist bereits im Bau. Baugenehmigung „Project 680“ eingereicht. Eine Feuerwerksshow ist über die Infrastruktur belegt, aber noch nicht angekündigt. Wartezeiten: Mine-Cart Madness im Schnitt 148 Minuten. Noch keine Jahreskarte, und die Einheimischen sind genervt. Stardust Racers steht bis zum 5. April wegen Renovierung still.
 
-**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` - JSON-strukturierte Prompts ersetzen Tag-Soup. @pictsbyaiverschachteltes Format verhindert "Concept Bleeding". Der Workflow, der zuerst auf Bearbeitung basiert, ist besser als Regeneration. Dann schreibt er dir einen Produktionsprompt, der genau das verwendet, was die Community als funktionierend bezeichnet.
+**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` – JSON-strukturierte Prompts lösen den Tag-Wildwuchs ab. Das verschachtelte Format von @pictsbyai verhindert „Concept Bleeding“. Bearbeiten schlägt neu generieren. Und danach schreibt dir die Skill einen produktionsreifen Prompt, der genau das umsetzt, was die Community als funktionierend beschrieben hat.
 
-## Was gibt's Neues
+## Was neu ist
 
-Seit der Ankündigung von v3.3 im Mai, Stand v3.11.1 (Juli 2026): 175 wurden PRs fusioniert – davon 122 von 52 Community-Beitragenden – über 15 Releases verteilt. Das ist es, was gelandet ist.
+Seit der Ankündigung von v3.3 im Mai und mit Stand v3.11.1 (Juli 2026): 175 gemergte PRs – 122 davon von 52 Beitragenden aus der Community – verteilt auf 15 Releases. Das ist gelandet.
 
-### Erste Klasse auf OpenAI Codex
+### Erstklassig auf OpenAI Codex
 
-/last30days ist jetzt ein natives Codex -Plugin mit geführter Einrichtung – kein Port, sondern ein erstklassiger Bürger. Renderer-bewusste Zitate bedeuten, dass Codex Ausgabe wie ein Brief statt wie eine URL-Suppe (#694) wirkt, und dieselbe Engine läuft auf Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawund 50+ Agent Skills Hosts. Codex Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex Authentifizierungskorrektur von [@tmchow](https://github.com/tmchow) (#698).
+/last30days ist jetzt ein natives Codex-Plugin mit geführtem Setup – keine Portierung, sondern ein vollwertiger Bürger. Renderer-bewusste Zitate sorgen dafür, dass die Codex-Ausgabe sich wie ein Briefing liest und nicht wie eine URL-Suppe (#694), und dieselbe Engine läuft auf Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw und 50+ Agent-Skills-Hosts. Codex-Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex-Auth-Fix von [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmemeund Digg – kostenlos, keine API Schlüssel
+### arXiv, Techmeme und Digg – kostenlos, ohne API-Schlüssel
 
-arXiv bringt die Zeitungen hinter dem Hype und Techmeme bringt die redaktionelle Tech-News-Ebene – kostenlos, null Schlüssel und First-Run-Setup installiert ihre CLI, sodass sie automatisch aktiviert werden (#709). Digg's AI 1000 Story-Cluster kommen ohne X Authentifizierung auf die gleiche Weise an – die Einrichtung installiert die kostenlose Digg CLI für dich (#590). Trustpilot Opt-in für Verbrauchermarkenforschung.
+arXiv liefert die Fachartikel hinter dem Hype, Techmeme die redaktionelle Tech-News-Ebene – kostenlos, ohne einen einzigen Schlüssel, und das Erst-Setup installiert ihre CLIs, sodass sie sich von selbst aktivieren (#709). Diggs AI-1000-Story-Cluster kommen genauso ohne X-Authentifizierung an: Das Setup installiert dir die kostenlose Digg-CLI (#590). Trustpilot ist optional zuschaltbar für Recherchen zu Consumer-Marken.
 
-### Kostenlose Reddit echte Punktzahlen und Top-Kommentare hervorgebracht
+### Reddit gratis, mit echten Scores und Top-Kommentaren
 
-Redditöffentliche .json API starb; der kostenlose Weg kam stärker zurück. Schlüsselloses RSS + Shreddit-Scraping (#457), dedizierte Subreddit-Entdeckung mit echten Upvote-Zahlen über arctic-shift (#696) und ein Relevanzboden, damit ein viraler Off-Topic-Beitrag dein Briefing nicht kapern kann (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API Schlüssel. Echte Wertungen. Top-Kommentare eingeschlossen.
+Reddits öffentliche .json-API ist gestorben; der kostenlose Weg kam stärker zurück. Schlüsselloses RSS plus Shreddit-Scraping (#457), gezielte Subreddit-Suche mit echten Upvote-Zahlen über arctic-shift (#696) und eine Relevanzschwelle, damit ein viraler Off-Topic-Beitrag dein Briefing nicht kapert (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API-Schlüssel. Echte Scores. Top-Kommentare inklusive.
 
 ### Die besten Kommentare in jedem Briefing
 
-Kommentare sind jetzt eine Standard-Ebene über Quellen hinweg: Instagram-Kommentare mit rangbasierter Diversität, damit fünf heiße Meinungen nicht alle aus einem Beitrag stammen (#751), YouTube Kommentare plus ein ScrapeCreators Transkript-Backup für den Fall, dass yt-DLP ausfällt (#637), und von der Menge gestimmte Kommentare werden in Best Takes gewichtet, damit die lustigsten Zeilen der Community die Bewertung überleben (#592, #608).
+Kommentare sind jetzt eine quellenübergreifend standardmäßig aktive Ebene: Instagram-Kommentare mit rangbasierter Vielfalt, damit fünf zugespitzte Meinungen nicht alle aus einem einzigen Beitrag stammen (#751), YouTube-Kommentare plus ein Transkript-Backup über ScrapeCreators, falls yt-dlp scheitert (#637), und von der Community hochgevotete Kommentare, die in die Best-Takes-Wertung einfließen, damit die witzigsten Zeilen die Bewertung überleben (#592, #608).
 
-### Ein Arztbefehl
+### Ein einziger doctor-Befehl
 
-Bitten Sie um eine Gesundheitsuntersuchung, der Arzt überprüft alle Quellen und verschreibt dann genaue Lösungen – welcher Schlüssel fehlt, welcher CLI fehlt PATH, welcher Keks abgelaufen ist (#753). Kein Raten mehr, warum X dünn war.
+Bitte um einen Health-Check: doctor prüft jede Quelle und verschreibt dann die genauen Korrekturen – welcher Schlüssel fehlt, welche CLI nicht im PATH liegt, welches Cookie abgelaufen ist (#753). Kein Rätselraten mehr, warum X so wenig geliefert hat.
 
-### X Suche, wieder aufgebaut
+### Die X-Suche, neu gebaut
 
-Die X -Pipeline wurde grundständig überarbeitet: FROM- und ABOUT-Lanes, sodass die eigenen Beiträge und das Gespräch darüber beide rangieren (#610), person-bewusste Subquery-Disambiguierung (#611), First-Party-Autoren-Grounding mit Interaktionssignal-Ranking (#613) und eine einzelne X -Quelle mit automatischem Backend-Failover (#622). Außerdem eine ehrliche `--diagnose` , die tatsächlich die Authentifizierung prüft (#609).
+Die X-Pipeline wurde von Grund auf überarbeitet: FROM- und ABOUT-Lanes, damit sowohl die eigenen Beiträge einer Person als auch das Gespräch über sie einsortiert werden (#610), personenbezogene Auflösung mehrdeutiger Unterabfragen (#611), Verifizierung der Urheberschaft aus erster Hand samt Ranking nach Interaktionssignalen (#613) und eine einzige X-Quelle mit automatischem Backend-Failover (#622). Dazu ein ehrliches `--diagnose`, das die Authentifizierung wirklich prüft (#609).
 
-### Weitere Quellen wurden aufgenommen
+### Weitere Quellen sind dazugekommen
 
-LinkedIn über ScrapeCreators, mit Artikeln mit hohem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits aktiviert sich automatisch für Ticker- und Krypto-Themen ([@wtiwana](https://github.com/wtiwana), #658). Perplexity wuchs direkt API Modi und asynchron Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn über ScrapeCreators, mit Artikeln als starkem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits aktiviert sich automatisch bei Ticker- und Krypto-Themen ([@wtiwana](https://github.com/wtiwana), #658). Perplexity hat direkte API-Modi und asynchrone Deep Research dazubekommen ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Von der Gemeinschaft gehärtet
+### Von der Community gehärtet
 
-Die Sicherheitswelle bestand fast ausschließlich aus Community-Arbeit: gespeicherte XSS-Korrekturen im HTML Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), gesperrte Cookie-Temp-Dateien, Supply-Chain-gehärtetes CI mit OpenSSF Scorecard und Build-Herkunftsattestation ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans sowie ein PR Abhängigkeits-Review-Gate ([@23241a6749](https://github.com/23241a6749)), ein Testdeckungsboden mit 60 % eingeführt und inzwischen auf 84 % erhöht ([@gourab5139014](https://github.com/gourab5139014)), und ein Hermes-Sicherheitsscan, der von allen KRITISCHEN Befunden freigearbeitet wurde (#768).
+Die Sicherheitswelle war fast vollständig Community-Arbeit: Fixes für Stored XSS im HTML-Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), abgesicherte temporäre Cookie-Dateien, eine gegen Supply-Chain-Angriffe gehärtete CI mit OpenSSF Scorecard und Build-Provenance-Attestierung ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans plus ein Dependency-Review-Gate für jeden PR ([@23241a6749](https://github.com/23241a6749)), eine Mindestgrenze für die Testabdeckung, eingeführt bei 60 % und inzwischen auf 84 % angehoben ([@gourab5139014](https://github.com/gourab5139014)), und ein Hermes-Sicherheitsscan, der inzwischen keinen einzigen CRITICAL-Befund mehr enthält (#768).
 
-### Weitere Reichweiten
+### Reicht weiter
 
-Hebräische und nicht-lateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-bewusste Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Windows Kompatibilitätswelle. Cookie-Extraktion über die gesamte Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS Keychain und Linux Pass(1)-Berechtigungsquellen. `--as-of` historischer Rückblick ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestellt Python 3.12 über UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Lesen der Jobseiten eines Unternehmens. Watchlist-Deltas zwischen den Durchläufen.
+Hebräisch und andere nichtlateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-taugliche Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Welle an Windows-Kompatibilität. Cookie-Extraktion für die gesamte Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS Keychain und pass(1) unter Linux als Quellen für Zugangsdaten. Historischer Rückblick mit `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestelltes Python 3.12 über uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Auslesen der Stellenseiten eines Unternehmens. Watchlist-Deltas zwischen zwei Durchläufen.
 
-### Immer noch in der Box von v3
+### Weiterhin ab Werk dabei seit v3
 
-Die v3-Grundlagen sind alle noch vorhanden: das Pre-Research-Gehirn, das die richtigen Handles, Subreddits und Hashtags löst, bevor ein einzelner API Aufruf auslöst (von [@j-sperling](https://github.com/j-sperling)gebaut); Best Takes Bewertung von Humor und Viralität neben Relevanz; Cross-Source-Cluster-Zusammenführung; Einzelpass-Vergleiche ("CLI 1 vs. MCP" in 3 Minuten, nicht 12); automatisch entdeckte `--competitors` Vergleiche; GitHub Person-Modus (`--github-user=steipete`); ELI5 Modus ("eli5 an" nach jedem Durchlauf); und teilbare, eigenständige HTML Briefs (`--emit=html`). Konfigurationsknöpfe befinden sich in [CONFIGURATION.md](CONFIGURATION.md).
+Die Grundlagen aus v3 sind alle noch da: das Pre-Research-Hirn, das die richtigen Handles, Subreddits und Hashtags ermittelt, bevor ein einziger API-Aufruf rausgeht (gebaut von [@j-sperling](https://github.com/j-sperling)); die Best-Takes-Wertung, die Humor und Viralität neben Relevanz berücksichtigt; quellenübergreifendes Cluster-Merging; Vergleiche in einem Durchgang („CLI vs MCP“ in 3 Minuten statt 12); automatisch gefundene `--competitors`-Vergleiche; der GitHub-Personenmodus (`--github-user=steipete`); der ELI5-Modus („eli5 on“ nach jedem Durchlauf); und teilbare, in sich geschlossene HTML-Briefings (`--emit=html`). Die Konfigurationsschalter stehen in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Installation
 
-| Oberfläche | Installation | Aktualisierungen |
+| Umgebung | Installation | Updates |
 |---------|---------|---------|
-| **Claude Code**(empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto über Marktplatz oder `claude plugin update last30days@last30days-skill` |
-| **Grok**(xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` dann `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLIoder einer von 50+ [Agent Skills](https://agentskills.io) Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(Web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) und hochladen über claude.ai > > Fähigkeiten anpassen > + > Fertigkeit erstellen > eine Fähigkeit hochladen | Neues Herunterladen und erneutes Hochladen |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) und ziehen in Einstellungen > Erweiterungen | Lade das neue Bundle neu herunter und ziehe es hinein |
+| **Claude Code** (empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatisch über den Marketplace, oder `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill`, dann `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI oder einer von 50+ [Agent Skills](https://agentskills.io)-Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (Browser) | [`last30days.skill` herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) und über claude.ai > Customize > Skills > + > Create skill > Upload a skill hochladen | Neu herunterladen und erneut hochladen |
+| **Claude Desktop** | [Die `.mcpb` für deine Plattform herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest) und in Settings > Extensions ziehen | Neu herunterladen und das neue Bundle hineinziehen |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (empfohlen)
@@ -169,46 +169,46 @@ Die v3-Grundlagen sind alle noch vorhanden: das Pre-Research-Gehirn, das die ric
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Empfohlen, weil der Claude Code Marktplatz Updates für dich verarbeitet – der Plugin-Cache ist versioniert und aktualisiert sich automatisch, wenn eine neue Version veröffentlicht wird. Führe `claude plugin update last30days@last30days-skill` aus, um eine Überprüfung zu erzwingen.
+Empfohlen, weil der Claude-Code-Marketplace die Updates für dich übernimmt: Der Plugin-Cache ist versioniert und aktualisiert sich automatisch, sobald ein neues Release erscheint. Mit `claude plugin update last30days@last30days-skill` erzwingst du eine Prüfung.
 
-Wenn du lieber den Agent-Skills-Installationspfad auf Claude Codenutzen möchtest, wird das ebenfalls unterstützt:
+Wenn du lieber den Agent-Skills-Installationsweg unter Claude Code nutzt, wird auch der unterstützt:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-Das native Plugin und die `npx skills` Installation können koexistieren. Beachte, dass Claude Code nicht über Installationsmethoden hinweg dedupliziert: Wenn du sowohl das Marketplace-Plugin als auch die `npx skills` Kopie aktiv hast, werden `/last30days` zwei Einträge angezeigt. Nutze pro Maschine eine Installationsmethode.
+Das native Plugin und die `npx skills`-Installation können nebeneinander existieren. Beachte aber: Claude Code dedupliziert nicht über Installationsmethoden hinweg. Wenn sowohl das Marketplace-Plugin als auch die `npx skills`-Kopie aktiv sind, taucht `/last30days` doppelt auf. Nutze pro Rechner eine Installationsmethode.
 
 ### Grok (xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) Installationen dauern 30 Tage als natives Plugin. Die direkte Installation verfolgt das Repository:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installiert last30days als natives Plugin. Die direkte Installation folgt dem Repository:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Oder füge dieses Repository als Marktplatzquelle hinzu und installiere dann nach Plugin-Namen:
+Oder füge dieses Repository als Marketplace-Quelle hinzu und installiere anschließend über den Plugin-Namen:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Füge `--trust` hinzu, um die Installationsbestätigung zu überspringen. Aktualisiere mit `grok plugin update last30days`. Grok liest auch die Claude Code Manifeste zur Kompatibilität; das native `.grok-plugin/` -Paar ist die First-Class-Lane (und was ein offizieller [xAI marketplace](https://github.com/xai-org/plugin-marketplace) auflistet). `npx skills add` bleibt ein gültiger Cross-Host-Fallback.
+Mit `--trust` überspringst du die Installationsbestätigung. Aktualisieren kannst du mit `grok plugin update last30days`. Grok liest aus Kompatibilitätsgründen auch die Claude-Code-Manifeste; das native `.grok-plugin/`-Paar ist der bevorzugte Weg – und genau darauf verweist ein offizieller Eintrag im [xAI-Marketplace](https://github.com/xai-org/plugin-marketplace). `npx skills add` bleibt ein gültiger Fallback über alle Hosts hinweg.
 
-### Codex, Cursor, Copilot, Gemini CLIund andere Agent Skills Hosts
+### Codex, Cursor, Copilot, Gemini CLI und weitere Agent-Skills-Hosts
 
-Installieren Sie über die offene [Agent Skills](https://agentskills.io) CLI – unterstützt 50+ Kabelbäume, darunter `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`und mehr (vollständige Liste auf dem [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Installiere über die offene [Agent Skills](https://agentskills.io)-CLI – sie unterstützt 50+ Hosts, darunter `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` und weitere (vollständige Liste im [Repository vercel-labs/skills](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-Das `-g` (globale) Flag wird in deinem Benutzerverzeichnis installiert, sodass die Skill in allen Projekten verfügbar ist. Ohne `-g`installiert `npx skills` projektlokal in `./.skills/` (mit dem Repository committiert). Für ein Research-the-World-Tool ist global das Richtige dafür.
+Das Flag `-g` (global) installiert in dein Benutzerverzeichnis, sodass die Skill in allen Projekten verfügbar ist. Ohne `-g` installiert `npx skills` projektlokal nach `./.skills/` (und wird mit dem Repository eingecheckt). Für ein Werkzeug, mit dem du die ganze Welt recherchierst, willst du die globale Installation.
 
-Codex Desktop- und andere Ordnermodus-Hosts können sowohl in normalen Ordnern als auch in Git-Repos funktionieren. Vor der ersten Recherche bitten Sie den Host-Agenten, das mitgelieferte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen; bei einem Quellcode-Checkout lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Er zeigt die Konfigurationsquelle, den Browser-Cookie-Plan, geplante Schreibvorgänge, optionale Befehle und ignorierte Projektkonfigurationen an, ohne Cookies zu lesen, Dateien zu schreiben oder Recherchen durchzuführen.
+Codex Desktop und andere Hosts, die auf Ordnerebene arbeiten, funktionieren sowohl in gewöhnlichen Ordnern als auch in Git-Repositories. Bitte den Host-Agenten vor der ersten Recherche, das mitgelieferte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen; in einem Checkout des Quellcodes lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Er zeigt dir, woher die Konfiguration stammt, welche Browser-Cookies gelesen würden, welche Dateien geschrieben würden, welche optionalen Befehle es gibt und welche Projektkonfiguration ignoriert wird – ohne Cookies zu lesen, Dateien zu schreiben oder eine Recherche zu starten.
 
-Standardmäßig wird dies für das Kabelbaum installiert, das `npx skills` erkennt. Um eine bestimmte (oder mehrere) anzuvisieren:
+Standardmäßig wird für den Host installiert, den `npx skills` erkennt. Um gezielt einen (oder mehrere) anzusprechen:
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Update später mit:
+Später aktualisieren mit:
 
 ```bash
 npx skills update last30days -g
 ```
 
-Oder aktualisiere alles, was du installiert hast, global über `npx skills`:
+Oder aktualisiere alles, was du global über `npx skills` installiert hast:
 
 ```bash
 npx skills update -g
 ```
 
-Liste und Entferne mit `npx skills list -g` und `npx skills remove last30days -g`.
+Auflisten und entfernen kannst du mit `npx skills list -g` und `npx skills remove last30days -g`.
 
-### claude.ai (Web)
+### claude.ai (Browser)
 
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) aus der neuesten Veröffentlichung
+1. [`last30days.skill` herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) – aus dem neuesten Release
 2. Geh zu [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Klicke auf die `+` -Taste im Skills-Panel > klicke auf `Create skill` > `Upload a skill` und durchstöber/leg die Datei ein
+3. Klicke im Skills-Panel auf `+`, dann auf `Create skill` > `Upload a skill`, und wähle die Datei aus oder zieh sie hinein
 
-Aktiviere zuerst "Code-Ausführung und Dateierstellung" unter Capabilities – Skills laufen ohne diese nicht aus.
+Aktiviere vorher unter Capabilities die Option „Code execution and file creation“ – ohne sie laufen Skills nicht.
 
 ### Claude Desktop
 
-Claude Desktop installiert `/last30days` als MCP -Server über ein `.mcpb` -Bundle (ein One-Click Model Context Protocol-Paket).
+Claude Desktop installiert `/last30days` als MCP-Server über ein `.mcpb`-Bundle (ein Model-Context-Protocol-Paket zum Ein-Klick-Installieren).
 
-1. Gehen Sie zum [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) und laden Sie die `.mcpb` für Ihre Plattform herunter:
+1. Öffne das [neueste Release](https://github.com/mvanhorn/last30days-skill/releases/latest) und lade die `.mcpb` für deine Plattform herunter:
    - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
    - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
    - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Öffnen Sie Claude Desktop, gehen Sie zu Einstellungen > Erweiterungen und ziehen Sie die Datei hinein.
-3. Wenn du aufgefordert wirst, füge API Schlüssel für die Quellen ein, die du aktivieren möchtest. Jedes Feld ist optional – die Engine verschlechtert sich in den reinen Webmodus, wenn du alle überspringst. Schlüssel werden in deinem Betriebssystem-Schlüsselbund gespeichert.
-4. Starte Claude Desktopneu. Bitte Claude , "Peter Steinberger" oder ein anderes Thema zu recherchieren, und es wird das `research` Tool aufgerufen.
+2. Öffne Claude Desktop, geh zu Settings > Extensions und zieh die Datei hinein.
+3. Füge auf Nachfrage die API-Schlüssel für die Quellen ein, die du aktivieren willst. Jedes Feld ist optional – überspringst du alle, fällt die Engine auf den reinen Web-Modus zurück. Die Schlüssel landen im Schlüsselbund deines Betriebssystems.
+4. Starte Claude Desktop neu. Bitte Claude, „zu Peter Steinberger zu recherchieren“ oder zu einem beliebigen anderen Thema, und es ruft das Tool `research` auf.
 
-**Host-Anforderung:** Python 3.12+ auf PATH. Das Bundle liefert die Engine-Quelle, verwendet aber deinen lokalen Python -Interpreter. Installiere von [python.org](https://www.python.org/downloads/) auf Windows; macOS und die meisten Linux Distributionen liefern eine kompatible Version aus.
+**Voraussetzung auf dem Host:** Python 3.12+ im PATH. Das Bundle bringt den Quellcode der Engine mit, nutzt aber deinen lokalen Python-Interpreter. Unter Windows installierst du ihn von [python.org](https://www.python.org/downloads/); macOS und die meisten Linux-Distributionen bringen bereits eine kompatible Version mit.
 
-**Schlüssel synchronisieren sich nicht mit der Code-Fähigkeit.** Claude Desktop und Claude Code pflegen absichtlich separate Zugangsdatenspeicher. Wenn du `~/.config/last30days/.env` bereits für die Code-Fähigkeit konfiguriert hast, gibst du dieselben Schlüssel hier einmal erneut ein.
+**Die Schlüssel werden nicht mit der Claude-Code-Skill geteilt.** Claude Desktop und Claude Code halten bewusst getrennte Speicher für Zugangsdaten. Wenn du `~/.config/last30days/.env` bereits für die Claude-Code-Skill eingerichtet hast, gibst du dieselben Schlüssel hier einmalig erneut ein.
 
-Windows Unterstützung wird aufgeschoben, bis die Einstiegspunkte pro Plattform geregelt sind; eine Folgeangelegenheit verfolgen.
+Windows-Unterstützung ist zurückgestellt, bis die plattformspezifischen Einstiegspunkte im Manifest geklärt sind; verfolgt wird das in einem eigenen Issue.
 
 ### OpenClaw
 
@@ -263,43 +263,44 @@ Windows Unterstützung wird aufgeschoben, bis die Einstiegspunkte pro Plattform 
 clawhub install last30days-official
 ```
 
-Für X/Twitter-Aktionsworkflows außerhalb `/last30days` Forschung, wie zum Beispiel Beiträge
-Tweets oder Antworten, Follower-Export, Medienhandhabung, Monitore und Gewinnspiele
-Bei Draws [TweetClaw](https://github.com/Xquik-dev/tweetclaw) als Begleiter verwenden
-OpenClaw Plugin. TweetClaw wird von Xquik-dev gepflegt und nur als ein
-Optionaler Begleitpfad, keine Abhängigkeit oder Unterstützung der letzten 30 Tage.
+Für X/Twitter-Aktionen außerhalb der `/last30days`-Recherche – Tweets oder
+Antworten posten, Follower exportieren, Medien verwalten, Accounts beobachten
+und Verlosungen auswerten – nutzt du [TweetClaw](https://github.com/Xquik-dev/tweetclaw)
+als ergänzendes OpenClaw-Plugin. TweetClaw wird von Xquik-dev gepflegt und ist
+hier nur als optionale Ergänzung aufgeführt, nicht als Abhängigkeit oder
+Empfehlung von last30days.
 
-### Handbuch (Entwickler)
+### Manuell (für Entwickler)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-Der Symlink hält die Installation beim Bearbeiten synchron mit deinem Arbeitsbaum – kein erneutes Kopieren erforderlich. Für `claude.ai`baue die `.skill` -Datei aus der Quelle: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
+Der Symlink hält die Installation beim Bearbeiten mit deinem Arbeitsverzeichnis synchron – erneutes Kopieren entfällt. Für `claude.ai` baust du die `.skill`-Datei aus dem Quellcode: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
 
-Reddit (mit Kommentaren), Hacker News, Polymarketund GitHub funktionieren sofort. Null Konfiguration. Führe `/last30days` einmal aus und der Setup-Wizard schaltet in 30 Sekunden weitere Quellen frei, einschließlich der kostenlosen arXiv und Techmeme CLIs.
+Reddit (mit Kommentaren), Hacker News, Polymarket und GitHub funktionieren sofort. Null Konfiguration. Führe `/last30days` einmal aus, und der Setup-Assistent schaltet in 30 Sekunden weitere Quellen frei, darunter die kostenlosen CLIs für arXiv und Techmeme.
 
-## Bringen Sie Ihre eigenen Schlüssel mit
+## Bring deine eigenen Schlüssel mit
 
-Diese Plattformen haben keine Beziehungen zueinander. X weiß nicht, was Reddit denkt. YouTube sieht TikToknicht. Aber du kannst deine eigenen API Schlüssel und Browser-Tokens mitbringen, und plötzlich hast du Zugriff auf alle auf einmal.
+Diese Plattformen haben nichts miteinander zu tun. X weiß nicht, was Reddit denkt. YouTube sieht TikTok nicht. Aber du kannst deine eigenen API-Schlüssel und Browser-Tokens mitbringen – und hast auf einen Schlag Zugriff auf alle gleichzeitig.
 
 | Quellen | Was du brauchst | Kosten |
 |---------|---------------|------|
 | Reddit (mit Kommentaren) + HN + Polymarket + GitHub + StockTwits | Nichts | Kostenlos |
-| arXiv + Techmeme | Kostenlose CLIS, automatisch durch Erststart-Einrichtung installiert | Kostenlos |
-| X / Twitter | Melden Sie sich in jedem Browser bei x.com an oder stellen Sie `XQUIK_API_KEY` / `XAI_API_KEY` | Browser-Cookies sind kostenlos; Schlüssel sind anbieterspezifisch |
+| arXiv + Techmeme | Kostenlose CLIs, die das Erst-Setup automatisch installiert | Kostenlos |
+| X / Twitter | In einem beliebigen Browser bei x.com anmelden, oder `XQUIK_API_KEY` / `XAI_API_KEY` setzen | Browser-Cookies sind kostenlos; Schlüssel hängen vom Anbieter ab |
 | YouTube | `brew install yt-dlp` | Kostenlos |
 | Bluesky | App-Passwort von bsky.app | Kostenlos |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube Kommentare | ScrapeCreators Schlüssel | 10.000 kostenlose Anrufe, dann PAYG |
-| Xiaohongshu (RED) | Führen Sie ein eingeloggtes x-mcp-Browser-Plugin oder `xiaohongshu-mcp` Dienst aus und melden Sie sich mit `--search xhs` pro Durchlauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env`an; die letzten 30 Tage testen automatisch `http://localhost:18060` dann `http://host.docker.internal:18060`, oder verwenden Sie `XIAOHONGSHU_API_BASE` für eine benutzerdefinierte URL | Kein Last 30days API Key; hängt von deinem lokalen Browser-Session-Dienst ab |
-| DripStack (Premium-Finanznewsletter) | Opt-in: `--search dripstack` pro Durchlauf oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Suche API |
-| Perplexity Sonar / Suche API / Tiefe Forschung | Perplexity Schlüssel oder OpenRouter-Schlüssel als Sonar-Fallback | Zahle nach Beginn. |
-| Web Suche | Brave Suchtaste | 2.000 kostenlose Anfragen pro Monat |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube-Kommentare | Ein ScrapeCreators-Schlüssel | 10.000 kostenlose Aufrufe, danach nutzungsabhängig |
+| Xiaohongshu (RED) | Ein eingeloggtes x-mcp-Browser-Plugin oder einen `xiaohongshu-mcp`-Dienst laufen lassen und die Quelle mit `--search xhs` pro Durchlauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env` zuschalten; last30days probiert automatisch `http://localhost:18060` und danach `http://host.docker.internal:18060`, oder du setzt `XIAOHONGSHU_API_BASE` für eine eigene URL | Kein last30days-API-Schlüssel nötig; hängt von deinem lokalen Browser-Session-Dienst ab |
+| DripStack (Premium-Finanznewsletter) | Zuschaltbar: `--search dripstack` pro Durchlauf, oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Such-API |
+| Perplexity Sonar / Search API / Deep Research | Ein Perplexity-Schlüssel, oder ein OpenRouter-Schlüssel als Sonar-Fallback | Nutzungsabhängig |
+| Websuche | Ein Brave-Search-Schlüssel | 2.000 kostenlose Anfragen pro Monat |
 
 ### macOS Keychain (optional)
 
-Auf macOS kannst du Schlüssel im System Keychain statt in einer `.env` -Datei speichern. Die Fähigkeit erkennt sie automatisch als Quelle mit niedrigster Priorität – `.env` die Dateien und die Prozessumgebung gewinnen trotzdem bei der Kollision.
+Unter macOS kannst du Schlüssel im System-Schlüsselbund statt in einer `.env`-Datei ablegen. Die Skill liest sie automatisch aus, allerdings mit der niedrigsten Priorität – bei einer Kollision gewinnen weiterhin `.env`-Dateien und die Prozessumgebung.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +314,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Elemente werden unter Service-Namen `last30days-<KEY>` für den aktuellen Nutzer gespeichert. Auf Nicht-Darwin-Plattformen ist der Loader ein No-Op, sodass es keine Verhaltensänderung für Linux/Windows Nutzer gibt.
+Die Einträge werden für den aktuellen Benutzer unter dem Dienstnamen `last30days-<KEY>` gespeichert. Auf Nicht-Darwin-Plattformen tut der Loader nichts, für Linux- und Windows-Nutzer ändert sich also am Verhalten nichts.
 
-Haben Sie bereits Schlüssel unter verschiedenen Keychain Service-Namen? Stellen Sie das in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschriebene nicht-geheime `LAST30DAYS_KEYCHAIN_ALIASES` Mapping ein, anstatt Geheimnisse zu kopieren.
+Du hast bereits Schlüssel unter anderen Keychain-Dienstnamen? Dann setz das nicht geheime Mapping `LAST30DAYS_KEYCHAIN_ALIASES`, das in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschrieben ist, statt Geheimnisse zu kopieren.
 
-Siehe [CONFIGURATION.md](CONFIGURATION.md) für die vollständige Schlüsselmatrix pro Quelle, Priorität des Reasoning-Providers und die Backend-Priorität der Websuche.
+Die vollständige Schlüsselmatrix pro Quelle, die Priorität der Reasoning-Anbieter und die Priorität der Websuche-Backends stehen in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Konfiguration
 
-Zwei Dinge, die du wahrscheinlich am ersten Tag wissen solltest:
+Zwei Dinge, die du vermutlich schon am ersten Tag wissen willst:
 
-**Wo Forschungsdateien gespeichert sind.** `LAST30DAYS_MEMORY_DIR` standardmäßig auf `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreiben Sie, indem Sie diesen Env-Var auf einen beliebigen Pfad in Ihrer Shell oder `--save-dir <path>` pro Durchlauf setzen. Verwenden Sie `--output <file>` , wenn Sie das gerenderte Ergebnis auf einem exakten Pfad benötigen, und verwenden Sie das von `--emit`gewählte Format. Verwenden Sie `--save-suffix=<name>` , um mehrere Varianten desselben Themas getrennt zu halten (z. B. pro Client). Jeder `--save-dir` Run erzeugt `<slug>-raw[-suffix].md`. Führen Sie `python3 skills/last30days/scripts/last30days.py --preflight` aus, um geplante Schreibarbeiten vor einem Forschungslauf zu überprüfen.
+**Wo die Rechercheergebnisse landen.** `LAST30DAYS_MEMORY_DIR` zeigt standardmäßig auf `~/Documents/Last30Days/` (unter Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreib das, indem du die Umgebungsvariable in deiner Shell auf einen beliebigen Pfad setzt, oder mit `--save-dir <path>` pro Durchlauf. Nutze `--output <file>`, wenn du das gerenderte Ergebnis an einem exakten Pfad brauchst – im Format, das `--emit` vorgibt. Mit `--save-suffix=<name>` hältst du mehrere Varianten desselben Themas auseinander (etwa pro Kunde). Jeder Durchlauf mit `--save-dir` erzeugt `<slug>-raw[-suffix].md`. Mit `python3 skills/last30days/scripts/last30days.py --preflight` siehst du vor einer Recherche, welche Dateien geschrieben würden.
 
-**Strukturierte Ausgabe für Agenten und Workflows.** Fragen Sie `/last30days` nach maschinenlesbaren JSON , um das stabile, versionierte Agentenprofil zu erhalten. Für den direkten Einsatz in der Engine in Skripten oder Entwicklung führen Sie `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`aus ; fügen Sie `--json-profile=raw` nur dann hinzu, wenn Sie den unversionierten internen `Report` Dump benötigen. Siehe das [JSON export field reference and versioning policy](docs/reference/json-export.md).
+**Strukturierte Ausgabe für Agenten und Workflows.** Bitte `/last30days` um maschinenlesbares JSON, dann bekommst du das stabile, versionierte Agentenprofil. Für den direkten Einsatz der Engine in Skripten oder in der Entwicklung führst du `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` aus; `--json-profile=raw` brauchst du nur, wenn du den unversionierten internen `Report`-Dump willst. Siehe die [Feldreferenz des JSON-Exports samt Versionierungsrichtlinie](docs/reference/json-export.md).
 
-**Themenlose Entdeckung.** Bitten Sie `/last30days what's trending in AI agents?` , ein ranglistetes Discovery-Briefing zu erhalten, anstatt ein bereits bekanntes Thema zu recherchieren – auf einem Agentenhost läuft das Drei-Befehle-Host-Judged Protocol (das Modell benennt Themen, filtert Müll, bewertet den Wert und schreibt die Inhaltswinkel). Für den direkten Einsatz in Skripten oder Cron, führen Sie `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (One-Shot: deterministische Themennamen, keine Angles); fügen Sie `--emit=json` für den versionierten Discovery-Vertrag hinzu. Discovery schließt sich gegenseitig mit einem Positionsthema und `--drill`aus.
+**Discovery ohne festes Thema.** Frag `/last30days what's trending in AI agents?`, um ein sortiertes Discovery-Briefing zu bekommen, statt ein Thema zu recherchieren, das du ohnehin kennst. Auf einem Agenten-Host läuft dafür das dreistufige, vom Host bewertete Protokoll (das Modell benennt Themen, filtert Müll heraus, bewertet ihre Relevanz und schreibt die inhaltlichen Ansätze). Für den direkten Einsatz der Engine in Skripten oder per Cron führst du `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (einmaliger Lauf: deterministische Themennamen, keine Ansätze); mit `--emit=json` bekommst du den versionierten Discovery-Vertrag. Discovery schließt ein positionsbasiertes Thema und `--drill` gegenseitig aus.
 
-**Trendüberwachung über Durchläufe hinweg.** Der Standardmodus erzeugt pro Durchlauf einen frischen Markdown-Snapshot. Um Erkenntnisse im Laufe der Zeit zu sammeln, fügen Sie `--store` hinzu, um in einer SQLite-Datenbank gespeichert zu werden, verwenden Sie [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) dann für geplante Durchläufe (mit optionalem Slack / Webhook-Delivery bei neuen Ergebnissen) und [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche/wöchentliche Digests. Das vollständige Rhythmusmuster ist in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Trendbeobachtung über mehrere Durchläufe.** Der Standardmodus erzeugt pro Durchlauf einen frischen Markdown-Snapshot. Um Erkenntnisse über die Zeit zu sammeln, hängst du `--store` an, damit sie in einer SQLite-Datenbank landen, und nutzt dann [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) für geplante Durchläufe (auf Wunsch mit Zustellung per Slack oder Webhook bei neuen Funden) sowie [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche oder wöchentliche Zusammenfassungen. Das vollständige Taktmuster steht in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Eine abonnierbare Forschungsbibliothek.** Bitten Sie `/last30days` , Ihren Bibliotheksfeed zu erstellen, oder verwenden Sie `python3 skills/last30days/scripts/last30days.py library feed` direkt für Skripting und Entwicklung. Sie wandelt gespeicherte Briefs in `index.html`, ein lokales Atom- `feed.xml`und lesbare Brief-Seiten um. Fügen Sie `--publish` nur dann hinzu, wenn Sie den HTML Index und die Brief-Seiten gehostet haben möchten; die Veröffentlichung ist standardmäßig explizit opt-in und öffentlich. Um den Atom-Feed abonnierbar zu machen, hosten Sie das generierte Ausgabeverzeichnis auf einem statischen Host wie GitHub Pages.
+**Eine abonnierbare Recherche-Bibliothek.** Bitte `/last30days`, deinen Bibliotheks-Feed zu bauen, oder nutze für Skripting und Entwicklung direkt `python3 skills/last30days/scripts/last30days.py library feed`. Das verwandelt gespeicherte Briefings in eine `index.html`, ein lokales Atom-`feed.xml` und lesbare Briefing-Seiten. Hänge `--publish` nur an, wenn der HTML-Index und die Briefing-Seiten gehostet werden sollen; das Veröffentlichen ist eine bewusste Entscheidung und standardmäßig öffentlich. Damit der Atom-Feed wirklich abonnierbar wird, hoste das erzeugte Ausgabeverzeichnis bei einem statischen Anbieter wie GitHub Pages.
 
-**Durchsuche alles, was du recherchiert hast.** Frag `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für die direkte Engine-Nutzung führe `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`aus. Die Suche ist offline und deterministisch: Sie indexiert schrittweise dieselben gespeicherten Briefs, die vom Bibliotheksfeed verwendet werden, führt übereinstimmende Shop-Sichtungen pro Durchlauf zusammen und gruppiert Ergebnisse nach Thema und Datum. Frische Durchläufe zeigen außerdem einen kompakten Abschnitt **Aus deiner Bibliothek** an, wenn frühere Forschung das aktuelle Thema überschneidet; setze `LAST30DAYS_LIBRARY_CONTEXT=off` so ein, dass dieser passive Kontext deaktiviert wird.
+**Durchsuche alles, was du schon recherchiert hast.** Frag `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für den direkten Einsatz der Engine führst du `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` aus. Die Suche läuft offline und deterministisch: Sie indexiert nach und nach dieselben gespeicherten Briefings, die auch der Bibliotheks-Feed nutzt, führt passende Treffer aus dem Store je Durchlauf zusammen und gruppiert die Ergebnisse nach Thema und Datum. Neue Durchläufe blenden außerdem einen kompakten Abschnitt **From your library** („aus deiner Bibliothek“) ein, wenn frühere Recherchen das aktuelle Thema überschneiden; mit `LAST30DAYS_LIBRARY_CONTEXT=off` schaltest du diesen passiven Kontext ab.
 
-Pro-Client-Wrapper-Skripte, benutzerdefinierte Kategorie-Peer-Subreddits und der experimentelle Beta-Kanal für laufende Anpassungen sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md)dokumentiert.
+Wrapper-Skripte pro Kunde, eigene Kategorie-Subreddits und der experimentelle Beta-Kanal für Anpassungen in Arbeit sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md) dokumentiert.
 
-## Showcase: Community-Forschungsfeeds
+## Showcase: Recherche-Feeds aus der Community
 
-Hast du ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine wunderbar enge Obsession mit den letzten 30 Tagen veröffentlicht? Teile die URL der öffentlichen Bibliothek – oder die Atom-URL nach dem Hosting `feed.xml` auf einem statischen Host – in [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532)Community-Feeds werden hier verlinkt, sobald ihre Eigentümer sie einreichen; der Thread ist in der Zwischenzeit der Sammelpunkt.
+Du hast mit last30days ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine herrlich spezielle Obsession veröffentlicht? Teil die URL deiner öffentlichen Bibliothek – oder die Atom-URL, sobald `feed.xml` bei einem statischen Anbieter liegt – im [Showcase-Thread der Community](https://github.com/mvanhorn/last30days-skill/issues/532). Community-Feeds werden hier verlinkt, sobald ihre Besitzer sie einreichen; bis dahin ist der Thread die Sammelstelle.
 
-## Wie es funktioniert
+## So funktioniert es
 
-1. **Du tippst ein Thema ein.** Person, Unternehmen, Produkt, Technologie, "X vs. Y." Alles.
-2. **Der Agent entscheidet, wer zählt.** Findet X Handles (einschließlich Gründer), GitHub Reposis, Subreddits, TikTok Hashtags YouTube Kanäle. Für "Kanye West" kennt es r/hiphopheads, @kanyewestund "bully review" auf YouTube. Für "OpenClaw" wird openclaw/openclaw auf GitHub aufgelöst und live die Sternenzahlen angezeigt.
-3. **Alle Quellen wurden parallel gesucht.** Multi-Query-Erweiterung. Ergebnisse bewertet nach Engagement, Relevanz, Frische.
-4. **Die Tiefe, die sonst niemand hat.** Vollständige YouTube Transkripte aus Reaktionsvideos. Top Reddit Kommentare mit Upvote-Zählen. TikTok Bildunterschriften. Polymarket Chancen. Nicht nur Titel und Links.
-5. **Gleiche Geschichte, fusioniert.** Wireless Festival am Redditangekündigt, besprochen am X, Ticketpreise auf TikTok = ein Cluster, nicht drei separate Artikel.
-6. **Zusammengefasst in einem Brief.** Basierend auf spezifischen Daten. Zitiert von der Quelle. Bewertet nach dem, womit sich die Leute tatsächlich beschäftigen. Nicht "Hier ist, was ich gefunden habe." Es ist "Hier ist, was zählt."
-7. **Dann wird es dein Experte.** Nach einem Durchlauf weiß deine Claude Sitzung alles, was die Community weiß. Stelle Nachfragen. Lass sie Prompts schreiben, E-Mails entwerfen, Reisen planen, Architektursysteme aufbauen – alles basiert auf dem, was gerade real ist.
+1. **Du tippst ein Thema ein.** Person, Unternehmen, Produkt, Technologie, „X vs Y“. Alles ist möglich.
+2. **Der Agent klärt, wer zählt.** Er findet X-Handles (auch die von Gründerinnen und Gründern), GitHub-Repos, Subreddits, TikTok-Hashtags und YouTube-Kanäle. Bei „Kanye West“ weiß er, dass r/hiphopheads, @kanyewest und „bully review“ auf YouTube dazugehören. Bei „OpenClaw“ löst er openclaw/openclaw auf GitHub auf und holt die aktuellen Sternzahlen.
+3. **Alle Quellen werden parallel durchsucht.** Erweiterung über mehrere Suchanfragen. Ergebnisse gewichtet nach Engagement, Relevanz und Aktualität.
+4. **Die Tiefe, die sonst niemand hat.** Vollständige YouTube-Transkripte aus Reaktionsvideos. Die besten Reddit-Kommentare samt Upvote-Zahlen. TikTok-Captions. Polymarket-Quoten. Nicht nur Titel und Links.
+5. **Dieselbe Geschichte, zusammengeführt.** Das Wireless Festival auf Reddit angekündigt, auf X diskutiert, Ticketpreise auf TikTok – das ergibt einen Cluster, nicht drei getrennte Einträge.
+6. **Zu einem Briefing verdichtet.** Auf konkreten Daten fußend. Nach Quelle belegt. Sortiert nach dem, womit Menschen wirklich interagieren. Nicht „hier ist, was ich gefunden habe“, sondern „hier ist, was zählt“.
+7. **Danach wird es dein Experte.** Nach einem einzigen Durchlauf weiß deine Claude-Sitzung alles, was die Community weiß. Stell Rückfragen. Lass sie Prompts schreiben, E-Mails entwerfen, Reisen planen, Systeme entwerfen – immer verankert in dem, was gerade wirklich stimmt.
 
 ## Was die Leute sagen
 
-> "Ich habe eine Claude Code Fähigkeit gefunden, die jedes Thema aus den letzten 30 Tagen Reddit, X, YouTubeund HN erforscht. Dann schreibt er die Prompts für dich. Ich habe vor jedem Inhalt, den ich schreibe, manuell Reddit und X nach Recherchen gesucht. Tab für Tab. Faden für Faden. Das ist der Teil, der 90 Minuten dauert. Das eliminiert es." -@itsjasonai
+> „Ich habe eine Claude-Code-Skill gefunden, die zu jedem Thema die letzten 30 Tage auf Reddit, X, YouTube und HN recherchiert. Und dann schreibt sie dir die Prompts. Vor jedem Text, den ich schreibe, habe ich das bisher von Hand auf Reddit und X gemacht. Tab für Tab. Thread für Thread. Genau das ist der Teil, der 90 Minuten frisst. Der fällt jetzt weg.“ – @itsjasonai
 
-> "Diese eine Fähigkeit hat meinen gesamten Recherche-Workflow ersetzt. Du gibst ihm ein Thema, sie sammelt Reddit, Xund das Web nach dem, worüber die Leute tatsächlich sprechen. Keine alten Blogbeiträge. Echte Gespräche der letzten 30 Tage." -@itswilsoncharles
+> „Diese eine Skill hat meinen kompletten Recherche-Workflow ersetzt. Du gibst ihr ein Thema, sie holt sich von Reddit, X und dem Web, worüber die Leute wirklich reden. Keine alten Blogbeiträge. Echte Gespräche aus den letzten 30 Tagen.“ – @itswilsoncharles
 
-> "5 der 10 trendigen Repos auf GitHub heute sind Claude Werkzeuge. #1: Mvanhorn/last30days-Fähigkeit" -@yieldhunter95
+> „5 der 10 Trending-Repos heute auf GitHub sind Claude-Tools. Nummer 1: mvanhorn/last30days-skill“ – @yieldhunter95
 
 ## Open Source
 
-MIT-Lizenz. Kein Tracking. Keine Analyse. Deine Forschung bleibt auf deinem Rechner. 2.700+ Tests.
+MIT-Lizenz. Kein Tracking. Keine Analytics. Deine Recherche bleibt auf deinem Rechner. Über 2.700 Tests.
 
-Gebaut mit Python 3.12+, yt-dlp, Node.js (bereitgestellt Bird Client für X Suche) und ScrapeCreators API. v3-Engine-Architektur von [@j-sperling](https://github.com/j-sperling).
+Gebaut mit Python 3.12+, yt-dlp, Node.js (mitgelieferter Bird-Client für die X-Suche) und der ScrapeCreators-API. Architektur der v3-Engine von [@j-sperling](https://github.com/j-sperling).
 
-Siehe [CONTRIBUTING.md](CONTRIBUTING.md) , um einen PRzu öffnen, [CONTRIBUTORS.md](CONTRIBUTORS.md) für die vollständige Liste der Community-Mitwirkenden und [CHANGELOG.md](CHANGELOG.md) für die Versionshistorie.
+Wie du einen PR aufmachst, steht in [CONTRIBUTING.md](CONTRIBUTING.md), die vollständige Liste der Community-Beitragenden in [CONTRIBUTORS.md](CONTRIBUTORS.md) und die Versionshistorie in [CHANGELOG.md](CHANGELOG.md).
 
-## Sterngeschichte
+## Sternverlauf
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.es.md
+++ b/README.es.md
@@ -16,9 +16,9 @@
   </a>
 </p>
 
-**Un motor de búsqueda liderado por agentes de IA, puntuado por votos positivos, me gusta y dinero real, no por editores.**
+**Un buscador dirigido por un agente de IA que puntúa por votos positivos, likes y dinero real, no por redacciones.**
 
-Este README rastrea la pipeline v3 actual. La especificación de habilidad en tiempo de ejecución reside en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la fuente de verdad para el comportamiento más reciente de comandos y configuración.
+Este README documenta el pipeline v3 actual. La especificación de ejecución de la skill vive en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la referencia definitiva sobre el comportamiento de los comandos y la configuración.
 
 **Claude Code (recomendado — actualizaciones automáticas vía marketplace):**
 ```
@@ -26,141 +26,141 @@ Este README rastrea la pipeline v3 actual. La especificación de habilidad en ti
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ [Agent Skills](https://agentskills.io) presentadores:**
+**Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ hosts de [Agent Skills](https://agentskills.io):**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` se instala globalmente para tu usuario, disponible en todos los proyectos. Hazlo por proyecto por ámbito.)
+(`-g` instala de forma global para tu usuario, así que la tienes disponible en todos tus proyectos. Omite ese flag si prefieres limitar la instalación a un proyecto.)
 
-Más opciones de instalación (claude.ai web, OpenClaw, manual) en la sección de [Install](#instalación) abajo.
+Más formas de instalarlo (claude.ai web, OpenClaw, manual) en la sección [Instalación](#instalación) de más abajo.
 
-Cero configuración. Reddit, HN, Polymarkety GitHub funcionan inmediatamente. Ejecuta una vez y el asistente de configuración desbloquea X, YouTube, TikTok, arXiv, Techmemey más en 30 segundos.
+Cero configuración. Reddit, HN, Polymarket y GitHub funcionan de inmediato. Ejecútalo una vez y el asistente de configuración desbloquea X, YouTube, TikTok, arXiv, Techmeme y más en 30 segundos.
 
 ---
 
-Reddit votos positivos. X me gusta. YouTube transcripciones. TikTok interacción. Polymarket probabilidades respaldadas por dinero real e información privilegiada. Eso son millones de personas votando con su atención y su cartera cada día. /last30days lo busca todo en paralelo, lo puntua según lo que realmente interactúan las personas reales, y un juez agente de IA lo sintetiza en un solo informe.
+Los votos positivos de Reddit. Los likes de X. Las transcripciones de YouTube. La interacción en TikTok. Las cuotas de Polymarket, respaldadas por dinero real y por información privilegiada. Eso son millones de personas votando cada día con su atención y su cartera. /last30days lo busca todo en paralelo, lo puntúa según aquello con lo que la gente interactúa de verdad, y un agente de IA hace de juez para sintetizarlo en un único informe.
 
-Google agrega editores. /last30days busca personas.
+Google agrega redacciones. /last30days busca personas.
 
-No puedes encontrar esta búsqueda en ningún otro sitio porque ninguna IA tiene acceso a todas. Google búsqueda no toca Reddit comentarios ni X publicaciones. ChatGPT tiene un acuerdo con Reddit pero no puede buscar X ni TikTok. Gemini tiene YouTube pero no Reddit. Claude no tiene ninguno de ellos de forma nativa. Cada plataforma es un jardín amurallado con su propio API, sus propios tokens, su propia autenticación. Pero puedes traer tus propias claves y sesiones de navegador, y de repente un agente de IA puede buscarlas todas a la vez, puntuarlas entre sí y decirte qué es lo que realmente importa.
+Esta búsqueda no la consigues en ningún otro sitio, porque ninguna IA tiene acceso a todo. Google no toca los comentarios de Reddit ni las publicaciones de X. ChatGPT tiene un acuerdo con Reddit, pero no puede buscar en X ni en TikTok. Gemini tiene YouTube, pero no Reddit. Claude no tiene ninguno de forma nativa. Cada plataforma es un jardín amurallado con su propia API, sus propios tokens y su propia autenticación. Pero tú puedes aportar tus claves y tus sesiones de navegador y, de golpe, un agente de IA las consulta todas a la vez, las compara entre sí y te dice qué importa de verdad.
 
-Ese es el desbloqueo. No hay un motor de búsqueda mejor. Una docena de plataformas desconectadas, conectadas por un agente.
+Ese es el desbloqueo. No se trata de un buscador mejor, sino de una docena de plataformas incomunicadas que un agente conecta entre sí.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Tienes una reunión mañana. Les Google a ellos. Obtienes su LinkedIn de 2023. /last30days te da lo que realmente están haciendo este mes: se unió a OpenAI para trabajar en Codex, luchar contra la prohibición de Anthropic sobre agentes externos, enviar 23 PRs con un 85% de tasa de fusión, construir "LobsterOS" para control de agentes entre dispositivos, y r/ClaudeCode alcanzó 569 votos positivos debatiendo si es un héroe o "insoportable". Dispersos por X publicaciones, hilos de Reddit , transcripciones de YouTube y GitHub commits. Nada de eso estaba en Google.
+Mañana tienes una reunión. Buscas a la persona en Google. Te sale su LinkedIn de 2023. /last30days te da lo que está haciendo de verdad este mes: se ha incorporado a OpenAI para trabajar en Codex, pelea contra el veto de Anthropic a los agentes de terceros, ha entregado 23 PR con un 85 % de tasa de merge, construye «LobsterOS» para controlar agentes entre dispositivos, y un hilo de r/ClaudeCode llegó a 569 votos positivos debatiendo si es un héroe o un «insoportable». Todo repartido entre publicaciones de X, hilos de Reddit, transcripciones de YouTube y commits de GitHub. Nada de eso estaba en Google.
 
 ## Por qué existe esto
 
-Lo construí para mantenerme al día en IA. Todo cambia cada día y los frikis de Reddit y X siempre están al pendiente primero. Necesitaba mejores indicaciones, y los datos de entrenamiento siempre iban meses por detrás de lo que la comunidad ya había descubierto.
+Lo construí para no quedarme atrás en IA. Todo cambia cada día y los frikis de Reddit y de X siempre se enteran primero. Necesitaba mejores prompts, y los datos de entrenamiento siempre iban meses por detrás de lo que la comunidad ya había averiguado.
 
-Pero se convirtió en algo más grande. Ahora lo hago antes de una llamada de ventas para saber la verdad de los últimos 30 días sobre un negocio. Antes de una reunión para leer los tuits recientes y las transcripciones de podcasts de alguien. Antes de un viaje Disney World para saber qué atracciones están cerradas y qué dice la comunidad sobre Genie+. Antes de construir nada para saber qué problemas están enfrentando realmente las personas.
+Pero acabó siendo algo más grande. Ahora lo lanzo antes de una llamada comercial, para conocer la verdad de los últimos 30 días sobre una empresa. Antes de una reunión, para leer los tuits recientes y las transcripciones de podcasts de la otra persona. Antes de un viaje a Disney World, para saber qué atracciones están cerradas y qué opina la comunidad sobre Genie+. Antes de construir nada, para saber con qué problemas se está encontrando la gente de verdad.
 
-Si te reúnes con un CEO, ¿has leído todos sus tuits y transcripciones de YouTube de los últimos 30 días? Sí.
+Si te vas a reunir con un CEO, ¿te has leído todos sus tuits y todas sus transcripciones de YouTube de los últimos 30 días? Yo sí.
 
-## Fuentes, puntuadas por el pueblo
+## Fuentes, puntuadas por la gente
 
 | Fuente | Lo que te dice la gente |
 |--------|--------------------------|
-| **Reddit** | La opinión sin filtros. Mejores comentarios con recuentos reales de votos, gratis, sin API clave. Las opiniones reales que Google entierra. |
-| **X / Twitter** | La opinión polémica, el hilo de expertos, la reacción de rompimiento. Primero en saber, primero en discutir. |
-| **YouTube** | La inmersión profunda de 45 minutos. En las transcripciones completas buscaron las 5 frases memorables que importan. |
-| **TikTok** | El creador llega a 3,6 millones de personas con una opinión que nunca encontrarás en Google. |
-| **Instagram Reels** | La perspectiva del influencer con transcripciones habladas. La señal cultural visual. |
-| **Hacker News** | El consenso de los desarrolladores. 825 puntos, 899 comentarios. Donde los técnicos realmente discuten. |
-| **Polymarket** | No opiniones. Probabilidades. Respaldado por dinero real. 96% de confianza en las ventas del álbum. 4% en una adquisición. |
-| **GitHub** | Para la gente: PR Velocity, repositorios principales por estrellas, notas de lanzamiento. Para temas: temas y debates. |
-| **Digg** | Agrupaciones de historias seleccionadas de la tabla de clasificación AI 1000 de Digg(~1000 cuentas de IA de alta señal en X), con comillas en línea atribuibles (sin necesidad de autenticación X ). Autoactivado cuando `digg-pp-cli` está en PATH. |
-| **arXiv** | Los papeles detrás del bombo. Nueva investigación en la ventana, gratis, sin API clave. Autoactivado cuando `arxiv-pp-cli` está en PATH (la primera configuración lo instala). |
-| **Techmeme** | La capa editorial de noticias tecnológicas, con fecha de 30 días. Gratis, sin API clave. Activado automáticamente cuando `techmeme-pp-cli` está en PATH (la primera ejecución lo instala). |
-| **LinkedIn** | La señal profesional. Publicaciones y artículos, con los artículos ponderados como alta señal. |
-| **StockTwits** | Sentimiento del trader. Se activa automáticamente cuando tu tema es un ticker o una criptomoneda. |
-| **Threads** | La capa de texto post-Twitter. Conversaciones de creadores y marcas. |
-| **Pinterest** | Descubrimiento visual. Pines, guarda y comenta productos e ideas. |
-| **Xiaohongshu (RED)** | Señales de estilo de vida, producto y creador chino. Solicitado explícitamente con `--search xhs` cuando un plugin de navegador x-mcp o servicio de `xiaohongshu-mcp` iniciado sesión está ejecutándose localmente. |
-| **Bluesky** | La capa social descentralizada. Publicaciones del Protocolo AT desde la migración posterior a Twitter. |
-| **Perplexity** | Síntesis de sonar en tierra, filas de búsqueda API puro e investigación profunda. |
-| **Web** | La cobertura editorial, las comparaciones en blogs. Una señal entre muchas, no la única. |
+| **Reddit** | La opinión sin filtros. Los mejores comentarios con su recuento real de votos positivos, gratis y sin clave de API. Las opiniones reales que Google entierra. |
+| **X / Twitter** | La reacción en caliente, el hilo del experto, la primera respuesta a una noticia de última hora. Los primeros en enterarse, los primeros en discutir. |
+| **YouTube** | El análisis a fondo de 45 minutos. Transcripciones completas, rastreadas para sacar las 5 frases citables que importan. |
+| **TikTok** | El creador que llega a 3,6 millones de personas con una lectura que nunca encontrarás en Google. |
+| **Instagram Reels** | La mirada de los influencers, con transcripción de lo que dicen. La señal de la cultura visual. |
+| **Hacker News** | El consenso de los desarrolladores. 825 puntos, 899 comentarios. Donde la gente técnica discute de verdad. |
+| **Polymarket** | No son opiniones. Son cuotas. Respaldadas por dinero real. 96 % de probabilidad en ventas de un álbum. 4 % en una adquisición. |
+| **GitHub** | Para personas: ritmo de PR, mejores repositorios por estrellas, notas de versión. Para temas: issues y discusiones. |
+| **Digg** | Grupos de noticias seleccionados del ranking AI 1000 de Digg (unas 1000 cuentas de IA con mucha señal en X), con citas atribuibles integradas y sin necesidad de autenticarte en X. Se activa solo cuando `digg-pp-cli` está en el PATH. |
+| **arXiv** | Los artículos científicos que hay detrás del ruido. Investigación nueva dentro de la ventana, gratis y sin clave de API. Se activa solo cuando `arxiv-pp-cli` está en el PATH (la configuración inicial lo instala). |
+| **Techmeme** | La capa editorial de la actualidad tecnológica, acotada a tu ventana de 30 días. Gratis y sin clave de API. Se activa solo cuando `techmeme-pp-cli` está en el PATH (la configuración inicial lo instala). |
+| **LinkedIn** | La señal profesional. Publicaciones y artículos, con los artículos ponderados como señal fuerte. |
+| **StockTwits** | El sentimiento de los traders. Se activa automáticamente cuando tu tema es un ticker o una criptomoneda. |
+| **Threads** | La capa de texto posterior a Twitter. Conversaciones de creadores y marcas. |
+| **Pinterest** | Descubrimiento visual. Pines, guardados y comentarios sobre productos e ideas. |
+| **Xiaohongshu (RED)** | Señales chinas sobre estilo de vida, productos y creadores. Se pide de forma explícita con `--search xhs` cuando tienes corriendo en local un plugin de navegador x-mcp con sesión iniciada o un servicio `xiaohongshu-mcp`. |
+| **Bluesky** | La capa social descentralizada. Publicaciones de AT Protocol surgidas de la migración posterior a Twitter. |
+| **Perplexity** | La síntesis fundamentada de Sonar, los resultados en bruto de la Search API y Deep Research. |
+| **Web** | La cobertura editorial, las comparativas de los blogs. Una señal entre muchas, no la única. |
 
-Los colaboradores de la comunidad siguen añadiendo más. Truth Social y otras fuentes de nicho están en el motor con más en camino.
+La comunidad no para de sumar fuentes. Truth Social y otras fuentes de nicho ya están en el motor, y vienen más.
 
-Un hilo Reddit con 1.500 votos positivos es una señal más fuerte que una entrada de blog que nadie ha leído. Un TikTok con 3,6 millones de visualizaciones te dice más sobre lo que es culturalmente relevante que una nota de prensa. Polymarket cuotas respaldadas por 66.000 dólares en volumen son más difíciles de discutir que la suposición de un experto.
+Un hilo de Reddit con 1.500 votos positivos es una señal más fuerte que una entrada de blog que no leyó nadie. Un TikTok con 3,6 millones de visualizaciones dice más sobre lo que es culturalmente relevante que cualquier nota de prensa. Unas cuotas de Polymarket respaldadas por 66.000 dólares de volumen son más difíciles de rebatir que la corazonada de un tertuliano.
 
-La síntesis se clasifica según lo que realmente se relacionó la gente real. Relevancia social, no SEO relevancia.
+La síntesis ordena según aquello con lo que la gente real ha interactuado de verdad. Relevancia social, no relevancia SEO.
 
-## Para qué la gente realmente lo usa
+## Para qué lo usa la gente en realidad
 
-**Antes de una reunión.** `/last30days Peter Steinberger` - se unió al equipo Codex de OpenAI, luchando contra la prohibición de agentes externos de Anthropic, 23 PRs fusionados con un 85% de tasa de fusión en GitHub, construyendo LobsterOS para el control de agentes entre dispositivos. Código r/Claude: "Desde que OpenClaw se lanzó, era bien sabido que si lo pasabas por cualquier cosa que no fuera la API, acabarían siendo baneados" (227 votos positivos). Eso no es culpa LinkedIn.
+**Antes de una reunión.** `/last30days Peter Steinberger` — se ha incorporado al equipo de Codex de OpenAI, pelea contra el veto de Anthropic a los agentes de terceros, 23 PR mergeadas con un 85 % de tasa de merge en GitHub, construye LobsterOS para controlar agentes entre dispositivos. r/ClaudeCode: «Desde que salió OpenClaw, todo el mundo sabía que, si lo pasabas por algo que no fuera la API, acabarías baneado» (227 votos positivos). Eso no está en LinkedIn.
 
-**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals` - las páginas actuales de empleos y carreras se citan como evidencias de cambios de enfoque: contratación hacia seguridad empresarial, éxito del cliente, infraestructura o expansión de productos. El informe dice lo que parece señalar la contratación, no lo que la hoja de ruta presentará.
+**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals` — las ofertas de empleo y las páginas de carreras actuales se convierten en pruebas citadas de un cambio de prioridades: contratación en seguridad para empresa, customer success, infraestructura o expansión de producto. El informe dice lo que la contratación parece señalar, no lo que la hoja de ruta va a entregar.
 
-**Para encontrar el tema antes de que alcance su punto máximo.** Pregúntale `/last30days what's exploding in AI agents?` y la habilidad cambia a modo descubrimiento: el motor barre Reddit listados de categorías, Hacker News historias principales/mejores, el feed AI 1000 de Diggy X cuando está autenticado; tu agente juzga las nominaciones (nombres, filtrado basura, calidad de contenido) y escribe podcast / X-ángulos de artículo; luego obtienes de 5 a 10 temas clasificados por velocidad. Cada resultado incluye números de fuentes cruzadas, una etiqueta de impulso y un seguimiento `/last30days "<topic>"` listo para publicarse.
+**Para encontrar el tema antes de su pico.** Pregunta `/last30days what's exploding in AI agents?` y la skill cambia a modo descubrimiento: el motor barre los listados por categoría de Reddit, la portada y las mejores historias de Hacker News, el feed AI 1000 de Digg y X si estás autenticado; tu agente evalúa las candidaturas (nombres, filtrado de ruido, interés real) y escribe enfoques para pódcast o para un artículo en X; después obtienes entre 5 y 10 temas ordenados por velocidad. Cada resultado incluye cifras de varias fuentes, una etiqueta de impulso y un comando `/last30days "<topic>"` listo para lanzar.
 
-**Cuando algo cae.** `/last30days Kanye West` - Reino Unido bloqueó su visado, el Wireless Festival canceló, los patrocinadores huyeron. Pero BULLY debutó en el puesto #2 en Billboard. Fantano volvió de su "Yay sabático" para reseñarlo (653.000 visualizaciones). SoFi Homecoming trajo a Lauryn Hill y Travis Scott para 44 canciones. Polymarket: «¿Volverá a tuitear Kanye?» 86% Sí. 23 hilos Reddit , 17 vídeos YouTube , 86.000 votos positivos.
+**Cuando sale algo nuevo.** `/last30days Kanye West` — el Reino Unido le bloqueó el visado, el Wireless Festival se canceló, los patrocinadores huyeron. Pero BULLY debutó en el número 2 del Billboard. Fantano volvió de su «Yay sabbatical» para reseñarlo (653.000 visualizaciones). En el SoFi Homecoming sacó al escenario a Lauryn Hill y a Travis Scott para 44 canciones. Polymarket: «¿Volverá Kanye a tuitear?» 86 % sí. 23 hilos de Reddit, 17 vídeos de YouTube, 86.000 votos positivos.
 
-**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Estos no son competidores, son capas." OpenClaw es el albacea (351K GitHub estrellas, en directo), Hermes es el cerebro que se auto-mejora (31K estrellas), Paperclip es el organigrama (49K estrellas). Recuento de estrellas extraído en directo del GitHub API, no entradas de blog obsoletas. Mesa lado a lado con arquitectura, memoria, seguridad, lo mejor para. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
+**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip` — «No son competidores, son capas.» OpenClaw es la capa de ejecución (351.000 estrellas en GitHub, en producción), Hermes es el cerebro que se mejora a sí mismo (31.000 estrellas), Paperclip es el organigrama (49.000 estrellas). El número de estrellas se saca en directo de la API de GitHub, no de entradas de blog caducadas. Tabla comparativa con arquitectura, memoria, seguridad y caso de uso ideal. Según @IMJustinBrooke: «OpenClaw = Charmander, Hermes = Charizard.»
 
-**Para entender el mundo.** `/last30days Iran vs USA` - Día 38 de la guerra. La fecha límite del martes de Trump para que Irán reabra el Estrecho de Ormuz. Dos aviones de guerra estadounidenses derribados. Petróleo a 126 dólares por barril. La AIE lo calificó como "la mayor interrupción del suministro en la historia del mercado global del petróleo." Polymarket: alto el fuego para el 31 de diciembre al 74%. 27 publicaciones X , 10 vídeos YouTube , 20 mercados de predicción.
+**Para entender el mundo.** `/last30days Iran vs USA` — día 38 de la guerra. El ultimátum de Trump, con plazo hasta el martes, para que Irán reabra el estrecho de Ormuz. Dos aviones de combate estadounidenses derribados. El petróleo a 126 dólares el barril. La AIE lo calificó como «la mayor interrupción de suministro de la historia del mercado mundial del petróleo». Polymarket: alto el fuego antes del 31 de diciembre al 74 %. 27 publicaciones de X, 10 vídeos de YouTube, 20 mercados de predicción.
 
-**Antes de un viaje.** `/last30days Universal Epic Universe` - Expansión ya en construcción. Permiso "Proyecto 680" presentado. Espectáculo de fuegos artificiales confirmado por infraestructura pero sin avisar. Tiempos de espera: Locura de vagonetas de mina de media 148 minutos. Aún no hay pase anual y los locales están frustrados. Stardust Racers en reformas hasta el 5 de abril.
+**Antes de un viaje.** `/last30days Universal Epic Universe` — la ampliación ya está en obras. Licencia «Project 680» presentada. El espectáculo de fuegos artificiales está confirmado por la infraestructura, pero sin anunciar. Tiempos de espera: Mine-Cart Madness promedia 148 minutos. Todavía no hay pase anual, y los vecinos están hartos. Stardust Racers cerrada por reforma hasta el 5 de abril.
 
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - Los prompts estructurados JSONestán reemplazando a la sopa de etiquetas. El formato anidado de @pictsbyaievita el "sangrado conceptual". El flujo de trabajo de edición primero vence a la regeneración. Luego te escribe un prompt de producción usando exactamente lo que la comunidad dijo que funciona.
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` — los prompts estructurados en JSON están sustituyendo al amontonamiento de etiquetas. El formato anidado de @pictsbyai evita el «concept bleeding». Editar gana a regenerar. Y después te escribe un prompt de producción aplicando exactamente lo que la comunidad ha dicho que funciona.
 
-## Qué hay de nuevo
+## Novedades
 
-Desde el anuncio de la v3.3 en mayo, a partir de la v3.11.1 (julio de 2026): 175 se fusionaron PRs —122 de 52 colaboradores de la comunidad— en 15 lanzamientos. Esto fue lo que me consiguió.
+Desde el anuncio de la v3.3 en mayo y hasta la v3.11.1 (julio de 2026): 175 PR mergeadas —122 de ellas de 52 colaboradores de la comunidad— repartidas en 15 versiones. Esto es lo que ha entrado.
 
-### Primera clase en OpenAI Codex
+### Ciudadano de primera en OpenAI Codex
 
-/last30days ahora es un plugin nativo de Codex con configuración guiada: no es un puerto, es un ciudadano de primera clase. Las citas conscientes del renderizador hacen que Codex salida se lea como un brief en lugar de una sopa de URL (#694), y el mismo motor funciona en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawy 50+ hosts Agent Skills . Codex manifiesto del plugin por [@rfoust](https://github.com/rfoust) (#686), Codex corrección de autenticación por [@tmchow](https://github.com/tmchow) (#698).
+/last30days ya es un plugin nativo de Codex con configuración guiada: no es un port, es un ciudadano de primera. Las citas tienen en cuenta el renderizador, así que la salida en Codex se lee como un informe y no como una sopa de URL (#694), y el mismo motor funciona en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw y 50+ hosts de Agent Skills. Manifiesto del plugin de Codex por [@rfoust](https://github.com/rfoust) (#686), corrección de autenticación en Codex por [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmemey Digg - gratis, sin llaves API
+### arXiv, Techmeme y Digg: gratis y sin claves de API
 
-arXiv trae a los periódicos detrás del bombo y Techmeme trae la capa editorial de noticias tecnológicas - gratis, cero llaves, y la configuración de primera ejecución instala sus CLIpara que se activen automáticamente (#709). Los clusters de historias AI 1000 de Diggllegan sin X autenticación de la misma manera: configuración instala el Digg CLI gratuito para ti (#590). Trustpilot se lanza opt-in para investigación de marca de consumo.
+arXiv aporta los artículos científicos que hay detrás del ruido y Techmeme la capa editorial de la actualidad tecnológica: gratis, sin una sola clave, y la configuración inicial instala sus CLI para que se activen solas (#709). Los grupos de noticias AI 1000 de Digg llegan igual, sin autenticarte en X: la configuración instala por ti la CLI gratuita de Digg (#590). Trustpilot está disponible como opción para investigar marcas de consumo.
 
-### Free Reddit ha hecho crecer puntuaciones reales y comentarios destacados
+### Reddit gratis, con puntuaciones reales y mejores comentarios
 
-Reddit.json API pública murió; el camino gratuito volvió más fuerte. RSS sin clave + scraping de shreddit (#457), descubrimiento de subreddit dedicado con conteos reales de votos positivos vía arctic-shift (#696), y un piso de relevancia para que una publicación viral fuera de tema no pueda secuestrar tu brief (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave API . Puntuaciones reales. Comentarios principales incluidos.
+La API pública .json de Reddit desapareció; la vía gratuita volvió más fuerte. RSS sin clave y scraping de shreddit (#457), descubrimiento de subreddits específicos con recuentos reales de votos positivos vía arctic-shift (#696), y un umbral de relevancia para que una publicación viral fuera de tema no secuestre tu informe (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave de API. Puntuaciones reales. Con los mejores comentarios incluidos.
 
 ### Los mejores comentarios en cada informe
 
-Los comentarios ahora son una capa predeterminada en todas las fuentes: comentarios de Instagram con diversidad basada en el ranking, así que cinco opiniones polémicas no provienen todas de una sola publicación (#751), YouTube comentarios más una copia de seguridad ScrapeCreators de transcripción para cuando YT-DLP se pone fuera (#637), y comentarios votados por el público ponderados en Best Takes para que las líneas más divertidas de la comunidad sobrevivan a la puntuación (#592, #608).
+Los comentarios son ya una capa activada por defecto en todas las fuentes: comentarios de Instagram con diversidad basada en el ranking, para que cinco opiniones rotundas no salgan todas de la misma publicación (#751), comentarios de YouTube más un respaldo de transcripción vía ScrapeCreators para cuando yt-dlp falla (#637), y comentarios votados por la comunidad ponderados dentro de Best Takes, para que las mejores frases sobrevivan a la puntuación (#592, #608).
 
-### Orden de un médico
+### Un único comando doctor
 
-Pide un chequeo médico y el médico revisa todas las fuentes, luego prescribe soluciones exactas: qué clave falta, cuál CLI está desajustada PATH, qué cookie caducó (#753). No más adivinanzas por qué X salió floja.
+Pide una revisión y doctor comprueba todas las fuentes y receta los arreglos exactos: qué clave falta, qué CLI no está en el PATH, qué cookie ha caducado (#753). Se acabó adivinar por qué X ha devuelto tan poco.
 
-### X búsqueda, reconstruida
+### La búsqueda en X, reconstruida
 
-La X pipeline recibió una renovación completa: carriles FROM y ABOUT, así que las publicaciones propias de una persona y la conversación sobre ambas se posicionan (#610), desambiguación de subconsultas conscientes de la persona (#611), puesta a tierra de autoría de primera mano con ranking de señal de interacción (#613), y una única fuente X con falla automática de backend (#622). Además, un `--diagnose` honesto que realmente sondea la autenticación (#609).
+El pipeline de X se rehízo de arriba abajo: carriles FROM y ABOUT para que se posicionen tanto las publicaciones de una persona como la conversación sobre ella (#610), desambiguación de subconsultas según la persona buscada (#611), verificación de la autoría de primera mano con ranking por señales de interacción (#613), y una única fuente X con conmutación automática entre backends (#622). Además, un `--diagnose` honesto que comprueba de verdad la autenticación (#609).
 
-### Se sumaron más fuentes
+### Se han sumado más fuentes
 
-LinkedIn vía ScrapeCreators, con artículos como high signal ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente para temas de tickers y cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity creció directamente en modos API y async Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn vía ScrapeCreators, con los artículos como señal fuerte ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente en temas de tickers y cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity ha ganado modos de API directos y Deep Research asíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Endurecidos por la comunidad
+### Endurecido por la comunidad
 
-La ola de seguridad consistía casi en su totalidad en trabajo comunitario: correcciones XSS almacenadas en el renderizador de HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies bloqueados, CI reforzado en cadena de suministro con OpenSSF Scorecard y atestación de procedencia de compilación ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), escaneos Semgrep y OSV-Scanner más una PR puerta de revisión de dependencias ([@23241a6749](https://github.com/23241a6749)), un piso de cobertura de pruebas introducido al 60% y desde entonces elevado al 84% ([@gourab5139014](https://github.com/gourab5139014)), y un escaneo de seguridad Hermes eliminado de todos los hallazgos CRÍTICOS (#768).
+La oleada de seguridad fue casi por completo trabajo de la comunidad: correcciones de XSS almacenado en el renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies blindados, CI endurecida frente a ataques a la cadena de suministro con OpenSSF Scorecard y atestación de procedencia de las builds ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), análisis con Semgrep y OSV-Scanner más un control de revisión de dependencias en cada PR ([@23241a6749](https://github.com/23241a6749)), un mínimo de cobertura de pruebas fijado al 60 % y elevado desde entonces al 84 % ([@gourab5139014](https://github.com/gourab5139014)), y un análisis de seguridad de Hermes que ya no arroja ningún hallazgo CRITICAL (#768).
 
 ### Llega más lejos
 
-Hebreo y lenguas no latinas ([@dudyme](https://github.com/dudyme)). Tokenización consciente de CJKpara fuentes chinas ([@An-idd](https://github.com/An-idd)). Una ola de compatibilidad Windows . Extracción de cookies a lo largo de toda la familia Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - además de fuentes de credenciales macOS Keychain y Linux pass(1). `--as-of` revisión histórica ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionado automáticamente Python 3.12 vía uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Deltas de la lista de seguimiento entre ejecuciones.
+Hebreo y otros idiomas no latinos ([@dudyme](https://github.com/dudyme)). Tokenización adaptada a CJK para las fuentes chinas ([@An-idd](https://github.com/An-idd)). Una oleada de compatibilidad con Windows. Extracción de cookies en toda la familia Chromium —Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov))— además del llavero de macOS y pass(1) en Linux como orígenes de credenciales. Consulta histórica hacia atrás con `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Instalación automática de Python 3.12 mediante uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Diferencias de la lista de seguimiento entre ejecuciones.
 
-### Sigue en la caja de la v3
+### Lo que ya venía de serie desde la v3
 
-Las bases de la v3 siguen aquí: el cerebro previo a la investigación que resuelve los handles, subreddits y hashtags correctos antes de que se active una sola llamada de API (creado por [@j-sperling](https://github.com/j-sperling)); Best Takes puntuación para humor y viralidad junto con relevancia; fusión de clústeres entre fuentes; comparaciones de un solo pase ("CLI vs MCP" en 3 minutos, no en 12); comparaciones `--competitors` descubiertas automáticamente; GitHub modo persona (`--github-user=steipete`); modo ELI5 ("eli5 activado" tras cualquier partida); y HTML briefs compartidos y autocontenidos (`--emit=html`). Los mandos de configuración están en [CONFIGURATION.md](CONFIGURATION.md).
+Los cimientos de la v3 siguen todos aquí: el cerebro previo a la investigación, que identifica las cuentas, subreddits y hashtags correctos antes de que salga una sola llamada a la API (obra de [@j-sperling](https://github.com/j-sperling)); la puntuación Best Takes, que valora el humor y la viralidad además de la relevancia; la fusión de clústeres entre fuentes; las comparativas en una sola pasada («CLI vs MCP» en 3 minutos, no en 12); las comparativas `--competitors` descubiertas de forma automática; el modo persona de GitHub (`--github-user=steipete`); el modo ELI5 («eli5 on» después de cualquier ejecución); y los informes HTML autocontenidos y compartibles (`--emit=html`). Los ajustes de configuración están en [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Instalación
 
-| Superficie | Instalación | Actualizaciones |
+| Entorno | Instalación | Actualizaciones |
 |---------|---------|---------|
-| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto a través del marketplace, o `claude plugin update last30days@last30days-skill` |
-| **Grok**( CLIde construcción xAI ) | `grok plugin marketplace add mvanhorn/last30days-skill` entonces `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLIo cualquiera de los 50+ [Agent Skills](https://agentskills.io) presentadores** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y sube a través de claude.ai > Personalizar > habilidades > + > Crear habilidades > Subir una habilidad | Volver a descargar y volver a subir |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrastra a Configuración > Extensiones | Vuelve a descargar y arrastra el nuevo paquete |
+| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automáticas vía marketplace, o `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` y después `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ hosts de [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Descarga `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y súbelo desde claude.ai > Customize > Skills > + > Create skill > Upload a skill | Volver a descargar y volver a subir |
+| **Claude Desktop** | [Descarga el `.mcpb` de tu plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrástralo a Settings > Extensions | Volver a descargar y arrastrar el nuevo paquete |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recomendado)
@@ -169,46 +169,46 @@ Las bases de la v3 siguen aquí: el cerebro previo a la investigación que resue
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recomendado porque el marketplace de Claude Code se encarga de las actualizaciones por ti: la caché del plugin está versionada y se actualiza automáticamente cuando se publica una nueva versión. Ejecuta `claude plugin update last30days@last30days-skill` para forzar una comprobación.
+Es la opción recomendada porque el marketplace de Claude Code se encarga de las actualizaciones por ti: la caché del plugin está versionada y se refresca sola cuando se publica una versión nueva. Ejecuta `claude plugin update last30days@last30days-skill` para forzar una comprobación.
 
-Si prefieres usar la ruta de instalación de agent-skills en Claude Code, eso también está soportado:
+Si prefieres usar la vía de instalación de Agent Skills en Claude Code, también está soportada:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-El plugin nativo y la instalación `npx skills` pueden coexistir. Ten en cuenta que Claude Code no se desduplica entre métodos de instalación: si tienes activas tanto el plugin del marketplace como la copia `npx skills` , `/last30days` mostrará dos entradas. Usa un método de instalación por máquina.
+El plugin nativo y la instalación con `npx skills` pueden convivir. Ojo: Claude Code no deduplica entre métodos de instalación. Si tienes activos a la vez el plugin del marketplace y la copia de `npx skills`, `/last30days` aparecerá dos veces. Usa un solo método de instalación por máquina.
 
-### Grok ( CLIde la construcción xAI)
+### Grok (xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) se instala en dur30days como un plugin nativo. La instalación directa rastrea el repositorio:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala last30days como plugin nativo. La instalación directa sigue el repositorio:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-O añadir este repositorio como fuente del marketplace y luego instalar por nombre del plugin:
+O añade este repositorio como fuente de marketplace y luego instálalo por nombre de plugin:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Añade `--trust` para saltarse la confirmación de instalación. Actualizar con `grok plugin update last30days`. Grok también lee los manifiestos de Claude Code para garantizar la compatibilidad; el par nativo de `.grok-plugin/` es el carril de primera clase (y lo que indica un listado oficial de [xAI marketplace](https://github.com/xai-org/plugin-marketplace) ). `npx skills add` sigue siendo un respaldo válido entre hosts.
+Añade `--trust` para saltarte la confirmación de instalación. Actualiza con `grok plugin update last30days`. Grok también lee los manifiestos de Claude Code por compatibilidad; el par nativo `.grok-plugin/` es la vía principal, y es a lo que apunta una entrada oficial en el [marketplace de xAI](https://github.com/xai-org/plugin-marketplace). `npx skills add` sigue siendo una alternativa válida para cualquier host.
 
-### Codex, Cursor, Copilot, Gemini CLIy otros anfitriones Agent Skills
+### Codex, Cursor, Copilot, Gemini CLI y otros hosts de Agent Skills
 
-Instala a través del [Agent Skills](https://agentskills.io) CLI abierto — soporta 50+ arneses incluyendo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`y más (lista completa en el [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Instálalo con la CLI abierta de [Agent Skills](https://agentskills.io): soporta 50+ hosts, entre ellos `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` y más (lista completa en el [repositorio vercel-labs/skills](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-La bandera `-g` (global) se instala en tu directorio de usuario, por lo que la habilidad está disponible en todos los proyectos. Sin `-g`, `npx skills` instala el proyecto localmente en `./.skills/` (comprometido con el repositorio). Para una herramienta de investigación del mundo, lo que quieres es global.
+El flag `-g` (global) instala en tu directorio de usuario, de modo que la skill queda disponible en todos los proyectos. Sin `-g`, `npx skills` instala solo en el proyecto, dentro de `./.skills/` (y se versiona con el repositorio). Para una herramienta que sirve para investigar el mundo entero, lo que quieres es la instalación global.
 
-Codex escritorio y otros hosts en modo carpeta pueden funcionar tanto en carpetas ordinarias como en repositorios Git. Antes de investigar primero, pide al agente host que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio skill cargado; en una comprobación de código, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Muestra el código fuente de configuración, el plan de cookies del navegador, las escrituras planificadas, los comandos opcionales y la configuración del proyecto ignorada sin leer cookies, escribir archivos ni ejecutar investigación.
+Codex de escritorio y otros hosts que trabajan a nivel de carpeta funcionan tanto en carpetas normales como en repositorios Git. Antes de la primera investigación, pídele al agente anfitrión que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio de la skill cargada; en un clon del código fuente, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Te muestra de dónde sale la configuración, qué cookies del navegador se leerían, qué archivos se escribirían, qué comandos opcionales hay y qué configuración de proyecto se ignora, todo ello sin leer cookies, sin escribir archivos y sin lanzar ninguna investigación.
 
-Por defecto, esto se instala para el arnés que `npx skills` detecte. Para apuntar a uno específico (o varios):
+Por defecto se instala para el host que detecte `npx skills`. Para apuntar a uno concreto (o a varios):
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Actualización más adelante con:
+Para actualizar más adelante:
 
 ```bash
 npx skills update last30days -g
 ```
 
-O actualiza todo lo que hayas instalado globalmente a través de `npx skills`:
+O actualiza todo lo que hayas instalado globalmente con `npx skills`:
 
 ```bash
 npx skills update -g
 ```
 
-Lista y elimina con `npx skills list -g` y `npx skills remove last30days -g`.
+Puedes listarlo y desinstalarlo con `npx skills list -g` y `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la última edición
-2. Ve a [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Haz clic en el botón `+` en el panel de Habilidades > haz clic en `Create skill` > `Upload a skill` y navega/suelta el archivo
+1. [Descarga `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la última versión publicada
+2. Entra en [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Pulsa el botón `+` del panel de Skills, luego `Create skill` > `Upload a skill`, y busca o arrastra el archivo
 
-Activa primero "Ejecución de código y creación de archivos" en Capacidades — las habilidades no funcionarán sin ella.
+Activa antes «Code execution and file creation» en Capabilities: sin eso, las skills no se ejecutan.
 
 ### Claude Desktop
 
-Claude Desktop instala `/last30days` como servidor MCP mediante un paquete `.mcpb` (un paquete Model Context Protocol de un solo clic).
+Claude Desktop instala `/last30days` como servidor MCP mediante un paquete `.mcpb` (un paquete de Model Context Protocol de un solo clic).
 
-1. Ve a la [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) y descarga el `.mcpb` para tu plataforma:
+1. Entra en la [última versión publicada](https://github.com/mvanhorn/last30days-skill/releases/latest) y descarga el `.mcpb` de tu plataforma:
    - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
    - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
    - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abre Claude Desktop, ve a Configuración > Extensiones y arrastra el archivo.
-3. Cuando te lo pidan, pega API claves para las fuentes que quieres activar. Cada campo es opcional: el motor se degrada a modo solo web si los saltas todos. Las claves se almacenan en el llavero de tu sistema operativo.
-4. Reinicia Claude Desktop. Pídele a Claude que "investigue a Peter Steinberger" o cualquier tema y llamará a la herramienta `research` .
+2. Abre Claude Desktop, ve a Settings > Extensions y arrastra el archivo ahí.
+3. Cuando te las pida, pega las claves de API de las fuentes que quieras activar. Todos los campos son opcionales: si los saltas todos, el motor se queda en modo solo web. Las claves se guardan en el llavero de tu sistema operativo.
+4. Reinicia Claude Desktop. Pídele a Claude que «investigue a Peter Steinberger», o cualquier otro tema, y llamará a la herramienta `research`.
 
-**Requisito de host:** Python 3.12+ en PATH. El paquete incluye el código fuente del motor pero utiliza tu intérprete de Python local. Instala desde [python.org](https://www.python.org/downloads/) en Windows; macOS y la mayoría de Linux distribuciones envían una versión compatible.
+**Requisito del anfitrión:** Python 3.12+ en el PATH. El paquete incluye el código del motor, pero usa tu intérprete de Python local. En Windows, instálalo desde [python.org](https://www.python.org/downloads/); macOS y la mayoría de distribuciones de Linux ya traen una versión compatible.
 
-**Las teclas no se sincronizan con la habilidad Código.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados por diseño. Si ya configuraste `~/.config/last30days/.env` para la habilidad Código, volverás a introducir las mismas teclas aquí una vez.
+**Las claves no se comparten con la skill de Claude Code.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados a propósito. Si ya configuraste `~/.config/last30days/.env` para la skill de Claude Code, aquí tendrás que introducir esas mismas claves una vez.
 
-Windows soporte se pospone hasta que se resuelvan los puntos de entrada del manifiesto por plataforma; se sigue en un número de seguimiento.
+La compatibilidad con Windows queda aplazada hasta resolver los puntos de entrada por plataforma del manifiesto; el seguimiento se hace en una incidencia aparte.
 
 ### OpenClaw
 
@@ -263,43 +263,44 @@ Windows soporte se pospone hasta que se resuelvan los puntos de entrada del mani
 clawhub install last30days-official
 ```
 
-Para X/Twitter acciones de trabajo fuera de la investigación `/last30days` , como publicar
-tuits o respuestas, exportación de seguidores, gestión de medios, monitores y sorteo
-Draws, usa a [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como compañero
-OpenClaw plugin. TweetClaw es mantenido por Xquik-dev y aparece solo como un
-Camino de compañero opcional, no una dependencia o endoso de Last30Days.
+Para flujos de acción en X/Twitter fuera de la investigación de `/last30days` —publicar
+tuits o respuestas, exportar seguidores, gestionar medios, monitorizar cuentas y
+resolver sorteos— usa [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como
+plugin complementario de OpenClaw. TweetClaw lo mantiene Xquik-dev y aparece aquí
+únicamente como opción complementaria: no es una dependencia ni una recomendación
+de last30days.
 
-### Manual (desarrollador)
+### Manual (para desarrolladores)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-El enlace simbólico mantiene la instalación sincronizada con tu árbol de trabajo mientras editas — no es necesario recopiar. Para `claude.ai`, compila el archivo `.skill` desde el código fuente: `bash skills/last30days/scripts/build-skill.sh` produce `dist/last30days.skill`.
+El enlace simbólico mantiene la instalación sincronizada con tu copia de trabajo a medida que editas, sin necesidad de volver a copiar nada. Para `claude.ai`, compila el archivo `.skill` desde el código fuente: `bash skills/last30days/scripts/build-skill.sh` genera `dist/last30days.skill`.
 
-Reddit (con comentarios), Hacker News, Polymarkety GitHub funcionan inmediatamente. Cero configuración. Ejecuta `/last30days` una vez y el asistente de configuración desbloquea más fuentes en 30 segundos, incluyendo la arXiv gratuita y la Techmeme CLIs.
+Reddit (con comentarios), Hacker News, Polymarket y GitHub funcionan de inmediato. Cero configuración. Ejecuta `/last30days` una vez y el asistente de configuración desbloquea más fuentes en 30 segundos, incluidas las CLI gratuitas de arXiv y Techmeme.
 
-## Trae tus propias llaves
+## Aporta tus propias claves
 
-Estas plataformas no tienen relaciones entre sí. X no sabe lo que Reddit piensa. YouTube no ve TikTok. Pero puedes traer tus propias claves de API y tokens de navegador, y de repente tienes acceso a todos a la vez.
+Estas plataformas no tienen ninguna relación entre sí. X no sabe lo que piensa Reddit. YouTube no ve TikTok. Pero tú puedes aportar tus claves de API y tus tokens de navegador y, de golpe, tienes acceso a todas a la vez.
 
 | Fuentes | Lo que necesitas | Coste |
 |---------|---------------|------|
 | Reddit (con comentarios) + HN + Polymarket + GitHub + StockTwits | Nada | Gratis |
-| arXiv + Techmeme | Free CLIs, instalado automáticamente por la primera ejecución | Gratis |
-| X / Twitter | Inicia sesión en x.com en cualquier navegador, o configura `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratuitas; las claves son específicas de cada proveedor |
+| arXiv + Techmeme | CLI gratuitas, instaladas automáticamente por la configuración inicial | Gratis |
+| X / Twitter | Inicia sesión en x.com en cualquier navegador, o define `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratis; las claves dependen del proveedor |
 | YouTube | `brew install yt-dlp` | Gratis |
-| Bluesky | Contraseña de la app de bsky.app | Gratis |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comentarios | ScrapeCreators clave | 10.000 llamadas gratis, luego PAYG |
-| Xiaohongshu (RED) | Ejecuta un plugin de navegador x-mcp o servicio `xiaohongshu-mcp` iniciado sesión y opta por `--search xhs` por partida o `INCLUDE_SOURCES=xiaohongshu` en `.env`; last30days auto-probes `http://localhost:18060` luego `http://host.docker.internal:18060`, o usa `XIAOHONGSHU_API_BASE` para una URL personalizada | No hay clave de API de últimos 30 días; depende del servicio local de sesiones de navegador |
-| DripStack (boletines financieros premium) | Opt-in: `--search dripstack` por partida, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin clave; búsqueda pública gratuita API |
-| Perplexity Sonar / API de búsqueda / Investigación profunda | Perplexity tecla, o clave OpenRouter como respaldo para Sonar | Paga según la acción |
-| Web búsqueda | Clave de búsqueda Brave | 2.000 consultas gratuitas al mes |
+| Bluesky | Una contraseña de aplicación de bsky.app | Gratis |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentarios de YouTube | Una clave de ScrapeCreators | 10.000 llamadas gratis y luego pago por uso |
+| Xiaohongshu (RED) | Ten corriendo un plugin de navegador x-mcp con sesión iniciada o un servicio `xiaohongshu-mcp`, y activa la fuente con `--search xhs` por ejecución o con `INCLUDE_SOURCES=xiaohongshu` en `.env`; last30days prueba automáticamente `http://localhost:18060` y después `http://host.docker.internal:18060`, o usa `XIAOHONGSHU_API_BASE` para una URL propia | No hace falta clave de API de last30days; depende de tu servicio local de sesión de navegador |
+| DripStack (boletines financieros premium) | Opcional: `--search dripstack` por ejecución, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin clave; API de búsqueda pública y gratuita |
+| Perplexity Sonar / Search API / Deep Research | Una clave de Perplexity, o una clave de OpenRouter como alternativa para Sonar | Pago por uso |
+| Búsqueda web | Una clave de Brave Search | 2.000 consultas gratis al mes |
 
-### macOS Keychain (opcional)
+### Llavero de macOS (opcional)
 
-En macOS puedes almacenar claves en el Keychain del sistema en lugar de un archivo `.env` . La habilidad las detecta automáticamente como la fuente de menor prioridad — `.env` archivos y entorno de procesos siguen ganando en la colisión.
+En macOS puedes guardar las claves en el llavero del sistema en lugar de en un archivo `.env`. La skill las recoge automáticamente como la fuente de menor prioridad: si hay conflicto, siguen ganando los archivos `.env` y el entorno del proceso.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +314,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Los elementos se almacenan bajo `last30days-<KEY>` de nombre de servicio para el usuario actual. En plataformas no Darwin, el cargador es no-op, por lo que no hay cambio de comportamiento para usuarios de Linux/Windows .
+Las entradas se guardan con el nombre de servicio `last30days-<KEY>` para el usuario actual. En plataformas que no son Darwin el cargador no hace nada, así que para quienes usan Linux o Windows no cambia el comportamiento.
 
-¿Ya tienes claves bajo diferentes nombres de servicio Keychain ? Configura el mapeo de `LAST30DAYS_KEYCHAIN_ALIASES` no secreto descrito en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) en lugar de copiar secretos.
+¿Ya tienes claves guardadas con otros nombres de servicio en el llavero? Define el mapeo no secreto `LAST30DAYS_KEYCHAIN_ALIASES` que se describe en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), en lugar de copiar secretos.
 
-Consulta [CONFIGURATION.md](CONFIGURATION.md) para la matriz completa de claves por fuente, prioridad del proveedor de razonamiento y prioridad del backend de búsqueda web.
+Consulta [CONFIGURATION.md](CONFIGURATION.md) para ver la matriz completa de claves por fuente, el orden de prioridad de los proveedores de razonamiento y el de los backends de búsqueda web.
 
 ## Configuración
 
-Dos cosas que probablemente querrás saber el primer día:
+Dos cosas que seguramente querrás saber desde el primer día:
 
-**Donde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` por defecto es `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Anula configurando esa variable ambiental a cualquier ruta de tu shell, o `--save-dir <path>` por partida. Usa `--output <file>` cuando necesites el resultado renderizado en una ruta exacta, usando el formato seleccionado por `--emit`. Usa `--save-suffix=<name>` para mantener separadas varias variaciones del mismo tema (por ejemplo, por cliente). Cada `--save-dir` ejecución produce `<slug>-raw[-suffix].md`. Ejecuta `python3 skills/last30days/scripts/last30days.py --preflight` para revisar las escrituras planificadas antes de una ejecución de investigación.
+**Dónde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` apunta por defecto a `~/Documents/Last30Days/` (en Windows: `C:\Users\<you>\Documents\Last30Days\`). Puedes cambiarlo definiendo esa variable de entorno en tu shell con la ruta que quieras, o con `--save-dir <path>` en una ejecución concreta. Usa `--output <file>` cuando necesites el resultado renderizado en una ruta exacta, con el formato que elijas en `--emit`. Usa `--save-suffix=<name>` para mantener separadas varias variantes del mismo tema (por cliente, por ejemplo). Cada ejecución con `--save-dir` genera `<slug>-raw[-suffix].md`. Ejecuta `python3 skills/last30days/scripts/last30days.py --preflight` para revisar qué se va a escribir antes de lanzar una investigación.
 
-**Salida estructurada para agentes y flujos de trabajo.** Pide `/last30days` JSON legibles por máquina para recibir el perfil estable y versionado del agente. Para uso directo del motor en scripts o desarrollo, ejecuta `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; añade `--json-profile=raw` solo cuando necesites el volcado interno de `Report` sin versiones. Consulta el [JSON export field reference and versioning policy](docs/reference/json-export.md).
+**Salida estructurada para agentes y flujos de trabajo.** Pídele a `/last30days` JSON legible por máquina y obtendrás el perfil de agente estable y versionado. Para usar el motor directamente en scripts o en desarrollo, ejecuta `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; añade `--json-profile=raw` solo si necesitas el volcado interno sin versionar de `Report`. Consulta la [referencia de campos de la exportación JSON y la política de versionado](docs/reference/json-export.md).
 
-**Descubrimiento sin tema.** Pide a `/last30days what's trending in AI agents?` que consigas un resumen de descubrimiento clasificado en lugar de investigar un tema que ya conoces; en un agente anfitrión esto ejecuta el protocolo de tres comandos host-judged (el modelo nombra temas, filtra basura, puntua la dignidad y escribe los ángulos de contenido). Para uso directo del motor en scripts o cron, ejecuta `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nombres deterministas de temas, sin ángulos); añade `--emit=json` para el contrato de descubrimiento versionado. El descubrimiento es mutuamente excluyente con un tema posicional y `--drill`.
+**Descubrimiento sin tema.** Pregunta `/last30days what's trending in AI agents?` para obtener un informe de descubrimiento ordenado, en lugar de investigar un tema que ya conoces. En un host con agente esto ejecuta el protocolo de tres comandos arbitrado por el host (el modelo propone los temas, filtra el ruido, puntúa lo que merece la pena y escribe los enfoques de contenido). Para usar el motor directamente en scripts o en cron, ejecuta `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (una sola pasada: nombres de tema deterministas, sin enfoques); añade `--emit=json` para el contrato de descubrimiento versionado. El descubrimiento es incompatible con un tema posicional y con `--drill`.
 
-**Monitorización de tendencias entre ejecuciones.** El modo predeterminado produce una instantánea de descuento nueva por ejecución. Para acumular hallazgos a lo largo del tiempo, añade `--store` para que persistan en una base de datos SQLite, luego usa [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con entrega opcional de Slack / webhook en nuevos hallazgos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios o semanales. El patrón completo de cadencia está en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Seguimiento de tendencias entre ejecuciones.** El modo por defecto genera una instantánea Markdown nueva en cada ejecución. Para ir acumulando hallazgos con el tiempo, añade `--store` y se guardarán en una base de datos SQLite; después usa [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con envío opcional por Slack o webhook cuando aparezcan hallazgos nuevos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios o semanales. El patrón de cadencia completo está en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Una biblioteca de investigación suscribible.** Pídete `/last30days` que construya tu feed de biblioteca, o úsala `python3 skills/last30days/scripts/last30days.py library feed` directamente para scripting y desarrollo. Convierte los briefs guardados en `index.html`, un `feed.xml`local de Atom y páginas breves legibles. Añade `--publish` solo cuando quieras que el índice de HTML y las páginas breves estén alojadas; la publicación es explícita opt-in y pública por defecto. Para que el feed de Atom sea suscribible, aloja el directorio de salida generado en un host estático como GitHub Pages.
+**Una biblioteca de investigación a la que suscribirse.** Pídele a `/last30days` que genere el feed de tu biblioteca, o usa directamente `python3 skills/last30days/scripts/last30days.py library feed` para scripting y desarrollo. Convierte los informes guardados en un `index.html`, un `feed.xml` Atom local y páginas de informe legibles. Añade `--publish` solo cuando quieras alojar el índice HTML y las páginas de informe; publicar es una decisión explícita y por defecto es público. Para que el feed Atom se pueda seguir de verdad, aloja el directorio de salida generado en un alojamiento estático como GitHub Pages.
 
-**Busca todo lo que has investigado.** Pregunta `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para uso directo del motor, ejecuta `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda es offline y determinista: indexa de forma incremental los mismos briefs guardados que usa el feed de la biblioteca, fusiona los avistamientos de la tienda correspondientes por ejecución y agrupa los resultados por tema y fecha. Las ejecuciones nuevas también muestran una sección compacta **Desde tu biblioteca** cuando investigaciones previas se solapan con el tema actual; configura `LAST30DAYS_LIBRARY_CONTEXT=off` para desactivar ese contexto pasivo.
+**Busca en todo lo que ya has investigado.** Pregunta `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para usar el motor directamente, ejecuta `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda es offline y determinista: indexa de forma incremental los mismos informes guardados que usa el feed de la biblioteca, fusiona las coincidencias registradas en el almacén de cada ejecución y agrupa los resultados por tema y fecha. Las ejecuciones nuevas muestran además una sección compacta **From your library** («desde tu biblioteca») cuando una investigación anterior se solapa con el tema actual; define `LAST30DAYS_LIBRARY_CONTEXT=off` para desactivar ese contexto pasivo.
 
-Los scripts wrapper por cliente, subreddits personalizados de categoría y el canal beta experimental para personalizaciones en proceso también están documentados en [CONFIGURATION.md](CONFIGURATION.md).
+Los scripts envoltorio por cliente, los subreddits de categoría personalizados y el canal beta experimental para personalizaciones en curso también están documentados en [CONFIGURATION.md](CONFIGURATION.md).
 
-## Showcase: feeds de investigación comunitaria
+## Escaparate: feeds de investigación de la comunidad
 
-¿Has publicado una actualización recurrente de IA, un seguimiento de mercado o una obsesión maravillosamente limitada con los últimos 30 días? Comparte la URL de la biblioteca pública—o la URL de Atom después de alojarla `feed.xml` en un host estático—en [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds comunitarios estarán enlazados aquí a medida que sus propietarios los envíen; el hilo es el punto de recogida mientras tanto.
+¿Has publicado con last30days una actualización periódica sobre IA, un seguimiento de mercado o una obsesión maravillosamente específica? Comparte la URL de tu biblioteca pública —o la URL de Atom, una vez alojado `feed.xml` en un alojamiento estático— en [el hilo de escaparate de la comunidad](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds de la comunidad se irán enlazando aquí a medida que sus autores los envíen; mientras tanto, el hilo es el punto de recogida.
 
 ## Cómo funciona
 
-1. **Escribes un tema.** Persona, empresa, producto, tecnología, "X vs Y." Cualquier cosa.
-2. **El agente decide quién importa.** Encuentra X cuentas (incluidos fundadores), repositorios de GitHub , subreddits TikTok hashtags YouTube canales. Para "Kanye West" conoce r/hiphopheads, @kanyewesty "bully review" en YouTube. Para "OpenClaw" resuelve openclaw/openclaw en GitHub y recoge recuentos de estrellas en directo.
-3. **Todas las fuentes buscadas en paralelo.** Expansión multiconsulta. Resultados puntuados por interacción, relevancia y frescura.
-4. **La profundidad que nadie más tiene.** Transcripciones completas YouTube de vídeos de reacción. Comentarios de Reddit con el recuento de votos positivos. TikTok pies de foto. Polymarket probabilidades. No solo títulos y enlaces.
-5. **Misma historia, fusionada.** El Festival Wireless anunciado el Reddit, se discutió en X, los precios de las entradas en TikTok = un grupo, no tres artículos separados.
-6. **Sintetizado en un solo informe.** Basado en datos específicos. Citado por fuente. Clasificado según lo que la gente realmente interactúa. No "esto es lo que encontré". Es "esto es lo que importa."
-7. **Entonces se convierte en tu experto.** Tras una sola partida, tu sesión Claude sabe todo lo que sabe la comunidad. Haz preguntas de seguimiento. Haz que escriba prompts, redacte correos electrónicos, planifique viajes, diseñe sistemas, todo basado en lo que es real ahora mismo.
+1. **Escribes un tema.** Una persona, una empresa, un producto, una tecnología, «X vs Y». Lo que sea.
+2. **El agente averigua quién importa.** Encuentra las cuentas de X (incluidas las de fundadores), los repositorios de GitHub, los subreddits, los hashtags de TikTok y los canales de YouTube. Para «Kanye West» sabe que hay que mirar r/hiphopheads, @kanyewest y «bully review» en YouTube. Para «OpenClaw» resuelve openclaw/openclaw en GitHub y trae el número de estrellas en directo.
+3. **Todas las fuentes se consultan en paralelo.** Expansión con varias consultas. Resultados puntuados por interacción, relevancia y frescura.
+4. **La profundidad que no tiene nadie más.** Transcripciones completas de YouTube de vídeos de reacción. Los mejores comentarios de Reddit con su recuento de votos positivos. Los textos de los TikTok. Las cuotas de Polymarket. No solo títulos y enlaces.
+5. **La misma historia, fusionada.** El Wireless Festival anunciado en Reddit, comentado en X y con los precios de las entradas en TikTok: un solo clúster, no tres entradas distintas.
+6. **Sintetizado en un único informe.** Anclado en datos concretos. Citado por fuente. Ordenado según aquello con lo que la gente interactúa de verdad. No es «esto es lo que he encontrado», es «esto es lo que importa».
+7. **Y después se convierte en tu experto.** Tras una sola ejecución, tu sesión de Claude sabe todo lo que sabe la comunidad. Haz preguntas de seguimiento. Pídele que escriba prompts, redacte correos, planifique viajes o diseñe arquitecturas, todo anclado en lo que es real ahora mismo.
 
 ## Lo que dice la gente
 
-> "He encontrado una habilidad Claude Code que investiga cualquier tema en Reddit, X, YouTubey HN de los últimos 30 días. Luego escribe los prompts para ti. He estado buscando manualmente Reddit y X investigación antes de cada contenido que escribo. Pestaña por pestaña. Hilo por hilo. Esa es la parte que tarda 90 minutos. Esto lo elimina." -@itsjasonai
+> «He encontrado una skill de Claude Code que investiga cualquier tema en Reddit, X, YouTube y HN de los últimos 30 días. Y luego te escribe los prompts. Antes de cada contenido que escribo, hacía esa búsqueda a mano en Reddit y X. Pestaña a pestaña. Hilo a hilo. Esa es la parte que se lleva 90 minutos. Esto la elimina.» —@itsjasonai
 
-> "Esta habilidad reemplazó todo mi flujo de trabajo de investigación. Le das un tema, raspa Reddit, Xy la web para encontrar de qué la gente realmente habla. No de viejas entradas de blog. Conversaciones reales de los últimos 30 días." -@itswilsoncharles
+> «Esta única skill ha sustituido todo mi flujo de investigación. Le das un tema y rastrea Reddit, X y la web para sacar de qué está hablando la gente de verdad. Nada de entradas de blog viejas. Conversaciones reales de los últimos 30 días.» —@itswilsoncharles
 
-> "5 de los 10 repositorios más populares en GitHub hoy son herramientas Claude . #1: Mvanhorn/last30days-habilidad" -@yieldhunter95
+> «5 de los 10 repos en tendencia hoy en GitHub son herramientas de Claude. El número 1: mvanhorn/last30days-skill» —@yieldhunter95
 
 ## Código abierto
 
-Licencia del MIT. Sin rastreo. Sin análisis. Tu investigación permanece en tu máquina. 2.700+ pruebas.
+Licencia MIT. Sin rastreo. Sin analíticas. Tu investigación se queda en tu máquina. Más de 2.700 pruebas.
 
-Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird para X búsqueda) y ScrapeCreators API. arquitectura del motor v3 por [@j-sperling](https://github.com/j-sperling).
+Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird incorporado para la búsqueda en X) y la API de ScrapeCreators. Arquitectura del motor v3 de [@j-sperling](https://github.com/j-sperling).
 
-Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para abrir una PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para la lista completa de colaboradores de la comunidad y [CHANGELOG.md](CHANGELOG.md) para el historial de versiones.
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para abrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para la lista completa de colaboradores de la comunidad y [CHANGELOG.md](CHANGELOG.md) para el historial de versiones.
 
-## Historia de Star
+## Evolución de las estrellas
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.fr.md
+++ b/README.fr.md
@@ -16,151 +16,151 @@
   </a>
 </p>
 
-**Un moteur de recherche dirigé par un agent IA, noté par des votes positifs, des likes et de l’argent réel - pas par des éditeurs.**
+**Un moteur de recherche piloté par un agent IA, qui classe les résultats selon les upvotes, les likes et l'argent réel — pas selon des rédacteurs.**
 
-Ce README suit le pipeline v3 actuel. La spécification de compétence à l’exécution se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui est la source de vérité pour le comportement de commande et de configuration les plus récents.
+Ce README décrit le pipeline v3 actuel. La spécification d'exécution de la skill se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui fait référence pour le comportement des commandes et de la configuration.
 
-**Claude Code (recommandé — mises à jour automatiques via le marketplace):**
+**Claude Code (recommandé — mises à jour automatiques via la marketplace) :**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI, ou n’importe lequel des 50+ [Agent Skills](https://agentskills.io) hôtes :**
+**Codex, Cursor, Copilot, Gemini CLI, ou l'un des 50+ hôtes [Agent Skills](https://agentskills.io) :**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` s’installe globalement pour votre utilisateur, disponible sur tous les projets. Réduisez-le à la portée par projet.)
+(`-g` installe la skill globalement pour votre utilisateur, donc disponible dans tous vos projets. Omettez ce flag pour une installation limitée au projet.)
 
-Plus d’options d’installation (claude.ai web, OpenClaw, manuel) dans la section [Install](#installation) ci-dessous.
+D'autres options d'installation (claude.ai web, OpenClaw, manuelle) dans la section [Installation](#installation) ci-dessous.
 
-Zéro configuration. Reddit, HN, Polymarketet GitHub fonctionnent immédiatement. Lancez-le une fois et l’assistant de configuration débloque X, YouTube, TikTok, arXiv, Techmemeet plus encore en 30 secondes.
+Zéro configuration. Reddit, HN, Polymarket et GitHub fonctionnent immédiatement. Lancez la skill une fois : l'assistant de configuration débloque X, YouTube, TikTok, arXiv, Techmeme et d'autres sources en 30 secondes.
 
 ---
 
-Reddit votes positifs. X likes. YouTube transcriptions. TikTok engagement. Polymarket probabilités soutenues par de l’argent réel et des informations privilégiées. Cela fait des millions de personnes votant chaque jour avec leur attention et leur portefeuille. /last30days recherche tout cela en parallèle, évalue selon ce avec quoi les vraies personnes interagissent réellement, et un juge IA synthétise tout en un seul mémoire.
+Les upvotes de Reddit. Les likes de X. Les transcriptions YouTube. L'engagement TikTok. Les cotes Polymarket, adossées à de l'argent réel et à des informations d'initiés. Ce sont des millions de personnes qui votent chaque jour avec leur attention et leur portefeuille. /last30days interroge tout cela en parallèle, classe les résultats selon ce avec quoi les gens interagissent vraiment, et un agent IA joue le rôle de juge pour en tirer un seul brief.
 
-Google agréga des éditeurs. /last30days recherche des gens.
+Google agrège des rédactions. /last30days interroge les gens.
 
-Vous ne pouvez pas trouver cette recherche ailleurs car aucune IA unique n’a accès à tout. Google recherche ne touche ni Reddit commentaires ni X publications. ChatGPT a un accord avec Reddit mais ne peut pas rechercher X ni TikTok. Gemini a YouTube mais pas Reddit. Claude n’en a aucun d’eux nativement. Chaque plateforme est un jardin clos avec ses propres API, ses propres jetons, sa propre authentification. Mais vous pouvez apporter vos propres clés et sessions de navigateur, et soudain un agent IA peut toutes les rechercher en même temps, les évaluer entre elles et vous dire ce qui compte réellement.
+Cette recherche est introuvable ailleurs, parce qu'aucune IA n'a accès à l'ensemble. Google ne touche ni aux commentaires Reddit ni aux posts X. ChatGPT a un accord avec Reddit mais ne sait chercher ni sur X ni sur TikTok. Gemini a YouTube mais pas Reddit. Claude n'a nativement accès à aucun des trois. Chaque plateforme est un jardin clos, avec son API, ses tokens et son authentification. Mais vous pouvez apporter vos propres clés et vos sessions de navigateur : d'un coup, un agent IA peut toutes les interroger en même temps, les comparer entre elles et vous dire ce qui compte vraiment.
 
-C’est ça le déblocage. Pas un meilleur moteur de recherche. Une douzaine de plateformes déconnectées, pontées par un agent.
+C'est ça, le déclic. Pas un meilleur moteur de recherche. Une douzaine de plateformes cloisonnées, reliées par un agent.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Vous avez une réunion demain. Vous les Google . Vous obtenez leur LinkedIn de 2023. /last30days vous donne ce qu’ils font réellement ce mois-ci : rejoindre OpenAI pour travailler sur Codex, combattre l’interdiction d’Anthropic sur les agents tiers, expédier 23 PRs à un taux de fusion de 85 %, construire des «LobsterOS» pour le contrôle multi-appareils des agents, et r/ClaudeCode a obtenu 569 votes positifs pour débattre de savoir s’il est un héros ou « insupportable ». Dispersé dans X posts, Reddit fils, YouTube transcriptions et GitHub commits. Rien de tout cela n’était sur Google.
+Vous avez une réunion demain. Vous cherchez la personne sur Google. Vous tombez sur son LinkedIn de 2023. /last30days vous donne ce qu'elle fait vraiment ce mois-ci : elle a rejoint OpenAI pour travailler sur Codex, elle conteste l'interdiction des agents tiers décrétée par Anthropic, elle a livré 23 PR avec un taux de merge de 85 %, elle construit « LobsterOS » pour piloter des agents entre appareils, et un fil r/ClaudeCode a atteint 569 upvotes en débattant de savoir si elle est un héros ou « insupportable ». Le tout dispersé entre des posts X, des fils Reddit, des transcriptions YouTube et des commits GitHub. Rien de tout ça n'était sur Google.
 
-## Pourquoi cela existe-t-il
+## Pourquoi ce projet existe
 
-Je l’ai construit pour suivre le rythme de l’IA. Tout change chaque jour et les Reddit et X nerds sont toujours à l’affût en premier. J’avais besoin de meilleurs indices, et les données d’entraînement avaient toujours des mois de retard sur ce que la communauté avait déjà compris.
+Je l'ai construit pour suivre le rythme de l'IA. Tout change chaque jour, et les passionnés de Reddit et de X sont toujours au courant les premiers. J'avais besoin de meilleurs prompts, et les données d'entraînement avaient toujours plusieurs mois de retard sur ce que la communauté avait déjà compris.
 
-Mais cela s’est transformé en quelque chose de plus important. Maintenant, je le passe avant un appel commercial pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion pour lire les tweets récents et les transcriptions de podcasts de quelqu’un. Avant un Disney World voyage pour savoir quelles attractions sont fermées et ce que la communauté dit à propos de Genie+. Avant de construire quoi que ce soit pour savoir quels problèmes les gens rencontrent réellement.
+Mais c'est devenu quelque chose de plus large. Aujourd'hui je le lance avant un rendez-vous commercial, pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion, pour lire les tweets récents et les transcriptions de podcasts de mon interlocuteur. Avant un séjour à Disney World, pour savoir quelles attractions sont fermées et ce que la communauté pense de Genie+. Avant de construire quoi que ce soit, pour savoir sur quels problèmes les gens butent réellement.
 
-Si vous rencontrez un PDG, avez-vous lu tous ses tweets et YouTube transcriptions des 30 derniers jours ? Oui.
+Si vous rencontrez un PDG, avez-vous lu tous ses tweets et toutes ses transcriptions YouTube des 30 derniers jours ? Moi, oui.
 
-## Sources, notées par le peuple
+## Les sources, classées par les gens
 
-| Source | Ce que les gens te disent |
+| Source | Ce que les gens vous disent |
 |--------|--------------------------|
-| **Reddit** | L’avis non filtré. Meilleurs commentaires avec de vrais votes positifs, gratuits, sans API clé. Les vraies opinions que Google enterre. |
-| **X / Twitter** | L’opinion controversée, le fil narratif de l’expert, la réaction qui s’est brisée. Premier à savoir, premier à argumenter. |
-| **YouTube** | L’analyse approfondie de 45 minutes. Les transcriptions complètes ont été recherchées pour les 5 phrases citables qui comptent. |
-| **TikTok** | Le créateur atteint 3,6 millions de personnes avec une vision que vous ne trouverez jamais sur Google. |
-| **Instagram Reels** | La perspective de l’influenceur avec des transcriptions de spoken word. Le signal visuel de la culture. |
-| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les techniciens argumentent réellement. |
-| **Polymarket** | Pas des opinions. Des cotes. Soutenu par de l’argent réel. 96 % de confiance sur les ventes d’album. 4 % sur une acquisition. |
-| **GitHub** | Pour les gens : PR Velocity, Top Repos par étoiles, notes de release. Pour les sujets : problèmes et discussions. |
-| **Digg** | Clusters d’histoires sélectionnés à partir du classement AI 1000 de Digg(~1000 comptes IA high-signal sur X), avec des citations en ligne attribuables (sans authentification X requise). Autoactivé lorsque `digg-pp-cli` est activé PATH. |
-| **arXiv** | Les papiers derrière tout ce battage médiatique. Nouvelle recherche dans la fenêtre, gratuite, sans API de touche. Auto-activé quand `arxiv-pp-cli` est en PATH (la première configuration l’installe). |
-| **Techmeme** | La couche éditoriale tech-news, avec une fenêtre de date à 30 jours. Gratuit, sans clé API . Activé automatiquement quand `techmeme-pp-cli` est en PATH (la première configuration l’installe). |
-| **LinkedIn** | Le signal professionnel. Publications et articles, avec des éléments pondérés en haut du signal. |
-| **StockTwits** | Le sentiment du trader. S’active automatiquement lorsque votre sujet est un ticker ou une crypto. |
-| **Threads** | La couche texte post-Twitter. Conversations de créateurs et de marques. |
-| **Pinterest** | Découverte visuelle. Épinglez, sauvegardez et commente des produits et des idées. |
-| **Xiaohongshu (RED)** | Signaux de mode de vie, produit et créateur chinois. Demandé explicitement avec `--search xhs` lorsqu’un plugin ou un service `xiaohongshu-mcp` navigateur x-mcp connecté fonctionne localement. |
-| **Bluesky** | La couche sociale décentralisée. Les publications du protocole AT issues de la migration post-Twitter. |
-| **Perplexity** | Synthèse sonar au sol, lignes de API de recherche brute, et recherche profonde. |
-| **Web** | La couverture éditoriale, les comparaisons sur les blogs. Un signal parmi tant d’autres, pas le seul. |
+| **Reddit** | L'avis brut. Les meilleurs commentaires avec leur vrai nombre d'upvotes, gratuit, sans clé API. Les vraies opinions que Google enterre. |
+| **X / Twitter** | La réaction à chaud, le fil d'expert, la première réaction à l'actualité. Premiers informés, premiers à débattre. |
+| **YouTube** | L'analyse approfondie de 45 minutes. Des transcriptions complètes, fouillées pour en extraire les 5 phrases citables qui comptent. |
+| **TikTok** | Le créateur qui touche 3,6 millions de personnes avec un angle que vous ne trouverez jamais sur Google. |
+| **Instagram Reels** | Le regard des influenceurs, avec la transcription de ce qui est dit. Le signal de la culture visuelle. |
+| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les gens techniques débattent vraiment. |
+| **Polymarket** | Pas des opinions. Des cotes. Adossées à de l'argent réel. 96 % de probabilité sur des ventes d'album. 4 % sur une acquisition. |
+| **GitHub** | Pour les personnes : rythme des PR, meilleurs dépôts par étoiles, notes de version. Pour les sujets : issues et discussions. |
+| **Digg** | Des groupes d'articles sélectionnés depuis le classement AI 1000 de Digg (environ 1000 comptes IA à fort signal sur X), avec des citations attribuables intégrées (sans authentification X). Activé automatiquement quand `digg-pp-cli` est présent dans le PATH. |
+| **arXiv** | Les articles scientifiques derrière le battage médiatique. La recherche publiée dans la fenêtre, gratuit, sans clé API. Activé automatiquement quand `arxiv-pp-cli` est présent dans le PATH (la configuration initiale l'installe). |
+| **Techmeme** | La couche éditoriale de l'actu tech, restreinte à votre fenêtre de 30 jours. Gratuit, sans clé API. Activé automatiquement quand `techmeme-pp-cli` est présent dans le PATH (la configuration initiale l'installe). |
+| **LinkedIn** | Le signal professionnel. Posts et articles, les articles étant pondérés comme signal fort. |
+| **StockTwits** | Le sentiment des traders. S'active automatiquement quand votre sujet est un ticker ou une crypto. |
+| **Threads** | La couche texte de l'après-Twitter. Les conversations des créateurs et des marques. |
+| **Pinterest** | La découverte visuelle. Épingles, enregistrements et commentaires sur des produits et des idées. |
+| **Xiaohongshu (RED)** | Les signaux chinois sur le lifestyle, les produits et les créateurs. À demander explicitement avec `--search xhs` quand un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` tourne en local. |
+| **Bluesky** | La couche sociale décentralisée. Les posts AT Protocol issus de la migration post-Twitter. |
+| **Perplexity** | La synthèse Sonar sourcée, les résultats bruts de la Search API et Deep Research. |
+| **Web** | La couverture éditoriale, les comparatifs de blogs. Un signal parmi d'autres, pas le seul. |
 
-Les contributeurs de la communauté n’arrêtent pas d’en ajouter. Truth Social et d’autres sources de niche sont en cours avec d’autres en préparation.
+La communauté en ajoute sans cesse. Truth Social et d'autres sources de niche sont déjà dans le moteur, et d'autres arrivent.
 
-Un fil de discussion Reddit avec 1 500 upvotes est un signal plus fort qu’un article de blog que personne n’a lu. Un TikTok avec 3,6 millions de vues en dit plus sur ce qui est culturellement pertinent qu’un communiqué de presse. Polymarket cotes soutenues par 66 000 $ de volume sont plus difficiles à contester qu’une supposition d’un commentateur.
+Un fil Reddit à 1 500 upvotes est un signal plus fort qu'un billet de blog que personne n'a lu. Un TikTok à 3,6 millions de vues en dit plus sur ce qui compte culturellement qu'un communiqué de presse. Des cotes Polymarket adossées à 66 000 $ de volume sont plus difficiles à contester que l'intuition d'un éditorialiste.
 
-La synthèse se classe selon ce avec quoi les vraies personnes interagissent réellement. La pertinence sociale, pas SEO pertinence.
+La synthèse classe selon ce avec quoi de vraies personnes ont vraiment interagi. La pertinence sociale, pas la pertinence SEO.
 
-## À quoi servent réellement les gens
+## Ce que les gens en font vraiment
 
-**Avant une réunion.** `/last30days Peter Steinberger` - a rejoint l’équipe Codex de OpenAI, luttant contre l’interdiction d’Anthropic sur les agents tiers, 23 PRs fusionnés avec un taux de fusion de 85 % sur GitHub, construisant LobsterOS pour le contrôle inter-appareils des agents. r/ClaudeCode : « Depuis la sortie de OpenClaw, il était largement connu que si vous le passiez par autre chose que le API, vous finiriez par être banni » (227 votes positifs). Ce n’est pas la faute de LinkedIn.
+**Avant une réunion.** `/last30days Peter Steinberger` — a rejoint l'équipe Codex d'OpenAI, conteste l'interdiction des agents tiers décrétée par Anthropic, 23 PR mergées avec un taux de merge de 85 % sur GitHub, construit LobsterOS pour piloter des agents entre appareils. r/ClaudeCode : « Depuis la sortie d'OpenClaw, tout le monde savait que si vous passiez par autre chose que l'API, vous finiriez par être banni » (227 upvotes). Ça, ce n'est pas sur LinkedIn.
 
-**Pour lire les signaux d’embauche.** `/last30days Listen Labs --hiring-signals` - les pages actuelles d’emplois et de carrières deviennent des preuves citées de changements de focus : recrutement vers la sécurité d’entreprise, la réussite client, l’infrastructure ou l’expansion produit. Le rapport indique ce que le recrutement semble signifier, pas ce que la feuille de route présentera.
+**Pour lire les signaux de recrutement.** `/last30days Listen Labs --hiring-signals` — les offres d'emploi et les pages carrières actuelles deviennent des preuves citées de changements de priorités : recrutements en sécurité entreprise, customer success, infrastructure ou expansion produit. Le rapport dit ce que le recrutement semble signaler, pas ce que la roadmap va livrer.
 
-**Pour trouver le sujet avant qu’il ne soit au sommet.** Demandez `/last30days what's exploding in AI agents?` et la compétence passe en mode découverte : le moteur balaie Reddit listes de catégories, Hacker News les articles de première ligne/les meilleures histoires, le fil AI 1000 de Digg, et X lorsqu’authentifié ; votre agent juge les nominations (noms, filtrage des indésirables, qualité du contenu) et écrit des angles d’article pour podcast / X; puis vous obtenez 5 à 10 sujets classés en vélocité. Chaque résultat inclut des chiffres cross-source, une étiquette de momentum, et un `/last30days "<topic>"` suivi prêt à être publié.
+**Pour repérer un sujet avant son pic.** Demandez `/last30days what's exploding in AI agents?` et la skill bascule en mode découverte : le moteur balaie les listings de catégories Reddit, la une et les meilleures histoires de Hacker News, le flux AI 1000 de Digg, et X si vous êtes authentifié ; votre agent évalue les candidats (noms, filtrage du bruit, intérêt réel) et rédige des angles pour un podcast ou un article X ; vous obtenez ensuite 5 à 10 sujets classés par vélocité. Chaque résultat comprend des chiffres multi-sources, une étiquette de momentum et une commande `/last30days "<topic>"` prête à lancer.
 
-**Quand quelque chose tombe.** `/last30days Kanye West` - Le Royaume-Uni a bloqué son visa, le Wireless Festival annulé, les sponsors ont fui. Mais BULLY a débuté #2 sur Billboard. Fantano est revenu de son « Yay sabbatique » pour le critiquer (653 000 vues). SoFi Homecoming a fait venir Lauryn Hill et Travis Scott pour 44 chansons. Polymarket: « Kanye tweetera-t-il encore ? » 86 % Oui. 23 fils Reddit , 17 vidéos YouTube , 86 000 votes positifs.
+**Quand quelque chose sort.** `/last30days Kanye West` — le Royaume-Uni a bloqué son visa, le Wireless Festival est annulé, les sponsors ont fui. Mais BULLY est entré n° 2 au Billboard. Fantano est revenu de son « Yay sabbatical » pour le chroniquer (653 000 vues). SoFi Homecoming a fait monter Lauryn Hill et Travis Scott sur scène pour 44 titres. Polymarket : « Kanye tweetera-t-il de nouveau ? » 86 % de oui. 23 fils Reddit, 17 vidéos YouTube, 86 000 upvotes.
 
-**Pour comparer les outils.** `/last30days OpenClaw vs Hermes vs Paperclip` - « Ce ne sont pas des concurrents, ce sont des couches. » OpenClaw est l’exécuteur (351K GitHub étoiles, en direct), Hermès est le cerveau qui s’améliore lui-même (31K étoiles), Paperclip est l’organigramme (49K étoiles). Comptage d’étoiles extrait en direct depuis le GitHub API, pas des articles de blog obsolètes. Table côte à côte avec architecture, mémoire, sécurité, meilleur pour. Par @IMJustinBrooke: «OpenClaw = Salamèche, Hermès = Dracaufeu. »
+**Pour comparer des outils.** `/last30days OpenClaw vs Hermes vs Paperclip` — « Ce ne sont pas des concurrents, ce sont des couches. » OpenClaw est la couche d'exécution (351 000 étoiles GitHub, en production), Hermes est le cerveau qui s'améliore tout seul (31 000 étoiles), Paperclip est l'organigramme (49 000 étoiles). Nombres d'étoiles récupérés en direct via l'API GitHub, pas repris de billets de blog périmés. Tableau comparatif avec architecture, mémoire, sécurité et cas d'usage idéal. Selon @IMJustinBrooke : « OpenClaw = Salamèche, Hermes = Dracaufeu. »
 
-**Pour comprendre le monde.** `/last30days Iran vs USA` - 38e jour de la guerre. La date limite de Trump mardi pour la réouverture du détroit d’Ormuz par l’Iran. Deux avions de guerre américains abattus. Le pétrole à 126 $ le baril. L’AIE a qualifié cela de « plus grande perturbation de l’approvisionnement de l’histoire du marché mondial du pétrole ». Polymarket: cessez-le-feu d’ici le 31 décembre à 74 %. 27 X posts, 10 vidéos YouTube , 20 marchés de prévision.
+**Pour comprendre le monde.** `/last30days Iran vs USA` — 38e jour de guerre. Ultimatum de Trump, fixé à mardi, pour que l'Iran rouvre le détroit d'Ormuz. Deux avions de combat américains abattus. Le pétrole à 126 $ le baril. L'AIE parle de « la plus grande perturbation d'approvisionnement de l'histoire du marché pétrolier mondial ». Polymarket : cessez-le-feu avant le 31 décembre à 74 %. 27 posts X, 10 vidéos YouTube, 20 marchés de prédiction.
 
-**Avant un voyage.** `/last30days Universal Epic Universe` - Extension déjà en construction. Permis « Projet 680 » déposé. Feu d’artifice confirmé par l’infrastructure mais sans prévenir. Temps d’attente : Mine Wagon Madness en moyenne 148 minutes. Pas encore de pass annuel, et les habitants sont frustrés. Stardust Racers en rénovation jusqu’au 5 avril.
+**Avant un voyage.** `/last30days Universal Epic Universe` — l'extension est déjà en construction. Permis « Project 680 » déposé. Spectacle de feux d'artifice confirmé par les travaux mais toujours pas annoncé. Temps d'attente : Mine-Cart Madness à 148 minutes en moyenne. Toujours pas de pass annuel, et les habitants s'agacent. Stardust Racers fermé pour rénovation jusqu'au 5 avril.
 
-**Pour apprendre quelque chose rapidement.** `/last30days Nano Banana Pro prompting` - JSONles prompts structurés remplacent la soupe de tags. Le format imbriqué de @pictsbyaiempêche le « concept saccade ». Le workflow d’édition d’abord vaut la régénération. Ensuite, il vous écrit une invite de production en utilisant exactement ce que la communauté a dit fonctionner.
+**Pour apprendre vite.** `/last30days Nano Banana Pro prompting` — les prompts structurés en JSON remplacent l'empilement de tags. Le format imbriqué de @pictsbyai évite le « concept bleeding ». Mieux vaut éditer que régénérer. Et ensuite, la skill vous écrit un prompt de production en appliquant exactement ce que la communauté a validé.
 
-## Quoi de neuf
+## Nouveautés
 
-Depuis l’annonce de la v3.3 en mai, à partir de la v3.11.1 (juillet 2026), 175 ont fusionné PRs - 122 d’entre eux issus de 52 contributeurs de la communauté - répartis sur 15 versions. C’est ce qui a été adopté.
+Depuis l'annonce de la v3.3 en mai, et jusqu'à la v3.11.1 (juillet 2026) : 175 PR mergées — dont 122 venant de 52 contributeurs de la communauté — réparties sur 15 versions. Voici ce qui a atterri.
 
-### Première classe sur OpenAI Codex
+### Citoyen de première classe sur OpenAI Codex
 
-/last30days est désormais un plugin Codex natif avec configuration guidée – pas un port, un citoyen de première classe. Les citations conscientes du rendu signifient que Codex sortie se lit comme un brief plutôt qu’un soup URL (#694), et le même moteur fonctionne sur Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawet 50+ hôtes Agent Skills . Codex manifeste du plugin par [@rfoust](https://github.com/rfoust) (#686), Codex correction d’authentification par [@tmchow](https://github.com/tmchow) (#698).
+/last30days est désormais un plugin Codex natif avec configuration guidée : pas un portage, un vrai citoyen de première classe. Les citations tiennent compte du rendu, ce qui fait que la sortie Codex se lit comme un brief et non comme une soupe d'URL (#694), et le même moteur tourne sur Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw et 50+ hôtes Agent Skills. Manifeste du plugin Codex par [@rfoust](https://github.com/rfoust) (#686), correctif d'authentification Codex par [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmemeet Digg - gratuit, sans API clés
+### arXiv, Techmeme et Digg — gratuits, sans clé API
 
-arXiv apporte les journaux derrière le battage médiatique et Techmeme apporte la couche éditoriale-actualité technique - gratuit, zéro clé, et la configuration en première exécution installe leurs CLIpour qu’ils s’activent automatiquement (#709). Les clusters d’histoires IA 1000 de Diggarrivent sans authentification X de la même manière – setup installe le Digg CLI gratuit pour vous (#590). Trustpilot envoient l’option pour la recherche sur la marque grand public.
+arXiv apporte les articles scientifiques derrière le battage médiatique et Techmeme la couche éditoriale de l'actu tech — gratuits, sans aucune clé, et la configuration initiale installe leurs CLI pour qu'ils s'activent tout seuls (#709). Les groupes d'articles AI 1000 de Digg arrivent de la même façon, sans authentification X : la configuration installe pour vous la CLI Digg gratuite (#590). Trustpilot est disponible en option pour la recherche sur les marques grand public.
 
-### Les Reddit gratuits ont fait fructifier de vrais scores et ont fait grimper les commentaires
+### Reddit gratuit, avec de vrais scores et les meilleurs commentaires
 
-Redditpublic .json API est mort ; le chemin gratuit est revenu plus fort. RSS sans clé + scraping shreddit (#457), découverte de subreddit dédié avec de vrais décomptes de votes via arctic-shift (#696), et un plancher de pertinence pour qu’un post viral hors sujet ne puisse pas détourner votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Pas de clé API . Scores réels. Commentaires principaux inclus.
+L'API .json publique de Reddit a disparu ; la voie gratuite est revenue plus forte. Flux RSS sans clé et scraping de shreddit (#457), découverte de subreddits dédiés avec de vrais décomptes d'upvotes via arctic-shift (#696), et un seuil de pertinence pour qu'un post viral hors sujet ne détourne pas votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Pas de clé API. De vrais scores. Les meilleurs commentaires inclus.
 
-### Les meilleurs commentaires dans chaque mémoire
+### Les meilleurs commentaires dans chaque brief
 
-Les commentaires sont désormais une couche par défaut entre les sources : les commentaires Instagram avec une diversité basée sur le classement, donc cinq opinions brûlantes ne proviennent pas toutes d’un même post (#751), YouTube commentaires plus une sauvegarde de ScrapeCreators transcription pour quand yt-dlp est éliminé (#637), et les commentaires votés par le public mis en Best Takes pour que les répliques les plus drôles de la communauté survivent au score (#592, #608).
+Les commentaires sont maintenant une couche activée par défaut sur toutes les sources : commentaires Instagram avec une diversité fondée sur le rang, pour que cinq avis tranchés ne viennent pas tous du même post (#751), commentaires YouTube plus une récupération de transcription via ScrapeCreators quand yt-dlp échoue (#637), et commentaires plébiscités par la communauté intégrés au scoring Best Takes, pour que les meilleures punchlines survivent au classement (#592, #608).
 
-### Commande un médecin
+### Une seule commande doctor
 
-Demandez un contrôle de santé et le médecin analyse toutes les sources, puis prescrit des solutions exactes - quelle clé manque, laquelle CLI est décalée PATH, quel cookie a expiré (#753). Plus de devinettes sur les raisons X sont revenues faibles.
+Demandez un diagnostic : doctor teste chaque source, puis prescrit les correctifs exacts — quelle clé manque, quelle CLI est absente du PATH, quel cookie a expiré (#753). Fini de deviner pourquoi X est revenu à vide.
 
-### X recherche, reconstruite
+### La recherche X, reconstruite
 
-Le pipeline X a bénéficié d’une refonte complète : les voies FROM et ABOUT pour que les posts d’une personne et la conversation à leur sujet soient tous deux classés (#610), désambiguïsation des sous-requêtes conscientes (#611), mise à la terre de l’auteur de première partie avec classement du signal d’interaction (#613), et une source X unique avec basculement automatique backend (#622). En plus d’un `--diagnose` honnête qui sonde réellement l’authentification (#609).
+Le pipeline X a été repensé de fond en comble : des voies FROM et ABOUT pour que les posts d'une personne et la conversation à son sujet soient classés tous les deux (#610), désambiguïsation des sous-requêtes selon la personne visée (#611), vérification de la paternité des posts avec classement par signaux d'interaction (#613), et une source X unique avec bascule automatique entre backends (#622). Plus un `--diagnose` honnête qui teste vraiment l'authentification (#609).
 
-### D’autres sources ont rejoint
+### De nouvelles sources
 
-LinkedIn via ScrapeCreators, avec des articles comme signal élevé ([@ravstr](https://github.com/ravstr), #702). StockTwits s’active automatiquement pour les thèmes ticker et crypto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity développé en modes API directs et asynchrone Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn via ScrapeCreators, avec les articles comme signal fort ([@ravstr](https://github.com/ravstr), #702). StockTwits s'active automatiquement sur les sujets liés aux tickers et aux cryptos ([@wtiwana](https://github.com/wtiwana), #658). Perplexity a gagné des modes API directs et Deep Research en asynchrone ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Endurci par la communauté
+### Durci par la communauté
 
-La vague de sécurité consistait presque entièrement en travail communautaire : correctifs stocked-XSS dans le moteur de rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI renforcé par la chaîne d’approvisionnement avec OpenSSF Scorecard et attestation de provenance de compilation ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), scans Semgrep et OSV-Scanner plus une porte de contrôle de dépendance PR ([@23241a6749](https://github.com/23241a6749)), un plancher de couverture de test introduit à 60 % et depuis porté à 84 % ([@gourab5139014](https://github.com/gourab5139014)), et un scan de sécurité Hermes effacé de toutes les conclusions CRITIQUES (#768).
+La vague sécurité est presque entièrement le fait de la communauté : correctifs XSS stocké dans le rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI durcie contre les attaques de chaîne d'approvisionnement avec OpenSSF Scorecard et attestation de provenance des builds ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), analyses Semgrep et OSV-Scanner plus un contrôle de revue des dépendances sur chaque PR ([@23241a6749](https://github.com/23241a6749)), un seuil plancher de couverture de tests instauré à 60 % puis relevé à 84 % ([@gourab5139014](https://github.com/gourab5139014)), et un audit de sécurité Hermes désormais sans aucune finding CRITICAL (#768).
 
-### Va plus loin
+### Une portée plus large
 
-Hébreu et langues non latines ([@dudyme](https://github.com/dudyme)). Tokenisation consciente CJKpour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague de compatibilité Windows . Extraction des cookies à travers toute la famille Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - plus macOS Keychain et Linux pass(1) sources de certification. `--as-of` rétrospection historique ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionnement automatique Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages d’emplois d’une entreprise. Deltas de la liste de surveillance entre les exécutions.
+L'hébreu et les langues non latines ([@dudyme](https://github.com/dudyme)). Une tokenisation adaptée au CJK pour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague d'améliorations sur Windows. L'extraction des cookies sur toute la famille Chromium — Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) — plus le trousseau macOS et pass(1) sous Linux comme sources d'identifiants. Le retour en arrière historique avec `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). L'installation automatique de Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages emploi d'une entreprise. Les écarts de watchlist d'une exécution à l'autre.
 
-### Toujours dans la boîte depuis la v3
+### Toujours livré depuis la v3
 
-Les fondations de la v3 sont toujours là : le cerveau pré-recherche qui résout les bons pseudos, subreddits et hashtags avant qu’un seul appel de API ne se déclenche (construit par [@j-sperling](https://github.com/j-sperling)) ; Best Takes la notation pour l’humour et la viralité en plus de la pertinence ; la fusion de clusters multisources ; les comparaisons en un seul passage («CLI vs MCP» en 3 minutes, pas 12) ; la découverte automatique `--competitors` comparaisons ; GitHub mode personne (`--github-user=steipete`) ; ELI5 mode (« eli5 on » après chaque partie ; et des briefs HTML partageables et autonomes (`--emit=html`). Les boutons de configuration sont présents dans [CONFIGURATION.md](CONFIGURATION.md).
+Les fondations de la v3 sont toujours là : le cerveau de pré-recherche qui identifie les bons comptes, subreddits et hashtags avant le moindre appel API (construit par [@j-sperling](https://github.com/j-sperling)) ; le scoring Best Takes, qui prend en compte l'humour et la viralité en plus de la pertinence ; la fusion de clusters entre sources ; les comparaisons en une seule passe (« CLI vs MCP » en 3 minutes, pas 12) ; les comparaisons `--competitors` découvertes automatiquement ; le mode personne de GitHub (`--github-user=steipete`) ; le mode ELI5 (« eli5 on » après n'importe quelle exécution) ; et des briefs HTML autonomes et partageables (`--emit=html`). Les options de configuration sont détaillées dans [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Installation
 
-| Surface | Installation | Mises à jour |
+| Environnement | Installation | Mises à jour |
 |---------|---------|---------|
-| **Claude Code**(recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via le marché, ou `claude plugin update last30days@last30days-skill` |
-| **Grok**(Build xAI CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` alors `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI, ou n’importe lequel des 50+ [Agent Skills](https://agentskills.io) hôtes** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(toile) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et téléverser via claude.ai > Personnaliser > compétences > + > Créer une compétence > Télécharger une compétence | Téléchargez et ré-téléchargez |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) et glisser dans Paramètres > Extensions | Retéléchargez et faites glisser le nouveau bundle |
+| **Claude Code** (recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatiques via la marketplace, ou `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` puis `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI, ou l'un des 50+ hôtes [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et envoyez-le via claude.ai > Customize > Skills > + > Create skill > Upload a skill | Retélécharger et renvoyer |
+| **Claude Desktop** | [Téléchargez le `.mcpb` de votre plateforme](https://github.com/mvanhorn/last30days-skill/releases/latest) et glissez-le dans Settings > Extensions | Retélécharger et glisser le nouveau bundle |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recommandé)
@@ -169,46 +169,46 @@ Les fondations de la v3 sont toujours là : le cerveau pré-recherche qui résou
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recommandé car le marché Claude Code gère les mises à jour pour vous — le cache des plugins est versionné et se rafraîchit automatiquement lorsqu’une nouvelle version est publiée. Lancez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
+Recommandé parce que la marketplace Claude Code gère les mises à jour pour vous : le cache du plugin est versionné et se rafraîchit automatiquement à chaque nouvelle version publiée. Lancez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
 
-Si vous préférez utiliser le chemin d’installation des compétences agent-skills sur Claude Code, c’est aussi pris en charge :
+Si vous préférez passer par le chemin d'installation Agent Skills sur Claude Code, c'est également pris en charge :
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-Le plugin natif et l’installation `npx skills` peuvent coexister. Notez que Claude Code ne déduppe pas entre les méthodes d’installation : si vous avez activé à la fois le plugin marketplace et la copie `npx skills` , `/last30days` affichera deux entrées. Utilisez une méthode d’installation par machine.
+Le plugin natif et l'installation `npx skills` peuvent coexister. Attention : Claude Code ne déduplique pas entre méthodes d'installation. Si le plugin de la marketplace et la copie `npx skills` sont actifs tous les deux, `/last30days` apparaîtra en double. Utilisez une seule méthode d'installation par machine.
 
-### Grok ( CLIde construction xAI)
+### Grok (xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) s’installe en dur30days en tant que plugin natif. L’installation directe suit le dépôt :
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installe last30days comme plugin natif. L'installation directe suit le dépôt :
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Ou ajoutez ce dépôt comme source marketplace, puis installez par nom de plugin :
+Ou ajoutez ce dépôt comme source de marketplace, puis installez par nom de plugin :
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Ajouter `--trust` pour sauter la confirmation d’installation. Mettre à jour avec `grok plugin update last30days`. Grok lit aussi les manifestes Claude Code pour la compatibilité ; la paire native `.grok-plugin/` est la voie de première classe (et ce à quoi indique une liste officielle [xAI marketplace](https://github.com/xai-org/plugin-marketplace) ). `npx skills add` reste une solution de secours valide entre hôtes.
+Ajoutez `--trust` pour sauter la confirmation d'installation. Mettez à jour avec `grok plugin update last30days`. Grok lit aussi les manifestes Claude Code par compatibilité ; la paire native `.grok-plugin/` reste la voie principale, et c'est elle que pointe une entrée officielle dans la [marketplace xAI](https://github.com/xai-org/plugin-marketplace). `npx skills add` reste une solution de repli valable, tous hôtes confondus.
 
-### Codex, Cursor, Copilot, Gemini CLI, et autres hôtes Agent Skills
+### Codex, Cursor, Copilot, Gemini CLI et autres hôtes Agent Skills
 
-Installation via l’open [Agent Skills](https://agentskills.io) CLI — prend en charge 50+ harnais incluant `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`et plus encore (liste complète sur le [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Installez via la CLI ouverte [Agent Skills](https://agentskills.io) — elle prend en charge 50+ hôtes, dont `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` et d'autres (liste complète sur le [dépôt vercel-labs/skills](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-Le drapeau `-g` (global) s’installe dans votre répertoire utilisateur, donc la compétence est disponible sur tous les projets. Sans `-g`, `npx skills` installe localement dans `./.skills/` (engagé avec le dépôt). Pour un outil de recherche du monde, global, c’est ce qu’il vous faut.
+Le flag `-g` (global) installe dans votre répertoire utilisateur, ce qui rend la skill disponible dans tous vos projets. Sans `-g`, `npx skills` installe localement dans `./.skills/` (versionné avec le dépôt). Pour un outil qui sert à explorer le monde entier, c'est bien l'installation globale que vous voulez.
 
-Codex hôtes de bureau et autres en mode dossier peuvent fonctionner dans des dossiers ordinaires ainsi que dans des dépôts Git. Avant de faire une première recherche, demandez à l’agent hôte d’exécuter les `scripts/last30days.py --preflight` fournis depuis le répertoire skill chargé ; lors d’une vérification de source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Elle affiche la source de configuration, le plan de cookies-navigateur, les écritures planifiées, les commandes optionnelles et la configuration du projet ignorée sans lire les cookies, écrire des fichiers ou lancer de recherche.
+Codex desktop et les autres hôtes qui travaillent au niveau du dossier fonctionnent aussi bien dans un dossier ordinaire que dans un dépôt Git. Avant la première recherche, demandez à l'agent hôte de lancer le `scripts/last30days.py --preflight` fourni depuis le répertoire de la skill chargée ; dans un clone du dépôt source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Elle affiche l'origine de la configuration, le plan de lecture des cookies de navigateur, les fichiers qui seront écrits, les commandes optionnelles et la configuration projet ignorée — sans lire de cookies, sans écrire de fichier et sans lancer de recherche.
 
-Par défaut, cela s’installe pour le faisceau `npx skills` détecte. Pour cibler un ou plusieurs :
+Par défaut, l'installation cible l'hôte que `npx skills` détecte. Pour en viser un en particulier (ou plusieurs) :
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Mise à jour plus tard avec :
+Pour mettre à jour plus tard :
 
 ```bash
 npx skills update last30days -g
 ```
 
-Ou mettez à jour tout ce que vous avez installé globalement via `npx skills`:
+Ou mettez à jour tout ce que vous avez installé globalement via `npx skills` :
 
 ```bash
 npx skills update -g
 ```
 
-Listez et supprimez avec `npx skills list -g` et `npx skills remove last30days -g`.
+Listez et désinstallez avec `npx skills list -g` et `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la dernière sortie
-2. Va à [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Cliquez sur le bouton `+` dans le panneau Compétences > cliquez sur `Create skill` > `Upload a skill` et parcourez/déposez le fichier
+1. [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) depuis la dernière version publiée
+2. Allez sur [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Cliquez sur le bouton `+` du panneau Skills, puis sur `Create skill` > `Upload a skill`, et déposez le fichier
 
-Activez d’abord « Exécution de code et création de fichiers » sous Capacités — les compétences ne s’exécuteront pas sans cela.
+Activez d'abord « Code execution and file creation » dans Capabilities — sans cela, les skills ne s'exécutent pas.
 
 ### Claude Desktop
 
-Claude Desktop installe `/last30days` en tant que serveur MCP via un bundle `.mcpb` (un package Model Context Protocol en un clic).
+Claude Desktop installe `/last30days` comme serveur MCP via un bundle `.mcpb` (un paquet Model Context Protocol en un clic).
 
-1. Allez sur le [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` pour votre plateforme :
+1. Ouvrez la [dernière version publiée](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` correspondant à votre plateforme :
    - macOS Apple Silicon : `last30days-pp-mcp-darwin-arm64.mcpb`
    - macOS Intel : `last30days-pp-mcp-darwin-amd64.mcpb`
    - Linux x86_64 : `last30days-pp-mcp-linux-amd64.mcpb`
-2. Ouvre Claude Desktop, va dans Paramètres > Extensions, et fais glisser le fichier dedans.
-3. Lorsqu’on vous le demande, collez API clés pour les sources que vous souhaitez activer. Chaque champ est optionnel — le moteur passe au mode web uniquement si vous les sautez tous. Les clés sont stockées dans votre trousseau d’OS.
-4. Redémarrez Claude Desktop. Demandez- Claude de « rechercher Peter Steinberger » ou n’importe quel sujet, et cela appellera l’outil `research` .
+2. Ouvrez Claude Desktop, allez dans Settings > Extensions et glissez-y le fichier.
+3. Quand l'application vous les demande, collez les clés API des sources que vous voulez activer. Tous les champs sont facultatifs : si vous les ignorez tous, le moteur se rabat sur le mode web uniquement. Les clés sont stockées dans le trousseau de votre système.
+4. Redémarrez Claude Desktop. Demandez à Claude de « faire des recherches sur Peter Steinberger », ou sur n'importe quel sujet, et il appellera l'outil `research`.
 
-**Exigence de l’hôte :** Python 3.12+ sur PATH. Le bundle envoie la source moteur mais utilise votre interprète Python local. Installez depuis [python.org](https://www.python.org/downloads/) sur Windows; macOS et la plupart des distributions Linux livrent une version compatible.
+**Prérequis côté hôte :** Python 3.12+ dans le PATH. Le bundle embarque le code du moteur mais utilise votre interpréteur Python local. Installez-le depuis [python.org](https://www.python.org/downloads/) sous Windows ; macOS et la plupart des distributions Linux fournissent déjà une version compatible.
 
-**Les clés ne se synchronisent pas avec la compétence Code.** Claude Desktop et Claude Code maintiennent des magasins d’identifiants séparés par conception. Si vous avez déjà configuré `~/.config/last30days/.env` pour la compétence Code, vous saisirez à nouveau les mêmes clés ici une fois.
+**Les clés ne sont pas partagées avec la skill Claude Code.** Claude Desktop et Claude Code maintiennent délibérément des stockages d'identifiants distincts. Si vous avez déjà configuré `~/.config/last30days/.env` pour la skill Claude Code, il faudra ressaisir les mêmes clés ici, une fois.
 
-Windows support est différé jusqu’à ce que les points d’entrée des manifestes par plateforme soient réglés ; suivre un problème de suivi.
+La prise en charge de Windows est reportée le temps de régler les points d'entrée par plateforme dans le manifeste ; le suivi se fait dans une issue dédiée.
 
 ### OpenClaw
 
@@ -263,43 +263,44 @@ Windows support est différé jusqu’à ce que les points d’entrée des manif
 clawhub install last30days-official
 ```
 
-Pour Xflux d’action /Twitter en dehors de la recherche `/last30days` , comme la publication
-tweets ou réponses, exportation d’abonnés, gestion des médias, surveillance et concours
-pioche, utilise [TweetClaw](https://github.com/Xquik-dev/tweetclaw) comme compagnon
-OpenClaw plugin. TweetClaw est maintenu par Xquik-dev et n’est listé que comme un
-Chemin de compagnon optionnel, pas une dépendance ou une endosse de Last30Days.
+Pour les workflows d'action sur X/Twitter en dehors des recherches `/last30days` —
+publier des tweets ou des réponses, exporter des abonnés, gérer les médias,
+surveiller des comptes, organiser des tirages au sort — utilisez
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw), le plugin OpenClaw
+complémentaire. TweetClaw est maintenu par Xquik-dev et n'est mentionné que comme
+option complémentaire : ce n'est ni une dépendance ni une recommandation de last30days.
 
-### Manuel (développeur)
+### Installation manuelle (développeurs)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-Le lien sym maintient l’installation synchronisée avec votre arbre de travail pendant la modification — pas besoin de recopier. Pour `claude.ai`, construisez le fichier `.skill` à partir de la source : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
+Le lien symbolique garde l'installation synchronisée avec votre copie de travail au fil de vos modifications — inutile de recopier quoi que ce soit. Pour `claude.ai`, construisez le fichier `.skill` depuis les sources : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
 
-Reddit (avec commentaires), Hacker News, Polymarketet GitHub fonctionnent immédiatement. Zéro configuration. Lancez- `/last30days` une fois et l’assistant de configuration débloque plus de sources en 30 secondes, y compris les arXiv gratuits et les Techmeme CLIs.
+Reddit (avec les commentaires), Hacker News, Polymarket et GitHub fonctionnent immédiatement. Zéro configuration. Lancez `/last30days` une fois : l'assistant de configuration débloque d'autres sources en 30 secondes, dont les CLI gratuites arXiv et Techmeme.
 
 ## Apportez vos propres clés
 
-Ces plateformes n’ont pas de relations entre elles. X ne sait pas ce que Reddit pense. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés de API et jetons navigateur, et soudainement vous avez accès à tout en même temps.
+Ces plateformes n'ont aucune relation entre elles. X ignore ce que pense Reddit. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés API et vos tokens de navigateur, et vous avez soudain accès à toutes en même temps.
 
-| Sources | Ce dont tu as besoin | Coût |
+| Sources | Ce qu'il vous faut | Coût |
 |---------|---------------|------|
-| Reddit (avec commentaires) + HN + Polymarket + GitHub + StockTwits | Rien | Gratuit |
-| arXiv + Techmeme | Free CLIs, installé automatiquement par la première exécution | Gratuit |
-| X / Twitter | Connectez-vous à x.com dans n’importe quel navigateur, ou configurez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies du navigateur sont gratuits ; les clés sont spécifiques à chaque fournisseur |
+| Reddit (avec les commentaires) + HN + Polymarket + GitHub + StockTwits | Rien | Gratuit |
+| arXiv + Techmeme | Des CLI gratuites, installées automatiquement à la configuration initiale | Gratuit |
+| X / Twitter | Connectez-vous à x.com dans n'importe quel navigateur, ou définissez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies de navigateur sont gratuits ; les clés dépendent du fournisseur |
 | YouTube | `brew install yt-dlp` | Gratuit |
-| Bluesky | Mot de passe de l’application depuis bsky.app | Gratuit |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube commentaires | ScrapeCreators clé | 10 000 appels gratuits, puis PAYG |
-| Xiaohongshu (RED) | Exécutez un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` et optez pour `--search xhs` par exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env`; last30days s’auto-sonde `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilisez `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Pas de clé de API des derniers 30 jours ; cela dépend de votre service local de session de navigateur |
-| DripStack (newsletters financières premium) | Opt-in : `--search dripstack` par partie, ou `INCLUDE_SOURCES=dripstack` en `.env` | Pas de clé ; recherche publique gratuite API |
-| Perplexity Sonar / API de recherche / Recherche approfondie | Perplexity clé, ou clé OpenRouter comme solution de secours Sonar | Payez au fur et à mesure |
-| Web recherche | Clé de recherche Brave | 2 000 requêtes gratuites par mois |
+| Bluesky | Un mot de passe d'application depuis bsky.app | Gratuit |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + commentaires YouTube | Une clé ScrapeCreators | 10 000 appels gratuits, puis paiement à l'usage |
+| Xiaohongshu (RED) | Faites tourner un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp`, puis activez la source avec `--search xhs` pour une exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env` ; last30days teste automatiquement `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilisez `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Aucune clé API last30days ; dépend de votre service local de session de navigateur |
+| DripStack (newsletters financières premium) | Sur activation : `--search dripstack` pour une exécution, ou `INCLUDE_SOURCES=dripstack` dans `.env` | Aucune clé ; API de recherche publique et gratuite |
+| Perplexity Sonar / Search API / Deep Research | Une clé Perplexity, ou une clé OpenRouter en repli pour Sonar | Paiement à l'usage |
+| Recherche web | Une clé Brave Search | 2 000 requêtes gratuites par mois |
 
-### macOS Keychain (optionnel)
+### Trousseau macOS (facultatif)
 
-Sur macOS , vous pouvez stocker les clés dans le Keychain système au lieu d’un fichier `.env` . La compétence les détecte automatiquement comme source de priorité la plus basse — `.env` fichiers et environnement de processus l’emportent toujours en cas de collision.
+Sous macOS, vous pouvez stocker vos clés dans le trousseau système plutôt que dans un fichier `.env`. La skill les récupère automatiquement, comme source de plus faible priorité : en cas de conflit, les fichiers `.env` et les variables d'environnement du processus l'emportent toujours.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +314,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Les éléments sont stockés sous le nom de service `last30days-<KEY>` pour l’utilisateur actuel. Sur les plateformes non-Darwin, le chargeur est un no-op, donc il n’y a pas de changement de comportement pour les utilisateurs Linux/Windows .
+Les entrées sont enregistrées sous le nom de service `last30days-<KEY>` pour l'utilisateur courant. Sur les plateformes non Darwin, le chargeur ne fait rien : aucun changement de comportement pour les utilisateurs Linux et Windows.
 
-Avez-vous déjà des clés sous différents noms de service Keychain ? Définissez la `LAST30DAYS_KEYCHAIN_ALIASES` non secrète décrite dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) au lieu de copier les secrets.
+Vous avez déjà des clés sous d'autres noms de service dans le trousseau ? Définissez la correspondance non secrète `LAST30DAYS_KEYCHAIN_ALIASES` décrite dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), plutôt que de recopier vos secrets.
 
-Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète de clés par source, la priorité du fournisseur de raisonnement et la priorité backend de recherche web.
+Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète des clés par source, l'ordre de priorité des fournisseurs de raisonnement et celui des backends de recherche web.
 
 ## Configuration
 
-Deux choses que vous voudrez probablement savoir dès le premier jour :
+Deux choses que vous voudrez sans doute savoir dès le premier jour :
 
-**Où les fichiers de recherche sont sauvegardés.** `LAST30DAYS_MEMORY_DIR` par défaut est `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Remplaça en définissant cette variable d’environnement sur n’importe quel chemin dans ton shell, ou `--save-dir <path>` par exécution. Utilise `--output <file>` lorsque tu as besoin que le résultat affiché soit sur un chemin exact, en utilisant le format choisi par `--emit`. Utilise `--save-suffix=<name>` pour séparer plusieurs variantes du même sujet (par exemple par client). Chaque exécution `--save-dir` produit `<slug>-raw[-suffix].md`. Exécute `python3 skills/last30days/scripts/last30days.py --preflight` pour revoir les écritures prévues avant une exécution de recherche.
+**Où sont enregistrés les fichiers de recherche.** `LAST30DAYS_MEMORY_DIR` vaut par défaut `~/Documents/Last30Days/` (sous Windows : `C:\Users\<you>\Documents\Last30Days\`). Redéfinissez cette variable d'environnement dans votre shell pour pointer ailleurs, ou passez `--save-dir <path>` sur une exécution. Utilisez `--output <file>` quand vous voulez le résultat rendu à un chemin précis, dans le format choisi par `--emit`. Utilisez `--save-suffix=<name>` pour garder séparées plusieurs variantes d'un même sujet (par client, par exemple). Chaque exécution avec `--save-dir` produit `<slug>-raw[-suffix].md`. Lancez `python3 skills/last30days/scripts/last30days.py --preflight` pour vérifier les écritures prévues avant une recherche.
 
-**Sortie structurée pour les agents et les flux de travail.** Demandez `/last30days` JSON lisibles par machine pour recevoir le profil d’agent stable et versionné. Pour une utilisation directe du moteur dans les scripts ou le développement, exécutez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; ajoutez `--json-profile=raw` uniquement lorsque vous avez besoin du vidage interne de `Report` non versionné. Voir le [JSON export field reference and versioning policy](docs/reference/json-export.md).
+**Sortie structurée pour les agents et les workflows.** Demandez à `/last30days` du JSON exploitable par une machine pour obtenir le profil d'agent stable et versionné. Pour un usage direct du moteur en script ou en développement, lancez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` ; n'ajoutez `--json-profile=raw` que si vous avez besoin du dump interne non versionné de `Report`. Voir la [référence des champs de l'export JSON et la politique de versionnement](docs/reference/json-export.md).
 
-**Découverte sans sujet.** Demandez- `/last30days what's trending in AI agents?` d’obtenir un brief de découverte classé au lieu de rechercher un sujet déjà connu – sur un agent hôte, cela exécute le protocole à trois commandes hôte-jugé (le modèle nomme les sujets, filtre les indésirables, note la valeur et écrit les angles de contenu). Pour une utilisation directe du moteur dans des scripts ou des crons, exécutez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte est mutuellement exclusive avec un sujet positionnel et `--drill`.
+**Découverte sans sujet imposé.** Demandez `/last30days what's trending in AI agents?` pour obtenir un brief de découverte classé, au lieu de rechercher un sujet que vous connaissez déjà. Sur un hôte agentique, cela déclenche le protocole en trois commandes arbitré par l'hôte (le modèle propose les sujets, écarte le bruit, note leur intérêt et rédige les angles éditoriaux). Pour un usage direct du moteur en script ou en cron, lancez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (en une passe : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte est incompatible avec un sujet positionnel et avec `--drill`.
 
-**Surveillance des tendances entre les exécutions.** Le mode par défaut produit un instantané de remarques fraîchement par exécution. Pour accumuler les résultats au fil du temps, ajoutez `--store` pour persister dans une base SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec une livraison optionnelle par Slack / webhook sur les nouvelles découvertes) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour les digestes quotidiens / hebdomadaires. Le schéma de cadence complet est dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Suivi des tendances d'une exécution à l'autre.** Le mode par défaut produit un instantané Markdown à chaque exécution. Pour accumuler les résultats dans le temps, ajoutez `--store` afin de les conserver dans une base SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec envoi facultatif sur Slack ou via webhook à chaque nouveau résultat) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour des synthèses quotidiennes ou hebdomadaires. Le schéma de cadence complet est dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Une bibliothèque de recherche abonnée.** Demandez- `/last30days` de construire votre fil d’actualité de bibliothèque, ou utilisez- `python3 skills/last30days/scripts/last30days.py library feed` directement pour le script et le développement. Cela transforme les briefs sauvegardés en `index.html`, un `feed.xml`Atom local et des pages brèves lisibles. Ajoutez `--publish` uniquement lorsque vous souhaitez que l’index HTML et les pages de briefs soient hébergés ; la publication est explicitement volontaire et publique par défaut. Pour rendre le flux Atom abonné, hébergez le répertoire de sortie généré sur un hôte statique tel que GitHub Pages.
+**Une bibliothèque de recherche à laquelle s'abonner.** Demandez à `/last30days` de générer le flux de votre bibliothèque, ou utilisez directement `python3 skills/last30days/scripts/last30days.py library feed` pour vos scripts et vos développements. La commande transforme les briefs enregistrés en un `index.html`, un `feed.xml` Atom local et des pages de brief lisibles. N'ajoutez `--publish` que si vous voulez héberger l'index HTML et les pages de brief ; la publication est un choix explicite, et publique par défaut. Pour rendre le flux Atom réellement abonnable, hébergez le répertoire de sortie généré sur un hébergeur statique comme GitHub Pages.
 
-**Recherchez tout ce que vous avez recherché.** Demandez `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour une utilisation directe du moteur, exécutez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe progressivement les mêmes briefs sauvegardés utilisés par le fil de la bibliothèque, fusionne les observations correspondantes à chaque exécution, et regroupe les résultats par sujet et date. Les nouvelles sessions font également apparaître une section compacte **Depuis votre bibliothèque** lorsque des recherches antérieures chevauchent le sujet actuel ; réglez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
+**Cherchez dans tout ce que vous avez déjà recherché.** Demandez `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour un usage direct du moteur, lancez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe au fil de l'eau les mêmes briefs enregistrés que le flux de bibliothèque, y fusionne les occurrences correspondantes conservées dans le store, et regroupe les résultats par sujet et par date. Les nouvelles exécutions affichent aussi une section compacte **From your library** (« depuis votre bibliothèque ») quand des recherches antérieures recoupent le sujet en cours ; définissez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
 
-Des scripts wrapper par client, des subreddits personnalisés par catégories peer et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
+Les scripts d'encapsulation par client, les subreddits de catégorie personnalisés et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
 
-## Vitrine : flux de recherche communautaires
+## Vitrine : les flux de recherche de la communauté
 
-Publié une mise à jour récurrente de l’IA, une surveillance du marché, ou une obsession merveilleusement étroite pour les dernier30 jours ? Partagez l’URL de la bibliothèque publique — ou l’URL Atom après `feed.xml` hébergé sur un hébergeur statique — dans [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Les fils communautaires seront liés ici au fur et à mesure que leurs propriétaires les soumettent ; le fil de discussion sert de point de collecte en attendant.
+Vous avez publié une veille IA récurrente, un suivi de marché ou une obsession merveilleusement pointue avec last30days ? Partagez l'URL de votre bibliothèque publique — ou l'URL Atom une fois `feed.xml` hébergé sur un hébergeur statique — dans [le fil vitrine de la communauté](https://github.com/mvanhorn/last30days-skill/issues/532). Les flux communautaires seront listés ici au fur et à mesure que leurs auteurs les proposeront ; en attendant, le fil sert de point de collecte.
 
-## Comment ça fonctionne
+## Comment ça marche
 
-1. **Tu tapes un sujet.** Personne, entreprise, produit, technologie, «X vs Y. » N’importe quoi.
-2. **L’agent décide qui compte.** Trouve X pseudos (y compris les fondateurs), GitHub dépôts, subreddits, hashtags TikTok YouTube chaînes. Pour « Kanye West », il connaît r/hiphopheads, @kanyewest, et « bully review » sur YouTube. Pour «OpenClaw», il résout openclaw/openclaw sur GitHub et récupère les comptes d’étoiles en direct.
-3. **Toutes les sources recherchées en parallèle.** Extension multi-requêtes. Résultats notés par engagement, pertinence, fraîcheur.
-4. **La profondeur que personne d’autre n’a.** Transcriptions complètes YouTube des vidéos de réactions. Meilleurs Reddit commentaires avec le nombre de votes positifs. TikTok légendes. Polymarket chances. Pas seulement les titres et les liens.
-5. **Même histoire, fusionnée.** Wireless Festival annoncé le Reddit, discuté sur X, prix des billets sur TikTok = un cluster, pas trois articles séparés.
-6. **Synthétisé en un seul mémoire.** Fondé sur des données spécifiques. Cité par source. Classée selon ce avec quoi les gens interagissent réellement. Pas « voici ce que j’ai trouvé ». C’est « voici ce qui compte ».
-7. **Puis il devient votre expert.** Après une seule partie, votre Claude session sait tout ce que la communauté sait. Posez des questions de suivi. Faites-lui écrire des suggestions, rédiger des e-mails, planifier des voyages, créer des systèmes d’architecture – tout cela ancré dans ce qui est réel en ce moment.
+1. **Vous saisissez un sujet.** Une personne, une entreprise, un produit, une technologie, « X vs Y ». N'importe quoi.
+2. **L'agent identifie qui compte.** Il trouve les comptes X (y compris ceux des fondateurs), les dépôts GitHub, les subreddits, les hashtags TikTok, les chaînes YouTube. Pour « Kanye West », il sait qu'il faut r/hiphopheads, @kanyewest et « bully review » sur YouTube. Pour « OpenClaw », il identifie openclaw/openclaw sur GitHub et récupère le nombre d'étoiles en direct.
+3. **Toutes les sources interrogées en parallèle.** Expansion multi-requêtes. Résultats classés selon l'engagement, la pertinence et la fraîcheur.
+4. **Une profondeur que personne d'autre n'a.** Les transcriptions YouTube complètes des vidéos de réaction. Les meilleurs commentaires Reddit avec leur nombre d'upvotes. Les légendes TikTok. Les cotes Polymarket. Pas seulement des titres et des liens.
+5. **Une même histoire, fusionnée.** Le Wireless Festival annoncé sur Reddit, commenté sur X, avec le prix des billets sur TikTok : un seul cluster, pas trois entrées distinctes.
+6. **Synthétisé en un seul brief.** Ancré dans des données précises. Sourcé. Classé selon ce avec quoi les gens interagissent vraiment. Pas « voilà ce que j'ai trouvé », mais « voilà ce qui compte ».
+7. **Ensuite, la skill devient votre experte.** Après une seule exécution, votre session Claude sait tout ce que sait la communauté. Posez vos questions de suivi. Faites-lui écrire des prompts, rédiger des e-mails, planifier des voyages, concevoir des architectures — le tout ancré dans la réalité du moment.
 
-## Ce que les gens disent
+## Ce que les gens en disent
 
-> « J’ai trouvé une compétence Claude Code qui recherche n’importe quel sujet à travers Reddit, X, YouTubeet HN des 30 derniers jours. Ensuite, il écrit les consignes pour vous. J’ai cherché manuellement Reddit et X recherches avant chaque contenu que j’écris. Onglet par onglet. Fil par fil. C’est la partie qui prend 90 minutes. Ça l’élimine. » -@itsjasonai
+> « J'ai trouvé une skill Claude Code qui fait des recherches sur n'importe quel sujet à travers Reddit, X, YouTube et HN sur les 30 derniers jours. Et elle écrit les prompts à votre place. Avant chaque contenu que j'écris, je faisais ces recherches à la main sur Reddit et X. Onglet par onglet. Fil par fil. C'est la partie qui prend 90 minutes. Elle disparaît. » — @itsjasonai
 
-> « Cette compétence a remplacé tout mon flux de recherche. Tu lui donnes un sujet, ça gratte Reddit, X, et le web pour trouver ce dont les gens parlent vraiment. Pas de vieux articles de blog. De vraies conversations des 30 derniers jours. » -@itswilsoncharles
+> « Cette seule skill a remplacé tout mon workflow de recherche. Vous lui donnez un sujet, elle récupère sur Reddit, X et le web ce dont les gens parlent vraiment. Pas de vieux billets de blog. De vraies conversations des 30 derniers jours. » — @itswilsoncharles
 
-> « 5 des 10 dépôts tendance sur GitHub aujourd’hui sont Claude outils. #1 : Mvanhorn/last30days- compétence » -@yieldhunter95
+> « 5 des 10 dépôts tendance du jour sur GitHub sont des outils Claude. N° 1 : mvanhorn/last30days-skill » — @yieldhunter95
 
 ## Open source
 
-Licence MIT. Pas de suivi. Pas d’analyses. Votre recherche reste sur votre machine. 2 700+ tests.
+Licence MIT. Aucun tracking. Aucune analytics. Vos recherches restent sur votre machine. Plus de 2 700 tests.
 
-Construit avec Python architecture du moteur v3.12+, yt-dlp, Node.js (client Bird fourni pour X recherche), et ScrapeCreators API. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
+Construit avec Python 3.12+, yt-dlp, Node.js (client Bird intégré pour la recherche X) et l'API ScrapeCreators. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
 
-Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté, et [CHANGELOG.md](CHANGELOG.md) pour l’historique des versions.
+Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir une PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté, et [CHANGELOG.md](CHANGELOG.md) pour l'historique des versions.
 
-## Histoire de Star
+## Évolution des étoiles
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,199 +16,199 @@
   </a>
 </p>
 
-**編集者ではなく、アップボート、いいね、リアルマネーで評価されるAIエージェント主導の検索エンジン。**
+**編集者ではなく、アップボート・いいね・実際に動いたお金でランク付けする、AIエージェント主導の検索エンジンです。**
 
-このREADMEは現在のv3パイプラインを追跡しています。ランタイムスキル仕様は [skills/last30days/SKILL.md](skills/last30days/SKILL.md)に存在し、これが最新のコマンドおよびセットアップ動作の真実の源です。
+このREADMEは現行のv3パイプラインについて説明しています。実行時のスキル仕様は [skills/last30days/SKILL.md](skills/last30days/SKILL.md) にあり、コマンドとセットアップの挙動についてはそちらが最新かつ正式なものです。
 
-**Claude Code (推奨 — マーケットプレイス経由の自動更新):**
+**Claude Code(推奨 — マーケットプレイス経由で自動更新):**
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 /plugin install last30days
 ```
 
-**Codex、 Cursor、 Copilot、 Gemini CLI、または50+ [Agent Skills](https://agentskills.io) ホストのいずれか:**
+**Codex、Cursor、Copilot、Gemini CLI、その他50以上の [Agent Skills](https://agentskills.io) ホスト:**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` ユーザーのグローバルにインストールされ、すべてのプロジェクトで利用可能です。プロジェクトごとにスコープに切り替えてください。)
+(`-g` を付けるとユーザー単位でグローバルにインストールされ、すべてのプロジェクトで使えます。プロジェクト単位に限定したい場合はこのフラグを外してください。)
 
-claude.ai ウェブ、 OpenClaw、マニュアルなどのインストールオプションは下の [Install](#設置) セクションにあります。
+その他のインストール方法(claude.aiのウェブ版、OpenClaw、手動)は下の [インストール](#インストール) セクションにあります。
 
-設定はゼロです。 Reddit、HN、 Polymarket、 GitHub はすぐに動作します。一度実行すると、セットアップウィザードが30秒で X、 YouTube、 TikTok、 arXiv、 Techmemeなどをアンロックします。
+設定は不要です。Reddit、HN、Polymarket、GitHub はすぐに使えます。一度実行すれば、セットアップウィザードが30秒で X、YouTube、TikTok、arXiv、Techmeme などを有効にします。
 
 ---
 
-Reddit アップボート。 X いいね。トランスクリプト YouTube 。関与 TikTok 。実際のお金と内部情報に裏付けられた Polymarket オッズ。毎日何百万人もの人々が自分の注意と財布を使って投票しているのです。 /last30days それらすべてを並行して検索し、実際に人々が関わっているもので評価し、AIエージェントの審査員がそれを一つのブリーフにまとめます。
+Reddit のアップボート。X のいいね。YouTube の文字起こし。TikTok のエンゲージメント。実際のお金とインサイダー情報に裏打ちされた Polymarket のオッズ。つまり、毎日何百万人もの人が自分の注意と財布で投票しているということです。/last30days はそのすべてを並行して検索し、実際に人々が反応したかどうかでスコアを付け、AIエージェントが判定役となって1本のブリーフにまとめます。
 
-Google 編集者を集約します。 /last30days 人を検索します。
+Google は編集者を束ねます。/last30days は人を検索します。
 
-この検索は他のどこでも得られません。なぜなら、単一のAIがすべてにアクセスできるわけではないからです。Google検索はコメントやX投稿Reddit触れません。ChatGPTRedditと契約していますが、XやTikTokは検索できません。GeminiはYouTubeはありますが、Redditはありません。Claudeはネイティブにそれらのどれも持っていません。各プラットフォームは独自のAPI、トークン、認証を持つ囲い庭園のようなものです。しかし、自分のキーやブラウザセッションを持ち込めば、AIエージェントがそれらを一度に検索し、互いにスコアリングし、何が本当に重要かを教えてくれます。
+この検索は他のどこでも手に入りません。単独のAIがすべてにアクセスできないからです。Google の検索は Reddit のコメントにも X の投稿にも届きません。ChatGPT は Reddit と提携していますが、X も TikTok も検索できません。Gemini には YouTube がありますが Reddit がありません。Claude はそのどれもネイティブには持っていません。どのプラットフォームも、独自のAPI・独自のトークン・独自の認証を備えた閉じた庭です。しかし自分のキーとブラウザセッションを持ち込めば、AIエージェントが一度にすべてを検索し、互いに突き合わせてスコアを付け、本当に重要なことを教えてくれるようになります。
 
-それがアンロックだ。これ以上の検索エンジンは一つもない。12の切り離されたプラットフォームがエージェントでつながっている。
+そこが突破口です。優れた検索エンジンが1つ増えるという話ではありません。断絶していた十数のプラットフォームを、エージェントが橋渡しするのです。
 
 ```
 /last30days Peter Steinberger
 ```
 
-明日会議がある。彼らをGoogle。2023年の彼らのLinkedInを手に入れる。/last30days今月実際にやっていることを教えてくれます:Codexに関わるためにOpenAIに参加し、Anthropicのサードパーティエージェント禁止に反対し、23PRsを85%のマージ率で出荷し、クロスデバイスエージェント制御のための「LobsterOS」を構築し、r/Claudeコードでは彼がヒーローか「耐え難い」かで569のアップボートを獲得しました。X投稿、Redditスレッド、YouTubeのトランスクリプト、そしてGitHubコミットに散らばっています。どれも入っていなかったGoogle。
+明日、打ち合わせがあるとします。その人を Google で調べると、出てくるのは2023年の LinkedIn です。/last30days なら、その人が今月実際にやっていることが分かります。Codex に取り組むため OpenAI に参加し、サードパーティ製エージェントを禁じた Anthropic の方針と争い、23本のPRをマージ率85%で送り、デバイスをまたいでエージェントを操作する「LobsterOS」を作っていて、さらに r/ClaudeCode では彼が英雄なのか「鼻につく」のかという議論が569アップボートを集めている。それらは X の投稿、Reddit のスレッド、YouTube の文字起こし、GitHub のコミットに散らばっていて、どれも Google には出てきませんでした。
 
-## なぜこれが存在するのか
+## なぜ作ったのか
 
-AIに追いつくために作りました。すべてが日々変わり、 Reddit や X オタクたちが常に最初に対応しています。より良いプロンプトが必要で、トレーニングデータはコミュニティがすでに把握しているものより常に数ヶ月遅れていました。
+AIの動きに追いつくために作りました。何もかもが日々変わり、Reddit と X の濃い人たちがいつも真っ先に把握しています。もっと良いプロンプトが必要でしたが、学習データはコミュニティがすでに突き止めたことより常に数か月遅れていました。
 
-しかし、それはもっと大きなものに発展しました。今では営業電話の前に、ビジネスの過去30日間の真実を知るために使っています。会議の前に誰かの最近のツイートやポッドキャストの書き起こしを読む前に。 Disney World 旅行の前に、どのライドが閉鎖されているか、コミュニティが Genie+について何を言っているかを知るために。何かを作る前に、人々が実際にどんな問題に直面しているのかを知るために。
+ただ、そこからもっと大きなものになりました。今では商談の前に走らせて、その会社について直近30日間の実情を押さえます。打ち合わせの前には、相手の最近のツイートやポッドキャストの文字起こしを読むために。ディズニー・ワールドに行く前には、どのアトラクションが休止中で、Genie+ についてコミュニティが何と言っているかを知るために。何かを作り始める前には、人々が実際にどんな問題にぶつかっているかを知るために。
 
-CEOと会う場合、過去30日間のツイートや議事録 YouTube 全部読んだ?読んだよ。
+CEOと会うとして、直近30日間のツイートと YouTube の文字起こしを全部読んできましたか。私は読んでいます。
 
-## 情報源は人々によって評価されました
+## 人々がスコアを付けた情報源
 
-| 出典 | 人々の言うこと |
+| 情報源 | 人々が教えてくれること |
 |--------|--------------------------|
-| **Reddit** | フィルターなしの意見。実際にアップボート数がつくトップコメント、無料、 API キーなし。 Google が埋めている本当の意見。 |
-| **X / Twitter** | 熱い意見、専門家のスレッド、そして激しい反応。最初に知り、最初に議論する。 |
-| **YouTube** | 45分間の深掘り。重要な引用可能な5文の全文を検索しました。 |
-| **TikTok** | クリエイターは360万人にリーチし、 Googleでは決して得られないような視点を持っています。 |
-| **Instagram Reels** | スポークンワードの書き起こしによるインフルエンサーの視点。ビジュアルカルチャーのシグナル。 |
-| **Hacker News** | 開発者の合意。825ポイント、899件のコメント。技術者たちが実際に議論している場面。 |
-| **Polymarket** | 意見じゃない。確率だ。本物の資金に裏付けられている。アルバム売上に96%の信頼。買収に4%の信頼。 |
-| **GitHub** | 人向けに: PR Velocity、スターによるトップリポジトリ、リリースノート。トピック:問題や議論。 |
-| **Digg** | DiggのAI 1000リーダーボード(Xで約1000のハイシグナルAIアカウント)からキュレーションされたストーリークラスターで、帰属可能なインライン引用付き(X認証不要)。`digg-pp-cli`がPATHオン時は自動有効化。 |
-| **arXiv** | 話題の裏にある論文。ウィンドウに新しいリサーチが表示され、無料、APIキーなし。PATH`arxiv-pp-cli`中は自動有効化(初回セットアップでインストール)。 |
-| **Techmeme** | テックニュース編集レイヤーで、30日以内の日付ウィンドウが表示されます。無料で API キーなし。 `techmeme-pp-cli` が PATH 上にあると自動で有効化されます(初回セットアップでインストールされます)。 |
-| **LinkedIn** | プロフェッショナルシグナル。投稿や記事、記事は高シグナルとして重み付けされています。 |
-| **StockTwits** | トレーダーのセンチメント。トピックがティッカーや暗号通貨の場合、自動で活性化されます。 |
-| **Threads** | Twitter後のテキスト層。クリエイターやブランドからの会話。 |
-| **Pinterest** | ビジュアルディスカバリー。製品やアイデアをピン、保存、コメント。 |
-| **Xiaohongshu (RED)** | 中国のライフスタイル、製品、クリエイターのシグナル。ログイン済みのx-mcpブラウザプラグインや`xiaohongshu-mcp`サービスがローカルで動作している場合、`--search xhs`に明示的にリクエストされます。 |
-| **Bluesky** | 分散型ソーシャルレイヤー。ATプロトコルはTwitter移行後の投稿です。 |
-| **Perplexity** | グラウンデッドソナー合成、生のサーチ API ロウ、そしてディープリサーチ。 |
-| **Web** | 編集報道やブログの比較。多くの兆候の一つであり、唯一のものではありません。 |
+| **Reddit** | フィルターのかかっていない本音。実際のアップボート数付きのトップコメントが、無料・APIキーなしで手に入ります。Google が埋もれさせてしまう本当の意見です。 |
+| **X / Twitter** | 勢いのある一言、専門家のスレッド、速報への最初の反応。誰よりも早く知り、誰よりも早く議論が始まります。 |
+| **YouTube** | 45分の掘り下げ。文字起こし全文を検索し、引用に値する5つの文だけを取り出します。 |
+| **TikTok** | Google では絶対に見つからない切り口で360万人に届いているクリエイター。 |
+| **Instagram Reels** | 話した内容の文字起こし付きで届く、インフルエンサーの視点。ビジュアル文化のシグナルです。 |
+| **Hacker News** | 開発者の総意。825ポイント、899コメント。技術寄りの人たちが本気で議論している場所です。 |
+| **Polymarket** | 意見ではなく、オッズ。実際のお金が裏付けています。アルバムの売上に96%、買収に4%といった具合です。 |
+| **GitHub** | 人物について: PRの勢い、スター数の多いリポジトリ、リリースノート。トピックについて: Issue と Discussion。 |
+| **Digg** | Digg の AI 1000 リーダーボード(X 上でシグナルの強いAI関連アカウント約1000件)から集めたストーリークラスター。出典をたどれるインライン引用付きで、X の認証は不要です。`digg-pp-cli` が PATH にあると自動的に有効になります。 |
+| **arXiv** | 話題の裏側にある論文。対象期間に出た新しい研究が、無料・APIキーなしで手に入ります。`arxiv-pp-cli` が PATH にあると自動的に有効になります(初回セットアップでインストールされます)。 |
+| **Techmeme** | テックニュースの編集レイヤーを、対象の30日間に絞って取得します。無料・APIキーなし。`techmeme-pp-cli` が PATH にあると自動的に有効になります(初回セットアップでインストールされます)。 |
+| **LinkedIn** | ビジネス面のシグナル。投稿と記事を拾い、記事は強いシグナルとして重み付けします。 |
+| **StockTwits** | トレーダーの温度感。調べる対象が銘柄コードや暗号資産のときに自動で有効になります。 |
+| **Threads** | Twitter 以後のテキストの層。クリエイターやブランドの会話です。 |
+| **Pinterest** | ビジュアル起点の発見。プロダクトやアイデアに対するピン・保存・コメント。 |
+| **Xiaohongshu(RED)** | 中国のライフスタイル・プロダクト・クリエイターのシグナル。ログイン済みの x-mcp ブラウザプラグイン、または `xiaohongshu-mcp` サービスがローカルで動いているときに、`--search xhs` で明示的に指定して使います。 |
+| **Bluesky** | 分散型のソーシャル層。Twitter 以後の移住で生まれた AT Protocol の投稿です。 |
+| **Perplexity** | 根拠付きの Sonar による統合、Search API の生の結果、そして Deep Research。 |
+| **Web** | 編集記事や、ブログの比較記事。数あるシグナルの1つであって、唯一のものではありません。 |
 
-コミュニティの貢献者たちが次々と追加しています。 Truth Social やその他のニッチなソースもエンジンに含まれており、今後も追加予定です。
+コミュニティが今も情報源を増やし続けています。Truth Social をはじめとするニッチな情報源もすでにエンジンに入っていて、さらに追加予定です。
 
-1,500アップボートの Reddit スレッドは、誰も読まないブログ記事よりも強いシグナルです。360万回の閲覧数を持つ TikTok は、プレスリリースよりも文化的に重要なことをよく伝えます。66,000ドルのボリュームに裏付けられた Polymarket 確率は、評論家の推測よりも議論しにくいです。
+1,500アップボートの Reddit スレッドは、誰にも読まれなかったブログ記事よりも強いシグナルです。360万回再生の TikTok は、プレスリリースよりも「今、文化的に何が効いているか」を語ります。6.6万ドルの出来高に裏打ちされた Polymarket のオッズは、評論家の当て推量よりも反論しにくいものです。
 
-総合は、実際の人々が実際に関わったものに基づいてランク付けされます。社会的関連性であり、 SEO 関連性ではありません。
+この統合処理は、実在の人々が実際に反応したかどうかで順位を付けます。SEO上の関連性ではなく、社会的な関連性です。
 
-## 実際に人々が使う用途
+## みんなが実際に使っている場面
 
-**会議前に。** `/last30days Peter Steinberger` - OpenAIの Codex チームに加わり、Anthropicのサードパーティエージェント禁止に反対し、23 PRs が85%の合併率で GitHubに統合され、デバイス間エージェント制御のための統合 LobsterOS を構築しました。r/ClaudeCode:「 OpenClaw リリース以来、 API以外の手段で処理するといずれBANされるというのは広く知られていました」(227アップボート)。これは LinkedInではありません。
+**打ち合わせの前に。** `/last30days Peter Steinberger` — OpenAI の Codex チームに参加、サードパーティ製エージェントを禁じた Anthropic の方針と対立、GitHub で23本のPRをマージ率85%でマージ、デバイスをまたいでエージェントを操作する LobsterOS を開発中。r/ClaudeCode では「OpenClaw が出てからずっと、API 以外の経路で動かせばいずれBANされると広く知られていた」(227アップボート)。これは LinkedIn には載っていません。
 
-**採用シグナルを読み取るため。** `/last30days Listen Labs --hiring-signals` - 現在の求人やキャリアページは、企業のセキュリティ、カスタマーサクセス、インフラ、製品拡大など、焦点の変化の証拠として引用されます。レポートは採用が示唆しているように見えるものを述べており、ロードマップが何を提供するかを示しています。
+**採用シグナルを読むために。** `/last30days Listen Labs --hiring-signals` — 現在の求人ページやキャリアページが、注力領域の変化を示す引用可能な根拠になります。エンタープライズ向けセキュリティ、カスタマーサクセス、インフラ、プロダクト拡張といった採用の動きです。レポートが述べるのは「採用が何を示唆しているように見えるか」であって、「ロードマップが何を出すか」ではありません。
 
-**ピーク前にトピックを見つけるために。** `/last30days what's exploding in AI agents?`に尋ねるとスキルは発見モードに切り替わります:エンジンはカテゴリーリストReddit、表出し/ベストストーリー、DiggのAI 1000フィード、認証時にXHacker Newsします。エージェントがノミネーション(名前、ジャンクフィルタリング、コンテンツの価値度)を審査し、ポッドキャストやX記事の角度を書きます。その後、5〜10件のVelocityランクのトピックが得られます。すべての結果にはクロスソースの数値、モメンタムラベル、そしてすぐに実行可能な`/last30days "<topic>"`フォローアップが含まれています。
+**ピークを迎える前の話題を見つけるために。** `/last30days what's exploding in AI agents?` と尋ねると、スキルはディスカバリーモードに切り替わります。エンジンが Reddit のカテゴリー一覧、Hacker News のフロントページとベストストーリー、Digg の AI 1000 フィード、そして認証済みであれば X を横断してさらいます。次にエージェントが候補を審査し(名前の妥当性、ノイズの除去、記事になるか)、ポッドキャストや X 記事の切り口を書きます。最後に、勢いの強さで並べた5〜10件のトピックが返ってきます。各結果には情報源をまたいだ数値、モメンタムのラベル、そしてそのまま実行できる `/last30days "<topic>"` が付いてきます。
 
-**何かが落ちるとき。** `/last30days Kanye West` - イギリスは彼のビザをブロックし、ワイヤレスフェスティバルは中止、スポンサーは逃げた。しかしBULLYはビルボードで#2をデビューさせた。ファンタノは「イェイ・サバティカル」から戻ってレビューを続けた(65万3千回)。SoFi Homecomingはローリン・ヒルとトラヴィス・スコットを招き、44曲を披露した。 Polymarket:「カニエはまたツイートするのか?」86%はイエス。23件の Reddit スレッド、17本の YouTube 動画、8万6千件のアップボート。
+**何かが出たとき。** `/last30days Kanye West` — イギリスがビザを却下、Wireless Festival は中止、スポンサーは離脱。それでも BULLY は Billboard 初登場2位。Fantano は「Yay sabbatical」から復帰してレビューを公開(65.3万回再生)。SoFi Homecoming では Lauryn Hill と Travis Scott を迎えて44曲を披露。Polymarket では「Kanye はまたツイートするか?」が「はい」86%。Reddit のスレッド23件、YouTube の動画17本、アップボート8.6万件。
 
-**ツールを比較するため。** `/last30days OpenClaw vs Hermes vs Paperclip` - 「これらは競合ではなく層だ。」 OpenClaw は執行者(351, GitHub 0星、ライブ)、ヘルメスは自己改善の脳(31,0星)、ペーパークリップは組織図(49,000星)。星の数はライブで取得されたもので、古びたブログ投稿ではなく GitHub APIから抽出される。建築、メモリ、セキュリティを備えた並列テーブル、ベストフォース。 @IMJustinBrookeによると:「OpenClaw =ヒトカゲ、ヘルメス=リザードン。」
+**ツールを比べるために。** `/last30days OpenClaw vs Hermes vs Paperclip` — 「これらは競合ではなくレイヤーだ」。OpenClaw は実行を担うレイヤー(GitHub スター35.1万、稼働中)、Hermes は自己改善する頭脳(スター3.1万)、Paperclip は組織図(スター4.9万)。スター数は古いブログ記事からではなく GitHub API からその場で取得しています。アーキテクチャ、メモリ、セキュリティ、向いている用途を並べた比較表付き。@IMJustinBrooke いわく「OpenClaw = ヒトカゲ、Hermes = リザードン」。
 
-**世界を理解するために。** `/last30days Iran vs USA` - 戦争38日目。トランプ大統領がイランにホルムズ海峡を再開させる火曜日の期限を掲げた。米軍機2機が撃墜された。石油は1バレルあたり126ドル。IEAはこれを「世界石油市場史上最大の供給混乱」と呼んだ。 Polymarket:12月31日までに停戦が74%で達成。27件の X 投稿、10本の YouTube 動画、20の予測市場。
+**世界の動きを理解するために。** `/last30days Iran vs USA` — 開戦から38日目。トランプ大統領はイランに対し、ホルムズ海峡の再開について火曜日を期限とする最後通告。米軍機2機が撃墜。原油は1バレル126ドル。IEA はこれを「世界の石油市場の歴史上最大の供給途絶」と呼びました。Polymarket では12月31日までの停戦が74%。X の投稿27件、YouTube の動画10本、予測市場20件。
 
-**旅行の前に。** `/last30days Universal Epic Universe` - 拡張工事がすでに進行中。「プロジェクト680」許可申請済み。インフラで花火大会が確認されたが、予告なし。待ち時間:鉱山カートの狂気、平均148分。まだ年間パスはなく、地元の人々は不満を抱いている。スターダストレーサーズは4月5日まで改装中。
+**旅行の前に。** `/last30days Universal Epic Universe` — 拡張エリアはすでに着工済み。「Project 680」の建設許可が申請されています。花火ショーはインフラの痕跡から確認できるものの、まだ発表はありません。待ち時間は Mine-Cart Madness が平均148分。年間パスはまだ出ておらず、地元の人たちは不満を漏らしています。Stardust Racers は4月5日まで改修で運休。
 
-**何かを素早く学ぶために。** `/last30days Nano Banana Pro prompting` - JSON構造化プロンプトがタグスープに取って代わっています。 @pictsbyaiのネスト形式は「コンセプトの漏れ」を防ぎます。編集優先のワークフローは再生よりも優れています。そしてコミュニティが「うまくいく」と言った方法で、まさに本番プロンプトを書いてくれます。
+**手早く学ぶために。** `/last30days Nano Banana Pro prompting` — JSON で構造化したプロンプトが、タグの寄せ集めに取って代わりつつあります。@pictsbyai の入れ子形式は「コンセプトの混線」を防ぎます。作り直すより、編集を前提にしたワークフローのほうが結果が出ます。そのうえで、コミュニティが「これは効く」と言った内容をそのまま使って、実運用向けのプロンプトを書いてくれます。
 
-## 新しいこと
+## 最近の変更
 
-5月のv3.3発表以降、v3.11.1(2026年7月)時点で、175件の統合 PRs 、そのうち122件は52人のコミュニティ貢献者から15のリリースにわたり統合されました。これが実現したものです。
+5月の v3.3 発表以降、v3.11.1(2026年7月)時点までで、15回のリリースにわたり175本のPRがマージされました。うち122本はコミュニティの52人によるものです。以下がその内容です。
 
-### ファーストクラス OpenAI Codex
+### OpenAI Codex での一級対応
 
-/last30days現在はネイティブの Codex プラグインで、ガイド付きセットアップが可能で、ポートではなく一流の市民です。レンダラー対応の引用により、Codex出力はURLスープではなくブリーフのように読み取れます(#694)、同じエンジンはClaude Code、Cursor、Copilot、Gemini CLI、Claude Desktop、OpenClaw、50+ Agent Skillsホストで動作します。プラグインマニフェストCodex[@rfoust](https://github.com/rfoust)(#686)、認証修正は[@tmchow](https://github.com/tmchow)(#698)によってCodexされています。
+/last30days は、ガイド付きセットアップを備えた Codex のネイティブプラグインになりました。移植版ではなく、一級の対応です。レンダラーを踏まえた引用処理によって、Codex での出力はURLの羅列ではなくブリーフとして読めるようになり(#694)、同じエンジンが Claude Code、Cursor、Copilot、Gemini CLI、Claude Desktop、OpenClaw、そして50以上の Agent Skills ホストで動きます。Codex のプラグインマニフェストは [@rfoust](https://github.com/rfoust)(#686)、Codex の認証まわりの修正は [@tmchow](https://github.com/tmchow)(#698)によるものです。
 
-### arXiv、 Techmeme、 Digg - 無料、 API キーなし
+### arXiv、Techmeme、Digg — 無料、APIキー不要
 
-arXiv 新聞を宣伝の後ろに引き込み、 Techmeme は編集技術ニュース層をもたらします。無料、ゼロキー、初回セットアップが CLIをインストールして自動的に有効化します(#709)。 DiggのAI 1000ストーリークラスターも同様の方法で X 認証なしに届きます。セットアップが無料 Digg CLI をインストールしてくれます(#590)。 Trustpilot 消費者ブランドリサーチのオプトインを出荷します。
+arXiv は話題の裏側にある論文を、Techmeme はテックニュースの編集レイヤーを持ち込みます。いずれも無料でキーは一切不要、しかも初回セットアップが各CLIをインストールするので自動的に有効になります(#709)。Digg の AI 1000 ストーリークラスターも同じように、X の認証なしで届きます。セットアップが無料の Digg CLI を入れてくれます(#590)。Trustpilot は消費者向けブランドの調査用に、任意で有効にできます。
 
-### 無料 Reddit は実際のスコアとトップコメントを増やしました
+### 無料の Reddit が、実数のスコアとトップコメント付きで復活
 
-Redditの公開.json API は死んだ。フリーパスはより強く復活した。キーレスRSS+シュレディットスクレイピング(#457)、arctic-shiftによる本当のアップボート数を持つ専用サブレディット発見(#696)、そしてバイラルなオフトピック投稿がブリーフを乗っ取らない関連性フロア(#488、ありがとう [@rzachsmith](https://github.com/rzachsmith)))。キーは API なし。リアルスコア。トップコメントも含まれている。
+Reddit の公開 .json API は終了しましたが、無料の経路はより強くなって戻ってきました。キー不要の RSS と shreddit のスクレイピング(#457)、arctic-shift 経由で実際のアップボート数まで取れるサブレディット特定(#696)、そして話題から外れたバズ投稿にブリーフを乗っ取られないようにする関連性の下限(#488、[@rzachsmith](https://github.com/rzachsmith) に感謝)。APIキーは不要。スコアは実数。トップコメントも込みです。
 
-### すべてのブリーフに最高のコメントが
+### どのブリーフにも最高のコメントを
 
-コメントは現在、ソース全体でデフォルトレイヤーとなっています。Instagramのコメントはランクベースの多様性で、5つのホットテイクが1つの投稿からすべて出てこないようにしています(#751)、 YouTube コメントと ScrapeCreators のトランスクリプトバックアップ(#637)、そしてコミュニティの最も面白いセリフがスコアリングに残るようにクラウド投票によるコメントは Best Takes に重み付けされています(#592、#608)。
+コメントは今や、どの情報源でも既定で有効なレイヤーです。Instagram のコメントは順位に基づいて分散させ、尖った意見5件が同じ投稿ばかりから出ないようにしています(#751)。YouTube のコメントに加えて、yt-dlp が失敗したときのために ScrapeCreators による文字起こしのバックアップも用意しました(#637)。さらに、コミュニティの投票で支持されたコメントを Best Takes のスコアに反映し、いちばん面白い一言が選別を生き延びるようにしています(#592、#608)。
 
-### 1人のドクター指令
+### doctor コマンド1つで
 
-健康診断を依頼すれば、医師はあらゆる情報源を調べ、どのキーが欠けているか、どの CLI が PATHか、どのクッキーが期限切れか(#753)と正確な修正を処方します。なぜ X が薄くなったのか、もう推測する必要はありません。
+ヘルスチェックを頼めば、doctor がすべての情報源を試したうえで、必要な対処をそのまま提示します。どのキーが足りないのか、どのCLIが PATH に入っていないのか、どのクッキーが期限切れなのか(#753)。X の結果が薄かった理由を当てずっぽうで探す必要はもうありません。
 
-### X 捜索、再建
+### X 検索の作り直し
 
-Xパイプラインは一から刷新されました。FROMレーンとABOUTレーンが導入され、本人の投稿とそれに関する会話が両方にランク付けされる(#610)、パーソンウェアなサブクエリの曖昧さ回避(#611)、インタラクション・シグナルランキングによるファーストパーティ著作権のグラウンディング(#613)、そして自動バックエンドフェイルオーバーを備えた単一のXソース(#622)。さらに、認証を実際にプローブする正直な`--diagnose`(#609)。
+X のパイプラインを一から作り直しました。FROM レーンと ABOUT レーンを設けて、本人の投稿と本人についての会話の両方が順位付けされるようにし(#610)、対象人物に応じてサブクエリの曖昧さを解消し(#611)、本人による投稿かどうかを裏付けたうえでインタラクションのシグナルで順位を付け(#613)、バックエンドを自動で切り替える単一の X ソースにまとめました(#622)。さらに、認証を実際に確かめる正直な `--diagnose` も入っています(#609)。
 
-### さらに多くの情報源が加わりました
+### 情報源が増えました
 
-LinkedInScrapeCreatorsを通じて、高信号の記事([@ravstr](https://github.com/ravstr)、#702)を掲載しています。StockTwitsティッカーや暗号通貨のトピックに対して自動でアクティベートされます([@wtiwana](https://github.com/wtiwana)、#658)。PerplexityダイレクトAPIモードと非同期のディープリサーチ([@sk-holmes](https://github.com/sk-holmes)、#629)を拡大しました。
+ScrapeCreators 経由の LinkedIn。記事は強いシグナルとして扱います([@ravstr](https://github.com/ravstr)、#702)。StockTwits は銘柄コードや暗号資産の話題で自動的に有効になります([@wtiwana](https://github.com/wtiwana)、#658)。Perplexity は直接APIモードと非同期の Deep Research に対応しました([@sk-holmes](https://github.com/sk-holmes)、#629)。
 
-### コミュニティによって鍛えられる
+### コミュニティによる堅牢化
 
-セキュリティの波はほぼ完全にコミュニティの作業によるものでした。 HTML レンダラーのストアドXSS修正([@iliaal](https://github.com/iliaal)、 [@aaronjmars](https://github.com/aaronjmars))、ロックダウンされたクッキー一時ファイル、OpenSSFスコアカードとビルドの出所証明([@shaanmajid](https://github.com/shaanmajid)、 [@hammadxcm](https://github.com/hammadxcm)、 [@aniruddh909](https://github.com/aniruddh909))を用いたサプライチェーン強化CI、SemgrepおよびOSV-Scannerスキャン、 PR 依存関係レビューゲート([@23241a6749](https://github.com/23241a6749))、60%で導入され現在84%に引き上げられたテストカバレッジの最低限([@gourab5139014](https://github.com/gourab5139014))、そしてすべての重要な発見を除去したHermesのセキュリティスキャン(#768)。
+セキュリティ面の改善は、ほぼすべてコミュニティの手によるものです。HTML レンダラーの格納型XSSの修正([@iliaal](https://github.com/iliaal)、[@aaronjmars](https://github.com/aaronjmars))、クッキーの一時ファイルの権限強化、OpenSSF Scorecard とビルド来歴の証明を組み込んだサプライチェーン耐性のあるCI([@shaanmajid](https://github.com/shaanmajid)、[@hammadxcm](https://github.com/hammadxcm)、[@aniruddh909](https://github.com/aniruddh909))、Semgrep と OSV-Scanner によるスキャンおよびPRごとの依存関係レビューゲート([@23241a6749](https://github.com/23241a6749))、60%で導入し現在は84%まで引き上げたテストカバレッジの下限([@gourab5139014](https://github.com/gourab5139014))、そして CRITICAL の指摘がゼロになった Hermes のセキュリティスキャン(#768)。
 
-### さらに遠くへ
+### 届く範囲が広がりました
 
-ヘブライ語および非ラテン語([@dudyme](https://github.com/dudyme))。CJK中国語ソースの認識トークン化([@An-idd](https://github.com/An-idd))。Windows互換性の波。Chromiumファミリー全体(Brave、Edge、Vivaldi、Opera、Arc([@andrey-esipov](https://github.com/andrey-esipov))にわたるクッキー抽出、さらに認証情報ソースmacOS Keychainとpass(1)Linux。`--as-of`過去の遡及([@chiyi-creator](https://github.com/chiyi-creator))。uv([@buntysomroy](https://github.com/buntysomroy))を経由Python3.12で自動プロビジョニング。`--hiring-signals`企業の求人ページを読むためのもの。実行間のウォッチリストの差。
+ヘブライ語をはじめとする非ラテン文字の言語に対応([@dudyme](https://github.com/dudyme))。中国語の情報源向けに CJK を考慮したトークナイズ([@An-idd](https://github.com/An-idd))。Windows 対応の改善もまとめて入りました。Chromium 系ブラウザ全体(Brave、Edge、Vivaldi、Opera、Arc)からのクッキー抽出([@andrey-esipov](https://github.com/andrey-esipov))に加え、macOS のキーチェーンと Linux の pass(1) も認証情報の取得元として使えます。`--as-of` による過去時点の振り返り([@chiyi-creator](https://github.com/chiyi-creator))。uv 経由での Python 3.12 の自動セットアップ([@buntysomroy](https://github.com/buntysomroy))。企業の求人ページを読む `--hiring-signals`。実行と実行のあいだのウォッチリスト差分。
 
-### まだv3のまま箱の中です
+### v3 から引き続き入っているもの
 
-v3の基盤はすべてまだ存在しています:単一の API コールが発信する前に適切なハンドルネーム、サブレディット、ハッシュタグを解析する事前研究の脳( [@j-sperling](https://github.com/j-sperling)が構築);ユーモアやバイラル性の Best Takes スコアリングと関連性を並行して評価するもの;ソース間のクラスター統合;シングルパス比較(「CLI vs MCP」を3分で行う、12分ではなく;自動発見 `--competitors` 比較; GitHub パーソンモード(`--github-user=steipete`); ELI5 モード("実行後に"eli5オン");そして共有可能で自己完結型の HTML ブリーフ(`--emit=html`)。設定ノブは [CONFIGURATION.md](CONFIGURATION.md)に存在します。
+v3 の土台はすべて健在です。APIコールを1件も投げる前に、適切なアカウント・サブレディット・ハッシュタグを特定する事前リサーチの頭脳([@j-sperling](https://github.com/j-sperling) が構築)。関連性だけでなくユーモアやバイラル性も見る Best Takes のスコアリング。情報源をまたいだクラスターの統合。1回のパスで済む比較(「CLI vs MCP」が12分ではなく3分)。自動で候補を見つける `--competitors` 比較。GitHub の人物モード(`--github-user=steipete`)。ELI5 モード(実行後に「eli5 on」)。そして共有できる自己完結型の HTML ブリーフ(`--emit=html`)。設定項目は [CONFIGURATION.md](CONFIGURATION.md) にまとまっています。
 
-## 設置
+## インストール
 
-| 表面 | 設置 | アップデート |
+| 環境 | インストール | 更新 |
 |---------|---------|---------|
-| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイス経由で自動更新、または `claude plugin update last30days@last30days-skill` |
-| **Grok**(xAIビルド CLI) | `grok plugin marketplace add mvanhorn/last30days-skill``grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex、 Cursor、 Copilot、 Gemini CLI、または50+のホストのいずれか [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(ウェブ) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) ・アップロード claude.ai > カスタマイズ > スキル > + > スキル作成 > スキルをアップロード | 再ダウンロードと再アップロード |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) して設定>拡張機能にドラッグします | 新しいバンドルを再ダウンロードしてドラッグしてください |
+| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイス経由で自動、または `claude plugin update last30days@last30days-skill` |
+| **Grok**(xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` のあとに `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex、Cursor、Copilot、Gemini CLI、その他50以上の [Agent Skills](https://agentskills.io) ホスト** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai**(ウェブ) | [`last30days.skill` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)し、claude.ai > Customize > Skills > + > Create skill > Upload a skill からアップロード | ダウンロードし直してアップロードし直す |
+| **Claude Desktop** | [お使いのプラットフォーム向けの `.mcpb` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest)し、Settings > Extensions にドラッグ | ダウンロードし直して新しいバンドルをドラッグ |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
-### Claude Code (推奨)
+### Claude Code(推奨)
 
 ```
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-おすすめです。なぜなら Claude Code マーケットプレイスがアップデートを代行してくれるからです。プラグインキャッシュはバージョン管理されており、新しいリリースが公開されると自動的にリフレッシュされます。 `claude plugin update last30days@last30days-skill` を実行してチェックを強制してください。
+Claude Code のマーケットプレイスが更新を代わりにやってくれるため、これが推奨です。プラグインのキャッシュはバージョン管理されていて、新しいリリースが公開されると自動で更新されます。`claude plugin update last30days@last30days-skill` を実行すれば、その場で確認を強制できます。
 
-Claude Codeでエージェントスキルインストールパスを使いたい場合は、こちらもサポートしています:
+Claude Code で Agent Skills 経由のインストールを使いたい場合も、それはそれで対応しています。
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-ネイティブプラグインと `npx skills` インストールは共存可能です。 Claude Code インストール方法間での重複除去はしないことに注意してください。マーケットプレイスプラグインと `npx skills` コピーの両方が有効 `/last30days` 、2つのエントリが表示されます。1台のマシンごとに1つのインストール方法を使いましょう。
+ネイティブプラグインと `npx skills` でのインストールは共存できます。ただし Claude Code はインストール方法をまたいだ重複排除を行いません。マーケットプレイス版のプラグインと `npx skills` のコピーを両方とも有効にしていると、`/last30days` が2件表示されます。1台につきインストール方法は1つにしてください。
 
-### Grok (xAIビルド CLI)
+### Grok(xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`)インストールはネイティブプラグインとして30日間有効です。直接インストールはリポジトリを追跡します:
+[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces)(`grok`)は last30days をネイティブプラグインとしてインストールします。直接インストールする場合はリポジトリを追跡します。
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-または、このリポジトリをマーケットプレイスのソースとして追加し、プラグイン名でインストールする方法もあります:
+あるいは、このリポジトリをマーケットプレイスのソースとして追加してから、プラグイン名でインストールすることもできます。
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-インストール確認をスキップするために `--trust` を追加してください。 `grok plugin update last30days`でアップデートします。 Grok 互換性のために Claude Code マニフェストも読みます。ネイティブ `.grok-plugin/` ペアがファーストクラスレーン(公式 [xAI marketplace](https://github.com/xai-org/plugin-marketplace) リストが示している通りです)。 `npx skills add` 有効なクロスホストのフォールバックとして機能しています。
+インストール時の確認を省きたい場合は `--trust` を付けてください。更新は `grok plugin update last30days` です。Grok は互換性のために Claude Code のマニフェストも読みますが、第一の経路はネイティブの `.grok-plugin/` のペアで、[xAI のマーケットプレイス](https://github.com/xai-org/plugin-marketplace)への公式掲載もこちらを指しています。`npx skills add` は、どのホストでも使える代替手段として引き続き有効です。
 
-### Codex、 Cursor、 Copilot、 Gemini CLI、その他の Agent Skills ホスト
+### Codex、Cursor、Copilot、Gemini CLI、その他の Agent Skills ホスト
 
-オープン [Agent Skills](https://agentskills.io) CLI 経由でインストール — `codex`、 `cursor`、 `github-copilot`、 `gemini-cli`、 `claude-code`、 `windsurf`、 `cline`、 `continue`、 `roo`、 `aider-desk`、 `opencode`、 `goose`など50+ハーネスに対応しています( [vercel-labs/skills repo](https://github.com/vercel-labs/skills)に全リスト)。
+オープンな [Agent Skills](https://agentskills.io) の CLI からインストールします。`codex`、`cursor`、`github-copilot`、`gemini-cli`、`claude-code`、`windsurf`、`cline`、`continue`、`roo`、`aider-desk`、`opencode`、`goose` など50以上のホストに対応しています(全一覧は [vercel-labs/skills リポジトリ](https://github.com/vercel-labs/skills)にあります)。
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-`-g`(グローバル)フラグはユーザーディレクトリにインストールされるため、スキルはすべてのプロジェクトで利用可能です。`-g`がなければ、`npx skills`プロジェクトローカルに`./.skills/`にインストールします(リポジトリとコミットしています)。世界を調査するツールとしては、グローバルが最適です。
+`-g`(グローバル)フラグを付けるとユーザーディレクトリにインストールされ、スキルをすべてのプロジェクトで使えます。`-g` を付けない場合、`npx skills` はプロジェクト内の `./.skills/` にインストールし、リポジトリと一緒にコミットされます。世界中を調べるためのツールなので、通常はグローバルが向いています。
 
-Codex デスクトップやその他のフォルダモードのホストは、通常のフォルダでもGitリポジトリでも動作します。最初の調査を行う前に、ホストエージェントにロードされたスキルディレクトリからバンドルされた `scripts/last30days.py --preflight` を実行するよう依頼してください。ソースチェックアウトでは、同等のコマンドは `python3 skills/last30days/scripts/last30days.py --preflight`です。これは設定ソース、ブラウザクッキー計画、計画された書き込み、オプションコマンド、無視されたプロジェクト設定をクッキーの読み取り、書き込み、リサーチを行わずに表示されます。
+Codex のデスクトップ版など、フォルダ単位で動くホストは、Git リポジトリでも普通のフォルダでも動作します。最初の調査を始める前に、読み込み済みのスキルディレクトリから同梱の `scripts/last30days.py --preflight` を実行するようホストのエージェントに頼んでください。ソースをチェックアウトしている場合、同等のコマンドは `python3 skills/last30days/scripts/last30days.py --preflight` です。設定の取得元、ブラウザのクッキーをどう扱う予定か、どのファイルを書き込む予定か、任意で使えるコマンド、無視されるプロジェクト設定を表示します。クッキーの読み取りもファイルの書き込みも調査の実行もしません。
 
-デフォルトでは、 `npx skills` 検出したハーネスに対してこの仕組みがインストールされます。特定のハーネス(または複数)をターゲットにするには:
+既定では、`npx skills` が検出したホスト向けにインストールされます。特定のホスト(または複数)を指定するには次のようにします。
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-後日更新:
+あとから更新するには次のようにします。
 
 ```bash
 npx skills update last30days -g
 ```
 
-または、 `npx skills`を通じてグローバルにインストールしたすべてのものを更新してください:
+`npx skills` でグローバルに入れたものをまとめて更新することもできます。
 
 ```bash
 npx skills update -g
 ```
 
-リストして `npx skills list -g` と `npx skills remove last30days -g`で削除してください。
+一覧表示と削除は `npx skills list -g` と `npx skills remove last30days -g` で行えます。
 
 ### claude.ai(ウェブ)
 
-1. 最新リリースからの[Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)
-2. [claude.ai > Customize > Skills](https://claude.ai/customize/skills)に行って
-3. スキルパネルの `+` ボタンをクリックし> `Create skill` > `Upload a skill` をクリックしてファイルを閲覧・ドロップしてください
+1. 最新リリースから [`last30days.skill` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)します
+2. [claude.ai > Customize > Skills](https://claude.ai/customize/skills) を開きます
+3. Skills パネルの `+` ボタンをクリックし、`Create skill` > `Upload a skill` と進んで、ファイルを選択するかドロップします
 
-まずは「Capabilities」で「コード実行とファイル作成」を有効にしてください。スキルはそれなしでは動作しません。
+先に Capabilities で「Code execution and file creation」を有効にしてください。これがないとスキルは動きません。
 
 ### Claude Desktop
 
-Claude Desktop`.mcpb`バンドル(ワンクリックのModel Context Protocolパッケージ)を通じて`/last30days`をMCPサーバーとしてインストールします。
+Claude Desktop では、`.mcpb` バンドル(ワンクリック版の Model Context Protocol パッケージ)を使って `/last30days` を MCP サーバーとしてインストールします。
 
-1. [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest)にアクセスし、あなたのプラットフォームの`.mcpb`をダウンロードしてください:
+1. [最新リリース](https://github.com/mvanhorn/last30days-skill/releases/latest)を開き、お使いのプラットフォーム向けの `.mcpb` をダウンロードします:
    - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS インテル: `last30days-pp-mcp-darwin-amd64.mcpb`
+   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
    - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Claude Desktopを開き、拡張機能>設定に行き、ファイルをドラッグします。
-3. 促されたら、有効にしたいソースのキーを API 貼り付けます。すべてのフィールドは任意で、すべてスキップするとエンジンはウェブ専用モードに劣化します。キーはOSのキーチェーンに保存されます。
-4. Claude Desktopを再起動してください。Claudeに「ピーター・スタインバーガーを調べて」など、どのトピックでも「リサーチ」と頼むと、`research`ツールを呼び出します。
+2. Claude Desktop を開き、Settings > Extensions に移動して、ファイルをドラッグします。
+3. 求められたら、有効にしたい情報源のAPIキーを貼り付けます。どの項目も任意です。すべて省略した場合、エンジンはウェブのみのモードに切り替わります。キーはOSのキーチェーンに保存されます。
+4. Claude Desktop を再起動します。Claude に「Peter Steinberger について調べて」などと頼めば、`research` ツールが呼び出されます。
 
-**ホスト要件:** PATHPython 3.12+。バンドルはエンジンソースを出荷しますが、ローカルのPythonインタプリタを使用します。Windows[python.org](https://www.python.org/downloads/)からインストールしてください;macOSおよびほとんどのLinuxディストリビューションは互換性のあるバージョンを出荷します。
+**ホスト側の要件:** PATH の通った Python 3.12以上。バンドルにはエンジンのソースが含まれますが、実行にはローカルの Python インタプリタを使います。Windows では [python.org](https://www.python.org/downloads/) からインストールしてください。macOS とたいていの Linux ディストリビューションには、対応するバージョンが最初から入っています。
 
-**キーはコードスキルと同期しません。** Claude Desktop と Claude Code は設計上別々の認証情報ストアを維持しています。コードスキルですでに `~/.config/last30days/.env` を設定している場合、同じキーをここで一度再入力します。
+**キーは Claude Code のスキルとは共有されません。** Claude Desktop と Claude Code は、設計上それぞれ別に認証情報を保管しています。Claude Code のスキル用にすでに `~/.config/last30days/.env` を設定していても、ここで同じキーをもう一度だけ入力する必要があります。
 
-Windows サポートはプラットフォームごとのマニフェストエントリポイントが解決されるまで延期されます。追跡はフォローアップの問題で行われます。
+Windows のサポートは、マニフェストのプラットフォーム別エントリーポイントが整理されるまで見送りとなっており、専用のIssueで追跡しています。
 
 ### OpenClaw
 
@@ -263,43 +263,43 @@ Windows サポートはプラットフォームごとのマニフェストエン
 clawhub install last30days-official
 ```
 
-X/Twitter のアクションワークフロー、例えば`/last30days`研究以外の作業、例えば投稿
-ツイートや返信、フォロワーのエクスポート、メディアの管理、モニター、プレゼント企画
-ドローを使い、 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) を仲間として使う
-OpenClaw プラグインです。 TweetClaw はXquik-devによって管理されており、
-オプションの伴侶パスであり、最後の30日間の依存や承認ではありません。
+`/last30days` の調査以外で X/Twitter を操作したい場合 — ツイートや返信の投稿、
+フォロワーのエクスポート、メディアの扱い、モニタリング、プレゼント企画の抽選など —
+には、OpenClaw の補助プラグインとして [TweetClaw](https://github.com/Xquik-dev/tweetclaw)
+を使ってください。TweetClaw は Xquik-dev が管理しており、ここでは任意の補助的な
+選択肢として挙げているだけです。last30days の依存でも推奨でもありません。
 
-### マニュアル(開発者)
+### 手動インストール(開発者向け)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-シンムリンクは編集中にインストールを作業ツリーと同期させ、再コピーは不要です。 `claude.ai`はソースから `.skill` ファイルをビルドします。 `bash skills/last30days/scripts/build-skill.sh` `dist/last30days.skill`を生成します。
+シンボリックリンクにしておけば、編集するたびに作業ツリーとインストール先が同期するので、コピーし直す必要はありません。`claude.ai` 用には、ソースから `.skill` ファイルをビルドしてください。`bash skills/last30days/scripts/build-skill.sh` で `dist/last30days.skill` が生成されます。
 
-Reddit (コメント付き)、 Hacker News、 Polymarket、 GitHub が即座に動作します。設定はゼロです。一度 `/last30days` 実行すると、セットアップウィザードが30秒でさらに多くのソースをアンロックし、無料の arXiv や Techmeme CLIsも含まれます。
+Reddit(コメント込み)、Hacker News、Polymarket、GitHub はすぐに使えます。設定は不要です。`/last30days` を一度実行すれば、セットアップウィザードが30秒でさらに多くの情報源を有効にします。無料の arXiv と Techmeme の CLI も含まれます。
 
-## 自分の鍵を持ってきてください
+## 自分のキーを持ち込む
 
-これらのプラットフォーム同士には関係性がありません。 X は Reddit がどう思っているか分かりません。 YouTube はそれを見 TikTok。しかし、自分の API キーやブラウザトークンを持っていけば、突然それらすべてに一度にアクセスできるようになります。
+これらのプラットフォーム同士には何のつながりもありません。X は Reddit が何を考えているかを知りませんし、YouTube に TikTok は見えていません。しかし自分のAPIキーとブラウザのトークンを持ち込めば、それらすべてに一度にアクセスできるようになります。
 
-| 出典 | 必要なもの | 費用 |
+| 情報源 | 必要なもの | 費用 |
 |---------|---------------|------|
-| Reddit (コメント付き)+ HN + Polymarket + GitHub + StockTwits | 何も | 無料 |
-| arXiv + Techmeme | 初開セットアップで自動インストールされる無料CLI | 無料 |
-| X / Twitter | どのブラウザでも x.com にログインするか、`XQUIK_API_KEY`/`XAI_API_KEY`設定してください。 | ブラウザクッキーは無料です。キーはプロバイダーごとに異なります |
+| Reddit(コメント込み)+ HN + Polymarket + GitHub + StockTwits | 不要 | 無料 |
+| arXiv + Techmeme | 無料のCLI。初回セットアップが自動でインストールします | 無料 |
+| X / Twitter | 任意のブラウザで x.com にログインするか、`XQUIK_API_KEY` / `XAI_API_KEY` を設定 | ブラウザのクッキーは無料。キーの料金は提供元によります |
 | YouTube | `brew install yt-dlp` | 無料 |
-| Bluesky | アプリパスワードは bsky.app から | 無料 |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube コメント | ScrapeCreators キー | 1万件の無料通話、そしてPAYG |
-| Xiaohongshu (RED) | ログインしたx-mcpブラウザプラグインや`xiaohongshu-mcp`サービスを実行し、`.env`で`--search xhs`の`INCLUDE_SOURCES=xiaohongshu`でオプトインしてください;最後に30日の自動プローブ`http://localhost:18060`、その後`http://host.docker.internal:18060`、またはカスタムURLとして`XIAOHONGSHU_API_BASE`を使う | last30daysの API キーはありません。ローカルのブラウザセッションサービスによります |
-| DripStack(プレミアム金融ニュースレター) | オプトイン:1回のランに`--search dripstack`、または`INCLUDE_SOURCES=dripstack``.env` | 鍵なし;無料の公開検索 API |
-| Perplexity ソナー / 捜索 API / 深層調査 | Perplexity キー、またはOpenRouterキーをSonarのフォールバックとして使います | 使い分ずつ支払ってください |
-| Web 検索 | Brave Searchキー | 月間2,000件の無料クエリ |
+| Bluesky | bsky.app のアプリパスワード | 無料 |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube のコメント | ScrapeCreators のキー | 1万リクエストまで無料、以降は従量課金 |
+| Xiaohongshu(RED) | ログイン済みの x-mcp ブラウザプラグインか `xiaohongshu-mcp` サービスを動かしたうえで、実行ごとに `--search xhs` を付けるか `.env` に `INCLUDE_SOURCES=xiaohongshu` を設定して有効化します。last30days は `http://localhost:18060`、次に `http://host.docker.internal:18060` の順に自動で接続を試し、独自のURLを使う場合は `XIAOHONGSHU_API_BASE` を指定します | last30days 側のAPIキーは不要。ローカルのブラウザセッションのサービス次第です |
+| DripStack(有料の金融ニュースレター) | 任意で有効化: 実行ごとに `--search dripstack`、または `.env` に `INCLUDE_SOURCES=dripstack` | キー不要。無料の公開検索APIを使います |
+| Perplexity Sonar / Search API / Deep Research | Perplexity のキー、または Sonar の代替として OpenRouter のキー | 従量課金 |
+| ウェブ検索 | Brave Search のキー | 月2,000クエリまで無料 |
 
-### macOS Keychain (任意)
+### macOS のキーチェーン(任意)
 
-macOSでは、`.env`ファイルではなくシステムKeychainにキーを保存できます。スキルは自動的にキーを最も優先度の低いソースとして取得します。`.env`ファイルやプロセス環境は衝突時に依然として優勢です。
+macOS では、キーを `.env` ファイルではなくシステムのキーチェーンに保存できます。スキルは最も優先度の低い取得元として自動的に読み込むため、衝突した場合は `.env` ファイルとプロセスの環境変数が優先されます。
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +313,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-アイテムは現在のユーザーのためにサービス名 `last30days-<KEY>` に保存されます。ダーウィン以外のプラットフォームではローダーはノーオペレーターであるため、 Linux/Windows ユーザーの挙動変更はありません。
+項目は現在のユーザー向けに、サービス名 `last30days-<KEY>` で保存されます。Darwin 以外のプラットフォームではローダーは何もしないため、Linux や Windows のユーザーにとって挙動は変わりません。
 
-すでに異なるKeychainサービス名でキーを持っていますか?秘密をコピーする代わりに、[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items)で説明された非秘密の`LAST30DAYS_KEYCHAIN_ALIASES`マッピングを設定しましょう。
+すでに別のサービス名でキーチェーンにキーを保存している場合は、秘密情報をコピーする代わりに、[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) で説明している秘密情報ではないマッピング `LAST30DAYS_KEYCHAIN_ALIASES` を設定してください。
 
-ソースごとの鍵マトリックス、推論提供者の優先順位、ウェブ検索のバックエンド優先度については、詳細 [CONFIGURATION.md](CONFIGURATION.md) を参照してください。
+情報源ごとのキーの一覧、推論プロバイダーの優先順位、ウェブ検索バックエンドの優先順位については [CONFIGURATION.md](CONFIGURATION.md) を参照してください。
 
-## 構成
+## 設定
 
-初日に知っておくべきことが2つあります:
+初日に知っておくとよいことが2つあります。
 
-**研究ファイルが保存される場所。** `LAST30DAYS_MEMORY_DIR`デフォルトは`~/Documents/Last30Days/`(Windows: `C:\Users\<you>\Documents\Last30Days\`)。そのenv varをシェル内の任意のパスに設定し、または1回の実行ごとに`--save-dir <path>`設定してオーバーライドしてください。正確なパスでレンダリング結果が必要な場合は、`--emit`が選択したフォーマットで`--output <file>`を使います。`--save-suffix=<name>`を使って同じトピックの複数のバリエーションを別々に管理してください(例:クライアントごと)。各`--save-dir`実行は`<slug>-raw[-suffix].md`を生成します。研究実行前に計画された書き込みを確認するために`python3 skills/last30days/scripts/last30days.py --preflight`実行してください。
+**調査ファイルの保存先。** `LAST30DAYS_MEMORY_DIR` の既定値は `~/Documents/Last30Days/` です(Windows では `C:\Users\<you>\Documents\Last30Days\`)。変更したい場合は、シェルでこの環境変数に任意のパスを設定するか、実行ごとに `--save-dir <path>` を指定します。レンダリング結果を特定のパスに出力したいときは `--output <file>` を使い、形式は `--emit` で選びます。同じトピックの複数のバリエーションを分けて残したいときは `--save-suffix=<name>` を使ってください(クライアントごとに分ける場合など)。`--save-dir` を付けた実行では `<slug>-raw[-suffix].md` が生成されます。調査を走らせる前に書き込み予定を確認するには `python3 skills/last30days/scripts/last30days.py --preflight` を実行してください。
 
-**エージェントおよびワークフロー向けの構造化出力。** 安定したバージョン管理されたエージェントプロファイルを受け取るための機械可読JSONを`/last30days`に求めてください。スクリプトや開発で直接エンジンを使う場合は、`python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`実行してください;バージョンのない内部`Report`ダンプが必要な時のみ`--json-profile=raw`追加してください。[JSON export field reference and versioning policy](docs/reference/json-export.md)を参照してください。
+**エージェントやワークフロー向けの構造化出力。** `/last30days` に機械可読なJSONを求めると、安定したバージョン付きのエージェント向けプロファイルが返ります。スクリプトや開発でエンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` を実行してください。バージョン管理されていない内部の `Report` のダンプが必要なときだけ `--json-profile=raw` を追加します。[JSONエクスポートのフィールド一覧とバージョニング方針](docs/reference/json-export.md)も参照してください。
 
-**トピックレスディスカバリー。** 既知のトピックを調べる代わりにランク付けされたディスカバリーブリーフを取得 `/last30days what's trending in AI agents?` を求めてください。エージェントホストでは、3コマンドのホストジャッジドプロトコルを実行します(モデルがトピック名、ジャンクをフィルタリングし、価値をスコアリングし、コンテンツの角度を書きます)。スクリプトやクロンで直接エンジンで使う場合は、 `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` を実行します(ワンショット:決定的なトピック名、アングルなし);バージョン付きディスカバリー契約のために、 `--emit=json` を追加します。ディスカバリーはポジショントピックと相互排他的であり、 `--drill`。
+**トピックを決めないディスカバリー。** すでに知っているトピックを調べる代わりに、順位付きのディスカバリーブリーフがほしいときは `/last30days what's trending in AI agents?` と尋ねてください。エージェントを備えたホストでは、ホストが判定する3コマンドのプロトコルが走ります(モデルがトピックを挙げ、ノイズを除き、取り上げる価値を採点し、コンテンツの切り口を書きます)。スクリプトや cron でエンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` を実行します(単発実行。トピック名は決定論的で、切り口は付きません)。バージョン付きのディスカバリー契約がほしい場合は `--emit=json` を追加してください。ディスカバリーは、位置引数のトピックや `--drill` とは併用できません。
 
-**実行をまたぐ傾向監視。** デフォルトモードでは1回の実行ごとに新しいマークダウンスナップショットが生成されます。時間をかけて発見を蓄積するには、SQLiteデータベースに永続化する `--store` を追加し、スケジュールされた実行には [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) (新しい発見にはオプションでSlackやwebhookの配信も可能)、日次・週次ダイジェストには日次 [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) を使います。完全なカデンスパターンは [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings)にあります。
+**実行をまたいだトレンド監視。** 既定のモードでは、実行のたびに新しい Markdown のスナップショットが作られます。時間をかけて結果を蓄積したい場合は `--store` を付けて SQLite データベースに保存し、定期実行には [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py)(新しい結果が出たときの Slack や Webhook への通知も任意で設定できます)、日次・週次のまとめには [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) を使ってください。運用サイクルの全体像は [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings) にあります。
 
-**購読可能な研究図書館です。** `/last30days`に図書館フィードを作成してもらうか、スクリプト作成や開発に直接使う`python3 skills/last30days/scripts/last30days.py library feed`をください。保存されたブリーフを`index.html`、ローカルのAtom `feed.xml`、読みやすいブリーフページに変換します。HTMLインデックスやブリーフページをホストしたい場合にのみ追加`--publish`;公開は明示的にオプトインし、デフォルトで公開されます。Atomフィードを購読可能にするには、生成された出力ディレクトリをGitHub Pagesのような静的ホストでホストしてください。
+**購読できる調査ライブラリ。** `/last30days` にライブラリのフィードを作らせるか、スクリプトや開発用には `python3 skills/last30days/scripts/last30days.py library feed` を直接使ってください。保存済みのブリーフが `index.html`、ローカルの Atom 形式の `feed.xml`、読みやすいブリーフのページに変換されます。HTML のインデックスとブリーフのページをホスティングしたいときだけ `--publish` を付けてください。公開は明示的に選ぶ形で、既定では誰でも見られる状態になります。Atom フィードを実際に購読できるようにするには、生成された出力ディレクトリを GitHub Pages のような静的ホスティングに置いてください。
 
-**調べたものをすべて検索してください。** `/last30days search my library for MCP servers` または質問 `/last30days have I researched MCP servers before?`。直接エンジン使用の場合は `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`を実行します。検索はオフラインかつ決定論的です。図書館フィードで使われる同じ保存ブリーフを段階的にインデックス化し、各ランごとに一致する店舗の目撃情報を統合し、トピックや日付で結果をグループ化します。新規の検索では、先行研究が現在のトピックと重複する場合、コンパクトな**あなたの図書館から**セクションが表示されます。その受動的なコンテキストを無効に `LAST30DAYS_LIBRARY_CONTEXT=off` 設定してください。
+**これまで調べたものをすべて検索する。** `/last30days search my library for MCP servers` や `/last30days have I researched MCP servers before?` と尋ねてください。エンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` を実行します。この検索はオフラインかつ決定論的です。ライブラリのフィードが使うのと同じ保存済みブリーフを少しずつインデックス化し、実行ごとにストアへ記録された該当分をまとめ、トピックと日付で結果をグループ化します。新しく実行したときも、過去の調査が今回のトピックと重なっていれば、**From your library**(あなたのライブラリから)というコンパクトなセクションが表示されます。この受動的な文脈表示をやめたい場合は `LAST30DAYS_LIBRARY_CONTEXT=off` を設定してください。
 
-クライアントごとのラッパースクリプト、カスタムカテゴリピアサブレディット、進行中のカスタマイズのための実験的ベータチャンネルも [CONFIGURATION.md](CONFIGURATION.md)でドキュメント化されています。
+クライアントごとのラッパースクリプト、カテゴリー用のサブレディットのカスタマイズ、作業中のカスタマイズを試す実験的なベータチャンネルについても [CONFIGURATION.md](CONFIGURATION.md) に記載しています。
 
-## 紹介:コミュニティリサーチフィード
+## ショーケース: コミュニティの調査フィード
 
-定期的なAIアップデート、市場観察、またはlast30daysへの非常に狭い執着を公開した?公共図書館のURL、または静的ホストで `feed.xml` ホスティングした後のAtomのURLを共有 [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532)。コミュニティフィードは所有者が投稿する際にここにリンクされます。スレッドがその間、収集の拠点となっています。
+last30days で、定期的なAIのまとめ、市場ウォッチ、あるいは見事にニッチな偏愛を公開しましたか。公開ライブラリのURL(または `feed.xml` を静的ホスティングに置いたあとの Atom のURL)を[コミュニティのショーケーススレッド](https://github.com/mvanhorn/last30days-skill/issues/532)で共有してください。コミュニティのフィードは、作者から届き次第ここにリンクしていきます。それまでのあいだは、このスレッドが集約先です。
 
 ## 仕組み
 
-1. **トピックをタイプします。** 人物、会社、製品、技術、「X vs Y」何でもいい。
-2. **エージェントが重要な人物を決定します。** Xハンドル(創業者を含む)、リポジトリ、サブレディット、TikTokハッシュタグ、YouTubeチャンネルGitHubを見つけます。「Kanye West」についてはr/hiphopheads、@kanyewest、そしてYouTubeの「bully review」を知っています。「OpenClaw」ではopenclaw/openclawをGitHubで解決し、ライブのスター数を取得します。
-3. **すべてのソースを並行検索。** 複数クエリの拡張。結果はエンゲージメント、関連性、新鮮度で評価されます。
-4. **他の誰にもない深み。**リアクション動画の全 YouTube トランスクリプト。アップボート数を含むトップ Reddit コメント。 TikTok キャプション。 Polymarket 確率。タイトルやリンクだけじゃない。
-5. **同じ話、統合済み。**ワイヤレスフェスティバルは Reddit日に発表され、 Xで議論、 TikTok のチケット価格は3つの別々の項目ではなく1つのクラスターです。
-6. **まとめて一つのブリーフにまとめた。** 具体的なデータに根ざしている。出典ごとに引用。人々が実際に関わるもので順位付け。「これが私の発見だ」ではなく「これが重要なことだ」ということだ。
-7. **そうすればあなたの専門家になります。** 一度の実行で、あなたの Claude セッションはコミュニティが知っているすべてを知っています。フォローアップの質問をしてください。プロンプトを書かせ、メールを下書きし、旅行計画を立て、アーキテクトシステムを計画し、すべて今の現実に基づいています。
+1. **トピックを入力します。** 人物、企業、プロダクト、技術、「X vs Y」。何でもかまいません。
+2. **エージェントが「誰が重要か」を特定します。** X のアカウント(創業者を含む)、GitHub のリポジトリ、サブレディット、TikTok のハッシュタグ、YouTube のチャンネルを見つけます。「Kanye West」なら r/hiphopheads、@kanyewest、YouTube の「bully review」だと分かります。「OpenClaw」なら GitHub 上の openclaw/openclaw を特定し、スター数をその場で取得します。
+3. **すべての情報源を並行して検索します。** 複数クエリへの展開。結果はエンゲージメント、関連性、新しさでスコア付けされます。
+4. **他にはない深さ。** リアクション動画の YouTube 全文文字起こし。アップボート数付きの Reddit のトップコメント。TikTok のキャプション。Polymarket のオッズ。タイトルとリンクだけではありません。
+5. **同じ話題はまとめます。** Reddit で告知され、X で語られ、TikTok にチケット価格が出た Wireless Festival は、3件の別々の項目ではなく1つのクラスターになります。
+6. **1本のブリーフに統合します。** 具体的なデータに基づき、情報源を明示し、実際に人々が反応したかどうかで順位を付けます。「見つけたものはこれです」ではなく「重要なのはこれです」を返します。
+7. **そのあとは、あなたの専門家になります。** 一度実行すれば、あなたの Claude のセッションはコミュニティが知っていることをすべて把握しています。続けて質問してください。プロンプトを書かせる、メールを下書きさせる、旅程を立てさせる、システム構成を設計させる。どれも「今、実際に起きていること」に基づきます。
 
-## 人々が言っていること
+## 使っている人の声
 
-> 「過去30日間の44Reddit、X、YouTube、HNのあらゆるトピックを調べるClaude Codeスキルを見つけました。そして、あなたのためにプロンプトを書きます。私は毎回のコンテンツを書く前に、RedditやXを手動で調査しています。タブごとに。スレッドごとに。そこが90分かかる部分です。これでその部分はなくなります。」-@itsjasonai
+> 「Reddit、X、YouTube、HN を横断して直近30日のあらゆるトピックを調べてくれる Claude Code のスキルを見つけた。しかもプロンプトまで書いてくれる。書く記事ごとに、これまでは Reddit と X を手作業で調べていた。タブごと、スレッドごとに。そこが90分かかっていた部分だ。それがなくなる。」 — @itsjasonai
 
-> 「この一つのスキルが、私の研究ワークフロー全体を置き換えました。トピックを与えると、実際に人々が話していることを Reddit、 X、ウェブからスクレイピングします。古いブログ記事ではありません。過去30日間の本当の会話です。」-@itswilsoncharles
+> 「このスキル1つで、私の調査ワークフローがまるごと置き換わった。トピックを渡すと、Reddit、X、ウェブから人々が本当に話していることを拾ってくる。古いブログ記事ではなく、直近30日の生の会話だ。」 — @itswilsoncharles
 
-> 「今日 GitHub でトレンド入りしている10のリポジトリのうち5つは Claude ツールです。#1:Mvanhorn/last30days-スキル」 -@yieldhunter95
+> 「今日 GitHub でトレンド入りしているリポジトリ10件のうち5件が Claude 関連のツール。1位は mvanhorn/last30days-skill」 — @yieldhunter95
 
 ## オープンソース
 
-MITライセンス。追跡なし。分析なし。研究はあなたのマシンに残る。2,700+テスト。
+MIT ライセンス。トラッキングなし。アナリティクスなし。調査結果はあなたのマシンに残ります。テストは2,700件以上。
 
-Python 3.12+、yt-dlp、Node.js(X検索用にベンダーBirdクライアント)、およびScrapeCreators API[@j-sperling](https://github.com/j-sperling)によるv3エンジンアーキテクチャで構築されています。
+Python 3.12以上、yt-dlp、Node.js(X 検索用に同梱した Bird クライアント)、ScrapeCreators API で構築しています。v3 のエンジンアーキテクチャは [@j-sperling](https://github.com/j-sperling) によるものです。
 
-PRを開くには[CONTRIBUTING.md](CONTRIBUTING.md)、コミュニティ貢献者の全リストは「[CONTRIBUTORS.md](CONTRIBUTORS.md)」、バージョン履歴は「[CHANGELOG.md](CHANGELOG.md)」を参照してください。
+PRの出し方は [CONTRIBUTING.md](CONTRIBUTING.md)、コミュニティの貢献者の一覧は [CONTRIBUTORS.md](CONTRIBUTORS.md)、バージョン履歴は [CHANGELOG.md](CHANGELOG.md) を参照してください。
 
-## スターの歴史
+## スター数の推移
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -16,9 +16,9 @@
   </a>
 </p>
 
-**Um mecanismo de busca liderado por agentes de IA, pontuado por votos positivos, curtidas e dinheiro real - não por editores.**
+**Um buscador conduzido por um agente de IA, que pontua por votos positivos, curtidas e dinheiro de verdade — não por redações.**
 
-Este README acompanha o pipeline v3 atual. A especificação de habilidade em tempo de execução está em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a fonte de verdade para o comportamento mais recente de comandos e configurações.
+Este README descreve o pipeline v3 atual. A especificação de execução da skill fica em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a referência definitiva sobre o comportamento dos comandos e da configuração.
 
 **Claude Code (recomendado — atualizações automáticas via marketplace):**
 ```
@@ -26,141 +26,141 @@ Este README acompanha o pipeline v3 atual. A especificação de habilidade em te
 /plugin install last30days
 ```
 
-**Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ [Agent Skills](https://agentskills.io) apresentadores:**
+**Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ hosts do [Agent Skills](https://agentskills.io):**
 ```
 npx skills add mvanhorn/last30days-skill -g
 ```
-(`-g` instala globalmente para seu usuário, disponível em todos os projetos. Coloque para o escopo por projeto.)
+(`-g` instala globalmente para o seu usuário, então fica disponível em todos os projetos. Omita essa flag se quiser limitar a instalação a um projeto.)
 
-Mais opções de instalação (claude.ai web, OpenClaw, manual) na seção [Install](#instalação) abaixo.
+Outras formas de instalar (claude.ai web, OpenClaw, manual) estão na seção [Instalação](#instalação), mais abaixo.
 
-Zero configuração. Reddit, HN, Polymarkete GitHub funcionam imediatamente. Execute uma vez e o assistente de configuração desbloqueia X, YouTube, TikTok, arXiv, Techmemee mais em 30 segundos.
+Configuração zero. Reddit, HN, Polymarket e GitHub funcionam de imediato. Rode uma vez e o assistente de configuração libera X, YouTube, TikTok, arXiv, Techmeme e mais em 30 segundos.
 
 ---
 
-Reddit votos positivos. X gostos. YouTube transcrições. TikTok engajamento. Polymarket probabilidades respaldadas por dinheiro real e informações privilegiadas. São milhões de pessoas votando com sua atenção e carteiras todos os dias. /last30days pesquisa tudo em paralelo, pontua pelo que pessoas reais realmente envolvem, e um juiz agente de IA sintetiza tudo em um único recurso.
+Os votos positivos do Reddit. As curtidas do X. As transcrições do YouTube. O engajamento no TikTok. As probabilidades do Polymarket, lastreadas em dinheiro de verdade e em informação privilegiada. São milhões de pessoas votando todo dia com a atenção e com o bolso. O /last30days busca tudo isso em paralelo, pontua pelo que as pessoas realmente engajam e um agente de IA atua como juiz para sintetizar tudo em um único briefing.
 
-Google agrega editores. /last30days pesquisa pessoas.
+O Google agrega redações. O /last30days busca pessoas.
 
-Você não pode encontrar essa busca em nenhum outro lugar porque nenhuma IA única tem acesso a tudo. Google busca não mexe Reddit comentários ou X postagens. ChatGPT tem um acordo com Reddit , mas não pode pesquisar X ou TikTok. Gemini tem YouTube , mas não Reddit. Claude não tem nenhuma delas nativamente. Cada plataforma é um jardim murado com seu próprio API, seus próprios tokens, sua própria autenticação. Mas você pode trazer suas próprias chaves e sessões de navegador, e de repente um agente de IA pode pesquisar todas de uma vez, pontuá-las entre si e dizer o que realmente importa.
+Essa busca você não encontra em nenhum outro lugar, porque nenhuma IA sozinha tem acesso a tudo. O Google não alcança nem os comentários do Reddit nem as publicações do X. O ChatGPT tem acordo com o Reddit, mas não consegue buscar no X nem no TikTok. O Gemini tem o YouTube, mas não o Reddit. O Claude não tem nenhum deles de forma nativa. Cada plataforma é um jardim murado, com API, tokens e autenticação próprios. Mas você pode trazer suas próprias chaves e sessões de navegador e, de repente, um agente de IA busca em todas ao mesmo tempo, compara umas com as outras e diz o que realmente importa.
 
-Esse é o desbloqueio. Não há um motor de busca melhor. Uma dúzia de plataformas desconectadas, conectadas por um agente.
+É esse o destravamento. Não é um buscador melhor: é uma dúzia de plataformas isoladas, conectadas por um agente.
 
 ```
 /last30days Peter Steinberger
 ```
 
-Você tem uma reunião amanhã. Você Google eles. Você recebe o LinkedIn deles de 2023. /last30days te dá o que eles realmente estão fazendo este mês: entrou na OpenAI para trabalhar em Codex, lutou contra a proibição da Anthropic sobre agentes terceirizados, enviou 23 PRs com 85% de taxa de fusão, construiu "LobsterOS" para controle de agentes entre dispositivos, e o código r/Claudeatingiu 569 votos positivos debatendo se ele é um herói ou "insuportável". Espalhados por X postagens, Reddit tópicos, transcrições YouTube e GitHub commits. Nada disso estava no Google.
+Você tem uma reunião amanhã. Procura a pessoa no Google. Aparece o LinkedIn dela de 2023. O /last30days entrega o que ela está fazendo de fato neste mês: entrou na OpenAI para trabalhar no Codex, enfrenta o veto da Anthropic a agentes de terceiros, entregou 23 PRs com 85 % de taxa de merge, constrói o "LobsterOS" para controlar agentes entre dispositivos, e uma thread no r/ClaudeCode chegou a 569 votos positivos discutindo se ele é um herói ou "insuportável". Tudo espalhado entre publicações no X, threads no Reddit, transcrições do YouTube e commits no GitHub. Nada disso estava no Google.
 
 ## Por que isso existe
 
-Eu o construí para acompanhar a IA. Tudo muda todo dia e os nerds Reddit e X sempre estão por dentro primeiro. Eu precisava de prompts melhores, e os dados de treinamento sempre estavam meses atrás do que a comunidade já havia descoberto.
+Construí para acompanhar o ritmo da IA. Tudo muda todo dia, e o pessoal do Reddit e do X sempre sabe primeiro. Eu precisava de prompts melhores, e os dados de treinamento estavam sempre meses atrás do que a comunidade já tinha descoberto.
 
-Mas virou algo maior. Agora eu faço isso antes de uma ligação de vendas para saber a verdade dos últimos 30 dias sobre um negócio. Antes de uma reunião para ler os tweets recentes e transcrições de podcasts de alguém. Antes de uma Disney World viagem para saber quais brinquedos estão fechados e o que a comunidade diz sobre Genie+. Antes de construir qualquer coisa para saber quais problemas as pessoas realmente estão enfrentando.
+Mas virou algo maior. Hoje eu rodo antes de uma call de vendas, para saber a verdade dos últimos 30 dias sobre uma empresa. Antes de uma reunião, para ler os tweets recentes e as transcrições de podcast de quem vou encontrar. Antes de uma viagem à Disney World, para saber quais brinquedos estão fechados e o que a comunidade acha do Genie+. Antes de construir qualquer coisa, para saber em quais problemas as pessoas realmente estão esbarrando.
 
-Se você está se reunindo com um CEO, já leu todos os tweets e transcrições de YouTube dos últimos 30 dias? Leu.
+Se você vai se reunir com um CEO, já leu todos os tweets e todas as transcrições do YouTube dos últimos 30 dias? Eu li.
 
-## Fontes, pontuadas pelo povo
+## Fontes, pontuadas pelas pessoas
 
-| Fonte | O que as pessoas te dizem |
+| Fonte | O que as pessoas te contam |
 |--------|--------------------------|
-| **Reddit** | A opinião sem filtros. Comentários no topo com contagens reais de votos, gratuito, sem API chave. As opiniões reais que Google enterram. |
-| **X / Twitter** | A opinião polêmica, o fio do especialista, a reação de quebra. Primeiro a saber, primeiro a discutir. |
-| **YouTube** | O mergulho profundo de 45 minutos. Transcrições completas buscadas pelas 5 frases citáveis que importam. |
-| **TikTok** | O criador alcançando 3,6 milhões de pessoas com uma opinião que você nunca encontrará sobre Google. |
-| **Instagram Reels** | A perspectiva do influenciador com transcrições de spoken word. O sinal cultural visual. |
-| **Hacker News** | O consenso dos desenvolvedores. 825 pontos, 899 comentários. Onde pessoas técnicas realmente discutem. |
-| **Polymarket** | Não opiniões. Probabilidades. Garantido por dinheiro real. 96% de confiança nas vendas do álbum. 4% em uma aquisição. |
-| **GitHub** | Para as pessoas: PR Velocity, top repos por estrelas, notas de release. Para tópicos: questões e discussões. |
-| **Digg** | Clusters de histórias selecionados do ranking AI 1000 da Digg(~1000 contas de IA de alta sinalização no X), com citações inline atribuíbles (sem necessidade de autenticação X ). Autoativado quando `digg-pp-cli` está ativado PATH. |
-| **arXiv** | Os papéis por trás do hype. Nova pesquisa na janela, gratuita, sem chave API . Ativado automaticamente quando `arxiv-pp-cli` está no PATH (a primeira configuração instala). |
-| **Techmeme** | A camada editorial de notícias tecnológicas, datada para seus 30 dias. Grátis, sem chave API . Ativada automaticamente quando `techmeme-pp-cli` está no PATH (a primeira execução instala). |
-| **LinkedIn** | O sinal profissional. Posts e artigos, com artigos ponderados como sinal alto. |
-| **StockTwits** | Sentimento do trader. Ativa-se automaticamente quando seu tema é um ticker ou criptomoeda. |
-| **Threads** | A camada de texto pós-Twitter. Conversas de criadores e marcas. |
-| **Pinterest** | Descoberta visual. Fixe, salve e comente sobre produtos e ideias. |
-| **Xiaohongshu (RED)** | Sinais de estilo de vida, produto e criador chineses. Solicitado explicitamente com `--search xhs` quando um plugin ou serviço de `xiaohongshu-mcp` do navegador x-mcp logado está rodando localmente. |
-| **Bluesky** | A camada social descentralizada. Postagens do Protocolo AT da migração pós-Twitter. |
-| **Perplexity** | Síntese de Sonar no Solo, Busca API Linhas brutas e Pesquisa Profunda. |
-| **Web** | A cobertura editorial, as comparações com blogs. Um sinal entre muitos, não o único. |
+| **Reddit** | A opinião sem filtro. Os melhores comentários com a contagem real de votos positivos, de graça e sem chave de API. As opiniões de verdade que o Google enterra. |
+| **X / Twitter** | A opinião quente, a thread do especialista, a primeira reação ao factual. Os primeiros a saber, os primeiros a discutir. |
+| **YouTube** | A análise de 45 minutos. Transcrições completas, garimpadas atrás das 5 frases citáveis que importam. |
+| **TikTok** | O criador que alcança 3,6 milhões de pessoas com uma leitura que você nunca vai achar no Google. |
+| **Instagram Reels** | O olhar dos influenciadores, com a transcrição do que é falado. O sinal da cultura visual. |
+| **Hacker News** | O consenso da turma de desenvolvimento. 825 pontos, 899 comentários. Onde o pessoal técnico discute de verdade. |
+| **Polymarket** | Não são opiniões. São probabilidades. Lastreadas em dinheiro de verdade. 96 % de confiança em vendas de um álbum. 4 % em uma aquisição. |
+| **GitHub** | Para pessoas: ritmo de PRs, principais repositórios por estrelas, notas de versão. Para assuntos: issues e discussions. |
+| **Digg** | Agrupamentos de histórias curados a partir do ranking AI 1000 do Digg (cerca de 1000 contas de IA com alto sinal no X), com citações atribuíveis embutidas e sem exigir autenticação no X. Ativa sozinho quando `digg-pp-cli` está no PATH. |
+| **arXiv** | Os artigos científicos por trás do hype. Pesquisa nova dentro da janela, de graça e sem chave de API. Ativa sozinho quando `arxiv-pp-cli` está no PATH (a configuração inicial instala). |
+| **Techmeme** | A camada editorial do noticiário de tecnologia, limitada à sua janela de 30 dias. De graça e sem chave de API. Ativa sozinho quando `techmeme-pp-cli` está no PATH (a configuração inicial instala). |
+| **LinkedIn** | O sinal profissional. Publicações e artigos, com os artigos ponderados como sinal forte. |
+| **StockTwits** | O humor dos traders. Ativa automaticamente quando seu assunto é um ticker ou uma cripto. |
+| **Threads** | A camada de texto do pós-Twitter. Conversas de criadores e marcas. |
+| **Pinterest** | Descoberta visual. Pins, itens salvos e comentários sobre produtos e ideias. |
+| **Xiaohongshu (RED)** | Sinais chineses sobre estilo de vida, produtos e criadores. É pedido explicitamente com `--search xhs` quando há um plugin de navegador x-mcp logado ou um serviço `xiaohongshu-mcp` rodando localmente. |
+| **Bluesky** | A camada social descentralizada. Publicações do AT Protocol vindas da migração pós-Twitter. |
+| **Perplexity** | A síntese fundamentada do Sonar, os resultados brutos da Search API e o Deep Research. |
+| **Web** | A cobertura editorial, as comparações de blog. Um sinal entre muitos, não o único. |
 
-Colaboradores da comunidade continuam adicionando mais. Truth Social e outras fontes de nicho estão no motor com mais a caminho.
+A comunidade não para de acrescentar fontes. Truth Social e outras fontes de nicho já estão no motor, e vêm mais por aí.
 
-Um tópico Reddit com 1.500 votos positivos é um sinal mais forte do que um post de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações diz mais sobre o que é culturalmente relevante do que um comunicado à imprensa. Polymarket probabilidades apoiadas em $66 mil em volume são mais difíceis de contestar do que um palpite de um comentarista.
+Uma thread do Reddit com 1.500 votos positivos é um sinal mais forte do que um post de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações diz mais sobre o que é culturalmente relevante do que qualquer release de imprensa. Probabilidades do Polymarket lastreadas em US$ 66 mil de volume são bem mais difíceis de contestar do que o palpite de um comentarista.
 
-A síntese é classificada pelo que as pessoas reais realmente se envolveram. Relevância social, não SEO relevância.
+A síntese ordena pelo que as pessoas de verdade realmente engajaram. Relevância social, não relevância de SEO.
 
 ## Para que as pessoas realmente usam
 
-**Antes de uma reunião.** `/last30days Peter Steinberger` - juntou-se à equipe Codex da OpenAI, lutando contra a proibição da Anthropic de agentes terceiros, 23 PRs fundiu com 85% de taxa de fusão na GitHub, construindo LobsterOS para controle de agentes entre dispositivos. Código r/Claude: "Desde OpenClaw lançado, era amplamente conhecido que, se você rodasse por qualquer coisa que não fosse a API, acabaria sendo banido" (227 votos positivos). Isso não é culpa LinkedIn.
+**Antes de uma reunião.** `/last30days Peter Steinberger` — entrou no time do Codex na OpenAI, enfrenta o veto da Anthropic a agentes de terceiros, 23 PRs mergeados com 85 % de taxa de merge no GitHub, constrói o LobsterOS para controlar agentes entre dispositivos. r/ClaudeCode: "Desde que o OpenClaw saiu, todo mundo já sabia que, se você rodasse por qualquer coisa que não fosse a API, uma hora ia ser banido" (227 votos positivos). Isso não está no LinkedIn.
 
-**Para ler sinais de contratação.** `/last30days Listen Labs --hiring-signals` - as páginas atuais de empregos e carreiras passam a ser evidências citadas para mudanças de foco: contratações para segurança empresarial, sucesso do cliente, infraestrutura ou expansão de produtos. O relatório diz o que a contratação parece sinalizar, não o que o roteiro irá trazer.
+**Para ler sinais de contratação.** `/last30days Listen Labs --hiring-signals` — as vagas e páginas de carreira atuais viram evidência citada de mudança de prioridade: contratação em segurança para empresas, customer success, infraestrutura ou expansão de produto. O relatório diz o que a contratação parece sinalizar, não o que o roadmap vai entregar.
 
-**Para encontrar o tema antes que ele atinja o auge.** Pergunte `/last30days what's exploding in AI agents?` e a habilidade muda para o modo descoberta: o motor varre Reddit listagens de categorias, Hacker News primeiras histórias/melhores, o feed AI 1000 da Digge X quando autenticado; seu agente avalia as indicações (nomes, filtragem de lixo, qualidade de conteúdo) e escreve podcast / X- ângulos de artigo; depois você recebe de 5 a 10 tópicos classificados por velocidade. Cada resultado inclui números de fontes cruzadas, um rótulo de momentum e um `/last30days "<topic>"` de acompanhamento pronto para rodar.
+**Para achar o assunto antes do pico.** Pergunte `/last30days what's exploding in AI agents?` e a skill muda para o modo descoberta: o motor varre as listagens por categoria do Reddit, a capa e as melhores histórias do Hacker News, o feed AI 1000 do Digg e o X quando você está autenticado; seu agente avalia as indicações (nomes, filtragem de ruído, se rende conteúdo) e escreve ângulos para podcast ou para um artigo no X; depois você recebe de 5 a 10 assuntos ordenados por velocidade. Cada resultado traz números de várias fontes, um rótulo de momentum e um comando `/last30days "<topic>"` pronto para rodar.
 
-**Quando algo cai.** `/last30days Kanye West` - O Reino Unido bloqueou seu visto, o Festival Wireless cancelou, os patrocinadores fugiram. Mas BULLY estreou em #2 na Billboard. Fantano voltou do seu "Yay sabático" para resenhar (653 mil visualizações). O SoFi Homecoming trouxe Lauryn Hill e Travis Scott para 44 músicas. Polymarket: "Será que Kanye vai tuitar de novo?" 86% Sim. 23 tópicos Reddit , 17 vídeos YouTube , 86 mil votos positivos.
+**Quando alguma coisa é lançada.** `/last30days Kanye West` — o Reino Unido bloqueou o visto dele, o Wireless Festival foi cancelado, os patrocinadores fugiram. Mas BULLY estreou em 2º na Billboard. Fantano voltou do "Yay sabbatical" para resenhar o disco (653 mil visualizações). No SoFi Homecoming, ele levou Lauryn Hill e Travis Scott ao palco para 44 músicas. Polymarket: "Kanye vai tuitar de novo?" 86 % sim. 23 threads no Reddit, 17 vídeos no YouTube, 86 mil votos positivos.
 
-**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` - "Esses não são concorrentes, são camadas." OpenClaw é o executor (351K GitHub estrelas, ao vivo), Hermes é o cérebro autoaperfeiçoador (31K estrelas), Paperclip é o organigrama (49K estrelas). Contagens de estrelas puxadas ao vivo do GitHub API, não posts de blog sem graça. Mesa lado a lado com arquitetura, memória, segurança, o melhor para. Por @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
+**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` — "Não são concorrentes, são camadas." O OpenClaw é a camada de execução (351 mil estrelas no GitHub, em produção), o Hermes é o cérebro que se aprimora sozinho (31 mil estrelas), o Paperclip é o organograma (49 mil estrelas). As contagens de estrelas vêm ao vivo da API do GitHub, não de posts de blog desatualizados. Tabela lado a lado com arquitetura, memória, segurança e melhor caso de uso. Segundo @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
 
-**Para entender o mundo.** `/last30days Iran vs USA` - Dia 38 da guerra. O prazo de terça-feira de Trump para o Irã reabrir o Estreito de Ormuz. Dois aviões de guerra americanos abatidos. Petróleo a $126/barril. A IEA chamou isso de "a maior interrupção do fornecimento na história do mercado global de petróleo." Polymarket: cessar-fogo até 31 de dezembro com 74%. 27 X postagens, 10 vídeos YouTube , 20 mercados de previsão.
+**Para entender o mundo.** `/last30days Iran vs USA` — dia 38 da guerra. O ultimato de Trump, com prazo até terça, para o Irã reabrir o Estreito de Ormuz. Dois caças americanos abatidos. Petróleo a US$ 126 o barril. A AIE chamou o episódio de "a maior interrupção de fornecimento da história do mercado global de petróleo". Polymarket: cessar-fogo até 31 de dezembro a 74 %. 27 publicações no X, 10 vídeos no YouTube, 20 mercados de previsão.
 
-**Antes de uma viagem.** `/last30days Universal Epic Universe` - Expansão já em construção. Permissão "Projeto 680" solicitada. Show de fogos de artifício confirmado pela infraestrutura, mas sem aviso. Tempos de espera: Loucura de Carrinhos de Mina com média de 148 minutos. Ainda sem passe anual, e os moradores locais estão frustrados. Stardust Racers em reforma até 5 de abril.
+**Antes de uma viagem.** `/last30days Universal Epic Universe` — a expansão já está em obras. Alvará do "Project 680" protocolado. Show de fogos confirmado pela infraestrutura, mas ainda não anunciado. Tempo de espera: Mine-Cart Madness com média de 148 minutos. Ainda sem passe anual, e os moradores estão irritados. Stardust Racers fechada para reforma até 5 de abril.
 
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` - JSONprompts estruturados estão substituindo o tag soup. O formato aninhado do @pictsbyaiimpede o "conceito de sangrar". O fluxo de trabalho editado primeiro vence regeneração. Depois, ele escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
+**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` — prompts estruturados em JSON estão substituindo a sopa de tags. O formato aninhado do @pictsbyai evita o "concept bleeding". Editar ganha de regerar. E depois a skill escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
 
 ## Novidades
 
-Desde o anúncio da v3.3 em maio, a partir da v3.11.1 (julho de 2026): 175 PRs se fundiram – 122 deles de 52 colaboradores da comunidade – em 15 lançamentos. Foi isso que apareceu.
+Desde o anúncio da v3.3 em maio e até a v3.11.1 (julho de 2026): 175 PRs mergeados — 122 deles de 52 pessoas da comunidade — distribuídos em 15 versões. Foi isso que entrou.
 
-### Primeira classe no OpenAI Codex
+### Cidadão de primeira classe no OpenAI Codex
 
-/last30days agora é um plugin nativo de Codex com configuração guiada – não é uma porta, é um cidadão de primeira classe. Citações conscientes do renderizador fazem com que Codex saída seja lida como um brief em vez de um soup de URL (#694), e o mesmo motor roda em Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClawe 50+ hosts Agent Skills . Codex manifesto de plugin por [@rfoust](https://github.com/rfoust) (#686), Codex correção de autenticação por [@tmchow](https://github.com/tmchow) (#698).
+O /last30days agora é um plugin nativo do Codex com configuração guiada: não é um port, é cidadão de primeira classe. As citações levam o renderizador em conta, então a saída no Codex se lê como um briefing e não como uma sopa de URLs (#694), e o mesmo motor roda no Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw e em 50+ hosts do Agent Skills. Manifesto do plugin do Codex por [@rfoust](https://github.com/rfoust) (#686), correção de autenticação no Codex por [@tmchow](https://github.com/tmchow) (#698).
 
-### arXiv, Techmemee Digg - grátis, sem chaves API
+### arXiv, Techmeme e Digg — de graça, sem chaves de API
 
-arXiv traz os jornais por trás do hype e Techmeme traz a camada editorial de notícias tecnológicas - grátis, zero chaves, e o setup de primeira execução instala seus CLIs para que sejam ativados automaticamente (#709). Clusters de histórias AI 1000 do Diggchegam sem X autenticação da mesma forma – setup instala o Digg CLI gratuito para você (#590). Trustpilot envia opt-in para pesquisa de marcas de consumo.
+O arXiv traz os artigos científicos por trás do hype e o Techmeme traz a camada editorial do noticiário de tecnologia — de graça, sem nenhuma chave, e a configuração inicial instala as CLIs deles para que ativem sozinhos (#709). Os agrupamentos de histórias AI 1000 do Digg chegam do mesmo jeito, sem autenticação no X: a configuração instala a CLI gratuita do Digg para você (#590). O Trustpilot está disponível como opção para pesquisa de marcas de consumo.
 
-### O Reddit gratuito aumentou as pontuações reais e os principais comentários
+### Reddit gratuito, com pontuações reais e melhores comentários
 
-Reddit.json API público morreu; o caminho gratuito voltou mais forte. RSS sem chave + scraping do shreddit (#457), descoberta de subreddit dedicado com contagens reais de votos positivos via arctic-shift (#696), e um piso de relevância para que um post viral fora do tema não possa sequestrar seu briefing (#488, obrigado [@rzachsmith](https://github.com/rzachsmith)). Sem chave API . Pontuações reais. Comentários principais incluídos.
+A API pública .json do Reddit morreu; o caminho gratuito voltou mais forte. RSS sem chave e scraping do shreddit (#457), descoberta de subreddits específicos com contagem real de votos positivos via arctic-shift (#696) e um piso de relevância para que um post viral fora do tema não sequestre seu briefing (#488, valeu [@rzachsmith](https://github.com/rzachsmith)). Sem chave de API. Pontuações reais. Melhores comentários incluídos.
 
 ### Os melhores comentários em cada briefing
 
-Os comentários agora são uma camada padrão em várias fontes: comentários no Instagram com diversidade baseada em ranking, então cinco opiniões polémicas não vêm todas de um único post (#751), comentários YouTube mais um backup de transcrição ScrapeCreators para quando o YT-DLP falha (#637), e comentários votados pelo público ponderados em Best Takes para que as falas mais engraçadas da comunidade sobrevivam à pontuação (#592, #608).
+Os comentários agora são uma camada ligada por padrão em todas as fontes: comentários do Instagram com diversidade baseada em ranking, para que cinco opiniões fortes não venham todas do mesmo post (#751), comentários do YouTube mais um backup de transcrição via ScrapeCreators para quando o yt-dlp falha (#637), e comentários votados pela comunidade entrando com peso no Best Takes, para que as melhores tiradas sobrevivam à pontuação (#592, #608).
 
-### Comando de um médico
+### Um único comando doctor
 
-Peça um exame de saúde e o médico verifica todas as fontes, depois prescreve soluções exatas – qual chave está faltando, qual CLI está errada PATH, qual cookie expirou (#753). Chega de adivinhar por que X voltou magra.
+Peça um diagnóstico: o doctor testa cada fonte e receita as correções exatas — qual chave está faltando, qual CLI não está no PATH, qual cookie expirou (#753). Chega de adivinhar por que o X voltou fraco.
 
-### X busca, reconstruída
+### A busca no X, reconstruída
 
-O pipeline X passou por uma reformulação de raiz: faixas FROM e ABOUT para que as próprias postagens e a conversa sobre elas sejam classificadas (#610), desambiguação de subquery consciente da pessoa (#611), aterramento de autoria de primeira parte com ranking de sinal de interação (#613), e uma única fonte X com failover automático de backend (#622). Além de um `--diagnose` honesto que realmente sonda a autenticação (#609).
+O pipeline do X foi refeito do zero: faixas FROM e ABOUT para que tanto as publicações da própria pessoa quanto a conversa sobre ela sejam ranqueadas (#610), desambiguação de subconsultas conforme a pessoa buscada (#611), verificação de autoria de primeira mão com ranqueamento por sinais de interação (#613) e uma única fonte X com failover automático entre backends (#622). Além de um `--diagnose` honesto, que testa a autenticação de verdade (#609).
 
-### Mais fontes se juntaram
+### Mais fontes entraram
 
-LinkedIn via ScrapeCreators, com artigos como high signal ([@ravstr](https://github.com/ravstr), #702). StockTwits ativa-se automaticamente para tópicos de ticker e cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity cresceu diretamente em modos API e Deep Research assíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
+LinkedIn via ScrapeCreators, com artigos como sinal forte ([@ravstr](https://github.com/ravstr), #702). O StockTwits ativa sozinho em assuntos de ticker e cripto ([@wtiwana](https://github.com/wtiwana), #658). O Perplexity ganhou modos de API diretos e Deep Research assíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
 
-### Endurecidos pela comunidade
+### Endurecido pela comunidade
 
-A onda de segurança foi quase inteiramente trabalho comunitário: correções armazenadas em XSS no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookies bloqueados, CI reforçado na cadeia de suprimentos com OpenSSF Scorecard e atestação de proveniência de compilações ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), varreduras Semgrep e OSV-Scanner além de uma porta de revisão de dependência PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de testes introduzido a 60% e desde então elevado para 84% ([@gourab5139014](https://github.com/gourab5139014)), e uma varredura de segurança Hermes limpa de todas as descobertas CRÍTICAS (#768).
+A onda de segurança foi quase toda trabalho da comunidade: correções de XSS armazenado no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookie protegidos, CI endurecida contra ataques à cadeia de suprimentos com OpenSSF Scorecard e atestação de proveniência de build ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), varreduras com Semgrep e OSV-Scanner mais um portão de revisão de dependências em cada PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de testes criado em 60 % e desde então elevado para 84 % ([@gourab5139014](https://github.com/gourab5139014)), e uma varredura de segurança do Hermes que hoje não tem nenhum achado CRITICAL (#768).
 
 ### Alcança mais longe
 
-Hebraico e línguas não latinas ([@dudyme](https://github.com/dudyme)). Tokenização consciente de CJKpara fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade Windows . Extração de cookies em toda a família Chromium - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - além de fontes de credenciais macOS Keychain e Linux pass(1). `--as-of` retrospecto histórico ([@chiyi-creator](https://github.com/chiyi-creator)). Provisão automática Python 3.12 via UV ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leitura das páginas de empregos de uma empresa. Deltas da lista de observação entre as execuções.
+Hebraico e outras línguas não latinas ([@dudyme](https://github.com/dudyme)). Tokenização adaptada a CJK para fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade com Windows. Extração de cookies em toda a família Chromium — Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) — além do Keychain do macOS e do pass(1) no Linux como origens de credenciais. Consulta retroativa com `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionamento automático do Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para ler as páginas de vagas de uma empresa. Deltas de watchlist entre execuções.
 
-### Ainda está na caixa da v3
+### O que já vinha de fábrica desde a v3
 
-As bases da v3 ainda estão todas aqui: o cérebro pré-pesquisa que resolve os handles, subreddits e hashtags corretos antes de uma única chamada API ser lançada (criado por [@j-sperling](https://github.com/j-sperling)); Best Takes pontuação para humor e viralidade junto com relevância; fusão de clusters entre fontes; comparações em passagem única ("CLI vs MCP" em 3 minutos, não 12); comparações `--competitors` descobertas automaticamente; modo pessoa GitHub (`--github-user=steipete`); modo ELI5 ("eli5 ligado" após qualquer execução); e briefs HTML compartilháveis e autônomos (`--emit=html`). Knobs de configuração vivem em [CONFIGURATION.md](CONFIGURATION.md).
+As bases da v3 continuam todas aqui: o cérebro de pré-pesquisa, que identifica os handles, subreddits e hashtags certos antes de disparar uma única chamada de API (construído por [@j-sperling](https://github.com/j-sperling)); a pontuação Best Takes, que considera humor e viralidade além de relevância; a fusão de clusters entre fontes; as comparações em uma única passada ("CLI vs MCP" em 3 minutos, não em 12); as comparações `--competitors` descobertas automaticamente; o modo pessoa do GitHub (`--github-user=steipete`); o modo ELI5 ("eli5 on" depois de qualquer execução); e os briefings HTML autocontidos e compartilháveis (`--emit=html`). Os ajustes de configuração estão em [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Instalação
 
-| Superfície | Instalação | Atualizações |
+| Ambiente | Instalação | Atualizações |
 |---------|---------|---------|
-| **Claude Code**(recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Atualização automática via marketplace ou `claude plugin update last30days@last30days-skill` |
-| **Grok**(Build xAI CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` então `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLIou qualquer um dos 50+ [Agent Skills](https://agentskills.io) apresentadores** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e envie via claude.ai > Personalizar > Habilidades > + > Criar habilidades > Enviar uma habilidade | Rebaixe e refaça o upload |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Configurações > Extensões | Baixe novamente e arraste o novo pacote |
+| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automáticas via marketplace, ou `claude plugin update last30days@last30days-skill` |
+| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` e depois `grok plugin install last30days` | `grok plugin update last30days` |
+| **Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ hosts do [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
+| **claude.ai** (web) | [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e envie por claude.ai > Customize > Skills > + > Create skill > Upload a skill | Baixar de novo e enviar de novo |
+| **Claude Desktop** | [Baixe o `.mcpb` da sua plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Settings > Extensions | Baixar de novo e arrastar o novo pacote |
 | **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
 
 ### Claude Code (recomendado)
@@ -169,46 +169,46 @@ As bases da v3 ainda estão todas aqui: o cérebro pré-pesquisa que resolve os 
 /plugin marketplace add mvanhorn/last30days-skill
 ```
 
-Recomendado porque o marketplace Claude Code gerencia as atualizações para você — o cache do plugin é versionado e atualiza automaticamente quando uma nova versão é lançada. Execute `claude plugin update last30days@last30days-skill` para forçar uma verificação.
+Recomendado porque o marketplace do Claude Code cuida das atualizações por você: o cache do plugin é versionado e se atualiza sozinho quando sai uma versão nova. Rode `claude plugin update last30days@last30days-skill` para forçar uma verificação.
 
-Se preferir usar o caminho de instalação de agentes-skills no Claude Code, isso também é suportado:
+Se preferir usar o caminho de instalação do Agent Skills no Claude Code, ele também é suportado:
 
 ```
 npx skills add mvanhorn/last30days-skill -g -a claude-code
 ```
 
-O plugin nativo e a instalação `npx skills` podem coexistir. Note que Claude Code não desduplica entre métodos de instalação: se você tiver tanto o plugin do marketplace quanto a cópia `npx skills` ativados, `/last30days` mostrará duas entradas. Use um método de instalação por máquina.
+O plugin nativo e a instalação com `npx skills` podem conviver. Só atenção: o Claude Code não deduplica entre métodos de instalação. Se você tiver ativos ao mesmo tempo o plugin do marketplace e a cópia do `npx skills`, o `/last30days` vai aparecer duas vezes. Use um método de instalação por máquina.
 
-### Grok (Build xAI CLI)
+### Grok (xAI Build CLI)
 
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala o last30days como um plugin nativo. A instalação direta acompanha o repositório:
+O [Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala o last30days como plugin nativo. A instalação direta acompanha o repositório:
 
 ```bash
 grok plugin install mvanhorn/last30days-skill
 ```
 
-Ou adicione esse repositório como uma fonte do marketplace e depois instale pelo nome do plugin:
+Ou adicione este repositório como fonte de marketplace e depois instale pelo nome do plugin:
 
 ```bash
 grok plugin marketplace add mvanhorn/last30days-skill
 grok plugin install last30days
 ```
 
-Adicione `--trust` para pular a confirmação da instalação. Atualize com `grok plugin update last30days`. Grok também lê os manifestos Claude Code para compatibilidade; o par nativo de `.grok-plugin/` é a linha de primeira classe (e o que uma listagem oficial [xAI marketplace](https://github.com/xai-org/plugin-marketplace) indica). `npx skills add` permanece um recurso válido entre hosts.
+Acrescente `--trust` para pular a confirmação de instalação. Atualize com `grok plugin update last30days`. O Grok também lê os manifestos do Claude Code por compatibilidade; o par nativo `.grok-plugin/` é o caminho principal — e é para ele que aponta um registro oficial no [marketplace da xAI](https://github.com/xai-org/plugin-marketplace). O `npx skills add` continua sendo uma alternativa válida em qualquer host.
 
-### Codex, Cursor, Copilot, Gemini CLIe outros Agent Skills hospedeiros
+### Codex, Cursor, Copilot, Gemini CLI e outros hosts do Agent Skills
 
-Instale via [Agent Skills](https://agentskills.io) CLI aberto — suporta 50+ chicotes incluindo `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`e mais (lista completa no [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+Instale pela CLI aberta do [Agent Skills](https://agentskills.io) — ela suporta 50+ hosts, entre eles `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` e outros (lista completa no [repositório vercel-labs/skills](https://github.com/vercel-labs/skills)).
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g
 ```
 
-A flag `-g` (global) se instala no seu diretório de usuário, então a habilidade está disponível em todos os projetos. Sem `-g`, `npx skills` instala o projeto localmente no `./.skills/` (comprometido com o repositório). Para uma ferramenta de pesquisa no mundo, global é o que você quer.
+A flag `-g` (global) instala no seu diretório de usuário, então a skill fica disponível em todos os projetos. Sem `-g`, o `npx skills` instala só no projeto, dentro de `./.skills/` (e vai versionado junto com o repositório). Para uma ferramenta feita para pesquisar o mundo inteiro, o que você quer é a instalação global.
 
-Codex servidores desktop e outros hosts em modo pasta podem funcionar tanto em pastas comuns quanto em repositórios Git. Antes de pesquisar, peça ao agente host para executar o `scripts/last30days.py --preflight` incluído do diretório de skill carregado; em uma verificação de código-fonte, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra a fonte de configuração, plano de cookies do navegador, escritas planejadas, comandos opcionais e configuração ignorada do projeto sem ler cookies, gravar arquivos ou rodar pesquisas.
+O Codex desktop e outros hosts que trabalham no nível de pasta funcionam tanto em pastas comuns quanto em repositórios Git. Antes da primeira pesquisa, peça ao agente host que rode o `scripts/last30days.py --preflight` que acompanha a skill, a partir do diretório da skill carregada; em um clone do código-fonte, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra de onde vem a configuração, quais cookies do navegador seriam lidos, quais arquivos seriam escritos, quais comandos opcionais existem e qual configuração de projeto está sendo ignorada — sem ler cookies, sem escrever arquivos e sem rodar pesquisa nenhuma.
 
-Por padrão, isso é instalado para o chicote que `npx skills` detectar. Para direcionar um específico (ou vários):
+Por padrão, a instalação vale para o host que o `npx skills` detectar. Para mirar em um específico (ou em vários):
 
 ```bash
 npx skills add mvanhorn/last30days-skill -g -a codex
@@ -217,45 +217,45 @@ npx skills add mvanhorn/last30days-skill -g -a gemini-cli
 npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
 ```
 
-Atualização depois com:
+Para atualizar depois:
 
 ```bash
 npx skills update last30days -g
 ```
 
-Ou atualize tudo que você instalou globalmente via `npx skills`:
+Ou atualize tudo que você instalou globalmente pelo `npx skills`:
 
 ```bash
 npx skills update -g
 ```
 
-Liste e remova com `npx skills list -g` e `npx skills remove last30days -g`.
+Dá para listar e remover com `npx skills list -g` e `npx skills remove last30days -g`.
 
 ### claude.ai (web)
 
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) do lançamento mais recente
-2. Vá para [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Clique no botão `+` no painel de Habilidades > clique em `Create skill` > `Upload a skill` e navegue/coloque o arquivo em
+1. [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) da versão mais recente
+2. Vá em [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
+3. Clique no botão `+` no painel de Skills, depois em `Create skill` > `Upload a skill`, e escolha ou arraste o arquivo
 
-Ative "Execução de código e criação de arquivo" primeiro em Capacidades — as habilidades não funcionam sem isso.
+Ative antes "Code execution and file creation" em Capabilities — sem isso, as skills não rodam.
 
 ### Claude Desktop
 
-Claude Desktop instala `/last30days` como um servidor MCP via um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
+O Claude Desktop instala o `/last30days` como servidor MCP por meio de um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
 
-1. Vá até o [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` para sua plataforma:
+1. Vá até a [versão mais recente](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` da sua plataforma:
    - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
    - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
    - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abra Claude Desktop, vá em Configurações > Extensões e arraste o arquivo.
-3. Quando solicitado, cole API chaves para as fontes que deseja ativar. Cada campo é opcional — o motor se degrada para modo apenas web se você pular todos. As chaves são armazenadas no chaveiro do seu sistema operacional.
-4. Reinicie Claude Desktop. Peça para Claude "pesquisar Peter Steinberger" ou qualquer outro tema e ele chamará a ferramenta de `research` .
+2. Abra o Claude Desktop, vá em Settings > Extensions e arraste o arquivo para lá.
+3. Quando for solicitado, cole as chaves de API das fontes que quiser ativar. Todo campo é opcional — se pular todos, o motor cai para o modo só web. As chaves ficam guardadas no chaveiro do seu sistema operacional.
+4. Reinicie o Claude Desktop. Peça ao Claude para "pesquisar sobre Peter Steinberger", ou sobre qualquer outro assunto, e ele vai chamar a ferramenta `research`.
 
-**Requisito de host:** Python 3.12+ no PATH. O pacote envia a fonte do motor, mas usa seu interpretador local de Python . Instale a partir do [python.org](https://www.python.org/downloads/) no Windows; macOS e a maioria das distros Linux enviam uma versão compatível.
+**Requisito do host:** Python 3.12+ no PATH. O pacote traz o código do motor, mas usa o seu interpretador Python local. No Windows, instale a partir do [python.org](https://www.python.org/downloads/); o macOS e a maioria das distribuições Linux já vêm com uma versão compatível.
 
-**As chaves não sincronizam com a habilidade Code.** Claude Desktop e Claude Code mantêm armazenamentos de credenciais separados por design. Se você já configurou `~/.config/last30days/.env` para a habilidade Code, vai digitar as mesmas chaves aqui uma vez novamente.
+**As chaves não são compartilhadas com a skill do Claude Code.** O Claude Desktop e o Claude Code mantêm armazenamentos de credenciais separados de propósito. Se você já configurou o `~/.config/last30days/.env` para a skill do Claude Code, vai precisar digitar essas mesmas chaves aqui uma vez.
 
-Windows suporte é adiado até que os pontos de entrada do manifesto por plataforma sejam resolvidos; acompanhe uma edição de acompanhamento.
+O suporte a Windows está adiado até que os pontos de entrada por plataforma no manifesto sejam resolvidos; o acompanhamento fica em uma issue à parte.
 
 ### OpenClaw
 
@@ -263,43 +263,44 @@ Windows suporte é adiado até que os pontos de entrada do manifesto por platafo
 clawhub install last30days-official
 ```
 
-Para Xfluxos de trabalho de ação no /Twitter fora da pesquisa `/last30days` , como postar
-Tweets ou respostas, exportação de seguidores, gerenciamento de mídia, monitores e sorteios
-Draws, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como companheiro
-OpenClaw plugin. TweetClaw é mantido pelo Xquik-dev e é listado apenas como um
-Caminho de companheiro opcional, não uma dependência ou endosso de Last30days.
+Para fluxos de ação no X/Twitter fora da pesquisa do `/last30days` — publicar
+tweets ou respostas, exportar seguidores, cuidar de mídia, monitorar contas e
+apurar sorteios — use o [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como
+plugin complementar do OpenClaw. O TweetClaw é mantido pelo Xquik-dev e aparece
+aqui apenas como opção complementar: não é dependência nem recomendação do
+last30days.
 
-### Manual (desenvolvedor)
+### Manual (para quem desenvolve)
 
 ```bash
 git clone https://github.com/mvanhorn/last30days-skill.git
 ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
 ```
 
-O symlink mantém a instalação sincronizada com sua árvore de trabalho enquanto você edita — não é necessário re-copiar. Para `claude.ai`, construa o arquivo `.skill` a partir da fonte: `bash skills/last30days/scripts/build-skill.sh` produz `dist/last30days.skill`.
+O symlink mantém a instalação em sincronia com sua árvore de trabalho conforme você edita — não precisa copiar de novo. Para o `claude.ai`, compile o arquivo `.skill` a partir do código-fonte: `bash skills/last30days/scripts/build-skill.sh` gera `dist/last30days.skill`.
 
-Reddit (com comentários), Hacker News, Polymarkete GitHub funcionam imediatamente. Configuração zero. Execute `/last30days` uma vez e o assistente de configuração desbloqueia mais fontes em 30 segundos, incluindo o arXiv gratuito e Techmeme CLIs.
+Reddit (com comentários), Hacker News, Polymarket e GitHub funcionam de imediato. Configuração zero. Rode `/last30days` uma vez e o assistente de configuração libera mais fontes em 30 segundos, incluindo as CLIs gratuitas do arXiv e do Techmeme.
 
 ## Traga suas próprias chaves
 
-Essas plataformas não têm relações entre si. X não sabe o que Reddit pensa. YouTube não vê TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador, e de repente tem acesso a todos ao mesmo tempo.
+Essas plataformas não têm relação nenhuma entre si. O X não sabe o que o Reddit pensa. O YouTube não enxerga o TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador e, de repente, tem acesso a todas ao mesmo tempo.
 
 | Fontes | O que você precisa | Custo |
 |---------|---------------|------|
-| Reddit (com comentários) + HN + Polymarket + GitHub + StockTwits | Nada | Grátis |
-| arXiv + Techmeme | Free CLIs, instalado automaticamente pela primeira vez | Grátis |
-| X / Twitter | Faça login em x.com em qualquer navegador, ou configure `XQUIK_API_KEY` / `XAI_API_KEY` | Cookies do navegador são gratuitos; as chaves são específicas do provedor |
-| YouTube | `brew install yt-dlp` | Grátis |
-| Bluesky | Senha do aplicativo do bsky.app | Grátis |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comentários | ScrapeCreators chave | 10.000 chamadas grátis, depois PAYG |
-| Xiaohongshu (RED) | Execute um plugin de navegador x-mcp logado ou serviço `xiaohongshu-mcp` e opte por `--search xhs` por execução ou `INCLUDE_SOURCES=xiaohongshu` no `.env`; last30days auto-sonda `http://localhost:18060` depois `http://host.docker.internal:18060`, ou use `XIAOHONGSHU_API_BASE` para uma URL personalizada | Sem chave de API de últimos 30 dias; depende do seu serviço local de sessão de navegador |
-| DripStack (boletins financeiros premium) | Opt-in: `--search dripstack` por tentativa, ou `INCLUDE_SOURCES=dripstack` em `.env` | Sem chave; busca pública gratuita API |
-| Perplexity Sonar / API de busca / Pesquisa Profunda | Perplexity chave, ou chave OpenRouter como recurso de replio do Sonar | Pague conforme a vida |
-| Web busca | Chave Brave Search | 2.000 consultas gratuitas/mês |
+| Reddit (com comentários) + HN + Polymarket + GitHub + StockTwits | Nada | De graça |
+| arXiv + Techmeme | CLIs gratuitas, instaladas automaticamente pela configuração inicial | De graça |
+| X / Twitter | Faça login em x.com em qualquer navegador, ou defina `XQUIK_API_KEY` / `XAI_API_KEY` | Os cookies do navegador são gratuitos; as chaves dependem do provedor |
+| YouTube | `brew install yt-dlp` | De graça |
+| Bluesky | Uma senha de aplicativo do bsky.app | De graça |
+| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentários do YouTube | Uma chave do ScrapeCreators | 10.000 chamadas gratuitas e depois pagamento por uso |
+| Xiaohongshu (RED) | Deixe rodando um plugin de navegador x-mcp logado ou um serviço `xiaohongshu-mcp` e habilite a fonte com `--search xhs` por execução ou com `INCLUDE_SOURCES=xiaohongshu` no `.env`; o last30days testa automaticamente `http://localhost:18060` e depois `http://host.docker.internal:18060`, ou use `XIAOHONGSHU_API_BASE` para uma URL própria | Não precisa de chave de API do last30days; depende do seu serviço local de sessão de navegador |
+| DripStack (newsletters financeiras premium) | Opcional: `--search dripstack` por execução, ou `INCLUDE_SOURCES=dripstack` no `.env` | Sem chave; API de busca pública e gratuita |
+| Perplexity Sonar / Search API / Deep Research | Uma chave do Perplexity, ou uma chave do OpenRouter como alternativa para o Sonar | Pagamento por uso |
+| Busca na web | Uma chave do Brave Search | 2.000 consultas gratuitas por mês |
 
-### macOS Keychain (opcional)
+### Keychain do macOS (opcional)
 
-No macOS você pode armazenar chaves no Keychain do sistema em vez de um arquivo `.env` . A habilidade as detecta automaticamente como a fonte de menor prioridade — `.env` arquivos e o ambiente de processos ainda vencem em colisão.
+No macOS você pode guardar as chaves no Keychain do sistema em vez de em um arquivo `.env`. A skill as encontra automaticamente como a origem de menor prioridade — em caso de conflito, os arquivos `.env` e o ambiente do processo continuam ganhando.
 
 ```bash
 # Interactive setup — prompts for each known key, skip with empty input
@@ -313,61 +314,61 @@ skills/last30days/scripts/setup-keychain.sh --list
 skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
 ```
 
-Os itens são armazenados sob `last30days-<KEY>` de nome de serviço para o usuário atual. Em plataformas que não são Darwin, o loader é um no-op, então não há mudança de comportamento para usuários Linux/Windows .
+Os itens ficam guardados sob o nome de serviço `last30days-<KEY>` para o usuário atual. Em plataformas que não são Darwin o carregador não faz nada, então não há mudança de comportamento para quem usa Linux ou Windows.
 
-Já tem chaves sob nomes de serviço Keychain diferentes? Defina o mapeamento de `LAST30DAYS_KEYCHAIN_ALIASES` não secreto descrito no [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) em vez de copiar segredos.
+Já tem chaves guardadas com outros nomes de serviço no Keychain? Defina o mapeamento não secreto `LAST30DAYS_KEYCHAIN_ALIASES` descrito em [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), em vez de copiar segredos.
 
-Veja [CONFIGURATION.md](CONFIGURATION.md) para a matriz completa de chaves por fonte, prioridade do provedor de raciocínio e prioridade backend de busca web.
+Veja [CONFIGURATION.md](CONFIGURATION.md) para a matriz completa de chaves por fonte, a ordem de prioridade dos provedores de raciocínio e a dos backends de busca web.
 
 ## Configuração
 
 Duas coisas que você provavelmente vai querer saber no primeiro dia:
 
-**Onde os arquivos de pesquisa são salvos.** `LAST30DAYS_MEMORY_DIR` padrão é `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Sobrescreva definindo essa var ambientalmente para qualquer caminho no seu shell, ou `--save-dir <path>` por execução. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, usando o formato selecionado por `--emit`. Use `--save-suffix=<name>` para manter múltiplas variações do mesmo tópico separadas (por exemplo, por cliente). Cada execução `--save-dir` produz `<slug>-raw[-suffix].md`. Execute `python3 skills/last30days/scripts/last30days.py --preflight` para revisar as escritas planejadas antes de uma execução de pesquisa.
+**Onde os arquivos de pesquisa são salvos.** O `LAST30DAYS_MEMORY_DIR` aponta por padrão para `~/Documents/Last30Days/` (no Windows: `C:\Users\<you>\Documents\Last30Days\`). Para mudar, defina essa variável de ambiente no seu shell com o caminho que quiser, ou use `--save-dir <path>` em uma execução específica. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, no formato escolhido por `--emit`. Use `--save-suffix=<name>` para manter separadas várias variações do mesmo assunto (por cliente, por exemplo). Cada execução com `--save-dir` gera `<slug>-raw[-suffix].md`. Rode `python3 skills/last30days/scripts/last30days.py --preflight` para conferir o que será escrito antes de disparar uma pesquisa.
 
-**Saída estruturada para agentes e fluxos de trabalho.** Peça `/last30days` JSON legíveis por máquina para receber o perfil estável e versionado do agente. Para uso direto do motor em scripts ou desenvolvimento, execute `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; adicione `--json-profile=raw` apenas quando precisar do despejo interno de `Report` sem versão. Veja o [JSON export field reference and versioning policy](docs/reference/json-export.md).
+**Saída estruturada para agentes e fluxos de trabalho.** Peça ao `/last30days` um JSON legível por máquina e você recebe o perfil de agente estável e versionado. Para usar o motor direto em scripts ou no desenvolvimento, rode `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; use `--json-profile=raw` só quando precisar do dump interno não versionado do `Report`. Veja a [referência de campos da exportação JSON e a política de versionamento](docs/reference/json-export.md).
 
-**Descoberta sem tópico.** Peça `/last30days what's trending in AI agents?` para obter um briefing de descoberta ranqueado em vez de pesquisar um tema que você já conhece – em um host agente, isso executa o protocolo de três comandos avaliados pelo host (o modelo nomeia tópicos, filtra lixo, avalia a dignidade e escreve os ângulos de conteúdo). Para uso direto do motor em scripts ou cron, execute `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: nomes determinísticos de tópicos, sem ângulos); adicione `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um tópico posicional e `--drill`.
+**Descoberta sem assunto definido.** Pergunte `/last30days what's trending in AI agents?` para receber um briefing de descoberta ordenado, em vez de pesquisar um assunto que você já conhece. Em um host com agente, isso executa o protocolo de três comandos arbitrado pelo host (o modelo nomeia os assuntos, filtra ruído, avalia o que vale a pena e escreve os ângulos de conteúdo). Para usar o motor direto em scripts ou no cron, rode `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (passada única: nomes de assunto determinísticos, sem ângulos); acrescente `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um assunto posicional e com `--drill`.
 
-**Monitoramento de tendências entre execuções.** O modo padrão produz um novo snapshot de markdown por execução. Para acumular descobertas ao longo do tempo, adicione `--store` para persistir em um banco de dados SQLite, depois use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com entrega opcional por Slack / webhook em novas descobertas) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para digestos diários/semanais. O padrão completo de cadência está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
+**Monitoramento de tendências entre execuções.** O modo padrão gera um snapshot Markdown novo a cada execução. Para acumular achados ao longo do tempo, acrescente `--store` e eles ficam guardados em um banco SQLite; depois use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com envio opcional por Slack ou webhook quando surgirem achados novos) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resumos diários ou semanais. O padrão de cadência completo está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
 
-**Uma biblioteca de pesquisa para assinantes.** Peça `/last30days` para construir seu feed de biblioteca, ou use- `python3 skills/last30days/scripts/last30days.py library feed` diretamente para scripts e desenvolvimento. Ele transforma briefs salvos em `index.html`, um `feed.xml`local do Atom e páginas breves legíveis. Adicione `--publish` apenas quando quiser que o índice HTML e as páginas de resumos sejam hospedados; a publicação é explícita com opt-in e pública por padrão. Para tornar o feed do Atom assinável, hospede o diretório de saída gerado em um host estático, como GitHub Pages.
+**Uma biblioteca de pesquisa que dá para assinar.** Peça ao `/last30days` que monte o feed da sua biblioteca, ou use direto `python3 skills/last30days/scripts/last30days.py library feed` para scripts e desenvolvimento. Ele transforma os briefings salvos em um `index.html`, um `feed.xml` Atom local e páginas de briefing legíveis. Acrescente `--publish` só quando quiser hospedar o índice HTML e as páginas de briefing; publicar é uma decisão explícita e, por padrão, é público. Para o feed Atom ficar realmente assinável, hospede o diretório de saída gerado em um serviço estático como o GitHub Pages.
 
-**Pesquise tudo o que você pesquisou.** Pergunte `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para uso direto do motor, execute `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A busca é offline e determinística: ela indexa incrementalmente os mesmos briefs salvos usados pelo feed da biblioteca, mescla os avistamentos correspondentes a cada rodada da loja e agrupa os resultados por tópico e data. Execuções novas também apresentam uma seção compacta **Da sua biblioteca** quando pesquisas anteriores sobrepõem ao tema atual; configure `LAST30DAYS_LIBRARY_CONTEXT=off` para desabilitar esse contexto passivo.
+**Busque em tudo que você já pesquisou.** Pergunte `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para usar o motor direto, rode `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A busca é offline e determinística: ela indexa aos poucos os mesmos briefings salvos que o feed da biblioteca usa, junta as ocorrências correspondentes registradas no store a cada execução e agrupa os resultados por assunto e data. Execuções novas também exibem uma seção compacta **From your library** ("da sua biblioteca") quando pesquisas anteriores se sobrepõem ao assunto atual; defina `LAST30DAYS_LIBRARY_CONTEXT=off` para desativar esse contexto passivo.
 
-Scripts wrapper por cliente, subreddits personalizados de categorias peer e o canal beta experimental para personalizações em andamento também são documentados em [CONFIGURATION.md](CONFIGURATION.md).
+Scripts wrapper por cliente, subreddits de categoria personalizados e o canal beta experimental para personalizações em andamento também estão documentados em [CONFIGURATION.md](CONFIGURATION.md).
 
-## Vitrine: feeds de pesquisa comunitária
+## Vitrine: feeds de pesquisa da comunidade
 
-Publicou uma atualização recorrente de IA, observação de mercado ou uma obsessão maravilhosamente restrita com os últimos 30 dias? Compartilhe a URL da biblioteca pública — ou a URL do Atom após hospedar `feed.xml` em um host estático — em [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade estarão linkados aqui conforme seus proprietários os enviarem; o tópico é o ponto de coleta enquanto isso.
+Publicou com o last30days um panorama recorrente de IA, um acompanhamento de mercado ou uma obsessão maravilhosamente específica? Compartilhe a URL da sua biblioteca pública — ou a URL do Atom, depois de hospedar o `feed.xml` em um serviço estático — na [thread de vitrine da comunidade](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade serão linkados aqui conforme as pessoas os enviarem; enquanto isso, a thread é o ponto de coleta.
 
 ## Como funciona
 
-1. **Você digita um tópico.** Pessoa, empresa, produto, tecnologia, "X vs Y." Qualquer coisa.
-2. **O agente resolve quem importa.** Encontra X usuários (incluindo fundadores), repositórios GitHub , subreddits TikTok hashtags YouTube canais. Para "Kanye West", ele conhece r/hiphopheads, @kanyeweste "bully review" no YouTube. Para "OpenClaw", resolve openclaw/openclaw no GitHub e busca contagens de estrelas ao vivo.
-3. **Todas as fontes buscadas em paralelo.** Expansão multi-consulta. Resultados avaliados por engajamento, relevância e frescura.
-4. **A profundidade que ninguém mais tem.** Transcrições YouTube completas de vídeos de reação. Comentários Reddit principais com contagem de votos positivos. TikTok legendas. Polymarket probabilidades. Não só títulos e links.
-5. **Mesma história, fundida.** O Wireless Festival anunciou em Reddit, discutido no X, preços dos ingressos em TikTok = um cluster, não três itens separados.
-6. **Sintetizado em um único resumo.** Baseado em dados específicos. Citado por fonte. Classificado pelo que as pessoas realmente se envolvem. Não "aqui está o que eu encontrei." É "aqui está o que importa."
-7. **Então ele se torna seu especialista.** Após uma única tentativa, sua sessão Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Faça com que ele escreva prompts, relabore e-mails, planeje viagens, arquitetede sistemas – tudo baseado no que é real agora.
+1. **Você digita um assunto.** Pessoa, empresa, produto, tecnologia, "X vs Y". Qualquer coisa.
+2. **O agente descobre quem importa.** Ele encontra os perfis do X (inclusive de fundadores), os repositórios do GitHub, os subreddits, as hashtags do TikTok e os canais do YouTube. Para "Kanye West" ele sabe que o caminho é r/hiphopheads, @kanyewest e "bully review" no YouTube. Para "OpenClaw" ele resolve openclaw/openclaw no GitHub e busca a contagem de estrelas ao vivo.
+3. **Todas as fontes buscadas em paralelo.** Expansão com várias consultas. Resultados pontuados por engajamento, relevância e frescor.
+4. **A profundidade que ninguém mais tem.** Transcrições completas do YouTube de vídeos de reação. Os melhores comentários do Reddit com a contagem de votos positivos. As legendas dos TikToks. As probabilidades do Polymarket. Não só títulos e links.
+5. **Mesma história, unificada.** O Wireless Festival anunciado no Reddit, discutido no X e com preço de ingresso no TikTok vira um cluster só, não três itens separados.
+6. **Sintetizado em um único briefing.** Ancorado em dados específicos. Citado por fonte. Ordenado pelo que as pessoas realmente engajam. Não é "olha o que eu encontrei", é "olha o que importa".
+7. **E então ele vira o seu especialista.** Depois de uma única execução, sua sessão do Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Peça para escrever prompts, redigir e-mails, planejar viagens, desenhar arquiteturas — tudo ancorado no que é real agora.
 
 ## O que as pessoas estão dizendo
 
-> "Encontrei uma habilidade Claude Code que pesquisa qualquer tema em Reddit, X, YouTubee HN dos últimos 30 dias. Depois escreve os prompts para você. Tenho pesquisado manualmente Reddit e X pesquisas antes de cada conteúdo que escrevo. Aba por aba. Thread por thread. Essa é a parte que leva 90 minutos. Isso elimina isso." -@itsjasonai
+> "Achei uma skill do Claude Code que pesquisa qualquer assunto no Reddit, X, YouTube e HN dos últimos 30 dias. E ainda escreve os prompts pra você. Antes de cada conteúdo que eu escrevo, eu fazia essa busca na mão no Reddit e no X. Aba por aba. Thread por thread. É justamente essa a parte que leva 90 minutos. Isso elimina ela." — @itsjasonai
 
-> "Essa habilidade substituiu todo o meu fluxo de trabalho de pesquisa. Você dá um tema, ele raspa Reddit, X, e a web para encontrar o que as pessoas realmente estão falando. Não posts antigos de blog. Conversas reais dos últimos 30 dias." -@itswilsoncharles
+> "Essa skill sozinha substituiu todo o meu fluxo de pesquisa. Você dá um assunto e ela raspa Reddit, X e a web atrás do que as pessoas estão falando de verdade. Nada de post de blog velho. Conversas reais dos últimos 30 dias." — @itswilsoncharles
 
-> "5 dos 10 repositórios em alta no GitHub hoje são Claude ferramentas. #1: Mvanhorn/last30days- habilidade" -@yieldhunter95
+> "5 dos 10 repositórios em alta no GitHub hoje são ferramentas do Claude. O nº 1: mvanhorn/last30days-skill" — @yieldhunter95
 
 ## Código aberto
 
-Licença do MIT. Sem rastreamento. Sem análises. Sua pesquisa fica na sua máquina. 2.700+ testes.
+Licença MIT. Sem rastreamento. Sem analytics. Sua pesquisa fica na sua máquina. Mais de 2.700 testes.
 
-Construído com Python 3.12+, YT-DLP, Node.js (cliente Bird fornecido para X busca) e ScrapeCreators API. arquitetura do motor v3 pela [@j-sperling](https://github.com/j-sperling).
+Construído com Python 3.12+, yt-dlp, Node.js (cliente Bird embarcado para a busca no X) e a API do ScrapeCreators. Arquitetura do motor v3 por [@j-sperling](https://github.com/j-sperling).
 
-Veja [CONTRIBUTING.md](CONTRIBUTING.md) para abrir uma PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para a lista completa de colaboradores da comunidade e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
+Veja [CONTRIBUTING.md](CONTRIBUTING.md) para abrir um PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para a lista completa de quem contribuiu e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
 
-## História da Star
+## Histórico de estrelas
 
 <a href="https://star-history.com/#mvanhorn/last30days-skill&Date">
   <picture>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,13 +103,13 @@ Google 聚合编辑选出的内容，`/last30days` 搜索真实的人。
 
 **突发事件发生时。** `/last30days Kanye West`——英国拒绝其签证，Wireless Festival 取消演出，赞助商纷纷离场；但《BULLY》首周登上 Billboard 第二名。Fantano 结束自己的 “Yay sabbatical” 回归评测（65.3 万次观看）；SoFi Homecoming 请来 Lauryn Hill 和 Travis Scott，共演出 44 首歌。Polymarket：“Kanye 还会再发推吗？”86% 认为会。共找到 23 个 Reddit 主题、17 个 YouTube 视频和 8.6 万次赞同。
 
-**比较工具。** `/last30days OpenClaw vs Hermes vs Paperclip`——“它们并非竞品，而是处于不同层次。”OpenClaw 是执行器（GitHub 35.1 万 Star，持续更新），Hermes 是会自我改进的大脑（3.1 万 Star），Paperclip 是组织结构图（4.9 万 Star）。Star 数来自 GitHub API 的实时数据，不是过期博客。报告会提供架构、记忆、安全性和适用场景的横向表格。正如 @IMJustinBrooke 所说：“OpenClaw = 小火龙，Hermes = 喷火龙。”
+**比较工具。** `/last30days OpenClaw vs Hermes vs Paperclip`——“它们并非竞品，而是处于不同层次。”OpenClaw 是执行层（GitHub 35.1 万 Star，已上线），Hermes 是会自我改进的大脑（3.1 万 Star），Paperclip 是组织结构图（4.9 万 Star）。Star 数来自 GitHub API 的实时数据，不是过期博客。报告会提供架构、记忆、安全性和适用场景的横向表格。正如 @IMJustinBrooke 所说：“OpenClaw = 小火龙，Hermes = 喷火龙。”
 
 **理解世界。** `/last30days Iran vs USA`——战争进入第 38 天。特朗普要求伊朗在周二的最后期限前重新开放霍尔木兹海峡；两架美国战机被击落；油价涨至每桶 126 美元。IEA 称之为“全球石油市场史上最大规模的供应中断”。Polymarket 认为 12 月 31 日前停火的概率为 74%。共找到 27 条 X 帖子、10 个 YouTube 视频和 20 个预测市场。
 
-**旅行之前。** `/last30days Universal Epic Universe`——扩建工程已经开工，“Project 680” 许可已提交；基础设施证实将有烟花表演，但官方尚未公布。Mine-Cart Madness 平均排队 148 分钟；年票仍未推出，本地游客对此不满；Stardust Racers 将停运翻修至 4 月 5 日。
+**旅行之前。** `/last30days Universal Epic Universe`——扩建工程已经开工，“Project 680” 许可已提交；基础设施证实将有烟花表演，但官方尚未公布。Mine-Cart Madness 平均排队 148 分钟；年票仍未推出，当地居民对此不满；Stardust Racers 将停运翻修至 4 月 5 日。
 
-**快速学习。** `/last30days Nano Banana Pro prompting`——JSON 结构化提示词正在取代标签堆砌；@pictsbyai 的嵌套格式能避免“概念串色”；先编辑、再生成的工作流优于反复重新生成。随后，它会严格依据社区验证有效的方法，为你写出一条可用于生产的提示词。
+**快速学习。** `/last30days Nano Banana Pro prompting`——JSON 结构化提示词正在取代标签堆砌；@pictsbyai 的嵌套格式能避免“概念串色”；以编辑为先的工作流优于反复重新生成。随后，它会严格依据社区验证有效的方法，为你写出一条可用于生产的提示词。
 
 ## 最近更新
 


### PR DESCRIPTION
## Summary

The five localized READMEs merged in #915 were machine-drafted and reviewed for structure, not for meaning. Several errors change what the docs claim rather than how they read. The product name `last30days` was translated as a date range, so the Grok section tells German readers that installations "take 30 days" and Japanese readers that they are "valid for 30 days". Japanese star counts are corrupted (351K renders as `351, GitHub 0星`) and a stray `44` sits inside a quoted tweet. A dropped negation makes the `--hiring-signals` paragraph claim in Spanish, Portuguese, and Japanese that the report predicts what the roadmap will ship — the opposite of what it does. The repo name is mangled inside @yieldhunter95's quote in all five, citing a repository that does not exist.

This rewrites FR/DE/ES/PT-BR/JA against the English source, preserving the structure the contract tests enforce. Patching line-by-line was not viable: roughly a third of the prose sentences needed touching, and the register problems (German alternating du/Sie, Japanese dropping out of です・ます mid-document) are not fixable in isolation.

Also fixed: recurring calques that read as howlers to a native speaker — papers→newspapers, grounded→electrically earthed, cookie→`Keks`, markdown→`descuento`, store→shop, harness→wiring harness, "hosts"→TV presenters, "run"→game round. And the TweetClaw paragraph, which was garbled in all five because the source line breaks were parsed as sentence boundaries.

One correction the Chinese README already had right: `From your library` stays untranslated. `library_index.py:28` matches that heading literally, so a localized string would not match what the renderer emits.

`README.zh-CN.md` is a separate commit. It predates #915, is in good shape, and needed only three wording fixes (`当地居民` for "locals", not `本地游客`; `执行层/已上线`; `以编辑为先`).

## Testing

- [x] `uv run pytest` — 3,581 passed, 5 skipped, 48 subtests passed
- [x] Added or updated tests that would catch a regression, or explained why not below

No new tests. `tests/test_readme_translations.py` (added by #915) already locks the structural contract — nav line, code fences, commands, external links, table shape, ordered-list count — and passes on all six files. It cannot catch this class of defect: every error here was structurally valid prose. Verified separately by grep that the mechanical classes are gone (zero markdown-boundary glue, zero stray punctuation spacing, zero product-name translations, zero mangled repo names); remaining hits were false positives (`Diggs` genitive, `CLIs` plural, `los últimos 30 días` as a genuine phrase).

## Changelog

- [ ] Added `changelog.d/<pr-or-issue>.<type>.md`
- [x] Skip changelog — documentation only (also add the `skip-changelog` label)

Matches #915's own changelog decision. The guard requires a fragment only for `skills/last30days/scripts/*`, `SKILL.md`, or `mcp/*`; this touches root READMEs only.

## Agent disclosure

### AI review

Claude reviewed all six localized READMEs line by line against `README.md`, classifying findings as mechanical (spacing, untranslated link text), terminological (calques, inconsistent renderings of the same term), or meaning-changing (dropped negations, reversed comparisons, corrupted numbers, translated identifiers). The meaning-changing set drove the decision to rewrite rather than patch. Each correction was verified against the English source; the `From your library` decision was verified against `library_index.py` rather than assumed.

### Security

N/A. Documentation only — no input handling, command execution, path handling, auth, secrets, or dependencies are touched.

## Notes

**This needs a native-speaker pass before merge.** Every correction here is verifiable against the English source, but the author is not a native speaker of these five languages. The marketing-voice sections are where fluent-but-slightly-off phrasing hides best, and the incorrect version is already public on `main`, so there is a real argument for taking the time rather than landing fast on top of it.

Worth considering as follow-up: the errors that mattered most were identifiers being translated (`last30days`, the repo path, ride names, `r/ClaudeCode`). A do-not-translate list committed alongside the READMEs would make the next re-translation regress less, and a test asserting those tokens appear literally in every localized file would catch the whole class mechanically.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Related: #915

https://claude.ai/code/session_016T5XBP3y6AMoFUbkcAuEh9
