### PR TITLE
fix(doctor): retry rate-limited probes instead of reporting a false outage

### DIFF
--- a/changelog.d/+doctor-transient-probe.fixed.md
+++ b/changelog.d/+doctor-transient-probe.fixed.md
@@ -1,0 +1,1 @@
+`doctor` no longer reports a rate-limited source as an outage. A probe refused with HTTP 429 is retried once and, if still refused, shown as unverified instead of `NOT WORKING`. Reddit was the visible case: a burst of keyless probes draws a 429 while the research lane, which retries with backoff, serves the same query fine. HTTP 403 still counts as a hard failure.

--- a/skills/last30days/scripts/lib/doctor.py
+++ b/skills/last30days/scripts/lib/doctor.py
@@ -48,6 +48,7 @@ import json
 import os
 import shutil
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -139,7 +140,14 @@ def audit_state(
             return AUDIT_UNVERIFIED
         return AUDIT_NOT_WORKING
     if probe_result is not None:
-        return AUDIT_WORKING if probe_result.get("ok") else AUDIT_NOT_WORKING
+        if probe_result.get("ok"):
+            return AUDIT_WORKING
+        # A transient refusal (host rate-limited THIS probe) is not evidence the
+        # source is broken: the lane retries with backoff and serves fine. Report
+        # it as unverified instead of claiming a working source is down.
+        if probe_result.get("transient"):
+            return AUDIT_UNVERIFIED
+        return AUDIT_NOT_WORKING
     if name in KEYLESS_ALWAYS_ON:
         return AUDIT_WORKING
     return AUDIT_UNVERIFIED
@@ -1484,6 +1492,18 @@ _HTTP_PROBE_URLS = {
 # refusing this client — the exact failure the engine hits — not reachability.
 _PROBE_BLOCKED_STATUSES = {"reddit": frozenset({403, 429})}
 
+# Blocked statuses that mean "refused this probe right now", not "the source is
+# down". Reddit answers a burst of keyless probes with 429 while the research
+# lane — which retries with backoff across several endpoints — serves the same
+# query fine. A single unretried 429 was reporting a healthy Reddit as NOT
+# WORKING, so these get one retry and, if still refused, downgrade to unverified
+# rather than a false outage. 403 stays hard: that is a real keyless block.
+_PROBE_TRANSIENT_STATUSES = {"reddit": frozenset({429})}
+
+# One retry only: the probe budget is the per-source deadline, and a source that
+# rate-limits twice in a row is worth surfacing as unverified.
+_PROBE_RETRY_DELAY_SECONDS = 2.0
+
 # Probe with the identity the lane sends, or the probe measures the User-Agent
 # rather than the endpoint (get_text sends http.BROWSER_USER_AGENT).
 _PROBE_HEADERS = {
@@ -1549,15 +1569,34 @@ def _http_ok(
         return False, f"{type(exc).__name__}: {exc}"
 
 
+def _transient_probe_detail(name: str, detail: str) -> bool:
+    """True when ``detail`` is a status this source may refuse us transiently.
+
+    ``_http_ok`` renders its verdict as ``HTTP {code}``; both live in this module,
+    so matching that shape here keeps the retry rule next to the codes it covers.
+    """
+    transient = _PROBE_TRANSIENT_STATUSES.get(name)
+    if not transient:
+        return False
+    return any(detail == f"HTTP {code}" for code in transient)
+
+
 def _probe_source(name: str, config: Dict[str, Any], timeout: float) -> Optional[Dict[str, Any]]:
     url = _HTTP_PROBE_URLS.get(name)
     if url:
-        ok, detail = _http_ok(
-            url,
-            timeout,
-            blocked_statuses=_PROBE_BLOCKED_STATUSES.get(name, frozenset()),
-            headers=_PROBE_HEADERS.get(name),
-        )
+        blocked = _PROBE_BLOCKED_STATUSES.get(name, frozenset())
+        headers = _PROBE_HEADERS.get(name)
+        ok, detail = _http_ok(url, timeout, blocked_statuses=blocked, headers=headers)
+        if not ok and _transient_probe_detail(name, detail):
+            time.sleep(_PROBE_RETRY_DELAY_SECONDS)
+            ok, detail = _http_ok(url, timeout, blocked_statuses=blocked, headers=headers)
+            if not ok and _transient_probe_detail(name, detail):
+                return {
+                    "ok": False,
+                    "transient": True,
+                    "detail": f"{detail} (rate-limited twice; the lane retries with backoff)",
+                    "probed": True,
+                }
         return {"ok": ok, "detail": detail, "probed": True}
     cli = CLI_DEPENDENCIES.get(name)
     if cli:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -868,6 +868,17 @@ class FourStateAudit(unittest.TestCase):
             doctor.audit_state("tiktok", rec, None, {"ok": False}),
         )
 
+    def test_transient_probe_failure_is_unverified_not_broken(self):
+        # A source that rate-limited the probe is unknown, not down. Calling it
+        # NOT WORKING sends people debugging a source that serves fine.
+        rec = {"tier": "ok", "status": "ok"}
+        self.assertEqual(
+            doctor.AUDIT_UNVERIFIED,
+            doctor.audit_state(
+                "reddit", rec, None, {"ok": False, "transient": True}
+            ),
+        )
+
     def test_render_json_keeps_legacy_keys_and_adds_audit(self):
         report = _build({})
         for name, rec in report["sources"].items():
@@ -971,8 +982,10 @@ class LiveProbe(unittest.TestCase):
         error = urllib.error.HTTPError(
             doctor._HTTP_PROBE_URLS["reddit"], code, "Blocked", {}, None
         )
-        with mock.patch(
-            "lib.doctor.urllib.request.urlopen", side_effect=error
+        with (
+            mock.patch("lib.doctor.urllib.request.urlopen", side_effect=error),
+            # 429 buys a retry; don't pay the real backoff in the suite.
+            mock.patch("lib.doctor.time.sleep"),
         ):
             return doctor._probe_source("reddit", {}, 5)
 
@@ -985,6 +998,64 @@ class LiveProbe(unittest.TestCase):
         res = self._probe_reddit_with_status(429)
         self.assertFalse(res["ok"])
         self.assertIn("429", res["detail"])
+
+    def test_reddit_probe_429_is_retried_once(self):
+        # A single keyless probe draws a 429 during a burst while the lane —
+        # which retries with backoff — serves the same query fine. Give the
+        # probe that same second chance before it accuses a working source.
+        with (
+            mock.patch(
+                "lib.doctor._http_ok", return_value=(False, "HTTP 429")
+            ) as http_ok,
+            mock.patch("lib.doctor.time.sleep") as sleep,
+        ):
+            res = doctor._probe_source("reddit", {}, 5)
+        self.assertEqual(2, http_ok.call_count)
+        sleep.assert_called_once_with(doctor._PROBE_RETRY_DELAY_SECONDS)
+        self.assertTrue(res["transient"])
+        self.assertIn("429", res["detail"])
+
+    def test_reddit_probe_429_then_ok_is_reachable(self):
+        # The retry is the whole point: a probe that lands on the second
+        # attempt reports plain success, with no transient residue.
+        with (
+            mock.patch(
+                "lib.doctor._http_ok",
+                side_effect=[(False, "HTTP 429"), (True, "HTTP 200")],
+            ),
+            mock.patch("lib.doctor.time.sleep"),
+        ):
+            res = doctor._probe_source("reddit", {}, 5)
+        self.assertTrue(res["ok"])
+        self.assertNotIn("transient", res)
+
+    def test_reddit_probe_403_is_not_retried(self):
+        # 403 is the standing keyless block, not a burst. Retrying it only
+        # doubles the wait before reporting a real outage.
+        with (
+            mock.patch(
+                "lib.doctor._http_ok", return_value=(False, "HTTP 403")
+            ) as http_ok,
+            mock.patch("lib.doctor.time.sleep") as sleep,
+        ):
+            res = doctor._probe_source("reddit", {}, 5)
+        self.assertEqual(1, http_ok.call_count)
+        sleep.assert_not_called()
+        self.assertFalse(res.get("transient", False))
+
+    def test_transient_retry_is_per_source(self):
+        # Like the blocked-status carve-out above, the retry is scoped to the
+        # source that actually rate-limits us.
+        with (
+            mock.patch(
+                "lib.doctor._http_ok", return_value=(False, "HTTP 429")
+            ) as http_ok,
+            mock.patch("lib.doctor.time.sleep") as sleep,
+        ):
+            res = doctor._probe_source("hackernews", {}, 5)
+        self.assertEqual(1, http_ok.call_count)
+        sleep.assert_not_called()
+        self.assertFalse(res.get("transient", False))
 
     def test_non_reddit_probe_keeps_4xx_as_reachable(self):
         # The blocked-status carve-out is per-source: a 4xx elsewhere still


### PR DESCRIPTION
## Summary

`doctor` reported Reddit as `✕ NOT WORKING` while Reddit was serving research runs fine in the same session. The probe had been refused with HTTP 429, and `_PROBE_BLOCKED_STATUSES` treats a blocked status as permanent. This retries a rate-limited probe once and, if it is still refused, reports it as **unverified** instead of a false outage. 403 stays a hard failure — that is the standing keyless block, not a burst.

The asymmetry is the bug: the research lane already retries with backoff across several endpoints, so it rides out the very 429 that a single unretried probe was treating as death. The health check was stricter than the thing it was checking, and it pointed users at a source that had nothing wrong with it.

## Testing

- [x] `uv run pytest` — 3602 passed, 6 skipped, 48 subtests passed
- [x] Added or updated tests that would catch a regression

Five new tests in `tests/test_doctor.py`: the retry fires exactly once and sleeps the declared backoff; a probe that lands on the second attempt reports plain success with no transient residue; 403 is not retried; the carve-out is scoped per source; and `audit_state` maps a transient probe failure to unverified rather than not-working. All five fail against `main` and pass with the fix.

## Changelog

- [x] Added `changelog.d/+doctor-transient-probe.fixed.md` (`fixed`)
- [ ] Skip changelog

## Agent disclosure

### AI review

Written and reviewed by a coding agent (Claude). Risks checked:

- **Could the retry mask a genuine outage?** It is bounded to one retry, and a source that refuses twice is surfaced as *unverified*, not as working. The fix trades a false negative for an honest "unknown", never for a false positive.
- **Could 403 get swept into the same bucket?** It is excluded explicitly and covered by a test asserting no retry and no transient flag.
- **Could the carve-out leak to other sources?** It is keyed per source, mirroring the existing `_PROBE_BLOCKED_STATUSES` structure, with a test pinning that scope.
- **Probe budget.** One extra 2s sleep, only on the failing path of a source that is already rate-limiting us.

The review also flagged that the new `time.sleep` would slow the existing `test_reddit_probe_429_is_not_reachable` by the full backoff. The shared test helper now patches `time.sleep`, so suite runtime is unchanged.

### Security

N/A. No input handling, command execution, path handling, auth, secrets, or dependency changes. The diff adds a stdlib `time` import, two module-level constants, and a retry branch inside an existing probe.

## Notes

Found while debugging a real run: `doctor` called Reddit down in a session where Reddit had just returned results. Reported as unverified, the same state reads honestly.

### Relationship to this change

- [x] None

## Related issues

N/A
