### PR TITLE
fix: save the full artifact on --emit=compact --save-dir runs

### DIFF
--- a/changelog.d/923.fixed.md
+++ b/changelog.d/923.fixed.md
@@ -1,0 +1,1 @@
+`--emit=compact --save-dir` runs now save the complete debug artifact (all clusters plus every per-source item, with the emoji footer citing the actual written path) instead of the compact stdout render, which had made most collected evidence unrecoverable from the raw file.

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -2304,6 +2304,15 @@ def _render_save_and_print(
                     json_profile=args.json_profile,
                     register=audience.name,
                 )
+            if args.emit not in {"json", "html"} and not entity_reports:
+                # Markdown saves keep the complete debug artifact (all clusters
+                # and per-source items), matching the render_fn-less path in
+                # save_output and the comparison peer saves. Saving the compact
+                # stdout render instead made most collected evidence
+                # unrecoverable from the raw file (#923). The stdout re-render
+                # above still runs so the visible footer cites the real path,
+                # and the saved artifact carries the same citation.
+                return render.render_full(report, save_path=display)
             return rendered
 
         save_path = save_output(

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -1710,8 +1710,12 @@ def _markdown_url_link(url: str) -> str:
     return _escape_markdown_plain_text(sanitized_url)
 
 
-def render_full(report: schema.Report) -> str:
-    """Full data dump: ALL clusters + ALL items by source. For saved files and debugging."""
+def render_full(report: schema.Report, save_path: str | None = None) -> str:
+    """Full data dump: ALL clusters + ALL items by source. For saved files and debugging.
+
+    When ``save_path`` is provided, the deterministic emoji footer is appended
+    so the saved artifact cites the file actually written (collision fallback
+    included), matching the stdout footer contract."""
     evidence_report = schema.without_sources(report, {"corpus"})
     # Start with the same header as compact
     non_empty = [s for s, items in sorted(report.items_by_source.items()) if items]
@@ -1897,6 +1901,10 @@ def render_full(report: schema.Report) -> str:
         lines.append("")
     lines.extend(_render_stats(evidence_report))
     lines.extend(_render_source_coverage(evidence_report))
+    if save_path:
+        footer_lines = _render_emoji_footer(evidence_report, save_path)
+        if footer_lines:
+            lines.extend(["", *footer_lines])
     return "\n".join(lines).strip() + "\n"
 
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -349,6 +349,34 @@ class CliV3Tests(unittest.TestCase):
             payload = json.loads(path.read_text())
             self.assertEqual("OpenClaw vs NanoClaw", payload["query"])
 
+    def test_compact_emit_saves_full_artifact_not_compact_render(self):
+        """A --emit=compact --save-dir run must save the complete debug
+        artifact (all clusters plus per-source items), not the compact stdout
+        render. Saving the compact render made most collected evidence
+        unrecoverable from the raw file (#923)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "skills/last30days/scripts/last30days.py",
+                    "compact save probe",
+                    "--mock",
+                    "--emit=compact",
+                    f"--save-dir={tmp}",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            saved = list(Path(tmp).glob("*.md"))
+            self.assertEqual(1, len(saved), saved)
+            content = saved[0].read_text(encoding="utf-8")
+            self.assertIn("## All Items by Source", content)
+            self.assertNotIn("## All Items by Source", result.stdout)
+
     def test_save_output_uses_unique_dated_fallback(self):
         report = self.make_report()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Fixes #923.

## What was wrong

`save_output` has two content paths. The `render_fn`-less path deliberately writes `render.render_full(report)` for markdown saves ("Markdown saves keep the complete debug artifact"), and comparison peer saves use exactly that path. But the main-topic save passes `render_fn=_render_with_actual_path`, whose return value re-renders the **stdout** emit — so on `--emit=compact` runs the saved raw file contained only the compact render (top ~8 clusters, stats, footer). On a real run that collected 139 items, 131 were unrecoverable from the raw file, defeating the file's stated purpose as the durable citation surface (Step 2.5) and biting hardest on exactly the concept-topic runs #887 describes, where the visible clusters underperform and the hosting model needs to re-read the corpus.

## The fix

- `_render_with_actual_path` still re-renders stdout so the visible footer cites the collision-resolved path, but for markdown-family single-entity saves it now returns `render.render_full(report, save_path=display)` as the file content.
- `render_full` gains an optional `save_path` and appends the deterministic emoji footer when set, so the saved artifact keeps the actual-path citation the render_fn mechanism exists for (`test_render_save_and_print_uses_actual_collision_path_in_file_and_stdout` still passes).
- JSON and HTML saves keep their wire formats; comparison main saves keep the merged comparison render; peer saves were already correct.

## Testing

- New regression test `test_compact_emit_saves_full_artifact_not_compact_render`: a `--mock --emit=compact --save-dir` run must save a file containing `## All Items by Source` while stdout does not.
- Full suite: passes, coverage 88.43% (floor 84%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
