### PR TITLE
fix(bluesky): honor requested search date window

### DIFF
--- a/changelog.d/984.fixed.md
+++ b/changelog.d/984.fixed.md
@@ -1,0 +1,1 @@
+Authenticated Bluesky searches now send RFC3339 date-time bounds, preventing valid date windows from being rejected as malformed requests.

--- a/skills/last30days/scripts/lib/bluesky.py
+++ b/skills/last30days/scripts/lib/bluesky.py
@@ -178,12 +178,22 @@ def _parse_date(item: Dict[str, Any]) -> Optional[str]:
 
 
 def _exclusive_until_date(to_date: str) -> str:
-    """Convert the inclusive pipeline end date to the API's exclusive bound."""
+    """Convert the inclusive pipeline end date to an RFC3339 exclusive bound."""
     try:
-        return (datetime.strptime(to_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+        value = datetime.strptime(to_date, "%Y-%m-%d") + timedelta(days=1)
+        return value.strftime("%Y-%m-%dT00:00:00Z")
     except ValueError:
         # Keep the request usable for callers that pass a provider-specific date value.
         return to_date
+
+
+def _inclusive_since_date(from_date: str) -> str:
+    """Convert the inclusive pipeline start date to an RFC3339 lower bound."""
+    try:
+        return datetime.strptime(from_date, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00Z")
+    except ValueError:
+        # Keep the request usable for callers that pass a provider-specific date value.
+        return from_date
 
 
 def search_bluesky(
@@ -236,7 +246,7 @@ def search_bluesky(
         "q": core_topic,
         "limit": str(min(count, 100)),
         "sort": "top",
-        "since": from_date,
+        "since": _inclusive_since_date(from_date),
         "until": _exclusive_until_date(to_date),
     }
     url = f"{_resolve_search_url(config)}?{urlencode(params)}"

--- a/skills/last30days/scripts/lib/bluesky.py
+++ b/skills/last30days/scripts/lib/bluesky.py
@@ -15,9 +15,8 @@ bad hygiene (no scope, can't revoke individually).
 import math
 import os
 import re
-import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from . import http, log
@@ -178,6 +177,15 @@ def _parse_date(item: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _exclusive_until_date(to_date: str) -> str:
+    """Convert the inclusive pipeline end date to the API's exclusive bound."""
+    try:
+        return (datetime.strptime(to_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+    except ValueError:
+        # Keep the request usable for callers that pass a provider-specific date value.
+        return to_date
+
+
 def search_bluesky(
     topic: str,
     from_date: str,
@@ -228,6 +236,8 @@ def search_bluesky(
         "q": core_topic,
         "limit": str(min(count, 100)),
         "sort": "top",
+        "since": from_date,
+        "until": _exclusive_until_date(to_date),
     }
     url = f"{_resolve_search_url(config)}?{urlencode(params)}"
 

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -204,8 +204,8 @@ class TestSearchBlueskyAuth(unittest.TestCase):
 
         search_url = mock_request.call_args_list[1].args[1]
         query = parse_qs(urlparse(search_url).query)
-        self.assertEqual(query["since"], ["2026-01-01"])
-        self.assertEqual(query["until"], ["2026-03-10"])
+        self.assertEqual(query["since"], ["2026-01-01T00:00:00Z"])
+        self.assertEqual(query["until"], ["2026-03-10T00:00:00Z"])
 
     @patch("lib.bluesky.http.request")
     def test_401_search_refreshes_session_once(self, mock_request):

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -2,7 +2,8 @@
 
 import os
 import unittest
-from unittest.mock import patch, MagicMock
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import patch
 
 from lib import bluesky
 
@@ -191,6 +192,20 @@ class TestSearchBlueskyAuth(unittest.TestCase):
         # Verify the search call included the Bearer token
         search_call = mock_request.call_args_list[1]
         self.assertEqual(search_call.kwargs.get("headers", {}), {"Authorization": "Bearer tok123"})
+
+    @patch("lib.bluesky.http.request")
+    def test_successful_search_passes_inclusive_date_window_to_api(self, mock_request):
+        mock_request.side_effect = [
+            {"accessJwt": "tok123", "refreshJwt": "ref456"},
+            {"posts": []},
+        ]
+        config = {"BSKY_HANDLE": "user.bsky.social", "BSKY_APP_PASSWORD": "pw"}
+        bluesky.search_bluesky("test", "2026-01-01", "2026-03-09", config=config)
+
+        search_url = mock_request.call_args_list[1].args[1]
+        query = parse_qs(urlparse(search_url).query)
+        self.assertEqual(query["since"], ["2026-01-01"])
+        self.assertEqual(query["until"], ["2026-03-10"])
 
     @patch("lib.bluesky.http.request")
     def test_401_search_refreshes_session_once(self, mock_request):


### PR DESCRIPTION
## Summary

Pass the requested date window to Bluesky's `app.bsky.feed.searchPosts` endpoint so the API can filter results before they enter the research pipeline. The pipeline treats `to_date` as inclusive, while the AT Protocol `until` parameter is exclusive, so the request uses the following calendar date as its upper bound.

## Changes

- Add `since=from_date` and an exclusive `until` date to Bluesky search requests.
- Keep non-`YYYY-MM-DD` values unchanged for compatibility with provider-specific callers.
- Add a regression test asserting the encoded request window.
- Remove pre-existing unused imports reported by Ruff in the touched modules.

## Verification

- `uv run pytest tests/test_bluesky.py -q` (26 passed)
- `uv run ruff check skills/last30days/scripts/lib/bluesky.py tests/test_bluesky.py` (passed)
- `bash skills/last30days/scripts/sync.sh` (passed; import checks passed for all deployment targets)
- `uv run pytest -q` (13 unrelated pre-existing failures in footer environment, device-auth mocks, store, and watchlist tests; no failures in Bluesky tests)
