### PR TITLE
fix: don't brand sources with items as failed from swallowed lane errors

### DIFF
--- a/changelog.d/+source-outcome-swallowed-lane-failure.fixed.md
+++ b/changelog.d/+source-outcome-swallowed-lane-failure.fixed.md
@@ -1,0 +1,1 @@
+Sources that return items are no longer branded `auth-failed` / `partial` when a swallowed lane-level HTTP failure (e.g. Reddit shreddit partials 403-ing on datacenter egress) is captured by the pipeline sink. The transport-failure outcome still surfaces when nothing was delivered, so `doctor` prescriptions are unaffected.

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -3538,8 +3538,16 @@ def _retrieve_stream(*args, **kwargs) -> tuple[list[dict], dict]:
         failures,
     )
     if outcome_note:
-        artifact = dict(artifact or {})
-        artifact["_source_outcome"] = outcome_note
+        # Lane-level HTTP failures (e.g. a blocked shreddit partial on a
+        # datacenter IP) are captured by the sink even when the source
+        # delivered items. Only attach them when the run produced nothing,
+        # or when the impl attached its own explicit outcome artifact (e.g.
+        # "primary failed; fallback returned N items"). A swallowed lane
+        # failure must not brand a successful source auth-failed/partial.
+        explicit = isinstance(artifact, dict) and bool(artifact.get("_source_outcome"))
+        if explicit or not items:
+            artifact = dict(artifact or {})
+            artifact["_source_outcome"] = outcome_note
     if module_backed:
         http.fixture_source_record(fixture_request, [items, artifact])
     return items, artifact

--- a/tests/test_reddit_transport_outcomes.py
+++ b/tests/test_reddit_transport_outcomes.py
@@ -11,7 +11,7 @@ capture sink -> source outcome -> postmortem bucket -- stays honest.
 import urllib.error
 from unittest import mock
 
-from lib import doctor, pipeline, schema
+from lib import doctor, http, pipeline, schema
 
 
 def _plan(source):
@@ -100,3 +100,88 @@ def test_postmortem_does_not_claim_success_after_a_reddit_block():
     assert "Succeeded: reddit" not in text
     assert "Failed:" in text
     assert schema.RATE_LIMITED in text
+
+
+def test_items_delivered_with_swallowed_lane_403_are_not_branded():
+    """Regression (datacenter egress): a source that returns items must not be
+    branded auth-failed/partial by a swallowed lane-level 403.
+
+    On hosts where Reddit blocks the shreddit partials (HTTP 403), the capture
+    sink records those failures even though the keyless lanes delivered items.
+    Before the fix, ``_retrieve_stream`` attached the captured failure as the
+    source outcome and the run reported ``auth-failed`` / ``partial after N
+    items: HTTP 403: Blocked`` for a source that actually succeeded.
+    """
+    lane_error = http.HTTPError(
+        "https://www.reddit.com/svc/shreddit/community-more-posts/top/?name=tea",
+        status_code=403,
+        body=b"Blocked",
+    )
+    subquery = schema.SubQuery(
+        label="primary",
+        search_query="matcha tea trends",
+        ranking_query="matcha tea trends",
+        sources=["reddit"],
+    )
+    with mock.patch.object(
+        pipeline,
+        "_retrieve_stream_impl",
+        return_value=([{"url": "https://www.reddit.com/r/tea/comments/abc/"}], {}),
+    ), mock.patch.object(http, "capture_failures") as cf, mock.patch.object(
+        http, "fixture_module_capture"
+    ):
+        cf.return_value.__enter__.return_value = [lane_error]
+        cf.return_value.__exit__.return_value = False
+        items, artifact = pipeline._retrieve_stream(
+            source="reddit",
+            topic="matcha tea trends",
+            subquery=subquery,
+            config={},
+            depth="quick",
+            date_range=("2026-07-08", "2026-08-08"),
+            runtime=schema.ProviderRuntime("local", "test-planner", "test-reranker"),
+            mock=False,
+            web_backend="auto",
+        )
+
+    assert items, "the run delivered items"
+    assert "_source_outcome" not in artifact, (
+        "swallowed lane failures must not brand a source that returned items"
+    )
+
+
+def test_swallowed_lane_403_still_brands_when_no_items_returned():
+    """The no-items case keeps the transport-failure outcome (issue #899): the
+    captured failure must still surface so doctor can prescribe a fix."""
+    lane_error = http.HTTPError(
+        "https://www.reddit.com/svc/shreddit/community-more-posts/top/?name=tea",
+        status_code=403,
+        body=b"Blocked",
+    )
+    subquery = schema.SubQuery(
+        label="primary",
+        search_query="matcha tea trends",
+        ranking_query="matcha tea trends",
+        sources=["reddit"],
+    )
+    with mock.patch.object(
+        pipeline, "_retrieve_stream_impl", return_value=([], {})
+    ), mock.patch.object(http, "capture_failures") as cf, mock.patch.object(
+        http, "fixture_module_capture"
+    ):
+        cf.return_value.__enter__.return_value = [lane_error]
+        cf.return_value.__exit__.return_value = False
+        items, artifact = pipeline._retrieve_stream(
+            source="reddit",
+            topic="matcha tea trends",
+            subquery=subquery,
+            config={},
+            depth="quick",
+            date_range=("2026-07-08", "2026-08-08"),
+            runtime=schema.ProviderRuntime("local", "test-planner", "test-reranker"),
+            mock=False,
+            web_backend="auto",
+        )
+
+    assert not items
+    assert artifact.get("_source_outcome", {}).get("state") == schema.AUTH_FAILED


### PR DESCRIPTION
## Summary

On datacenter egress, Reddit blocks the keyless shreddit partials (`/svc/shreddit/*`) with HTTP 403. The pipeline's `capture_failures()` sink records those lane-level failures, and `_retrieve_stream` attached the captured failure as the source outcome **even when the source delivered items** — so a healthy Reddit run reported `auth-failed` / `partial after N items: HTTP 403: Blocked`, and the synthesis layer was told to distrust a source that worked.

This PR only attaches the captured-failure outcome when the run produced nothing, or when the impl attached its own explicit outcome artifact (e.g. "primary failed; fallback returned N items"). A swallowed lane failure no longer brands a successful source.

## Testing

- [x] `uv run pytest` (full suite; coverage 88.39% vs the 84% gate — the one failure, `test_setup_wizard.py::TestWriteApiKey::test_unwritable_target_returns_false`, also fails on clean `main` here because the suite runs as root, which bypasses the test's read-only permission setup; unrelated to this change)
- [x] Added regression tests:
  - items delivered + captured lane 403 → no `_source_outcome` attached
  - no items + captured lane 403 → transport-failure outcome still attached (issue #899 behavior preserved)

## Changelog

- [x] Added `changelog.d/+source-outcome-swallowed-lane-failure.fixed.md`

## Agent disclosure

### AI review

Change reviewed against the outcome machinery introduced by #899/#900: the no-items transport-failure reporting is untouched (covered by the existing `test_reddit_transport_outcomes.py` suite plus a new guard test). The `record_failure` → `PARTIAL` conversion in `RetrievalBundle` still applies to explicit impl artifacts, so intentional partial signals ("public fallback returned N items") keep surfacing.

### Security

N/A — no input handling, command execution, or auth changes.

## Notes

Motivated by a real run on a VPS: `"matcha tea trends" --search=reddit` returned 5 threads / 205 upvotes / 266 comments yet the run labeled Reddit `auth-failed: HTTP 403: Blocked` and told the model "do not interpret a failed source as no discussion." Companion PR `feat/reddit-arctic-listing-fallback` makes the shreddit lanes actually recover on such hosts; this fix keeps the outcome honest in the interim and for any future lane that 403s while other lanes deliver.

### Relationship to this change

- [x] None

## Related issues

N/A
