### PR TITLE
Add consent-gated Windows MCP host controls

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -94,6 +94,15 @@ Re-run onboarding by deleting `~/.config/last30days/.env`. The mechanical work l
 
 ---
 
+## MCP host controls
+
+These variables configure the local Go MCP server and are read from its process environment, not from the engine's `.env` files:
+
+| Env var | Default | Accepted values | Behavior and precedence |
+|---|---|---|---|
+| `LAST30DAYS_PYTHON` | unset | An executable name or path | Selects the Python 3.12+ interpreter used by the MCP server. A caller-supplied `RunOptions.PythonPath` remains the test/caller override; otherwise this variable must resolve to an executable. When it is unset, the server looks up `python3` on `PATH`. An empty or unresolvable value is an error rather than a fallback. |
+| `LAST30DAYS_MCP_ALLOW_BROWSER_COOKIES` | unset (deny) | `1`, `true`, `yes`, or `on`, case-insensitive | A recognized truthy value removes the MCP layer's default `--no-browser-cookies` flag. Every other value keeps that denial. This switch grants no consent by itself: browser-cookie access still requires the engine's separately recorded consent and `FROM_BROWSER` configuration. |
+
 ## API keys (`.env`)
 
 The skill reads keys from a `.env` file. Two locations are supported:

--- a/changelog.d/+windows-mcp-host-controls.added.md
+++ b/changelog.d/+windows-mcp-host-controls.added.md
@@ -1,0 +1,1 @@
+The local MCP server can now use an explicit `LAST30DAYS_PYTHON` interpreter and a default-deny, consent-gated `LAST30DAYS_MCP_ALLOW_BROWSER_COOKIES` switch, enabling reproducible Windows Claude Desktop deployments without weakening the existing cookie-access default.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -29,7 +29,9 @@ The output `.mcpb` lands at `build/last30days-pp-mcp-<os>-<arch>.mcpb`. Drag it 
 
 ## Runtime requirements
 
-End users need Python 3.12+ on PATH. The bundle ships the engine source but relies on the host interpreter.
+End users need Python 3.12+. The bundle ships the engine source but relies on the host interpreter and does not install Python. By default the server looks up `python3` on `PATH`; set `LAST30DAYS_PYTHON` to an explicit Python executable when the default lookup is not suitable.
+
+MCP research denies browser-cookie access by default by passing `--no-browser-cookies`. Set `LAST30DAYS_MCP_ALLOW_BROWSER_COOKIES` to `1`, `true`, `yes`, or `on` (case-insensitive) to remove that MCP-layer denial. Empty, false, unset, and unrecognized values keep the denial in place. Enabling this variable does not create consent: browser-cookie use still requires the engine's separately recorded consent and configuration.
 
 ## Versioning
 

--- a/mcp/internal/engine/run.go
+++ b/mcp/internal/engine/run.go
@@ -36,11 +36,15 @@ const DefaultTimeout = 5 * time.Minute
 // (seconds, integer). Honored by Run when RunOptions.Timeout is zero.
 const TimeoutEnvOverride = "LAST30DAYS_MCP_TIMEOUT"
 
+// PythonEnvOverride lets operators select the Python 3.12+ executable used
+// by the MCP server. When unset, Run preserves the python3 PATH lookup.
+const PythonEnvOverride = "LAST30DAYS_PYTHON"
+
 // RunOptions configures one invocation of the embedded Python engine.
 // PythonPath is exposed so tests can substitute a stub interpreter without
 // manipulating the process PATH.
 type RunOptions struct {
-	PythonPath string        // resolved python3 binary; empty means look up DefaultPythonBinary on PATH
+	PythonPath string        // resolved test/caller override; empty honors PythonEnvOverride, then DefaultPythonBinary
 	CacheDir   string        // engine.Ensure result; lib/ here is added to PYTHONPATH
 	Args       []string      // arguments after last30days.py (topic, --emit=..., etc.)
 	ExtraEnv   []string      // appended to os.Environ() for the child process
@@ -113,12 +117,29 @@ func Run(ctx context.Context, opts RunOptions) (*RunResult, error) {
 	return res, fmt.Errorf("engine: subprocess failed to start: %w", err)
 }
 
-// resolvePython returns an absolute path to the interpreter or an error
-// naming the install URL. If the caller supplied a path we trust it - tests
-// rely on this to inject a stub. Otherwise we look up python3 on PATH.
+// resolvePython returns a resolved interpreter path or a clear error. A
+// caller-supplied path remains the highest-priority test seam. Otherwise an
+// explicitly configured LAST30DAYS_PYTHON must resolve successfully; only
+// an absent override falls back to the existing python3 PATH lookup.
 func resolvePython(override string) (string, error) {
 	if override != "" {
 		return override, nil
+	}
+	if configured, ok := os.LookupEnv(PythonEnvOverride); ok {
+		if configured == "" {
+			return "", fmt.Errorf(
+				"engine: %s is set but empty; set it to a Python %s+ executable or unset it to use %s on PATH",
+				PythonEnvOverride, MinPythonVersion, DefaultPythonBinary,
+			)
+		}
+		path, err := exec.LookPath(configured)
+		if err != nil {
+			return "", fmt.Errorf(
+				"engine: %s=%q does not resolve to an executable (need Python %s+, install from %s): %w",
+				PythonEnvOverride, configured, MinPythonVersion, PythonInstallURL, err,
+			)
+		}
+		return path, nil
 	}
 	path, err := exec.LookPath(DefaultPythonBinary)
 	if err == nil {

--- a/mcp/internal/engine/run_test.go
+++ b/mcp/internal/engine/run_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -220,10 +221,100 @@ func TestRunTimesOut(t *testing.T) {
 	}
 }
 
+func TestResolvePythonHonorsEnvOverride(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	t.Setenv(PythonEnvOverride, executable)
+	t.Setenv("PATH", "")
+
+	got, err := resolvePython("")
+	if err != nil {
+		t.Fatalf("resolvePython: %v", err)
+	}
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat resolved path %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(executable)
+	if err != nil {
+		t.Fatalf("stat override path %q: %v", executable, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("resolvePython = %q, want executable %q", got, executable)
+	}
+}
+
+func TestResolvePythonRejectsInvalidEnvOverride(t *testing.T) {
+	t.Run("missing path", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing-python")
+		t.Setenv(PythonEnvOverride, missing)
+
+		_, err := resolvePython("")
+		if err == nil {
+			t.Fatal("expected invalid override error")
+		}
+		if !strings.Contains(err.Error(), PythonEnvOverride) || !strings.Contains(err.Error(), strconv.Quote(missing)) {
+			t.Fatalf("error %q does not identify invalid %s path %q", err, PythonEnvOverride, missing)
+		}
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		t.Setenv(PythonEnvOverride, "")
+
+		_, err := resolvePython("")
+		if err == nil {
+			t.Fatal("expected empty override error")
+		}
+		if !strings.Contains(err.Error(), PythonEnvOverride) || !strings.Contains(err.Error(), "set but empty") {
+			t.Fatalf("error %q does not clearly identify the empty override", err)
+		}
+	})
+}
+
+func TestResolvePythonDefaultsToPython3Lookup(t *testing.T) {
+	dir := t.TempDir()
+	name := DefaultPythonBinary
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+		t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+	}
+	candidate := filepath.Join(dir, name)
+	if err := os.WriteFile(candidate, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write default python stub: %v", err)
+	}
+	t.Setenv(PythonEnvOverride, "temporarily-set-for-cleanup")
+	if err := os.Unsetenv(PythonEnvOverride); err != nil {
+		t.Fatalf("unset %s: %v", PythonEnvOverride, err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := resolvePython("")
+	if err != nil {
+		t.Fatalf("resolvePython: %v", err)
+	}
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat resolved path %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(candidate)
+	if err != nil {
+		t.Fatalf("stat default stub %q: %v", candidate, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("resolvePython = %q, want python3 lookup result %q", got, candidate)
+	}
+}
+
 func TestRunMissingPython(t *testing.T) {
 	cache := stageCache(t)
 	// Empty PATH guarantees the lookup fails. PythonPath stays unset so Run
 	// falls through to exec.LookPath.
+	t.Setenv(PythonEnvOverride, "temporarily-set-for-cleanup")
+	if err := os.Unsetenv(PythonEnvOverride); err != nil {
+		t.Fatalf("unset %s: %v", PythonEnvOverride, err)
+	}
 	t.Setenv("PATH", "")
 
 	_, err := Run(context.Background(), RunOptions{CacheDir: cache})

--- a/mcp/internal/tools/research.go
+++ b/mcp/internal/tools/research.go
@@ -20,6 +20,11 @@ type Config struct {
 	Version string
 }
 
+// BrowserCookiesEnvOverride is an explicit MCP-layer opt-in. It only removes
+// the default-deny CLI flag; the engine still enforces its own recorded
+// browser-cookie consent and configuration.
+const BrowserCookiesEnvOverride = "LAST30DAYS_MCP_ALLOW_BROWSER_COOKIES"
+
 // Register adds every tool this server exposes to s. The caller supplies a
 // Config so test harnesses can pin a version without touching globals.
 func Register(s *server.MCPServer, cfg Config) {
@@ -87,11 +92,22 @@ func makeResearchHandler(cfg Config) server.ToolHandlerFunc {
 }
 
 func researchRunArgs(topic, emit string, save bool) []string {
-	runArgs := []string{topic, "--emit=" + emit, "--no-browser-cookies"}
+	runArgs := []string{topic, "--emit=" + emit}
+	if !browserCookiesAllowed() {
+		runArgs = append(runArgs, "--no-browser-cookies")
+	}
 	if save {
 		runArgs = append(runArgs, "--save-dir", mcpSaveDir())
 	}
 	return runArgs
+}
+
+func browserCookiesAllowed() bool {
+	raw := os.Getenv(BrowserCookiesEnvOverride)
+	return raw == "1" ||
+		strings.EqualFold(raw, "true") ||
+		strings.EqualFold(raw, "yes") ||
+		strings.EqualFold(raw, "on")
 }
 
 func mcpSaveDir() string {

--- a/mcp/internal/tools/research_test.go
+++ b/mcp/internal/tools/research_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -98,6 +99,10 @@ func TestBoolArgument(t *testing.T) {
 }
 
 func TestResearchRunArgsIncludesNoBrowserCookies(t *testing.T) {
+	t.Setenv(BrowserCookiesEnvOverride, "temporarily-set-for-cleanup")
+	if err := os.Unsetenv(BrowserCookiesEnvOverride); err != nil {
+		t.Fatalf("unset %s: %v", BrowserCookiesEnvOverride, err)
+	}
 	args := researchRunArgs("OpenAI", "compact", false)
 	want := []string{"OpenAI", "--emit=compact", "--no-browser-cookies"}
 	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
@@ -105,7 +110,38 @@ func TestResearchRunArgsIncludesNoBrowserCookies(t *testing.T) {
 	}
 }
 
+func TestResearchRunArgsAllowsBrowserCookiesForTruthyOptIn(t *testing.T) {
+	for _, value := range []string{"1", "true", "TRUE", "yes", "YeS", "on", "ON"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(BrowserCookiesEnvOverride, value)
+			args := researchRunArgs("OpenAI", "compact", false)
+			want := []string{"OpenAI", "--emit=compact"}
+			if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+				t.Fatalf("%s=%q: args = %#v, want %#v", BrowserCookiesEnvOverride, value, args, want)
+			}
+		})
+	}
+}
+
+func TestResearchRunArgsDeniesBrowserCookiesForFalseAndUnrecognizedValues(t *testing.T) {
+	for _, value := range []string{"", "0", "false", "no", "off", "enabled", " true "} {
+		name := value
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(BrowserCookiesEnvOverride, value)
+			args := researchRunArgs("OpenAI", "compact", false)
+			want := []string{"OpenAI", "--emit=compact", "--no-browser-cookies"}
+			if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+				t.Fatalf("%s=%q: args = %#v, want %#v", BrowserCookiesEnvOverride, value, args, want)
+			}
+		})
+	}
+}
+
 func TestResearchRunArgsSaveUsesSupportedSaveDir(t *testing.T) {
+	t.Setenv(BrowserCookiesEnvOverride, "")
 	t.Setenv("LAST30DAYS_MEMORY_DIR", "")
 	args := researchRunArgs("OpenAI", "html", true)
 	got := strings.Join(args, "\x00")
@@ -119,6 +155,7 @@ func TestResearchRunArgsSaveUsesSupportedSaveDir(t *testing.T) {
 }
 
 func TestResearchRunArgsSaveUsesMemoryDirEnvOverride(t *testing.T) {
+	t.Setenv(BrowserCookiesEnvOverride, "")
 	t.Setenv("LAST30DAYS_MEMORY_DIR", "/tmp/last30days-reports")
 	args := researchRunArgs("OpenAI", "html", true)
 	want := []string{"OpenAI", "--emit=html", "--no-browser-cookies", "--save-dir", "/tmp/last30days-reports"}


### PR DESCRIPTION
## Summary

Adds two default-safe MCP host controls needed for reproducible Windows Claude Desktop deployments: an explicit Python interpreter override and a consent-gated way to remove the MCP layer's browser-cookie denial. Existing behavior remains unchanged when the variables are unset.

## Testing

- [x] Full Python suite in Python 3.12: `3590 passed, 13 skipped, 48 subtests passed`
- [x] Native Windows Go 1.26.5: `go test ./...`
- [x] Added focused tests for Python resolution, invalid overrides, cookie default denial, recognized truthy opt-in, and false/unrecognized values
- [x] `git diff --check`

## Changelog

- [x] Added `changelog.d/+windows-mcp-host-controls.added.md`
- [ ] Skip changelog — chore/internal only

## Agent disclosure

### AI review

Cursor implemented the initial patch in an isolated worktree. A separate standards review flagged that the new variables were missing from `CONFIGURATION.md`; that was corrected. A separate spec review found no missing or out-of-scope behavior. Native Windows testing then caught a platform-specific assertion bug in the invalid-path test that Linux container testing missed; the test now checks the quoted Windows path correctly. Codex independently inspected the final diff and reran the complete Go and Python suites.

### Security

Cookie access remains denied by default. Only exact case-insensitive truthy values (`1`, `true`, `yes`, `on`) remove the MCP-level `--no-browser-cookies` argument, and engine consent/configuration is still required. Empty, false, and unrecognized values fail closed. `LAST30DAYS_PYTHON` must resolve to an executable; an invalid or empty override returns a clear error rather than falling back. No secrets are read, stored, logged, or added to configuration files by this change.

## Notes

This PR does not add Windows to the published MCPB platform manifest or change release packaging. It enables a manually registered Windows MCP binary to select the correct interpreter and use separately consented browser cookies.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

N/A
