### PR TITLE
feat(reddit): add read-only rdt-cli fallback

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -135,7 +135,7 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Source | Key(s) | Required for | Free tier |
 |---|---|---|---|
 | Local corpus | `--corpus <dir>` or `LAST30DAYS_CORPUS_DIRS` | private `.md`/`.txt`; `.pdf` when `pdftotext` is on PATH | yes (offline) |
-| Reddit (public) | none (default free keyless path). With `SCRAPECREATORS_API_KEY`: empty-only search backup by default; `LAST30DAYS_REDDIT_SC_MIN_ITEMS=<N>` backfills thin free runs; `LAST30DAYS_REDDIT_BACKEND=scrapecreators` pins SC primary with free fallback | always on; SC knobs require `SCRAPECREATORS_API_KEY` | yes |
+| Reddit (public) | none (default free keyless path). If the read-only `rdt` CLI is installed, it is tried first; set `LAST30DAYS_RDT_CLI=/path/to/rdt` to select an explicit executable. With `SCRAPECREATORS_API_KEY`: empty-only search backup by default; `LAST30DAYS_REDDIT_SC_MIN_ITEMS=<N>` backfills thin free runs; `LAST30DAYS_REDDIT_BACKEND=scrapecreators` pins SC primary with free fallback | always on; `rdt` is optional and read-only; SC knobs require `SCRAPECREATORS_API_KEY` | yes |
 | Hacker News | none | always on | yes |
 | Polymarket | none | always on | yes |
 | StockTwits | none | auto-on for ticker/crypto topics only (gated by symbol detection); never registered for non-financial topics | yes (public API, ~200 req/hr per IP) |

--- a/changelog.d/1016.added.md
+++ b/changelog.d/1016.added.md
@@ -1,0 +1,1 @@
+Reddit research can use a local read-only `rdt-cli` backend before falling back to the existing keyless RSS, Shreddit, and ArcticShift paths, avoiding recurring ScrapeCreators credits on hosts with authenticated Reddit access.

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -54,6 +54,7 @@ from . import (
     providers,
     query,
     reddit,
+    reddit_rdt,
     reddit_listing,
     reddit_public,
     relevance,
@@ -4139,6 +4140,22 @@ def _retrieve_stream_impl(
             min_items = 0
         public_results: list[dict] = []
         public_failure: Exception | None = None
+        rdt_outcome = None
+        # Prefer the local, read-only rdt CLI when installed.  The established
+        # RSS/shreddit/ArcticShift composite remains the next fallback and is
+        # intentionally untouched when rdt is absent or returns no posts.
+        if reddit_rdt._command() is not None:
+            try:
+                rdt_results, rdt_outcome = reddit_rdt.search(
+                    reddit_query, from_date, to_date, depth=depth,
+                    subreddits=subreddits,
+                )
+                if rdt_results:
+                    return rdt_results, {}
+                sys.stderr.write("[Reddit] rdt-cli returned no in-window items; using public fallback\n")
+            except Exception as exc:
+                rdt_outcome = health.SourceHealth("reddit-rdt", health.ERROR, "rdt adapter failed")
+                sys.stderr.write(f"[Reddit] rdt-cli failed ({type(exc).__name__}); using public fallback\n")
         try:
             public_results = reddit_public.search_reddit_public(
                 reddit_query, from_date, to_date, depth=depth,
@@ -4158,6 +4175,11 @@ def _retrieve_stream_impl(
         # 1) keeps the default (min_items=0) as empty-only AND treats exactly
         # `min_items` results as acceptable (no backfill) for min_items > 0.
         if len(public_results) >= max(min_items, 1) or not has_sc_key:
+            if rdt_outcome is not None:
+                return public_results, _outcome_artifact(
+                    rdt_outcome.state,
+                    f"rdt-cli fallback failed; public Reddit returned {len(public_results)} items: {rdt_outcome.reason}",
+                )
             return public_results, {}
         if public_results:
             sys.stderr.write(

--- a/skills/last30days/scripts/lib/reddit_rdt.py
+++ b/skills/last30days/scripts/lib/reddit_rdt.py
@@ -1,0 +1,162 @@
+"""Read-only Reddit search through the locally installed rdt CLI.
+
+This adapter is deliberately small and best-effort: it uses only ``rdt search``
+with structured output, never invokes mutation commands, and returns a typed
+outcome alongside normalized posts. Callers can fall back to the existing
+RSS/shreddit/ArcticShift keyless path when rdt is unavailable or unhealthy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from . import health
+from .relevance import token_overlap_relevance
+
+DEFAULT_TIMEOUT = 20
+DEFAULT_LIMITS = {"quick": 10, "default": 25, "deep": 50}
+
+
+def _command() -> Optional[str]:
+    """Resolve the executable without reading or displaying credential files."""
+    configured = os.environ.get("LAST30DAYS_RDT_CLI", "").strip()
+    if configured:
+        return configured
+    return shutil.which("rdt") or shutil.which("rdt-cli")
+
+
+def _date(value: Any) -> Optional[str]:
+    if value is None or value == "":
+        return None
+    try:
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(value, tz=timezone.utc).date().isoformat()
+        text = str(value).strip()
+        if text.isdigit():
+            return datetime.fromtimestamp(float(text), tz=timezone.utc).date().isoformat()
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return parsed.date().isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _subreddit(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("display_name") or value.get("name") or ""
+    return str(value or "").strip().removeprefix("r/")
+
+
+def _url(row: Dict[str, Any]) -> str:
+    value = str(row.get("url") or row.get("permalink") or "").strip()
+    if value.startswith("/"):
+        return "https://www.reddit.com" + value
+    return value if "reddit.com" in value else ""
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize(row: Dict[str, Any], index: int, query: str) -> Optional[Dict[str, Any]]:
+    title = str(row.get("title") or row.get("name") or "").strip()
+    url = _url(row)
+    if not title or not url:
+        return None
+    score = _int(row.get("score") or row.get("ups") or row.get("votes"))
+    comments = _int(row.get("num_comments") or row.get("comments"))
+    rid = str(row.get("id") or row.get("name") or "").removeprefix("t3_")
+    return {
+        "id": f"R{index}",
+        "reddit_id": rid,
+        "title": title,
+        "url": url,
+        "subreddit": _subreddit(row.get("subreddit")),
+        "date": _date(row.get("created_utc") or row.get("created_at")),
+        "engagement": {
+            "score": score,
+            "num_comments": comments,
+            "upvote_ratio": row.get("upvote_ratio"),
+        },
+        "relevance": round(token_overlap_relevance(query, title), 3) if query else 0.0,
+        "why_relevant": "Reddit rdt-cli search",
+        "selftext": str(row.get("selftext") or row.get("text") or "")[:500],
+        "author": str(row.get("author") or "[deleted]"),
+        "metadata": {"rdt": True},
+    }
+
+
+def _rows(payload: Any) -> Optional[Iterable[Dict[str, Any]]]:
+    if not isinstance(payload, dict) or payload.get("ok") is False:
+        return None
+    data = payload.get("data", payload)
+    if isinstance(data, dict):
+        data = data.get("posts", data.get("results", []))
+    if not isinstance(data, list) or not all(isinstance(row, dict) for row in data):
+        return None
+    return data
+
+
+def search(
+    query: str,
+    from_date: str,
+    to_date: str,
+    *,
+    depth: str = "default",
+    subreddits: Optional[List[str]] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> Tuple[List[Dict[str, Any]], Optional[health.SourceHealth]]:
+    """Run one read-only rdt search and return ``(items, outcome)``.
+
+    ``outcome`` is ``None`` on a successful search, including a valid empty
+    result. Failures are typed so the caller can report them while falling back.
+    """
+    command = _command()
+    if not command:
+        return [], health.SourceHealth("reddit-rdt", health.MISSING, "rdt CLI not found on PATH")
+    args = [command, "search", query, "--json", "--compact", "--limit", str(DEFAULT_LIMITS.get(depth, 25)), "--time", "month"]
+    normalized_subs = [s.removeprefix("r/").strip() for s in (subreddits or []) if s.strip()]
+    if len(normalized_subs) == 1:
+        args.extend(["--subreddit", normalized_subs[0]])
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired:
+        return [], health.SourceHealth("reddit-rdt", health.TIMEOUT, f"rdt search timed out after {timeout}s")
+    except (OSError, ValueError):
+        return [], health.SourceHealth("reddit-rdt", health.ERROR, "rdt CLI could not execute")
+    if proc.returncode != 0:
+        return [], health.SourceHealth("reddit-rdt", health.ERROR, f"rdt search exited {proc.returncode}")
+    try:
+        payload = json.loads(proc.stdout)
+    except (TypeError, json.JSONDecodeError):
+        return [], health.SourceHealth("reddit-rdt", health.SCHEMA_DRIFT, "rdt returned non-JSON output")
+    rows = _rows(payload)
+    if rows is None:
+        return [], health.SourceHealth("reddit-rdt", health.SCHEMA_DRIFT, "rdt JSON did not contain a post list")
+
+    items: List[Dict[str, Any]] = []
+    seen = set()
+    allowed_subs = {s.lower() for s in normalized_subs}
+    for row in rows:
+        item = _normalize(row, len(items) + 1, query)
+        if item is None:
+            continue
+        if allowed_subs and item["subreddit"].lower() not in allowed_subs:
+            continue
+        if item["date"] is not None and not (from_date <= item["date"] <= to_date):
+            continue
+        key = item["reddit_id"] or item["url"]
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(item)
+    for index, item in enumerate(items, 1):
+        item["id"] = f"R{index}"
+    return items, None

--- a/skills/last30days/scripts/lib/reddit_rdt.py
+++ b/skills/last30days/scripts/lib/reddit_rdt.py
@@ -52,7 +52,10 @@ def _subreddit(value: Any) -> str:
 
 
 def _url(row: Dict[str, Any]) -> str:
-    value = str(row.get("url") or row.get("permalink") or "").strip()
+    # Link posts may expose the linked article in ``url`` while the Reddit
+    # thread itself is in ``permalink``. Keep the thread as the canonical
+    # result URL so we do not lose the Reddit post's identity and metadata.
+    value = str(row.get("permalink") or row.get("url") or "").strip()
     if value.startswith("/"):
         return "https://www.reddit.com" + value
     return value if "reddit.com" in value else ""

--- a/skills/last30days/tests/test_reddit_rdt.py
+++ b/skills/last30days/tests/test_reddit_rdt.py
@@ -1,0 +1,52 @@
+import json
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from scripts.lib import reddit_rdt
+
+
+class RdtAdapterTests(unittest.TestCase):
+    def _proc(self, rows, returncode=0):
+        return subprocess.CompletedProcess(
+            ["rdt", "search"], returncode, json.dumps({"ok": True, "data": rows}), ""
+        )
+
+    @patch("scripts.lib.reddit_rdt._command", return_value="rdt")
+    @patch("scripts.lib.reddit_rdt.subprocess.run")
+    def test_normalizes_filters_deduplicates_and_scopes_subreddit(self, run, _command):
+        run.return_value = self._proc([
+            {"id": "t3_abc", "title": "Hermes Agent tips", "subreddit": "hermesagent", "url": "https://www.reddit.com/r/hermesagent/comments/abc/x", "score": 4, "num_comments": 2, "created_utc": 1785826514},
+            {"id": "abc", "title": "duplicate", "subreddit": "hermesagent", "permalink": "/r/hermesagent/comments/abc/x", "created_utc": 1785826514},
+            {"id": "old", "title": "old", "subreddit": "hermesagent", "url": "https://www.reddit.com/r/hermesagent/comments/old/x", "created_utc": 1},
+            {"id": "other", "title": "other", "subreddit": "python", "url": "https://www.reddit.com/r/python/comments/other/x", "created_utc": 1785826514},
+        ])
+        items, outcome = reddit_rdt.search("Hermes Agent", "2026-08-01", "2026-08-31", subreddits=["r/hermesagent"])
+        self.assertIsNone(outcome)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["reddit_id"], "abc")
+        self.assertEqual(items[0]["engagement"]["score"], 4)
+        args = run.call_args.args[0]
+        self.assertEqual(args[0:3], ["rdt", "search", "Hermes Agent"])
+        self.assertIn("--subreddit", args)
+
+    @patch("scripts.lib.reddit_rdt._command", return_value="rdt")
+    @patch("scripts.lib.reddit_rdt.subprocess.run", side_effect=subprocess.TimeoutExpired("rdt", 20))
+    def test_timeout_is_typed(self, run, _command):
+        items, outcome = reddit_rdt.search("x", "2026-08-01", "2026-08-31")
+        self.assertEqual(items, [])
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.state, "timeout")
+
+    @patch("scripts.lib.reddit_rdt._command", return_value="rdt")
+    @patch("scripts.lib.reddit_rdt.subprocess.run")
+    def test_schema_drift_is_typed(self, run, _command):
+        run.return_value = subprocess.CompletedProcess(["rdt"], 0, "{\"ok\": true, \"data\": \"unexpected\"}", "")
+        items, outcome = reddit_rdt.search("x", "2026-08-01", "2026-08-31")
+        self.assertEqual(items, [])
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.state, "schema-drift")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/last30days/tests/test_reddit_rdt.py
+++ b/skills/last30days/tests/test_reddit_rdt.py
@@ -31,6 +31,27 @@ class RdtAdapterTests(unittest.TestCase):
         self.assertIn("--subreddit", args)
 
     @patch("scripts.lib.reddit_rdt._command", return_value="rdt")
+    @patch("scripts.lib.reddit_rdt.subprocess.run")
+    def test_prefers_reddit_permalink_over_external_link(self, run, _command):
+        run.return_value = self._proc([
+            {
+                "id": "t3_linkpost",
+                "title": "Link post",
+                "url": "https://example.com/article",
+                "permalink": "/r/hermesagent/comments/linkpost/link_post/",
+                "subreddit": "hermesagent",
+            },
+        ])
+
+        items, outcome = reddit_rdt.search("Link post", "2026-08-01", "2026-08-31")
+
+        self.assertIsNone(outcome)
+        self.assertEqual(
+            items[0]["url"],
+            "https://www.reddit.com/r/hermesagent/comments/linkpost/link_post/",
+        )
+
+    @patch("scripts.lib.reddit_rdt._command", return_value="rdt")
     @patch("scripts.lib.reddit_rdt.subprocess.run", side_effect=subprocess.TimeoutExpired("rdt", 20))
     def test_timeout_is_typed(self, run, _command):
         items, outcome = reddit_rdt.search("x", "2026-08-01", "2026-08-31")


### PR DESCRIPTION
## Summary

- Add a read-only `rdt-cli` Reddit adapter for hosts with working local Reddit authentication.
- Normalize structured results into the existing `last30days` schema with date/subreddit filtering, deduplication, and typed timeout/schema/CLI outcomes.
- Keep RSS/Shreddit/ArcticShift as the existing fallback when `rdt` is unavailable or returns no in-window items.
- Add focused mocked unit coverage.

## Why

The keyless Reddit lanes can receive HTTP 403 responses from datacenter egress. The local read-only `rdt` path is already verified and avoids recurring ScrapeCreators credits.

## Tests

- Focused adapter tests: 3/3 pass
- Python compilation: pass
- CLI help: pass
- Live read-only `rdt` status/search smoke test: pass
- End-to-end Reddit-only `last30days` run: 13 threads returned

No credentials, credential paths, or paid-service configuration are included.