### PR TITLE
Unwrap the media object on Instagram user reels

### DIFF
--- a/changelog.d/+ig-user-reels-media-wrapper.fixed.md
+++ b/changelog.d/+ig-user-reels-media-wrapper.fixed.md
@@ -1,0 +1,1 @@
+Instagram creator reels (`--ig-creators`) now parse. `/v1/instagram/user/reels` nests each item under `media`, so items came back with no caption, author, URL, date, or view count. View counts also fall back to `ig_play_count`.

--- a/skills/last30days/scripts/lib/instagram.py
+++ b/skills/last30days/scripts/lib/instagram.py
@@ -178,6 +178,11 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
         if not isinstance(raw, dict):
             continue
 
+        # /v1/instagram/user/reels nests every field under "media";
+        # /v2/instagram/reels/search returns them flat.
+        if isinstance(raw.get("media"), dict):
+            raw = raw["media"]
+
         # Extract reel ID and shortcode
         reel_pk = str(raw.get("id", raw.get("pk", "")))
         shortcode = raw.get("shortcode", raw.get("code", ""))
@@ -192,7 +197,13 @@ def _parse_items(raw_items: List[Dict[str, Any]], core_topic: str) -> List[Dict[
             text = raw.get("desc", raw.get("text", ""))
 
         # Engagement metrics
-        play_count = raw.get("video_play_count") or raw.get("video_view_count") or raw.get("play_count") or 0
+        play_count = (
+            raw.get("video_play_count")
+            or raw.get("video_view_count")
+            or raw.get("play_count")
+            or raw.get("ig_play_count")
+            or 0
+        )
         like_count = raw.get("like_count") or 0
         comment_count = raw.get("comment_count") or 0
 

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -117,5 +117,53 @@ class TestExpandInstagramQueries(unittest.TestCase):
         queries = expand_instagram_queries("Kanye West", "quick")
         self.assertEqual(len(queries), 1)
 
+class TestInstagramMediaWrapper(unittest.TestCase):
+    """/v1/instagram/user/reels nests each item under "media"."""
+
+    def _wrapped(self):
+        return {
+            "media": {
+                "pk": "3963765146907609231",
+                "code": "DcCH2ZygIiP",
+                "caption": {"text": "eclipse from 50,000 feet #eclipse"},
+                "user": {"username": "nasa"},
+                "taken_at": 1786060800,
+                "play_count": 4551344,
+                "ig_play_count": 4551344,
+                "like_count": 82487,
+                "comment_count": 903,
+            }
+        }
+
+    def test_unwraps_media(self):
+        item = _parse_items([self._wrapped()], "eclipse")[0]
+        self.assertEqual("3963765146907609231", item["video_id"])
+        self.assertEqual("nasa", item["author_name"])
+        self.assertIn("eclipse", item["text"])
+        self.assertEqual(
+            "https://www.instagram.com/reel/DcCH2ZygIiP", item["url"])
+        self.assertEqual(4551344, item["engagement"]["views"])
+        self.assertEqual(82487, item["engagement"]["likes"])
+        self.assertEqual(903, item["engagement"]["comments"])
+        self.assertIsNotNone(item["date"])
+
+    def test_flat_item_still_parses(self):
+        flat = self._wrapped()["media"]
+        item = _parse_items([flat], "eclipse")[0]
+        self.assertEqual("nasa", item["author_name"])
+        self.assertEqual(4551344, item["engagement"]["views"])
+
+    def test_ig_play_count_fallback(self):
+        raw = self._wrapped()
+        del raw["media"]["play_count"]
+        item = _parse_items([raw], "eclipse")[0]
+        self.assertEqual(4551344, item["engagement"]["views"])
+
+    def test_media_not_a_dict_is_ignored(self):
+        item = _parse_items(
+            [{"media": "nope", "pk": "1", "user": {"username": "x"}}], "t")[0]
+        self.assertEqual("x", item["author_name"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`_parse_items` reads the outer item object, but `/v1/instagram/user/reels` nests every field under `media`. Reels from the `--ig-creators` path came back with no caption, author, URL, date, and 0 views, and still counted toward the result set. This PR unwraps `media` when it is a dict, leaves the flat `/v2/instagram/reels/search` shape unchanged, and adds `ig_play_count` to the view-count fallback chain.

The path matters more now. ScrapeCreators no longer returns `video_play_count` from `/v1/instagram/post`, and their recommended workaround is to page through user reels for the view count.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

`tests/test_instagram.py` gains `TestInstagramMediaWrapper`: a wrapped item parses to full fields, a flat item still parses, `ig_play_count` fills in when `play_count` is absent, and a non-dict `media` value is ignored.

Verified against a live `/v1/instagram/user/reels?handle=nasa` response. Before the change, three items parsed to empty text, empty author, `date: None`, and `views: 0`. After, they parse to `@nasa` and `@spherevegas` with 4,551,344 / 8,242,222 / 11,222,584 views and correct dates and reel URLs.

Four tests fail on this machine both with and without the change: `tests/test_backend_descriptors.py::TestGetXSourceStatusGrokPin::test_unpinned_with_store_does_not_return_grok_source` and three in `tests/test_grok_surfacing.py`. They are unrelated to Instagram and reproduce on a clean `main`.

## Changelog

- [x] Added `changelog.d/+ig-user-reels-media-wrapper.fixed.md`

## Agent disclosure

### AI review

Written with Claude Code. The review checked three risks. First, whether the unwrap breaks the flat `reels/search` shape: it does not, because the guard only fires when `media` is a dict, and a regression test covers the flat case. Second, whether the payload key is stable: the live response sets both `play_count` and `ig_play_count` on `media`, so both stay in the fallback chain. Third, whether `_parse_date` handles the nested `taken_at`, which is a unix int rather than the ISO string `reels/search` returns: the existing timestamp branch handles it, confirmed by the live parse producing correct dates.

### Security

N/A. No input handling, command execution, path handling, auth, or dependency changes. The added test data is public NASA reel metadata with no keys or tokens.

## Notes

The fix does not add view counts anywhere they were absent by design. It only restores the fields the user-reels payload already carries.

### Relationship to this change

- [x] None

## Related issues

N/A
