### PR TITLE
feat(reddit): arctic-shift fallback for shreddit listing lanes

### DIFF
--- a/changelog.d/+reddit-arctic-listing-fallback.added.md
+++ b/changelog.d/+reddit-arctic-listing-fallback.added.md
@@ -1,0 +1,1 @@
+Reddit keyless discovery now falls back to the arctic-shift archive when the shreddit listing partials return nothing — hosts on datacenter egress (where Reddit 403s `/svc/shreddit`) keep scored Reddit discovery, score backfill, and discover-mode listings instead of reporting `auth-failed`.

--- a/skills/last30days/scripts/lib/reddit_arctic.py
+++ b/skills/last30days/scripts/lib/reddit_arctic.py
@@ -16,16 +16,22 @@ count rather than failing the Reddit source.
 
 import sys
 import time
-from typing import Dict, List
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 from . import http
 
 API = "https://arctic-shift.photon-reddit.com/api/posts/ids"
+SEARCH_API = "https://arctic-shift.photon-reddit.com/api/posts/search"
 BATCH = 50          # ids per request
 TIMEOUT = 15
 MAX_BATCHES = 3     # cap total requests per run (bounds latency + rate-limit risk)
 PACE_SECONDS = 0.4  # gap between batches; arctic-shift answers 422 "slow down"
 CACHE_MAX = 4096    # hard size bound so the in-run memo can never grow unbounded
+# Listing-lane knobs (mirror reddit_listing's DEPTH_LIMITS so callers get the
+# same per-depth volume from either backend).
+_LISTING_DEPTH_LIMITS = {"quick": 10, "default": 25, "deep": 50}
+_MAX_LISTING_SUBS = 8  # cap concurrent subreddits per listing call
 # In-run memo: base36 id -> {score, num_comments}. Module-level so repeated
 # fetch_scores calls within one `/last30days` run (e.g. across subqueries) reuse
 # results, but capped at CACHE_MAX entries (never reached in a normal CLI run).
@@ -90,3 +96,110 @@ def fetch_scores(post_ids: List[str]) -> Dict[str, Dict[str, int]]:
                 _cache[rid] = entry
             out[rid] = entry
     return out
+
+
+def _epoch_to_date(value: Any) -> Optional[str]:
+    """Epoch seconds -> YYYY-MM-DD (UTC), or None on garbage."""
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).date().isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _normalize_listing_row(row: Dict[str, Any], query: str = "") -> Dict[str, Any]:
+    """Normalize an arctic-shift post row to reddit_listing.parse_cards shape.
+
+    Mirrors the shreddit card schema (title/url/score/num_comments/subreddit/
+    created_utc/author/selftext/date/engagement/relevance/metadata.post_id) so
+    reddit_keyless can consume either backend interchangeably.
+    """
+    from .relevance import token_overlap_relevance
+
+    pid = str(row.get("id") or "").removeprefix("t3_")
+    permalink = row.get("permalink") or ""
+    title = row.get("title") or ""
+    try:
+        score = int(row.get("score") or 0)
+    except (TypeError, ValueError):
+        score = 0
+    try:
+        num_comments = int(row.get("num_comments") or 0)
+    except (TypeError, ValueError):
+        num_comments = 0
+    author = row.get("author") or "[deleted]"
+    if author in ("[deleted]", "[removed]"):
+        author = "[deleted]"
+    url = f"https://www.reddit.com{permalink}" if permalink.startswith("/") else (permalink or "")
+    return {
+        "id": "",
+        "title": title,
+        "url": url,
+        "score": score,
+        "num_comments": num_comments,
+        "subreddit": row.get("subreddit") or "",
+        "created_utc": row.get("created_utc"),
+        "author": author,
+        "selftext": row.get("selftext") or "",
+        "date": _epoch_to_date(row.get("created_utc")),
+        "engagement": {"score": score, "num_comments": num_comments, "upvote_ratio": None},
+        "relevance": round(token_overlap_relevance(query, title), 3) if query else 0.0,
+        "why_relevant": "Reddit listing (arctic-shift)",
+        "metadata": {"post_id": pid},
+    }
+
+
+def fetch_listings(
+    subreddits: List[str],
+    depth: str = "default",
+    query: str = "",
+    sorts: Optional[List[str]] = None,
+    timeframe: str = "month",
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Scored subreddit listings from the arctic-shift archive, keyless.
+
+    Drop-in fallback for ``reddit_listing.fetch_listings`` (shreddit partials),
+    which datacenter IPs get HTTP 403 on. Arctic-shift serves recent posts with
+    real score/num_comments from any IP. ``sorts``/``timeframe`` are accepted
+    for signature parity and ignored — the archive has no top/hot/new lanes, so
+    the caller's engagement ranking does the sorting.
+
+    Best-effort, never raises: returns ``[]`` on any failure.
+    """
+    if not subreddits:
+        return []
+    n = limit or _LISTING_DEPTH_LIMITS.get(depth, _LISTING_DEPTH_LIMITS["default"])
+    out: List[Dict[str, Any]] = []
+    for i, sub in enumerate(subreddits[:_MAX_LISTING_SUBS]):
+        sub = sub.removeprefix("r/").strip()
+        if not sub or sub.lower() == "all":
+            continue
+        if i:
+            time.sleep(PACE_SECONDS)
+        try:
+            data = http.get(
+                f"{SEARCH_API}?subreddit={sub}&limit={n}&sort=desc",
+                headers={"User-Agent": http.BROWSER_USER_AGENT},
+                timeout=TIMEOUT,
+            )
+        except Exception as e:  # network error / non-200 — degrade, never raise
+            _log(f"listing search failed r/{sub}: {e}")
+            continue
+        rows = (data or {}).get("data")
+        if not isinstance(rows, list):
+            _log(f"unexpected listing response for r/{sub}: {str(data)[:80]}")
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            post = _normalize_listing_row(row, query)
+            if post["url"]:
+                out.append(post)
+
+    seen: set = set()
+    unique: List[Dict[str, Any]] = []
+    for p in out:
+        if p["url"] not in seen:
+            seen.add(p["url"])
+            unique.append(p)
+    return unique

--- a/skills/last30days/scripts/lib/reddit_keyless.py
+++ b/skills/last30days/scripts/lib/reddit_keyless.py
@@ -72,6 +72,31 @@ def _apply_scores(post: Dict[str, Any], scored: Dict[str, int]) -> None:
     post["engagement"]["num_comments"] = scored["num_comments"]
 
 
+def _scored_listings(
+    subreddits: List[str],
+    depth: str = "default",
+    query: str = "",
+    sorts: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Scored subreddit listings: shreddit partials, arctic-shift fallback.
+
+    The shreddit ``community-more-posts`` partials 403 from datacenter IPs
+    (and any host Reddit decides to block). When they return nothing, fall
+    back to the arctic-shift archive (keyless, IP-agnostic, real scores) so
+    discovery and score backfill keep working. Never raises.
+    """
+    posts = reddit_listing.fetch_listings(subreddits, depth=depth, query=query, sorts=sorts)
+    if not posts:
+        try:
+            posts = reddit_arctic.fetch_listings(subreddits, depth=depth, query=query, sorts=sorts)
+        except Exception as exc:  # the fallback must never break the pipeline
+            _log(f"arctic-shift listing fallback failed: {exc}")
+            posts = []
+        if posts:
+            _log(f"arctic-shift listing fallback: {len(posts)} posts")
+    return posts
+
+
 def _discover(
     topic: str,
     depth: str,
@@ -83,7 +108,7 @@ def _discover(
     # an on-topic post whose title lacks the entity name is never dropped.
     dedicated_posts: List[Dict[str, Any]] = []
     if dedicated_subreddits:
-        dedicated_posts = reddit_listing.fetch_listings(
+        dedicated_posts = _scored_listings(
             dedicated_subreddits, depth=depth, query=topic, sorts=DEDICATED_SORTS
         )
         for p in dedicated_posts:
@@ -98,7 +123,7 @@ def _discover(
     if subreddits:
         # Targeted run: the caller chose these subreddits, so their listing cards
         # are on-topic — include them as scored discovery AND as a score source.
-        listing_posts = reddit_listing.fetch_listings(subreddits, depth=depth, query=topic)
+        listing_posts = _scored_listings(subreddits, depth=depth, query=topic)
         score_source = listing_posts
     else:
         # Bare global run: subreddits derived from noisy RSS results are NOT
@@ -107,7 +132,7 @@ def _discover(
         # would flood results with high-upvote but irrelevant posts.
         listing_posts = []
         derived = _top_subreddits(rss_posts)
-        score_source = reddit_listing.fetch_listings(derived, depth=depth, query=topic)
+        score_source = _scored_listings(derived, depth=depth, query=topic)
     _log(
         f"Tier 1 (RSS) {len(rss_posts)} posts; "
         f"{'listing discovery ' + str(len(listing_posts)) if subreddits else 'score-only'}; "

--- a/skills/last30days/scripts/lib/reddit_listing.py
+++ b/skills/last30days/scripts/lib/reddit_listing.py
@@ -245,6 +245,17 @@ def fetch_discovery_listings(
             continue
         seen.add(item["url"])
         unique.append(item)
+    if not unique and errors:
+        # Shreddit partials are blocked for some hosts (datacenter IPs get
+        # HTTP 403 on /svc/shreddit). Fall back to the arctic-shift archive,
+        # which serves scored recent listings from any IP keyless.
+        from . import reddit_arctic
+        arctic_items = reddit_arctic.fetch_listings(
+            subreddits, depth=depth, query=query, sorts=("rising", "top")
+        )
+        if arctic_items:
+            _log(f"discovery arctic fallback: {len(arctic_items)} posts")
+            return {"items": arctic_items, "errors": []}
     return {"items": unique, "errors": errors}
 
 

--- a/tests/test_reddit_arctic.py
+++ b/tests/test_reddit_arctic.py
@@ -60,6 +60,80 @@ class TestFetchScores:
         assert g.call_count == 1
         assert set(out) == {"a", "b"}
 
+
+def _listing_row(pid="abc123", title="matcha farm tour", score=406, ncmt=88,
+                 created=1783000000, subreddit="tea", permalink="/r/tea/comments/abc123/x/"):
+    return {
+        "id": pid, "title": title, "score": score, "num_comments": ncmt,
+        "created_utc": created, "subreddit": subreddit,
+        "permalink": permalink, "author": "u", "selftext": "",
+    }
+
+
+class TestFetchListings:
+    """fetch_listings serves scored subreddit listings from the archive —
+    the keyless fallback for hosts where shreddit partials 403."""
+
+    def test_returns_normalized_scored_posts(self):
+        with mock.patch.object(
+            reddit_arctic.http, "get",
+            return_value=_resp([_listing_row()]),
+        ) as g:
+            out = reddit_arctic.fetch_listings(["tea"], query="matcha")
+        assert len(out) == 1
+        post = out[0]
+        assert post["title"] == "matcha farm tour"
+        assert post["score"] == 406
+        assert post["engagement"]["score"] == 406
+        assert post["num_comments"] == 88
+        assert post["subreddit"] == "tea"
+        assert post["metadata"]["post_id"] == "abc123"  # t3_ prefix stripped
+        assert post["date"] == "2026-07-02"  # created_utc -> YYYY-MM-DD
+        assert post["url"].startswith("https://www.reddit.com/r/tea/comments/")
+        assert post["why_relevant"] == "Reddit listing (arctic-shift)"
+        # one call per subreddit, recent-first, depth-default volume
+        assert "subreddit=tea" in g.call_args[0][0]
+        assert "limit=25" in g.call_args[0][0]
+
+    def test_strips_r_prefix_and_skips_all(self):
+        with mock.patch.object(reddit_arctic.http, "get",
+                               return_value=_resp([_listing_row(subreddit="tea")])) as g:
+            out = reddit_arctic.fetch_listings(["r/tea", "all", ""])
+        assert len(out) == 1
+        assert g.call_count == 1  # only r/tea fetched; "all"/"" skipped
+
+    def test_depth_controls_volume(self):
+        for depth, want in (("quick", 10), ("default", 25), ("deep", 50)):
+            with mock.patch.object(reddit_arctic.http, "get",
+                                   return_value=_resp([_listing_row()])) as g:
+                reddit_arctic.fetch_listings(["tea"], depth=depth)
+            assert f"limit={want}" in g.call_args[0][0], depth
+
+    def test_dedupes_by_url(self):
+        rows = [_listing_row(), _listing_row()]
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp(rows)):
+            out = reddit_arctic.fetch_listings(["tea"])
+        assert len(out) == 1
+
+    def test_network_error_degrades_to_empty(self):
+        with mock.patch.object(reddit_arctic.http, "get", side_effect=Exception("boom")):
+            assert reddit_arctic.fetch_listings(["tea"]) == []
+
+    def test_rate_limit_response_degrades_to_empty(self):
+        with mock.patch.object(reddit_arctic.http, "get",
+                               return_value={"error": "Timeout. Maybe slow down a bit"}):
+            assert reddit_arctic.fetch_listings(["tea"]) == []
+
+    def test_empty_subreddits_returns_empty(self):
+        assert reddit_arctic.fetch_listings([]) == []
+
+    def test_removed_author_normalized(self):
+        row = _listing_row()
+        row["author"] = "[deleted]"
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp([row])):
+            out = reddit_arctic.fetch_listings(["tea"])
+        assert out[0]["author"] == "[deleted]"
+
     def test_cache_is_size_bounded(self):
         # The in-run memo never grows past CACHE_MAX; scores are still returned
         # for the current call once the cache is full.

--- a/tests/test_reddit_keyless.py
+++ b/tests/test_reddit_keyless.py
@@ -33,6 +33,8 @@ class TestDiscovery:
         with mock.patch.object(reddit_keyless.reddit_rss, "search_rss",
                                return_value=[_post(1), _post(2)]) as rss, \
              mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings",
                                return_value=[]):
             out = reddit_keyless._discover("topic", "default", ["test"])
         assert len(out) == 2
@@ -253,3 +255,55 @@ class TestSlotPriority:
         with mock.patch("lib.rerank._primary_entity", side_effect=Exception("boom")):
             out = reddit_keyless._slot_priority("openclaw", posts)
         assert out == posts
+
+
+class TestScoredListingsFallback:
+    """_scored_listings falls back to the arctic-shift archive when the
+    shreddit listing partials return nothing (datacenter egress 403)."""
+
+    def test_arctic_fallback_when_shreddit_empty(self):
+        arctic_post = _scored(1, score=406)
+        with mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings",
+                               return_value=[arctic_post]) as arctic:
+            out = reddit_keyless._scored_listings(["tea"], depth="quick", query="matcha")
+        assert out == [arctic_post]
+        arctic.assert_called_once_with(["tea"], depth="quick", query="matcha", sorts=None)
+
+    def test_shreddit_results_skip_arctic(self):
+        shreddit_post = _scored(1, score=42)
+        with mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[shreddit_post]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings") as arctic:
+            out = reddit_keyless._scored_listings(["tea"], depth="quick", query="matcha")
+        assert out == [shreddit_post]
+        arctic.assert_not_called()
+
+    def test_both_empty_returns_empty(self):
+        with mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings",
+                               return_value=[]):
+            out = reddit_keyless._scored_listings(["tea"], depth="quick", query="matcha")
+        assert out == []
+
+    def test_never_raises_when_arctic_fails(self):
+        with mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings",
+                               side_effect=Exception("boom")):
+            out = reddit_keyless._scored_listings(["tea"], depth="quick", query="matcha")
+        assert out == []
+
+    def test_dedicated_sorts_passed_through(self):
+        with mock.patch.object(reddit_keyless.reddit_listing, "fetch_listings",
+                               return_value=[]), \
+             mock.patch.object(reddit_keyless.reddit_arctic, "fetch_listings",
+                               return_value=[]) as arctic:
+            reddit_keyless._scored_listings(
+                ["Kanye"], depth="default", query="Kanye", sorts=["top", "hot", "new"]
+            )
+        arctic.assert_called_once_with(
+            ["Kanye"], depth="default", query="Kanye", sorts=["top", "hot", "new"]
+        )

--- a/tests/test_reddit_listing.py
+++ b/tests/test_reddit_listing.py
@@ -83,3 +83,45 @@ class TestScoreIndex:
         first = next(iter(idx.values()))
         assert set(first.keys()) == {"score", "num_comments"}
         assert any(v["score"] == 52692 for v in idx.values())
+
+
+class TestFetchDiscoveryListingsFallback:
+    """fetch_discovery_listings falls back to arctic-shift when every shreddit
+    partial fails (datacenter egress 403), and clears the errors on success."""
+
+    def test_arctic_fallback_when_all_shreddit_feeds_fail(self):
+        arctic_post = {
+            "id": "", "title": "matcha farm tour", "url": "https://www.reddit.com/r/tea/comments/abc/x/",
+            "score": 406, "num_comments": 88, "subreddit": "tea", "created_utc": None,
+            "author": "u", "selftext": "", "date": "2026-07-02",
+            "engagement": {"score": 406, "num_comments": 88, "upvote_ratio": None},
+            "relevance": 0.5, "why_relevant": "Reddit listing (arctic-shift)",
+            "metadata": {"post_id": "abc"},
+        }
+        with mock.patch.object(rl.http, "get_text", return_value=None), \
+             mock.patch("lib.reddit_arctic.fetch_listings", return_value=[arctic_post]) as arctic:
+            result = rl.fetch_discovery_listings(["tea"], query="matcha", depth="quick")
+        assert result["items"] == [arctic_post]
+        assert result["errors"] == []  # recovered — no failure to report
+        arctic.assert_called_once()
+
+    def test_errors_preserved_when_arctic_also_empty(self):
+        with mock.patch.object(rl.http, "get_text", return_value=None), \
+             mock.patch("lib.reddit_arctic.fetch_listings", return_value=[]):
+            result = rl.fetch_discovery_listings(["tea"], query="matcha", depth="quick")
+        assert result["items"] == []
+        assert result["errors"]  # the shreddit failures still surface
+
+    def test_no_arctic_call_when_shreddit_succeeds(self):
+        with mock.patch.object(rl.http, "get_text", return_value=_html()), \
+             mock.patch("lib.reddit_arctic.fetch_listings") as arctic:
+            result = rl.fetch_discovery_listings(["technology"], query="netherlands", depth="quick")
+        assert result["items"]  # parsed shreddit cards
+        assert result["errors"] == []
+        arctic.assert_not_called()
+
+    def test_no_subreddits_skips_fallback(self):
+        with mock.patch("lib.reddit_arctic.fetch_listings") as arctic:
+            result = rl.fetch_discovery_listings([], query="matcha", depth="quick")
+        assert result == {"items": [], "errors": []}
+        arctic.assert_not_called()


### PR DESCRIPTION
## Summary

On datacenter egress, Reddit 403s the keyless `/svc/shreddit` listing partials and soft-blocks `search.rss` (HTTP 200 + empty body), so the keyless Reddit pipeline returned zero items and reported `auth-failed` on those hosts. This PR adds a fallback to the **arctic-shift archive** (https://arctic-shift.photon-reddit.com — public Reddit archive, keyless, IP-agnostic, already used for score backfill in `reddit_arctic.fetch_scores`) as the scored listing lane:

- `reddit_arctic.fetch_listings()` — new scored listing lane mirroring `reddit_listing`'s post schema (real `score`/`num_comments`, `YYYY-MM-DD` dates, dedupe, best-effort never-raises)
- `reddit_keyless._scored_listings()` — shreddit-first, arctic-shift fallback for the dedicated / listing / score-only lanes; fallback failure is caught so it can never break the pipeline
- `reddit_listing.fetch_discovery_listings()` — falls back to arctic when every shreddit partial fails, and clears the error bucket when the fallback recovers the source (keeps `--discover` mode honest)

Verified live on a VPS: `"matcha tea trends" --days=30 --search=reddit` went from 0 items / `auth-failed` to **5 threads, 205 upvotes, 266 comments** (r/tea, r/MatchaEverything), and `"ai agents"` across reddit+digg+arxiv+techmeme+hn+github returned all six sources clean.

## Testing

- [x] `uv run pytest` (full suite; coverage 88.41% vs the 84% gate — the one failure, `test_setup_wizard.py::TestWriteApiKey::test_unwritable_target_returns_false`, also fails on clean `main` here because the suite runs as root, which bypasses the test's read-only permission setup; unrelated to this change)
- [x] Added tests:
  - `test_reddit_arctic.py::TestFetchListings` — normalization, real scores, `t3_` strip, depth volume, dedupe, `r/`-prefix strip, rate-limit/network degradation, empty input
  - `test_reddit_keyless.py::TestScoredListingsFallback` — fallback fires on empty shreddit results, skipped when shreddit delivers, never raises, sorts pass-through
  - `test_reddit_listing.py::TestFetchDiscoveryListingsFallback` — recovery clears errors, errors preserved when arctic is also empty, no arctic call when shreddit succeeds
  - Updated `test_keyless_path_runs_rss_and_listings` to mock the fallback lane

## Changelog

- [x] Added `changelog.d/+reddit-arctic-listing-fallback.added.md`

## Agent disclosure

### AI review

Reviewed against the shreddit-lane semantics in #899/#900 (transport failures must surface when nothing is recovered): `fetch_discovery_listings` clears `errors` **only** when the arctic fallback actually returns items, so an unrecovered block still reaches the doctor. The fallback is best-effort and never raises in either module; `_scored_listings` additionally catches fallback exceptions so a broken arctic-shift can only degrade discovery, never crash the run. Arctic-shift rows are normalized to the exact `reddit_listing.parse_cards` schema so downstream dedupe/ranking/relevance paths are unchanged.

### Security

No new command execution or auth paths — one new HTTPS GET to a public read-only API the skill already calls (score backfill). No secrets involved. The arctic-shift endpoint is third-party infra; degradation behavior is covered by tests (`{"error": ...}` and network-failure cases return empty, never raise).

## Notes

Reddit's own endpoints remain blocked on such hosts (nothing this PR can change); arctic-shift listings are recency-sorted with real scores rather than top/hot/new lanes, so the caller's engagement ranking does the ordering (the fallback lane documents this). Comment-text enrichment via shreddit still degrades silently on blocked hosts — follow-up candidate for an arctic-shift comments lane.

### Relationship to this change

- [x] None

## Related issues

Companion to `fix/source-outcome-swallowed-lane-failures` (outcome honesty when lanes 403 while items are delivered).
