### PR TITLE
fix(arxiv): preserve adapter-valid papers during normalization

### DIFF
--- a/changelog.d/946.fixed.md
+++ b/changelog.d/946.fixed.md
@@ -1,0 +1,1 @@
+Adapter-valid arXiv papers are no longer dropped by the report date window during normalization.

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -79,6 +79,10 @@ def normalize_source_items(
         normalizer(source, item, index, from_date, to_date)
         for index, item in enumerate(items)
     ]
+    if source == "arxiv":
+        # The adapter owns arXiv's 365-day recency contract. Applying the
+        # report window again here drops relevant papers the adapter accepted.
+        return normalized
     if source == "jobs":
         # A careers board is a snapshot of CURRENTLY OPEN roles. An open posting
         # is current evidence regardless of when it was posted, so date-windowing

--- a/tests/test_normalize_v3.py
+++ b/tests/test_normalize_v3.py
@@ -45,6 +45,32 @@ class NormalizeV3Tests(unittest.TestCase):
         )
         self.assertEqual([], normalized)
 
+    def test_arxiv_keeps_adapter_valid_items_older_than_report_window(self):
+        items = [
+            {
+                "id": "http://arxiv.org/abs/2509.00001v1",
+                "title": "Reliable Agent Memory",
+                "url": "https://arxiv.org/abs/2509.00001v1",
+                "summary": "A study of memory systems for coding agents.",
+                "author": "Ada Lovelace",
+                "authors": ["Ada Lovelace"],
+                "date": "2025-09-04",
+                "relevance": 0.9,
+            }
+        ]
+
+        normalized = normalize.normalize_source_items(
+            "arxiv",
+            items,
+            "2026-07-06",
+            "2026-08-05",
+        )
+
+        self.assertEqual(1, len(normalized))
+        self.assertEqual("Reliable Agent Memory", normalized[0].title)
+        self.assertEqual("https://arxiv.org/abs/2509.00001v1", normalized[0].url)
+        self.assertEqual("2025-09-04", normalized[0].published_at)
+
     def test_youtube_top_comments_passthrough_with_field_mapping(self):
         """YT comments from enrich_with_comments use likes/text; normalize must
         carry them into metadata as the Reddit-compatible {score, excerpt} shape."""


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 sentences. -->

Preserve arXiv papers that already passed the adapter's 365-day recency gate instead of applying the report's narrower date window a second time. Add normalization-seam regression coverage and a release-note fragment for the fix.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused proof passed: `uv run pytest tests/test_arxiv_source.py tests/test_normalize_v3.py` reported 37 passed, and the new arXiv regression first failed before the production change and passed afterward. The final full-suite run reported 3581 passed, 5 skipped, 48 subtests passed, and one unrelated pre-existing failure in `tests/test_footer_nudge_suppression.py::FooterNudgeSuppressionTests::test_bare_run_emits_web_promo`; the same exact test also fails on an untouched detached `upstream/main` worktree at `52f5331`.

## Changelog

If this change should appear in the next release notes, add a fragment under `changelog.d/` (see `changelog.d/README.md` and [CONTRIBUTING.md](../CONTRIBUTING.md)). Do **not** edit `CHANGELOG.md` or bump version/manifest files in this PR.

- [x] Added `changelog.d/<pr-or-issue>.<type>.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Independent review checked the source-specific date-policy boundary, neighboring source behavior, regression coverage, changelog compliance, and diff hygiene. A final source-aware review found no actionable defects; no review-driven code changes were needed.

### Security

Reviewed date and metadata handling plus the changed control-flow boundary. The patch adds no command execution, path handling, authentication, secret access, dependency, or external-I/O behavior; no security follow-up is needed.

## Notes

Deterministic proof covers the reproduced adapter-to-normalization drop. A disposable live `arxiv-pp-cli` 2026.7.2 run also found 10 entries for `video generation`; 3 passed the adapter's 365-day policy and all 3 reached the final arXiv report source with state `ok` and no source error. The old shared 30-day filter would have retained none of those 3.

### Relationship to this change

Disclose employment, contracting, equity, or other paid ties to a company/product/service this PR adds or meaningfully promotes (example: you work at the API vendor being integrated).

- [x] None
- [ ] Yes — disclosure: <!-- who / what relationship -->

## Related issues

<!-- Fixes #123 / Relates to #456 — or N/A -->

Fixes #946
