### PR TITLE
feat(reddit): arctic-shift fallback for shreddit comment enrichment

### DIFF
--- a/changelog.d/+reddit-arctic-comments-fallback.added.md
+++ b/changelog.d/+reddit-arctic-comments-fallback.added.md
@@ -1,0 +1,1 @@
+Reddit comment enrichment now falls back to the arctic-shift archive when the shreddit comment partials return nothing — hosts on datacenter egress (where Reddit 403s `/svc/shreddit`) keep top-comment text (ranked by score) instead of silently degrading to counts only.

--- a/skills/last30days/scripts/lib/reddit_arctic.py
+++ b/skills/last30days/scripts/lib/reddit_arctic.py
@@ -16,16 +16,21 @@ count rather than failing the Reddit source.
 
 import sys
 import time
-from typing import Dict, List
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 from . import http
 
 API = "https://arctic-shift.photon-reddit.com/api/posts/ids"
+COMMENTS_API = "https://arctic-shift.photon-reddit.com/api/comments/search"
 BATCH = 50          # ids per request
 TIMEOUT = 15
 MAX_BATCHES = 3     # cap total requests per run (bounds latency + rate-limit risk)
 PACE_SECONDS = 0.4  # gap between batches; arctic-shift answers 422 "slow down"
 CACHE_MAX = 4096    # hard size bound so the in-run memo can never grow unbounded
+# Comment fallback: fetch a wide recency slice, then rank by score client-side
+# (the archive's sort_type only supports created_utc).
+MAX_COMMENT_ROWS = 100
 # In-run memo: base36 id -> {score, num_comments}. Module-level so repeated
 # fetch_scores calls within one `/last30days` run (e.g. across subqueries) reuse
 # results, but capped at CACHE_MAX entries (never reached in a normal CLI run).
@@ -90,3 +95,63 @@ def fetch_scores(post_ids: List[str]) -> Dict[str, Dict[str, int]]:
                 _cache[rid] = entry
             out[rid] = entry
     return out
+
+
+def _comment_date(value: Any) -> Optional[str]:
+    """Epoch seconds -> YYYY-MM-DD (UTC), or None on garbage."""
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).date().isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def fetch_post_comments(post_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+    """Top comments for a post from the arctic-shift archive, keyless.
+
+    Drop-in fallback for ``reddit_shreddit.parse_comments`` output on hosts
+    where the shreddit comment partials 403 (datacenter egress). Rows carry
+    the same dict shape (score/author/body/excerpt/permalink/date/url), are
+    ranked by score desc, and capped at ``limit``. Best-effort, never raises:
+    returns ``[]`` on any failure so the caller keeps whatever it had.
+    """
+    pid = str(post_id or "").removeprefix("t3_")
+    if not pid:
+        return []
+    try:
+        data = http.get(
+            f"{COMMENTS_API}?link_id=t3_{pid}&limit={MAX_COMMENT_ROWS}&sort=desc",
+            headers={"User-Agent": http.BROWSER_USER_AGENT},
+            timeout=TIMEOUT,
+        )
+    except Exception as e:  # network error / non-200 — degrade, never raise
+        _log(f"comments lookup failed t3_{pid}: {e}")
+        return []
+    rows = (data or {}).get("data")
+    if not isinstance(rows, list):
+        _log(f"unexpected comments response for t3_{pid}: {str(data)[:80]}")
+        return []
+
+    comments: List[Dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        author = row.get("author") or "[deleted]"
+        body = row.get("body") or ""
+        if author in ("[deleted]", "[removed]") or body in ("[deleted]", "[removed]"):
+            continue
+        try:
+            score = int(row.get("score") or 0)
+        except (TypeError, ValueError):
+            score = 0
+        permalink = row.get("permalink") or ""
+        comments.append({
+            "score": score,
+            "author": author,
+            "body": body[:300],
+            "excerpt": body[:200],
+            "permalink": permalink,
+            "date": _comment_date(row.get("created_utc")),
+            "url": f"https://reddit.com{permalink}" if permalink else "",
+        })
+    comments.sort(key=lambda c: c.get("score", 0), reverse=True)
+    return comments[:limit]

--- a/skills/last30days/scripts/lib/reddit_shreddit.py
+++ b/skills/last30days/scripts/lib/reddit_shreddit.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from . import http
+from . import reddit_arctic
 from . import reddit_enrich
 
 # Up to N posts enriched per run, by depth (mirrors reddit_public.ENRICH_LIMITS).
@@ -163,10 +164,20 @@ def fetch_comments(
     sub, post_id = ref
 
     html_text = http.reddit_keyless_get_text(_svc_url(sub, post_id), timeout=timeout, accept="text/html")
-    if not html_text:
+    comments = parse_comments(html_text, limit=MAX_COMMENTS) if html_text else []
+    total = _total_comments(html_text) if html_text else None
+    if not comments:
+        # The shreddit comment partials 403 on some hosts (datacenter egress).
+        # Fall back to the arctic-shift archive, which serves scored comments
+        # from any IP keyless (ranked by score client-side).
+        try:
+            comments = reddit_arctic.fetch_post_comments(post_id, limit=MAX_COMMENTS)
+        except Exception as exc:  # the fallback must never break enrichment
+            _log(f"arctic comment fallback failed: {exc}")
+            comments = []
+    if not comments:
         return {"top_comments": [], "comment_insights": [], "num_comments": None}
 
-    comments = parse_comments(html_text, limit=MAX_COMMENTS)
     insights = reddit_enrich.extract_comment_insights(comments)
     return {
         "top_comments": [
@@ -180,5 +191,5 @@ def fetch_comments(
             for c in comments
         ],
         "comment_insights": insights,
-        "num_comments": _total_comments(html_text),
+        "num_comments": total,
     }

--- a/tests/test_reddit_arctic.py
+++ b/tests/test_reddit_arctic.py
@@ -85,3 +85,64 @@ class TestFetchScores:
         with mock.patch.object(reddit_arctic.http, "get", return_value=_resp(rows)):
             out = reddit_arctic.fetch_scores(["ok", "bad"])
         assert out == {"ok": {"score": 7, "num_comments": 3}}
+
+
+def _comment_row(pid="mjwb1hg", author="u", body="great thread", score=42,
+                 created=1783000000, permalink="/r/tea/comments/abc123/x/mjwb1hg/"):
+    return {
+        "id": pid, "author": author, "body": body, "score": score,
+        "created_utc": created, "permalink": permalink, "link_id": "t3_abc123",
+    }
+
+
+class TestFetchPostComments:
+    """fetch_post_comments serves a post's top comments from the archive —
+    the keyless fallback for hosts where the shreddit comment partials 403."""
+
+    def test_returns_normalized_comments_sorted_desc(self):
+        rows = [_comment_row(score=1), _comment_row(score=99), _comment_row(score=42)]
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp(rows)) as g:
+            out = reddit_arctic.fetch_post_comments("abc123", limit=10)
+        assert [c["score"] for c in out] == [99, 42, 1]
+        first = out[0]
+        assert first["author"] == "u"
+        assert first["body"] == "great thread"
+        assert first["excerpt"] == "great thread"
+        assert first["date"] == "2026-07-02"
+        assert first["url"] == "https://reddit.com/r/tea/comments/abc123/x/mjwb1hg/"
+        # link_id uses the t3_ prefix; wide recency slice, ranked client-side
+        assert "link_id=t3_abc123" in g.call_args[0][0]
+        assert f"limit={reddit_arctic.MAX_COMMENT_ROWS}" in g.call_args[0][0]
+
+    def test_strips_t3_prefix_from_post_id(self):
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp([_comment_row()])) as g:
+            reddit_arctic.fetch_post_comments("t3_abc123")
+        assert "link_id=t3_abc123" in g.call_args[0][0]
+
+    def test_limit_capped(self):
+        rows = [_comment_row(score=i) for i in range(5)]
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp(rows)):
+            out = reddit_arctic.fetch_post_comments("abc123", limit=2)
+        assert len(out) == 2
+
+    def test_deleted_and_removed_filtered(self):
+        rows = [_comment_row(author="[deleted]"), _comment_row(body="[removed]"),
+                _comment_row(score=7)]
+        with mock.patch.object(reddit_arctic.http, "get", return_value=_resp(rows)):
+            out = reddit_arctic.fetch_post_comments("abc123")
+        assert len(out) == 1 and out[0]["score"] == 7
+
+    def test_network_error_degrades_to_empty(self):
+        with mock.patch.object(reddit_arctic.http, "get", side_effect=Exception("boom")):
+            assert reddit_arctic.fetch_post_comments("abc123") == []
+
+    def test_rate_limit_response_degrades_to_empty(self):
+        with mock.patch.object(reddit_arctic.http, "get",
+                               return_value={"error": "Timeout. Maybe slow down a bit"}):
+            assert reddit_arctic.fetch_post_comments("abc123") == []
+
+    def test_empty_post_id_returns_empty(self):
+        with mock.patch.object(reddit_arctic.http, "get") as g:
+            assert reddit_arctic.fetch_post_comments("") == []
+            assert reddit_arctic.fetch_post_comments(None) == []
+        g.assert_not_called()

--- a/tests/test_reddit_shreddit.py
+++ b/tests/test_reddit_shreddit.py
@@ -98,6 +98,56 @@ class TestFetchComments:
 
     def test_fetch_failure_returns_empty(self):
         url = "https://www.reddit.com/r/Rakuten/comments/1taeiw0/title/"
-        with mock.patch.object(rs.http, "get_text", return_value=None):
+        with mock.patch.object(rs.http, "get_text", return_value=None), \
+             mock.patch.object(rs.reddit_arctic, "fetch_post_comments", return_value=[]):
             out = rs.fetch_comments(url)
+        assert out["top_comments"] == [] and out["num_comments"] is None
+
+
+class TestFetchCommentsFallback:
+    """fetch_comments falls back to the arctic-shift archive when the shreddit
+    comment partials return nothing (datacenter egress 403)."""
+
+    URL = "https://www.reddit.com/r/Rakuten/comments/1taeiw0/title/"
+
+    def _arctic_comment(self, score=10, body="great thread", author="u"):
+        return {
+            "score": score, "date": "2026-07-02", "author": author,
+            "body": body, "excerpt": body[:200], "permalink": "/r/Rakuten/comments/1taeiw0/x/",
+            "url": "https://reddit.com/r/Rakuten/comments/1taeiw0/x/",
+        }
+
+    def test_arctic_fallback_when_shreddit_empty(self):
+        comments = [self._arctic_comment(score=42)]
+        with mock.patch.object(rs.http, "get_text", return_value=None), \
+             mock.patch.object(rs.reddit_arctic, "fetch_post_comments",
+                               return_value=comments) as arctic:
+            out = rs.fetch_comments(self.URL)
+        assert out["top_comments"] == [{
+            "score": 42, "date": "2026-07-02", "author": "u",
+            "excerpt": "great thread", "url": "https://reddit.com/r/Rakuten/comments/1taeiw0/x/",
+        }]
+        assert out["comment_insights"] == [] or isinstance(out["comment_insights"], list)
+        assert out["num_comments"] is None  # archive rows carry no post total
+        arctic.assert_called_once_with("1taeiw0", limit=rs.MAX_COMMENTS)
+
+    def test_shreddit_results_skip_arctic(self):
+        with mock.patch.object(rs.http, "get_text", return_value=_html()), \
+             mock.patch.object(rs.reddit_arctic, "fetch_post_comments") as arctic:
+            out = rs.fetch_comments(self.URL)
+        assert out["top_comments"]  # shreddit parse results
+        assert out["num_comments"] == 14
+        arctic.assert_not_called()
+
+    def test_both_empty_returns_empty(self):
+        with mock.patch.object(rs.http, "get_text", return_value=None), \
+             mock.patch.object(rs.reddit_arctic, "fetch_post_comments", return_value=[]):
+            out = rs.fetch_comments(self.URL)
+        assert out["top_comments"] == [] and out["num_comments"] is None
+
+    def test_never_raises_when_arctic_fails(self):
+        with mock.patch.object(rs.http, "get_text", return_value=None), \
+             mock.patch.object(rs.reddit_arctic, "fetch_post_comments",
+                               side_effect=Exception("boom")):
+            out = rs.fetch_comments(self.URL)
         assert out["top_comments"] == [] and out["num_comments"] is None


### PR DESCRIPTION
## Summary

On datacenter egress, Reddit 403s the keyless `/svc/shreddit/comments` partials, so comment enrichment silently degraded to counts only — briefs carried upvote/comment *counts* but no comment *text*. This PR adds a fallback to the **arctic-shift archive** (`/api/comments/search`, keyless, IP-agnostic — same archive as the existing score backfill):

- `reddit_arctic.fetch_post_comments()` — a post's comments normalized to `reddit_shreddit.parse_comments` shape (score/author/body/excerpt/permalink/date/url), ranked by score client-side (the archive's `sort_type` only supports `created_utc`), best-effort never-raises
- `reddit_shreddit.fetch_comments()` — falls back to arctic when the shreddit partial returns nothing; the fallback call is guarded so enrichment can never break. `num_comments` stays `None` on the fallback (archive rows carry no post total — discovery already holds the count)

Verified live from a datacenter host: `fetch_comments` on a blocked post now returns 10 top comments (scores 133/56/46…) with comment insights.

## Testing

- [x] `uv run pytest` (full suite; coverage 88.40% vs the 84% gate — the one failure, `test_setup_wizard.py::TestWriteApiKey::test_unwritable_target_returns_false`, also fails on clean `main` here because the suite runs as root, which bypasses the test's read-only permission setup; unrelated to this change)
- [x] Added tests:
  - `test_reddit_arctic.py::TestFetchPostComments` — normalization, score-desc ranking, `t3_` prefix handling, limit cap, deleted/removed filtering, rate-limit/network degradation, empty input
  - `test_reddit_shreddit.py::TestFetchCommentsFallback` — fallback fires on empty shreddit result, skipped when shreddit delivers, both-empty returns empty, never raises
  - Updated `test_fetch_failure_returns_empty` to mock the fallback lane

## Changelog

- [x] Added `changelog.d/+reddit-arctic-comments-fallback.added.md`

## Agent disclosure

### AI review

Mirrors the review done for the listing-lane fallback (PR #960): the fallback only engages when the shreddit partial yields nothing; `comment_insights` extraction runs on the normalized rows so the renderer contract (`top_comments`/`comment_insights` shape) is unchanged; `num_comments` degradation to `None` matches the existing "never raises, caller falls through" contract (`_enrich_one` in `reddit_keyless` only sets a comment count when non-None). Both new paths are covered by mocked-network tests and one live verification run.

### Security

No new command execution or auth paths — one new HTTPS GET to the same public read-only archive the skill already calls (score backfill). No secrets involved. Degradation on `{"error": ...}` / network failure returns empty, never raises.

## Notes

Comment rows are snapshots from the archive (slightly stale vs live, same caveat as the score backfill). Sorting is client-side by score over a 100-row recency slice. If the shreddit comment partials come back for a host, behavior is unchanged (shreddit first, arctic only as fallback).

### Relationship to this change

- [x] None

## Related issues

Companion to `feat/reddit-arctic-listing-fallback` (#960) — together they restore full keyless Reddit (discovery, scores, and comments) on datacenter-egress hosts.
