### PR TITLE
chore(release): bump version to 3.21.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "author": {
         "name": "Matt Van Horn",
         "url": "https://github.com/mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and the web.",
   "author": {
     "name": "Matt Van Horn",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "last30days",
       "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "category": "productivity",
       "source": {
         "source": "url",

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
   "author": {
     "name": "Matt Van Horn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project uses [towncrier](https://towncrier.readthedocs.io/). Upcoming notes
 
 <!-- towncrier release notes start -->
 
+## [3.21.0] - 2026-08-14
+
+### Changed
+
+- X backend priority changed: bird (browser cookies) is now first in the auto chain, ahead of xai/xurl/xquik. Cookies beat XAI_API_KEY when both are present. Grok CLI is demoted to opt-in only: a leftover `~/.grok/auth.json` no longer steals the X lane. Pin `LAST30DAYS_X_BACKEND=grok` to enable it explicitly.
+
+
 ## [3.20.0] - 2026-08-14
 
 ### Added

--- a/changelog.d/+bird-first-grok-opt-in.changed.md
+++ b/changelog.d/+bird-first-grok-opt-in.changed.md
@@ -1,1 +1,0 @@
-X backend priority changed: bird (browser cookies) is now first in the auto chain, ahead of xai/xurl/xquik. Cookies beat XAI_API_KEY when both are present. Grok CLI is demoted to opt-in only: a leftover `~/.grok/auth.json` no longer steals the X lane. Pin `LAST30DAYS_X_BACKEND=grok` to enable it explicitly.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "last30days-skill",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
   "settings": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "last30days-skill"
-version = "3.20.0"
+version = "3.21.0"
 description = "Multi-source last-30-days research skill"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: last30days
-version: "3.20.0"
+version: "3.21.0"
 description: "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web. Includes a doctor health check to diagnose broken or missing sources."
 argument-hint: 'last30days nvidia earnings reaction | last30days AI video tools | last30days what users want in react'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
@@ -412,7 +412,7 @@ If your Bash call to `last30days.py` does NOT include the FULL pre-flight checkl
 
 ---
 
-# last30days v3.20.0: Research Any Topic from the Last 30 Days
+# last30days v3.21.0: Research Any Topic from the Last 30 Days
 
 > **Permissions overview:** Reads public web/platform data and optionally saves research briefings to `LAST30DAYS_MEMORY_DIR` (defaults to `~/Documents/Last30Days`). X/Twitter search uses optional user-provided tokens (AUTH_TOKEN/CT0 env vars). Bluesky search uses optional app password (BSKY_HANDLE/BSKY_APP_PASSWORD env vars - create at bsky.app/settings/app-passwords). On hosts with `uv` and no Python 3.12+, the preflight may install a uv-managed CPython 3.12 (one-time ~28MB download, announced on stderr). All credential usage and data writes are documented in the [Security & Permissions](#security--permissions) section.
 

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "last30days-skill"
-version = "3.20.0"
+version = "3.21.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Automated release prep for v3.21.0; towncrier + lockstep bumps.

## Summary

- Built `CHANGELOG.md` from `changelog.d/` via towncrier
- Bumped every lockstep version surface (skill, pyproject, plugin/marketplace manifests, uv.lock)

## Test plan

- [ ] `uv run pytest` (CI)
- [ ] Confirm `tests/test_plugin_contract.py::test_versions_match_across_manifests` passes
- [ ] After merge, confirm tag `v3.21.0` is created and [Release](../actions/workflows/release.yml) attaches artifacts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-673de3af-7acc-4679-aa23-eacbb96c1874?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-673de3af-7acc-4679-aa23-eacbb96c1874&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

