### PR TITLE
feat: refresh reasoning provider model support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -354,6 +354,8 @@ An explicit `--register` wins over `LAST30DAYS_REGISTER`; the environment/config
 
 When you invoke `/last30days` from Claude Code, Codex, or Gemini, the host model **is** the reasoning provider for plan + synthesis - you don't need any of the keys above unless you also run the script headlessly (cron, CI, watchlist).
 
+Headless runs use role-matched defaults: Gemini 3.5 Flash-Lite for planning and normal reranking, Gemini 3.6 Flash for deep reranking, GPT-5.6 Luna with `none` reasoning effort for OpenAI, Grok 4.5 with `low` reasoning effort for xAI, and Gemini 3.5 Flash-Lite through OpenRouter. Override planner and reranker models with `LAST30DAYS_PLANNER_MODEL` and `LAST30DAYS_RERANK_MODEL`. Override the xAI model used for X search with `LAST30DAYS_X_MODEL`.
+
 ---
 
 ## Web search backend priority

--- a/changelog.d/+current-reasoning-models.changed.md
+++ b/changelog.d/+current-reasoning-models.changed.md
@@ -1,0 +1,1 @@
+Refresh headless reasoning defaults for Gemini, OpenAI, xAI, and OpenRouter, including request compatibility for Gemini 3.5/3.6 and GPT-5.6.

--- a/docs/how-search-works.md
+++ b/docs/how-search-works.md
@@ -101,7 +101,7 @@ X search has **two backends** — the skill auto-detects which to use.
 if node_available and AUTH_TOKEN and CT0:
     use bundled Bird    # Free, popup-free, env-authenticated
 elif XAI_API_KEY:
-    use xAI API         # Paid, uses grok-4-1-fast
+    use xAI API         # Paid, uses grok-4.5 with low reasoning effort
 else:
     skip X entirely     # No X results
 ```
@@ -117,7 +117,8 @@ Authorization: Bearer {XAI_API_KEY}
 **Payload:**
 ```json
 {
-  "model": "grok-4-1-fast",
+  "model": "grok-4.5",
+  "reasoning": { "effort": "low" },
   "tools": [{ "type": "x_search" }],
   "input": "Search X for posts about {topic} from {from_date} to {to_date}..."
 }

--- a/skills/last30days/scripts/evaluate_search_quality.py
+++ b/skills/last30days/scripts/evaluate_search_quality.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from lib import env as envlib
 from lib import schema
-from lib.providers import GEMINI_FLASH_LITE
+from lib.providers import GEMINI_FLASH_LITE, gemini_generation_config
 
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
@@ -215,7 +215,10 @@ def extract_gemini_text(payload: dict[str, Any]) -> str:
 def call_gemini_judge(api_key: str, model: str, prompt: str) -> dict[str, Any]:
     body = {
         "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"temperature": 0, "responseMimeType": "application/json"},
+        "generationConfig": gemini_generation_config(
+            model,
+            response_mime_type="application/json",
+        ),
     }
     request = Request(
         GEMINI_API_URL.format(model=model, api_key=api_key),

--- a/skills/last30days/scripts/lib/providers.py
+++ b/skills/last30days/scripts/lib/providers.py
@@ -10,20 +10,39 @@ from typing import Any
 
 from . import env, http, schema
 
-GEMINI_FLASH_LITE = "gemini-3.1-flash-lite"
-GEMINI_PRO = "gemini-3.1-pro-preview"
-OPENAI_DEFAULT = "gpt-5.4-nano"
-XAI_DEFAULT = "grok-4-1-fast"
+GEMINI_FLASH_LITE = "gemini-3.5-flash-lite"
+GEMINI_DEEP = "gemini-3.6-flash"
+OPENAI_DEFAULT = "gpt-5.6-luna"
+XAI_DEFAULT = "grok-4.5"
 
 GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
 OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 XAI_RESPONSES_URL = "https://api.x.ai/v1/responses"
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
-# OpenRouter routes the Gemini Flash Lite tier as the -preview slug; that is the
-# stable form on that routing layer even though native Gemini's GEMINI_FLASH_LITE
-# constant is suffix-free. If GEMINI_FLASH_LITE moves to a non-preview stable ID,
-# double-check that OpenRouter's slug still maps to the same upstream model.
-OPENROUTER_DEFAULT = "google/gemini-3.1-flash-lite-preview"
+OPENROUTER_DEFAULT = "google/gemini-3.5-flash-lite"
+
+
+def gemini_generation_config(
+    model: str,
+    *,
+    response_mime_type: str | None = None,
+) -> dict[str, Any]:
+    """Build a generateContent config compatible with old and current Gemini models."""
+    config: dict[str, Any] = {}
+    match = re.match(r"^gemini-(\d+)\.(\d+)", model)
+    if match and tuple(map(int, match.groups())) < (3, 5):
+        config["temperature"] = 0
+    if response_mime_type:
+        config["responseMimeType"] = response_mime_type
+    return config
+
+
+def _uses_gpt_56_contract(model: str) -> bool:
+    return model == "gpt-5.6" or model.startswith("gpt-5.6-")
+
+
+def _uses_grok_45_contract(model: str) -> bool:
+    return model == "grok-4.5" or model.startswith("grok-4.5-")
 
 
 class ReasoningClient:
@@ -68,10 +87,13 @@ class GeminiClient(ReasoningClient):
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "contents": [{"parts": [{"text": prompt}]}],
-            "generationConfig": {"temperature": 0},
         }
-        if response_mime_type:
-            body["generationConfig"]["responseMimeType"] = response_mime_type
+        generation_config = gemini_generation_config(
+            model,
+            response_mime_type=response_mime_type,
+        )
+        if generation_config:
+            body["generationConfig"] = generation_config
         if tools:
             body["tools"] = tools
         return http.post(
@@ -118,6 +140,8 @@ class OpenAIClient(ReasoningClient):
             "input": prompt,
             "temperature": 0,
         }
+        if _uses_gpt_56_contract(model):
+            payload["reasoning"] = {"effort": "none"}
         response = http.post(
             os.environ.get("OPENAI_BASE_URL", OPENAI_RESPONSES_URL),
             payload,
@@ -149,6 +173,8 @@ class XAIClient(ReasoningClient):
             "model": model,
             "input": [{"role": "user", "content": prompt}],
         }
+        if _uses_grok_45_contract(model):
+            payload["reasoning"] = {"effort": "low"}
         response = http.post(
             os.environ.get("XAI_BASE_URL", XAI_RESPONSES_URL),
             payload,
@@ -201,18 +227,18 @@ _MODEL_DEFAULTS: dict[str, tuple[str, str]] = {
 }
 
 
-def _resolve_model_pins(config: dict[str, Any], depth: str, provider_name: str) -> tuple[str, str, str]:
-    """Resolve planner, rerank, and grounding model pins for a provider."""
+def _resolve_model_pins(config: dict[str, Any], depth: str, provider_name: str) -> tuple[str, str]:
+    """Resolve planner and rerank model pins for a provider."""
     default_planner, default_rerank = _MODEL_DEFAULTS.get(provider_name, (GEMINI_FLASH_LITE, GEMINI_FLASH_LITE))
     if depth == "deep" and provider_name == "gemini":
-        default_rerank = GEMINI_PRO
+        default_rerank = GEMINI_DEEP
 
     planner_model = config.get("LAST30DAYS_PLANNER_MODEL") or default_planner
     rerank_model = config.get("LAST30DAYS_RERANK_MODEL") or default_rerank
 
     if provider_name == "gemini":
-        _require_gemini_31(planner_model, role="planner")
-        _require_gemini_31(rerank_model, role="rerank")
+        _require_gemini_model(planner_model, role="planner")
+        _require_gemini_model(rerank_model, role="rerank")
 
     return planner_model, rerank_model
 
@@ -321,11 +347,11 @@ def _resolve_x_backend(config: dict[str, Any]) -> str | None:
     return env.get_x_source(config)
 
 
-def _require_gemini_31(model: str, *, role: str) -> None:
-    if model.startswith("gemini-3.1-"):
+def _require_gemini_model(model: str, *, role: str) -> None:
+    if model.startswith("gemini-"):
         return
     raise RuntimeError(
-        f"{role} must use a Gemini 3.1 model. Got: {model}"
+        f"{role} must use a Gemini model. Got: {model}"
     )
 
 

--- a/skills/last30days/scripts/lib/schema.py
+++ b/skills/last30days/scripts/lib/schema.py
@@ -36,7 +36,7 @@ def _first_non_none(*values: Any) -> Any:
 class ProviderRuntime:
     """Resolved runtime provider selection."""
 
-    reasoning_provider: Literal["gemini", "openai", "xai", "local"]
+    reasoning_provider: Literal["gemini", "openai", "xai", "openrouter", "local"]
     planner_model: str
     rerank_model: str
     x_search_backend: Literal["xai", "bird"] | None = None

--- a/skills/last30days/scripts/lib/xai_x.py
+++ b/skills/last30days/scripts/lib/xai_x.py
@@ -121,6 +121,8 @@ def search_x(
             }
         ],
     }
+    if model == "grok-4.5" or model.startswith("grok-4.5-"):
+        payload["reasoning"] = {"effort": "low"}
 
     return http.post(XAI_RESPONSES_URL, payload, headers=headers, timeout=timeout)
 

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -112,6 +112,28 @@ class EvaluatorV3Tests(unittest.TestCase):
         with self.assertRaises(ValueError):
             evaluator.extract_gemini_text({"candidates": [{"content": {"parts": [{}]}}]})
 
+    def test_current_gemini_judge_omits_deprecated_sampling_parameters(self):
+        payload = {
+            "candidates": [
+                {"content": {"parts": [{"text": '{"items": []}'}]}}
+            ]
+        }
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+        with mock.patch.object(evaluator, "urlopen", return_value=response) as urlopen:
+            result = evaluator.call_gemini_judge(
+                "key",
+                "gemini-3.5-flash-lite",
+                "prompt",
+            )
+        request = urlopen.call_args.args[0]
+        body = json.loads(request.data)
+        self.assertEqual({"items": []}, result)
+        self.assertEqual(
+            {"responseMimeType": "application/json"},
+            body["generationConfig"],
+        )
+
     def test_get_judgments_uses_cache_and_skips_when_not_configured(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp)

--- a/tests/test_internals_v3.py
+++ b/tests/test_internals_v3.py
@@ -546,8 +546,6 @@ class TestXaiModelDefault(unittest.TestCase):
         self.assertNotEqual(providers.XAI_DEFAULT, "grok-3-mini-fast",
                             "grok-3-mini-fast returns HTTP 400 from xAI API")
 
-    def test_default_is_grok_4_generation(self):
+    def test_default_is_current_grok_generation(self):
         from lib import providers
-        self.assertIn("grok-4", providers.XAI_DEFAULT,
-                      f"XAI_DEFAULT should be a grok-4 model, got: {providers.XAI_DEFAULT}")
-
+        self.assertEqual("grok-4.5", providers.XAI_DEFAULT)

--- a/tests/test_providers_v3.py
+++ b/tests/test_providers_v3.py
@@ -1,9 +1,11 @@
 import json
 import unittest
-from typing import get_args
+from typing import get_args, get_type_hints
+from unittest.mock import patch
 
 from lib import env
 from lib import providers
+from lib import schema
 
 
 class ProvidersV3Tests(unittest.TestCase):
@@ -14,7 +16,37 @@ class ProvidersV3Tests(unittest.TestCase):
         )
         self.assertEqual("gemini", runtime.reasoning_provider)
         self.assertEqual("gemini", client.name)
-        self.assertTrue(runtime.planner_model.startswith("gemini-3.1-"))
+        self.assertEqual("gemini-3.5-flash-lite", runtime.planner_model)
+
+    def test_deep_gemini_uses_current_flash_for_reranking(self):
+        runtime, _ = providers.resolve_runtime(
+            {"GOOGLE_API_KEY": "test", "LAST30DAYS_REASONING_PROVIDER": "gemini"},
+            depth="deep",
+        )
+        self.assertEqual("gemini-3.5-flash-lite", runtime.planner_model)
+        self.assertEqual("gemini-3.6-flash", runtime.rerank_model)
+
+    def test_gemini_model_pins_accept_current_and_older_families(self):
+        runtime = providers.mock_runtime(
+            {
+                "LAST30DAYS_REASONING_PROVIDER": "gemini",
+                "LAST30DAYS_PLANNER_MODEL": "gemini-3.6-flash",
+                "LAST30DAYS_RERANK_MODEL": "gemini-2.5-flash",
+            },
+            depth="default",
+        )
+        self.assertEqual("gemini-3.6-flash", runtime.planner_model)
+        self.assertEqual("gemini-2.5-flash", runtime.rerank_model)
+
+    def test_gemini_model_pins_reject_cross_provider_models(self):
+        with self.assertRaisesRegex(RuntimeError, "planner must use a Gemini model"):
+            providers.mock_runtime(
+                {
+                    "LAST30DAYS_REASONING_PROVIDER": "gemini",
+                    "LAST30DAYS_PLANNER_MODEL": "gpt-5.6-luna",
+                },
+                depth="default",
+            )
 
     def test_auto_falls_back_to_openai(self):
         runtime, client = providers.resolve_runtime(
@@ -26,6 +58,7 @@ class ProvidersV3Tests(unittest.TestCase):
             depth="default",
         )
         self.assertEqual("openai", runtime.reasoning_provider)
+        self.assertEqual("gpt-5.6-luna", runtime.planner_model)
 
     def test_auto_falls_back_to_xai(self):
         runtime, client = providers.resolve_runtime(
@@ -33,6 +66,7 @@ class ProvidersV3Tests(unittest.TestCase):
             depth="default",
         )
         self.assertEqual("xai", runtime.reasoning_provider)
+        self.assertEqual("grok-4.5", runtime.planner_model)
 
     def test_auto_returns_local_runtime_when_no_keys(self):
         runtime, client = providers.resolve_runtime(
@@ -73,6 +107,65 @@ class ProvidersV3Tests(unittest.TestCase):
         self.assertFalse(hasattr(providers, "CODEX_RESPONSES_URL"))
         with self.assertRaises(TypeError):
             providers.OpenAIClient("token", "codex", "acct")
+
+    def test_current_gemini_omits_deprecated_sampling_parameters(self):
+        response = {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+        for model in ("gemini-3.5-flash-lite", "gemini-3.6-flash", "gemini-4.0-flash"):
+            with self.subTest(model=model):
+                with patch("lib.providers.http.post", return_value=response) as post:
+                    text = providers.GeminiClient("key").generate_text(
+                        model,
+                        "prompt",
+                        response_mime_type="application/json",
+                    )
+                body = post.call_args.args[1]
+                self.assertEqual("ok", text)
+                self.assertEqual(
+                    {"responseMimeType": "application/json"},
+                    body["generationConfig"],
+                )
+                self.assertNotIn("temperature", body["generationConfig"])
+
+    def test_older_gemini_pin_keeps_temperature_zero(self):
+        response = {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+        with patch("lib.providers.http.post", return_value=response) as post:
+            providers.GeminiClient("key").generate_text("gemini-3.1-flash-lite", "prompt")
+        self.assertEqual({"temperature": 0}, post.call_args.args[1]["generationConfig"])
+
+    def test_openai_56_preserves_low_latency_reasoning_contract(self):
+        with patch("lib.providers.http.post", return_value={"output_text": "ok"}) as post:
+            text = providers.OpenAIClient("token").generate_text("gpt-5.6-luna", "prompt")
+        self.assertEqual("ok", text)
+        payload = post.call_args.args[1]
+        self.assertEqual({"effort": "none"}, payload["reasoning"])
+        self.assertEqual(0, payload["temperature"])
+
+    def test_older_openai_pin_does_not_receive_56_only_fields(self):
+        with patch("lib.providers.http.post", return_value={"output_text": "ok"}) as post:
+            providers.OpenAIClient("token").generate_text("gpt-4.1-mini", "prompt")
+        self.assertNotIn("reasoning", post.call_args.args[1])
+
+    def test_grok_45_uses_low_reasoning_for_planning_and_reranking(self):
+        with patch("lib.providers.http.post", return_value={"output_text": "ok"}) as post:
+            text = providers.XAIClient("token").generate_text("grok-4.5", "prompt")
+        self.assertEqual("ok", text)
+        self.assertEqual({"effort": "low"}, post.call_args.args[1]["reasoning"])
+
+    def test_older_xai_pin_does_not_receive_45_only_fields(self):
+        with patch("lib.providers.http.post", return_value={"output_text": "ok"}) as post:
+            providers.XAIClient("token").generate_text("grok-4.3", "prompt")
+        self.assertNotIn("reasoning", post.call_args.args[1])
+
+    def test_openrouter_default_tracks_current_flash_lite(self):
+        runtime = providers.mock_runtime(
+            {"LAST30DAYS_REASONING_PROVIDER": "openrouter"},
+            depth="default",
+        )
+        self.assertEqual("google/gemini-3.5-flash-lite", runtime.planner_model)
+
+    def test_provider_runtime_type_contract_includes_openrouter(self):
+        provider_type = get_type_hints(schema.ProviderRuntime)["reasoning_provider"]
+        self.assertIn("openrouter", get_args(provider_type))
 
 
 class TestExtractJson(unittest.TestCase):

--- a/tests/test_xai_x.py
+++ b/tests/test_xai_x.py
@@ -1,7 +1,8 @@
 import json
 import unittest
+from unittest import mock
 
-from lib.xai_x import parse_x_response
+from lib.xai_x import parse_x_response, search_x
 
 
 def _wrap_items(items):
@@ -58,6 +59,32 @@ class TestXaiXEngagementZero(unittest.TestCase):
         self.assertEqual(3, eng["reposts"])
         self.assertEqual(1, eng["replies"])
         self.assertEqual(0, eng["quotes"])
+
+
+class TestXaiXRequest(unittest.TestCase):
+    def test_grok_45_search_uses_low_reasoning(self):
+        with mock.patch("lib.xai_x.http.post", return_value={}) as post:
+            search_x(
+                "key",
+                "grok-4.5",
+                "topic",
+                "2026-07-01",
+                "2026-07-31",
+            )
+        payload = post.call_args.args[1]
+        self.assertEqual({"effort": "low"}, payload["reasoning"])
+        self.assertEqual("grok-4.5", payload["model"])
+
+    def test_older_model_pin_does_not_receive_45_only_fields(self):
+        with mock.patch("lib.xai_x.http.post", return_value={}) as post:
+            search_x(
+                "key",
+                "grok-4.3",
+                "topic",
+                "2026-07-01",
+                "2026-07-31",
+            )
+        self.assertNotIn("reasoning", post.call_args.args[1])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Refresh the headless reasoning-provider matrix to current role-matched models:

- Gemini 3.5 Flash-Lite for planning/default reranking and Gemini 3.6 Flash for deep reranking
- GPT-5.6 Luna for OpenAI's high-volume role, with explicit `reasoning.effort=none`
- Grok 4.5 for xAI reasoning and X search, with explicit low reasoning effort
- Gemini 3.5 Flash-Lite through OpenRouter

The Gemini request builder now omits deprecated sampling parameters for 3.5/3.6 and future model families while preserving `temperature=0` for older pinned models. Gemini pins are validated by provider namespace instead of a 3.1-only allowlist, and OpenRouter is included in the runtime provider type contract.

References: [latest Gemini models](https://ai.google.dev/gemini-api/docs/latest-model), [Gemini deprecations](https://ai.google.dev/gemini-api/docs/deprecations), [GPT-5.6 migration guidance](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6), [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna), and [Grok 4.5 reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning).

## Testing

- [x] `uv run --python 3.12 pytest --cov --cov-report=term-missing` — 3,594 passed, 6 skipped, 88.49% coverage
- [x] `go test -race ./...`
- [x] Added regression tests for defaults, old-model pins, provider validation, Gemini sampling parameters, GPT-5.6/xAI reasoning settings, evaluator requests, X search requests, and OpenRouter typing
- [x] Live OpenRouter smoke tests passed for `google/gemini-3.5-flash-lite` and `google/gemini-3.6-flash`
- [x] Live model catalogs confirmed both native Gemini IDs and both OpenRouter IDs

A native Gemini generation smoke reached the API but was quota-blocked with HTTP 429. OpenAI and xAI generation were not run because those API keys are not configured; their request contracts are covered by unit tests against the current official API guidance.

## Changelog

- [x] Added `changelog.d/+current-reasoning-models.changed.md`
- [ ] Skip changelog — chore/internal only

## Agent disclosure

### AI review

Codex audited all provider defaults, model guards, request payloads, model-pin compatibility, documentation, and nearby type contracts. The review preserved older user-pinned model behavior, added version-gated Gemini request construction, made GPT-5.6 and Grok 4.5 reasoning effort explicit for the existing low-latency roles, and added tests for every changed contract.

### Security

No credential-loading, auth, shell execution, dependency, or secret-storage behavior changed. Live smoke tests used existing environment credentials without printing their values.

## Notes

The current model defaults are now documented in `CONFIGURATION.md`. Historical fixtures that intentionally exercise older model strings remain unchanged.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

N/A
