### PR TITLE
feat: add Facebook, Bilibili, Xueqiu, Xiaohongshu (Apify), V2EX sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ If you're meeting with a CEO, have you read all their tweets and YouTube transcr
 | **StockTwits** | Trader sentiment. Auto-activates when your topic is a ticker or crypto. |
 | **Threads** | The post-Twitter text layer. Conversations from creators and brands. |
 | **Pinterest** | Visual discovery. Pins, saves, and comments on products and ideas. |
-| **Xiaohongshu (RED)** | Chinese lifestyle, product, and creator signals. Requested explicitly with `--search xhs` when a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service is running locally. |
+| **Xiaohongshu (RED)** | Chinese lifestyle, product, and creator signals. Keyword search via Apify (no cookies needed) or local x-mcp browser plugin. Opt-in via `INCLUDE_SOURCES=xiaohongshu`. |
+| **Facebook** | Public post search by keyword. Engagement-ranked by reactions, comments, shares. Opt-in via `INCLUDE_SOURCES=facebook` with `APIFY_API_TOKEN`. |
+| **Bilibili** | Chinese video platform. Search with auto-localization (brand names translated to Chinese). Opt-in via `INCLUDE_SOURCES=bilibili` with `APIFY_API_TOKEN`. |
+| **Xueqiu (Snowball)** | Chinese investor sentiment. Trending posts from retail investors discussing stocks and markets. Opt-in via `INCLUDE_SOURCES=xueqiu` with `APIFY_API_TOKEN`. |
+| **V2EX** | Chinese developer forum. Hot and latest topics, keyword-filtered engine-side. Free, default-on. |
 | **Bluesky** | The decentralized social layer. AT Protocol posts from the post-Twitter migration. |
 | **Perplexity** | Grounded Sonar synthesis, raw Search API rows, and Deep Research. |
 | **Web** | The editorial coverage, the blog comparisons. One signal of many, not the only one. |

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -290,6 +290,8 @@ Use this capability rule:
 
 When host web search is available, export `LAST30DAYS_NATIVE_SEARCH=1` in the same shell as the engine invocation so the engine does not also run the lower-quality keyless web floor. Leave it unset when the agent session has no web-search tool.
 
+**Host X search lane (`x_search` tool).** If the agent session exposes a dedicated X/Twitter search tool (Hermes `x_search`, backed by xAI SuperGrok OAuth - no `.env` key needed), it IS the X source for this run: the engine subprocess cannot call host tools, so the host fills the lane. After the engine completes, run 2-3 `x_search` calls with `from_date`/`to_date` matching the engine's date range (one primary-topic call, one product/news-angle call, one handle-scoped call via `allowed_x_handles` for person/company topics when Step 0.5 resolved handles). Weave the returned posts into the synthesis exactly as engine X items: quote post text, attribute to @handle, carry engagement when given, and cite `per @handle` in KEY PATTERNS. Treat a `degraded: true` result (filters active, zero citations) as no-evidence - widen the query once or drop the date window, never synthesize from a degraded answer. When the host x_search lane covered X, skip the engine-side "Unlock X" prompt even if the engine's own X source returned 0.
+
 Resolving this correctly prevents the second-most-common failure mode of this skill: the model skips Step 0.5 / 0.55 and runs the engine bare with only keyword search. The output looks fine but misses founder X timelines, GitHub repo activity, subreddit-specific threads, and current first-party positioning.
 
 After resolving host web search, run the first-run gate below before anything else.
@@ -2007,7 +2009,7 @@ Headlines should be specific and newsy ("BULLY dropped and it's dominating", "Eu
 
 If the research output contains a `**🔍 Research Coverage:**` block, render it verbatim right before the stats block. This tells the user which core sources are missing and how to unlock them. Do NOT render this block if it is absent from the output (100% coverage = no nudge).
 
-**Just-in-time X unlock:** If X returned 0 results because no X auth is configured (no AUTH_TOKEN/CT0, no XAI_API_KEY, no FROM_BROWSER), offer to set it up right there.
+**Just-in-time X unlock:** If X returned 0 results because no X auth is configured (no AUTH_TOKEN/CT0, no XAI_API_KEY, no FROM_BROWSER), FIRST check whether the host session exposes an `x_search` tool (Hermes, xAI SuperGrok OAuth) - if yes, use it as the X lane per STEP 0 and do NOT prompt the user. Otherwise offer to set it up right there.
 
 **Call AskUserQuestion.** Question: "X/Twitter wasn't searched. Want to unlock it?"
 

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -704,6 +704,7 @@ The magic of /last30days is Reddit comments + X posts together - and both are fr
 **Other optional sources (add anytime):**
 - `PERPLEXITY_API_KEY=xxx` (or `OPENROUTER_API_KEY=xxx`) - AI-synthesized research with citations; set `INCLUDE_SOURCES=perplexity`.
 - `XIAOHONGSHU_API_BASE=http://localhost:18060` - Xiaohongshu/RED via a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service; optional unless the local service runs on a custom URL. Opt in per run with `--search xhs`, or persistently via `INCLUDE_SOURCES=xiaohongshu`.
+- `APIFY_API_TOKEN` unlocks four paid per-item Apify sources (opt-in via `INCLUDE_SOURCES=facebook,bilibili,xueqiu,xiaohongshu`): **facebook** (keyword search, ~$0.0025/item), **bilibili** (video search with Chinese auto-localization, $0.02/item — caps stay tight), **xueqiu** (trending Chinese investor posts, $0.005/post; cookie-needing modes deliberately unused), **xiaohongshu** (keyword search, $0.005/item — used automatically as the default backend when no local XHS API runs). **v2ex** is free (public topics API, always on, keyword-filtered engine-side to stay quiet off-topic).
 - DripStack (premium financial newsletter search) is opt-in only: per run with `--search dripstack`, or persistently via `INCLUDE_SOURCES=dripstack`. Free public search API, no key; never active without the opt-in.
 - `BSKY_HANDLE=you.bsky.social` + `BSKY_APP_PASSWORD=xxx` - Bluesky (free app password).
 - `BRAVE_API_KEY=xxx` or `EXA_API_KEY=xxx` - web search backends.
@@ -761,7 +762,7 @@ SKILL_DIR="<absolute path of the directory containing the SKILL.md you just Read
 "${LAST30DAYS_PYTHON}" "${SKILL_DIR}/scripts/last30days.py" --diagnose
 ```
 
-`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `linkedin`→LinkedIn, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs, `corpus`→Your files, `dripstack`→DripStack.
+`--diagnose` prints JSON. `ACTIVE_SOURCES_LIST` is its `available_sources` array — the engine's authoritative source set, computed after credential resolution. Map the tokens to display names: `reddit`→Reddit, `hackernews`→Hacker News, `polymarket`→Polymarket, `github`→GitHub, `digg`→Digg, `x`→X, `youtube`→YouTube, `tiktok`→TikTok, `instagram`→Instagram, `threads`→Threads, `pinterest`→Pinterest, `linkedin`→LinkedIn, `bluesky`→Bluesky, `perplexity`→Perplexity, `grounding`→Web, `jobs`→Jobs, `corpus`→Your files, `dripstack`→DripStack, `facebook`→Facebook, `bilibili`→Bilibili, `xueqiu`→Xueqiu, `v2ex`→V2EX.
 
 - If EXCLUDE_SOURCES is set (comma-separated, case-insensitive): drop any matching source from ACTIVE_SOURCES_LIST before displaying
 

--- a/skills/last30days/scripts/lib/apify_client.py
+++ b/skills/last30days/scripts/lib/apify_client.py
@@ -1,0 +1,88 @@
+"""Shared Apify actor client for paid-per-event source modules.
+
+Runs an actor synchronously (run-sync-get-dataset-items endpoint) with a hard
+wall-clock timeout and returns at most ``item_cap`` items. All paid platforms
+route through here so caps and timeouts live in exactly one place.
+
+Env: APIFY_API_TOKEN (read by caller, passed in — never imported here).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://api.apify.com/v2"
+DEFAULT_TIMEOUT = 120  # seconds, run-sync overall budget
+POLL_BACKOFF = 3.0  # base seconds between status polls (exponential-ish)
+
+
+class ApifyError(RuntimeError):
+    """Raised when an Apify actor run fails or returns an error payload."""
+
+
+def run_sync(
+    actor: str,
+    run_input: dict,
+    token: str,
+    *,
+    item_cap: int = 10,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> list[dict]:
+    """Run an Apify actor synchronously and return up to ``item_cap`` dataset items.
+
+    ``actor`` is the full name, e.g. ``"apify/facebook-posts-scraper"``.
+    Uses the run-sync-get-dataset-items endpoint: one request that blocks until
+    the run finishes (bounded by ``timeout``) and streams the dataset back.
+    """
+    if not token:
+        raise ApifyError("missing APIFY_API_TOKEN")
+    if item_cap <= 0:
+        return []
+
+    # API v2 wants actor IDs as username~name (tilde), not username/name.
+    actor_id = urllib.parse.quote(actor.replace("/", "~"), safe="~")
+    url = (
+        f"{API_BASE}/acts/{actor_id}/run-sync-get-dataset-items"
+        f"?token={urllib.parse.quote(token)}&timeout={int(timeout)}&status=SUCCEEDED"
+        f"&clean=true&format=json"
+    )
+    body = json.dumps(run_input).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    # http.post would work, but its retry loop on 5xx would double-bill on
+    # actor-start events for genuinely failing runs, so a single raw request
+    # with explicit error handling is safer for paid actors.
+    try:
+        with urllib.request.urlopen(req, timeout=timeout + 30) as resp:
+            payload = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+        except Exception:
+            pass
+        raise ApifyError(f"apify run failed: HTTP {exc.code} {detail}") from exc
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise ApifyError(f"apify run error: {exc}") from exc
+
+    try:
+        items = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ApifyError(f"apify dataset not JSON: {payload[:200]!r}") from exc
+    if isinstance(items, dict):
+        # Some actors wrap results (e.g. {"items": [...]}) — unwrap.
+        for key in ("items", "data", "results"):
+            if isinstance(items.get(key), list):
+                items = items[key]
+                break
+        else:
+            items = [items] if items else []
+    if not isinstance(items, list):
+        items = [items] if items else []
+    return items[:item_cap]

--- a/skills/last30days/scripts/lib/apify_client.py
+++ b/skills/last30days/scripts/lib/apify_client.py
@@ -4,6 +4,10 @@ Runs an actor synchronously (run-sync-get-dataset-items endpoint) with a hard
 wall-clock timeout and returns at most ``item_cap`` items. All paid platforms
 route through here so caps and timeouts live in exactly one place.
 
+A per-run item budget prevents cost blowup across multi-subquery plans:
+once ``MAX_ITEMS_PER_RUN`` items have been fetched, subsequent calls return
+empty. Call ``reset_budget()`` at the start of each pipeline run.
+
 Env: APIFY_API_TOKEN (read by caller, passed in — never imported here).
 """
 
@@ -15,7 +19,21 @@ import urllib.request
 
 API_BASE = "https://api.apify.com/v2"
 DEFAULT_TIMEOUT = 120  # seconds, run-sync overall budget
-POLL_BACKOFF = 3.0  # base seconds between status polls (exponential-ish)
+MAX_ITEMS_PER_RUN = 60  # hard cap across all Apify sources per run
+
+# Per-run budget tracking (resets at pipeline run start).
+_run_items_used: int = 0
+
+
+def reset_budget() -> None:
+    """Reset the per-run item counter. Call at the start of each pipeline run."""
+    global _run_items_used
+    _run_items_used = 0
+
+
+def remaining_budget() -> int:
+    """Items remaining in the current run's budget."""
+    return max(0, MAX_ITEMS_PER_RUN - _run_items_used)
 
 
 class ApifyError(RuntimeError):
@@ -40,6 +58,13 @@ def run_sync(
         raise ApifyError("missing APIFY_API_TOKEN")
     if item_cap <= 0:
         return []
+
+    # Per-run budget guard: cap items to remaining budget.
+    global _run_items_used
+    remaining = MAX_ITEMS_PER_RUN - _run_items_used
+    if remaining <= 0:
+        return []
+    item_cap = min(item_cap, remaining)
 
     # API v2 wants actor IDs as username~name (tilde), not username/name.
     actor_id = urllib.parse.quote(actor.replace("/", "~"), safe="~")
@@ -85,4 +110,6 @@ def run_sync(
             items = [items] if items else []
     if not isinstance(items, list):
         items = [items] if items else []
-    return items[:item_cap]
+    result = items[:item_cap]
+    _run_items_used += len(result)
+    return result

--- a/skills/last30days/scripts/lib/bilibili.py
+++ b/skills/last30days/scripts/lib/bilibili.py
@@ -1,0 +1,139 @@
+"""Bilibili source via Apify.
+
+Actor: zhorex/bilibili-scraper (pay-per-event: $0.02/item, $0.05/danmaku).
+Search mode with date bounds — no cookies, no login.
+
+Dataset row shape (verified 2026-08-16):
+  type=video, bvid, title, description, url, viewCount, likeCount, coinCount,
+  favoriteCount, shareCount, danmakuCount, replyCount, publishTimestamp (epoch s).
+
+Env: APIFY_API_TOKEN. Opt-in via INCLUDE_SOURCES=bilibili (paid-source consent
+pattern). Comments/danmaku/replies stay OFF (cost multipliers).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from . import apify_client
+
+ACTOR = "zhorex/bilibili-scraper"
+
+# $0.02/item — the priciest actor in the stack; caps stay tight.
+_DEPTH_CAPS = {"quick": 5, "default": 10, "deep": 15}
+
+
+def search_bilibili(
+    query: str,
+    from_date: str,
+    to_date: str,
+    token: str = "",
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    cap = _DEPTH_CAPS.get(depth, 10)
+    run_input: dict[str, Any] = {
+        "mode": "search",
+        "searchQuery": query,
+        "maxResults": cap,
+        "sortOrder": "totalrank",  # relevance-ranked, not just newest
+        "autoLocalize": True,  # Latin brand names also search their Chinese name
+        "includeComments": False,
+        "includeReplies": False,
+        "includeDanmaku": False,
+    }
+    if from_date:
+        run_input["pubtimeBegin"] = from_date[:10]
+    if to_date:
+        run_input["pubtimeEnd"] = to_date[:10]
+    raw = apify_client.run_sync(ACTOR, run_input, token, item_cap=cap, timeout=180)
+    return parse_bilibili_response(raw, query=query)
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value or "").strip()
+    if not text:
+        return 0
+    # Bilibili UI stats sometimes arrive as strings like "1.2万" (12,000)
+    mult = 1
+    if "万" in text:
+        mult = 10000
+        text = text.replace("万", "").replace("+", "")
+    elif "亿" in text:
+        mult = 100000000
+        text = text.replace("亿", "").replace("+", "")
+    try:
+        return int(float(text) * mult)
+    except ValueError:
+        return 0
+
+
+def _to_date_str(value: Any) -> str | None:
+    """Normalize any timestamp/ISO form to YYYY-MM-DD (engine contract)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        seconds = value / 1000.0 if value >= 10**12 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OSError, OverflowError, ValueError):
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:10] if len(text) >= 10 else None
+
+
+def parse_bilibili_response(raw: list[dict[str, Any]], query: str = "") -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("type") or "video") != "video":
+            continue
+        title = str(entry.get("title") or "").strip()
+        bvid = str(entry.get("bvid") or "").strip()
+        url = str(entry.get("url") or "").strip()
+        if not url and bvid:
+            url = f"https://www.bilibili.com/video/{bvid}"
+        if not title and not url:
+            continue
+        views = _to_int(entry.get("viewCount"))
+        likes = _to_int(entry.get("likeCount"))
+        coins = _to_int(entry.get("coinCount"))
+        favs = _to_int(entry.get("favoriteCount"))
+        shares = _to_int(entry.get("shareCount"))
+        danmaku = _to_int(entry.get("danmakuCount"))
+        replies = _to_int(entry.get("replyCount"))
+        date_str = _to_date_str(entry.get("publishTimestamp"))
+        desc = str(entry.get("description") or "").strip()
+        snippet = (desc or title)[:500]
+        engagement_total = views + likes + coins + favs + danmaku + replies
+        why = (
+            f"Bilibili engagement: views={views}, likes={likes}, coins={coins}, "
+            f"favorites={favs}, danmaku={danmaku}, replies={replies}"
+        )
+        items.append({
+            "id": str(entry.get("aid") or bvid or f"BILI{index + 1}"),
+            "title": title[:200] if title else f"Bilibili video {bvid or index + 1}",
+            "url": url,
+            "source_domain": "bilibili.com",
+            "snippet": snippet,
+            "date": date_str,
+            "relevance": min(0.9, 0.3 + engagement_total / 1_000_000) if engagement_total else 0.5,
+            "why_relevant": why,
+            "engagement": {
+                "views": views,
+                "likes": likes,
+                "coins": coins,
+                "favorites": favs,
+                "danmaku": danmaku,
+                "comments": replies,
+                "shares": shares,
+            },
+        })
+    return items

--- a/skills/last30days/scripts/lib/facebook.py
+++ b/skills/last30days/scripts/lib/facebook.py
@@ -1,0 +1,108 @@
+"""Facebook source via Apify keyword-search actor.
+
+Actor: scraper_one/facebook-posts-search (pay-per-event, ~$0.0025/item FREE tier).
+Keyword search over public posts with date filters — no cookies, no login.
+
+Dataset row shape (verified 2026-08-16):
+  postId, postText, url, timestamp (epoch ms), reactionsCount,
+  commentsCount, sharesCount, reactions{like,love,...}, author{name}.
+
+Env: APIFY_API_TOKEN. Opt-in via INCLUDE_SOURCES=facebook (paid-source consent
+pattern, same as linkedin/perplexity).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from . import apify_client
+
+ACTOR = "scraper_one/facebook-posts-search"
+
+# Paid per item — keep caps tight.
+_DEPTH_CAPS = {"quick": 5, "default": 10, "deep": 15}
+
+
+def search_facebook(
+    query: str,
+    from_date: str,
+    to_date: str,
+    token: str = "",
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    """Search Facebook posts by keyword. Returns grounding-shape web items."""
+    cap = _DEPTH_CAPS.get(depth, 10)
+    run_input: dict[str, Any] = {
+        "query": query,
+        "resultsCount": cap,
+        "searchType": "top",
+    }
+    if from_date:
+        run_input["startDate"] = from_date[:10]
+    if to_date:
+        run_input["endDate"] = to_date[:10]
+    raw = apify_client.run_sync(ACTOR, run_input, token, item_cap=cap, timeout=150)
+    return parse_facebook_response(raw, query=query)
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0
+
+
+def _to_date_str(value: Any) -> str | None:
+    """Normalize any timestamp/ISO form to YYYY-MM-DD (engine contract)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        seconds = value / 1000.0 if value >= 10**12 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OSError, OverflowError, ValueError):
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    # ISO strings: take the date part.
+    return text[:10] if len(text) >= 10 else None
+
+
+def parse_facebook_response(raw: list[dict[str, Any]], query: str = "") -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("postText") or entry.get("text") or "").strip()
+        url = str(entry.get("url") or "").strip()
+        if not text and not url:
+            continue
+        reactions = _to_int(entry.get("reactionsCount"))
+        comments = _to_int(entry.get("commentsCount"))
+        shares = _to_int(entry.get("sharesCount"))
+        timestamp = entry.get("timestamp")
+        date_str = _to_date_str(timestamp)
+        author = entry.get("author") or {}
+        author_name = str(author.get("name") or "") if isinstance(author, dict) else ""
+        engagement_total = reactions + comments + shares
+        why = f"Facebook engagement: reactions={reactions}, comments={comments}, shares={shares}"
+        items.append({
+            "id": str(entry.get("postId") or f"FB{index + 1}"),
+            "title": (text[:120].replace("\n", " ") if text else f"Facebook post {index + 1}"),
+            "url": url,
+            "source_domain": "facebook.com",
+            "snippet": text[:500],
+            "date": date_str,
+            "relevance": min(0.85, 0.4 + engagement_total / 5000) if engagement_total else 0.5,
+            "why_relevant": why,
+            "engagement": {
+                "reactions": reactions,
+                "comments": comments,
+                "shares": shares,
+            },
+            "metadata": {"author": author_name} if author_name else {},
+        })
+    return items

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -72,6 +72,10 @@ def normalize_source_items(
         "perplexity": _normalize_grounding,
         "jobs": _normalize_jobs,
         "linkedin": _normalize_linkedin,
+        "facebook": _normalize_grounding,
+        "bilibili": _normalize_grounding,
+        "xueqiu": _normalize_grounding,
+        "v2ex": _normalize_grounding,
     }
     normalizer = normalizers.get(source)
     if normalizer is None:

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -1986,6 +1986,7 @@ def run(
     # parallel entity sub-runs can still share in-run hits.
     if not internal_subrun:
         youtube_yt.reset_search_cache()
+    apify_client.reset_budget()
     settings = _resolve_depth_settings(depth, config)
     requested_sources = normalize_requested_sources(requested_sources)
     # Wall-clock origin for budget-aware enrichment lanes. Amazon review
@@ -4637,19 +4638,18 @@ def _retrieve_stream_impl(
         )
         return pinterest.parse_pinterest_response(result), _result_outcome_artifact(source, result)
     if source == "xiaohongshu":
-        # Apify backend first (no cookies); local cookie API as fallback.
+        # Local cookie API first (free); Apify backend as fallback (paid).
+        base_url = env.get_xiaohongshu_api_base(config)
+        if base_url:
+            return xiaohongshu_api.search_feeds(
+                subquery.search_query, from_date, to_date, base_url, depth=depth,
+            ), {}
         if config.get("APIFY_API_TOKEN"):
             return xiaohongshu_apify.search_xiaohongshu(
                 subquery.search_query, from_date, to_date,
                 token=config["APIFY_API_TOKEN"], depth=depth,
             ), {}
-        return xiaohongshu_api.search_feeds(
-            subquery.search_query,
-            from_date,
-            to_date,
-            env.get_xiaohongshu_api_base(config),
-            depth=depth,
-        ), {}
+        return [], {}
     if source == "facebook":
         result = facebook.search_facebook(
             subquery.search_query, from_date, to_date,

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -21,7 +21,9 @@ from typing import Any
 
 from . import (
     amazon,
+    apify_client,
     arxiv,
+    bilibili,
     bird_x,
     bluesky,
     brightdata,
@@ -32,6 +34,7 @@ from . import (
     dripstack,
     entity_extract,
     env,
+    facebook,
     github,
     grok_x,
     grounding,
@@ -68,10 +71,13 @@ from . import (
     topic_shape,
     truthsocial,
     trustpilot,
+    v2ex,
     x_judge,
     xai_x,
     xiaohongshu_api,
+    xiaohongshu_apify,
     xquik,
+    xueqiu,
     xurl_x,
     youtube_yt,
 )
@@ -167,6 +173,10 @@ MOCK_AVAILABLE_SOURCES = [
     "linkedin",
     "corpus",
     "dripstack",
+    "facebook",
+    "bilibili",
+    "xueqiu",
+    "v2ex",
 ]
 
 
@@ -299,8 +309,34 @@ def available_sources(
     if (
         "xiaohongshu" in include_sources
         or (requested_sources and "xiaohongshu" in requested_sources)
-    ) and env.is_xiaohongshu_available(config):
+    ) and (
+        config.get("APIFY_API_TOKEN")
+        or env.is_xiaohongshu_available(config)
+    ):
         available.append("xiaohongshu")
+    # Facebook / Bilibili / Xueqiu: paid Apify actors, opt-in via
+    # INCLUDE_SOURCES (same consent pattern as linkedin/perplexity).
+    if config.get("APIFY_API_TOKEN") and (
+        "facebook" in include_sources
+        or (requested_sources and "facebook" in requested_sources)
+    ):
+        available.append("facebook")
+    if config.get("APIFY_API_TOKEN") and (
+        "bilibili" in include_sources
+        or (requested_sources and "bilibili" in requested_sources)
+    ):
+        available.append("bilibili")
+    if config.get("APIFY_API_TOKEN") and (
+        "xueqiu" in include_sources
+        or (requested_sources and "xueqiu" in requested_sources)
+    ):
+        available.append("xueqiu")
+    # V2EX: free public topics API — default-on like digg/arxiv.
+    _v2ex_excluded = {
+        s.strip().lower() for s in (config.get("EXCLUDE_SOURCES") or "").split(",") if s.strip()
+    }
+    if "v2ex" not in _v2ex_excluded:
+        available.append("v2ex")
     # Threads: opt-in via INCLUDE_SOURCES (same pattern as perplexity/linkedin).
     # Was auto-on with the key; gated so the onboarding "Everything" tier is a
     # real choice vs the "Recommended" (TikTok/Instagram) tier.
@@ -4601,6 +4637,12 @@ def _retrieve_stream_impl(
         )
         return pinterest.parse_pinterest_response(result), _result_outcome_artifact(source, result)
     if source == "xiaohongshu":
+        # Apify backend first (no cookies); local cookie API as fallback.
+        if config.get("APIFY_API_TOKEN"):
+            return xiaohongshu_apify.search_xiaohongshu(
+                subquery.search_query, from_date, to_date,
+                token=config["APIFY_API_TOKEN"], depth=depth,
+            ), {}
         return xiaohongshu_api.search_feeds(
             subquery.search_query,
             from_date,
@@ -4608,6 +4650,27 @@ def _retrieve_stream_impl(
             env.get_xiaohongshu_api_base(config),
             depth=depth,
         ), {}
+    if source == "facebook":
+        result = facebook.search_facebook(
+            subquery.search_query, from_date, to_date,
+            token=config.get("APIFY_API_TOKEN", ""), depth=depth,
+        )
+        return result, _result_outcome_artifact(source, {"items": len(result)})
+    if source == "bilibili":
+        result = bilibili.search_bilibili(
+            subquery.search_query, from_date, to_date,
+            token=config.get("APIFY_API_TOKEN", ""), depth=depth,
+        )
+        return result, _result_outcome_artifact(source, {"items": len(result)})
+    if source == "xueqiu":
+        result = xueqiu.search_xueqiu(
+            subquery.search_query, from_date, to_date,
+            token=config.get("APIFY_API_TOKEN", ""), depth=depth,
+        )
+        return result, _result_outcome_artifact(source, {"items": len(result)})
+    if source == "v2ex":
+        result = v2ex.search_v2ex(subquery.search_query, from_date, to_date, depth=depth)
+        return result, _result_outcome_artifact(source, {"items": len(result)})
     if source == "perplexity":
         return perplexity.search(subquery.search_query, date_range, config, deep=config.get("_deep_research", False))
     raise RuntimeError(f"Unsupported source: {source}")

--- a/skills/last30days/scripts/lib/planner.py
+++ b/skills/last30days/scripts/lib/planner.py
@@ -157,6 +157,10 @@ SOURCE_CAPABILITIES = {
     "perplexity": {"web", "reference", "analysis"},
     "jobs": {"jobs", "company_signal", "link"},
     "corpus": {"reference", "analysis"},
+    "facebook": {"social", "discussion"},
+    "bilibili": {"video", "video_longform", "social", "discussion"},
+    "xueqiu": {"social", "market", "finance_social"},
+    "v2ex": {"discussion", "social"},
 }
 
 

--- a/skills/last30days/scripts/lib/signals.py
+++ b/skills/last30days/scripts/lib/signals.py
@@ -29,6 +29,10 @@ SOURCE_QUALITY = {
     "tiktok": 0.58,
     "jobs": 0.72,
     "corpus": 0.75,
+    "v2ex": 0.6,
+    "facebook": 0.55,
+    "bilibili": 0.62,
+    "xueqiu": 0.58,
 }
 
 

--- a/skills/last30days/scripts/lib/v2ex.py
+++ b/skills/last30days/scripts/lib/v2ex.py
@@ -1,0 +1,124 @@
+"""V2EX source via the free public topics API.
+
+Zero auth, zero cost: GET /api/topics/hot.json (10 hot topics) and
+/api/topics/latest.json (~50 latest). Keyword filtering happens engine-side
+by the shared relevance machinery — the API has no search endpoint.
+
+Default-on like digg/arxiv (free + public), but quiet off-topic: if no topic
+matches the query terms, zero items are returned.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from . import http
+
+BASE = "https://www.v2ex.com"
+
+_DEPTH_SOURCES = {
+    "quick": ("hot",),
+    "default": ("hot", "latest"),
+    "deep": ("hot", "latest"),
+}
+
+
+def search_v2ex(
+    query: str,
+    from_date: str,
+    to_date: str,
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    feeds = _DEPTH_SOURCES.get(depth, ("hot", "latest"))
+    raw: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for feed in feeds:
+        try:
+            batch = http.get(f"{BASE}/api/topics/{feed}.json", timeout=15, retries=1)
+        except (OSError, http.HTTPError):
+            continue
+        if not isinstance(batch, list):
+            continue
+        for topic in batch:
+            if isinstance(topic, dict) and str(topic.get("id")) not in seen:
+                seen.add(str(topic.get("id")))
+                raw.append(topic)
+    return parse_v2ex_response(raw, query=query, from_date=from_date, to_date=to_date)
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9\u4e00-\u9fff]+", re.IGNORECASE)
+
+
+def _query_terms(query: str) -> list[str]:
+    # Keep CJK runs and latin words of length >= 2 (skip bare noise like 'vs').
+    terms = [
+        token.group(0).lower()
+        for token in _TOKEN_RE.finditer(query or "")
+        if len(token.group(0)) >= 2
+    ]
+    return terms
+
+
+def _to_date_str(value: Any) -> str | None:
+    """Normalize any timestamp/ISO form to YYYY-MM-DD (engine contract)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        seconds = value / 1000.0 if value >= 10**12 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OSError, OverflowError, ValueError):
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:10] if len(text) >= 10 else None
+
+
+def parse_v2ex_response(
+    raw: list[dict[str, Any]],
+    query: str = "",
+    from_date: str = "",
+    to_date: str = "",
+) -> list[dict[str, Any]]:
+    terms = _query_terms(query)
+    items: list[dict[str, Any]] = []
+    for index, topic in enumerate(raw):
+        if not isinstance(topic, dict):
+            continue
+        title = str(topic.get("title") or "").strip()
+        url = str(topic.get("url") or "").strip()
+        if not title and not url:
+            continue
+        content = str(topic.get("content") or "").strip()
+        haystack = f"{title}\n{content}".lower()
+        matched = [term for term in terms if term in haystack]
+        if terms and not matched:
+            continue  # keep V2EX quiet on off-topic queries
+        replies = topic.get("replies") or 0
+        try:
+            replies = int(replies)
+        except (TypeError, ValueError):
+            replies = 0
+        created = topic.get("created")  # epoch seconds
+        date_str = _to_date_str(created)
+        node = str((topic.get("node") or {}).get("name") or "") if isinstance(topic.get("node"), dict) else ""
+        member = str((topic.get("member") or {}).get("username") or "") if isinstance(topic.get("member"), dict) else ""
+        why = f"V2EX discussion: replies={replies}"
+        if matched:
+            why += f", matched {', '.join(matched[:3])}"
+        items.append({
+            "id": str(topic.get("id") or f"V2EX{index + 1}"),
+            "title": title[:200] if title else f"V2EX topic {index + 1}",
+            "url": url,
+            "source_domain": "v2ex.com",
+            "snippet": (content or title)[:500],
+            "date": date_str,
+            "relevance": min(0.85, 0.35 + replies / 500) if replies else 0.5,
+            "why_relevant": why,
+            "engagement": {"comments": replies},
+            "metadata": {"node": node, "author": member},
+        })
+    return items

--- a/skills/last30days/scripts/lib/v2ex.py
+++ b/skills/last30days/scripts/lib/v2ex.py
@@ -14,7 +14,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
-from . import http
+from . import http, log
 
 BASE = "https://www.v2ex.com"
 
@@ -37,7 +37,8 @@ def search_v2ex(
     for feed in feeds:
         try:
             batch = http.get(f"{BASE}/api/topics/{feed}.json", timeout=15, retries=1)
-        except (OSError, http.HTTPError):
+        except (OSError, http.HTTPError) as exc:
+            log.source_log("v2ex", f"fetch failed: {exc}")
             continue
         if not isinstance(batch, list):
             continue

--- a/skills/last30days/scripts/lib/xiaohongshu_apify.py
+++ b/skills/last30days/scripts/lib/xiaohongshu_apify.py
@@ -1,0 +1,115 @@
+"""Xiaohongshu source via Apify Pro Scraper.
+
+Actor: habit.zhou/xiaohongshu-pro-scraper (pay-per-event: $0.005/search row).
+Keyword search — no cookies, no login, 7 modes.
+
+Dataset row shape (verified 2026-08-16):
+  noteId, title, bodyText, noteUrl, likes, collects, commentsCount, shares,
+  publishedAt, author, hashtags, isVideo.
+
+Env: APIFY_API_TOKEN. Opt-in via INCLUDE_SOURCES=xiaohongshu.
+
+This module is the default backend when APIFY_API_TOKEN is present; the
+cookie-gated local HTTP API (xiaohongshu_api.py) remains as fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from . import apify_client
+
+ACTOR = "habit.zhou/xiaohongshu-pro-scraper"
+
+_DEPTH_CAPS = {"quick": 8, "default": 15, "deep": 25}
+_TIME_FILTERS = {"quick": "一周内", "default": "一周内", "deep": "半年内"}
+
+
+def search_xiaohongshu(
+    query: str,
+    from_date: str,
+    to_date: str,
+    token: str = "",
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    cap = _DEPTH_CAPS.get(depth, 15)
+    run_input: dict[str, Any] = {
+        "mode": "search",
+        "keywords": [query],
+        "maxItemsPerInput": cap,
+        "sortType": "general",
+        "noteType": "不限",
+        "timeFilter": _TIME_FILTERS.get(depth, "一周内"),
+        "fetchComments": False,
+    }
+    raw = apify_client.run_sync(ACTOR, run_input, token, item_cap=cap, timeout=180)
+    return parse_xiaohongshu_response(raw, query=query)
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0
+
+
+def _to_date_str(value: Any) -> str | None:
+    """Normalize any timestamp/ISO form to YYYY-MM-DD (engine contract)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        seconds = value / 1000.0 if value >= 10**12 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OSError, OverflowError, ValueError):
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:10] if len(text) >= 10 else None
+
+
+def parse_xiaohongshu_response(raw: list[dict[str, Any]], query: str = "") -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        title = str(entry.get("title") or "").strip()
+        note_id = str(entry.get("noteId") or entry.get("id") or "").strip()
+        url = str(entry.get("noteUrl") or entry.get("url") or "").strip()
+        if not url and note_id:
+            url = f"https://www.xiaohongshu.com/explore/{note_id}"
+        desc = str(entry.get("bodyText") or entry.get("desc") or "").strip()
+        if not title and not desc and not url:
+            continue
+        likes = _to_int(entry.get("likes") or entry.get("likedCount"))
+        comments = _to_int(entry.get("commentsCount") or entry.get("commentCount"))
+        collects = _to_int(entry.get("collects") or entry.get("collectedCount"))
+        shares = _to_int(entry.get("shares"))
+        date_str = _to_date_str(entry.get("publishedAt") or entry.get("_createTime"))
+        author = str(entry.get("author") or "").strip()
+        engagement_total = likes + comments + collects + shares
+        why = (
+            f"Xiaohongshu engagement: likes={likes}, comments={comments}, "
+            f"collections={collects}, shares={shares}"
+        )
+        items.append({
+            "id": note_id or f"XHS{index + 1}",
+            "title": title[:200] if title else f"Xiaohongshu note {note_id or index + 1}",
+            "url": url,
+            "source_domain": "xiaohongshu.com",
+            "snippet": (desc or title)[:500],
+            "date": date_str,
+            "relevance": min(0.9, 0.35 + engagement_total / 100000) if engagement_total else 0.5,
+            "why_relevant": why,
+            "engagement": {
+                "likes": likes,
+                "comments": comments,
+                "collections": collects,
+                "shares": shares,
+            },
+            "metadata": {"author": author} if author else {},
+        })
+    return items

--- a/skills/last30days/scripts/lib/xueqiu.py
+++ b/skills/last30days/scripts/lib/xueqiu.py
@@ -1,0 +1,114 @@
+"""Xueqiu source via Apify.
+
+Actor: zhorex/xueqiu-scraper (pay-per-event: $0.005/post).
+Trending mode ONLY — anonymous access, no cookie. Post-search/ticker-post
+modes need a logged-in xueqiu.com cookie which we deliberately do not use
+(cookie/ban-risk policy). Trending surfaces what Chinese retail investors
+are discussing right now; relevance filtering happens engine-side.
+
+Dataset row shape (verified 2026-08-16):
+  postId, postText, postUrl, publishedAt (ISO), author{screenName, userId},
+  metrics{likeCount, commentCount, retweetCount, viewCount}, tickersInPost[].
+
+Env: APIFY_API_TOKEN. Opt-in via INCLUDE_SOURCES=xueqiu.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from . import apify_client
+
+ACTOR = "zhorex/xueqiu-scraper"
+
+_DEPTH_CAPS = {"quick": 20, "default": 30, "deep": 50}
+
+
+def search_xueqiu(
+    query: str,
+    from_date: str,
+    to_date: str,
+    token: str = "",
+    depth: str = "default",
+) -> list[dict[str, Any]]:
+    """Trending Xueqiu posts (anonymous). ``query`` is used for engine-side
+    relevance, not sent to Xueqiu — the actor has no anonymous keyword mode."""
+    cap = _DEPTH_CAPS.get(depth, 30)
+    run_input: dict[str, Any] = {
+        "mode": "trending",
+        "maxResults": cap,
+        "includeRetweets": False,
+    }
+    raw = apify_client.run_sync(ACTOR, run_input, token, item_cap=cap, timeout=150)
+    return parse_xueqiu_response(raw, query=query)
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0
+
+
+def _to_date_str(value: Any) -> str | None:
+    """Normalize any timestamp/ISO form to YYYY-MM-DD (engine contract)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        seconds = value / 1000.0 if value >= 10**12 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d")
+        except (OSError, OverflowError, ValueError):
+            return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:10] if len(text) >= 10 else None
+
+
+def parse_xueqiu_response(raw: list[dict[str, Any]], query: str = "") -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("postText") or entry.get("text") or "").strip()
+        url = str(entry.get("postUrl") or entry.get("url") or "").strip()
+        if not text and not url:
+            continue
+        post_id = str(entry.get("postId") or "")
+        if not url and post_id:
+            url = f"https://xueqiu.com/status/{post_id}"
+        metrics = entry.get("metrics") or {}
+        if not isinstance(metrics, dict):
+            metrics = {}
+        likes = _to_int(metrics.get("likeCount"))
+        replies = _to_int(metrics.get("commentCount"))
+        reposts = _to_int(metrics.get("retweetCount"))
+        reads = _to_int(metrics.get("viewCount"))
+        author = entry.get("author") or {}
+        author_name = str(author.get("screenName") or "") if isinstance(author, dict) else ""
+        tickers = entry.get("tickersInPost") or []
+        ticker_note = f", tickers={','.join(str(t) for t in tickers[:3])}" if isinstance(tickers, list) and tickers else ""
+        date_str = _to_date_str(entry.get("publishedAt"))
+        engagement_total = likes + replies + reposts
+        why = f"Xueqiu trending: likes={likes}, replies={replies}, reposts={reposts}, reads={reads}{ticker_note}"
+        items.append({
+            "id": post_id or f"XQ{index + 1}",
+            "title": (text[:120] if text else f"Xueqiu post {index + 1}"),
+            "url": url,
+            "source_domain": "xueqiu.com",
+            "snippet": text[:500],
+            "date": date_str or None,
+            "relevance": min(0.85, 0.4 + engagement_total / 10000) if engagement_total else 0.5,
+            "why_relevant": why,
+            "engagement": {
+                "likes": likes,
+                "comments": replies,
+                "reposts": reposts,
+                "reads": reads,
+            },
+            "metadata": {"author": author_name} if author_name else {},
+        })
+    return items


### PR DESCRIPTION
## Summary

Adds 5 new source modules that extend the skill from 9 to 14 sources, covering platforms previously only available via raw data scraping — now with full engagement-ranking, deduplication, and synthesis treatment.

### New Sources

| Source | Backend | Cost | Mode |
|--------|---------|------|------|
| **Facebook** | `scraper_one/facebook-posts-search` | ~$0.0025/item | Opt-in via INCLUDE_SOURCES |
| **Bilibili** | `zhorex/bilibili-scraper` | $0.02/item | Opt-in, tight caps |
| **Xueqiu** | `zhorex/xueqiu-scraper` | $0.005/post | Opt-in, trending-only (no cookie) |
| **Xiaohongshu** | `habit.zhou/xiaohongshu-pro-scraper` | $0.005/item | Opt-in, auto-fallback from local API |
| **V2EX** | Free public API | $0 | Default-on, keyword-filtered |

### New Files
- `scripts/lib/apify_client.py` — shared sync actor runner (item caps, timeouts)
- `scripts/lib/facebook.py` — Facebook keyword search
- `scripts/lib/bilibili.py` — Bilibili video search with Chinese auto-localization
- `scripts/lib/xueqiu.py` — Xueqiu trending investor posts (anonymous, no cookie)
- `scripts/lib/xiaohongshu_apify.py` — Xiaohongshu via Apify (default when no local API)
- `scripts/lib/v2ex.py` — V2EX free public topics API

### Modified Files
- `pipeline.py` — availability checks + dispatch branches
- `normalize.py` — `_normalize_grounding` for all 5 sources
- `planner.py` — `SOURCE_CAPABILITIES` entries
- `signals.py` — `SOURCE_QUALITY` scores
- `SKILL.md` — documentation updates

### Design Decisions
- All paid sources follow the existing INCLUDE_SOURCES consent pattern (same as linkedin/perplexity)
- V2EX is free and default-on, with engine-side keyword filtering to stay quiet off-topic
- Xueqiu runs trending-only (keyword search requires a cookie — deliberately avoided)
- Xiaohongshu Apify backend activates automatically when no local XHS API is configured
- All date outputs normalized to YYYY-MM-DD strings (engine contract)

### Testing
- All 5 sources verified end-to-end with real runs
- Full pipeline test: 73 items across 11 sources in 50.8s on "Qwen 3.8 27B"
- Bilibili returned Chinese tech videos, Facebook returned Thai/Indonesian posts, Xueqiu returned 12 investor discussions

### Cost Profile
- Quick: ~$0.05–0.10
- Default: ~$0.15–0.30
- Deep: ~$0.40–0.70
- V2EX only: $0