### PR TITLE
fix(grok): decode CLI stdout as UTF-8, not the OS locale codec

### DIFF
--- a/changelog.d/+grok-x-windows-utf8-decode.fixed.md
+++ b/changelog.d/+grok-x-windows-utf8-decode.fixed.md
@@ -1,0 +1,1 @@
+The Grok CLI's stdout is now decoded as UTF-8 instead of the OS locale codec. On Windows (cp1252), an emoji or smart quote in an X post's text crashed the decode inside `subprocess.run`, which surfaced as "no items parsed" from the `grok` X backend rather than a real error.

--- a/skills/last30days/scripts/lib/grok_x.py
+++ b/skills/last30days/scripts/lib/grok_x.py
@@ -693,6 +693,12 @@ def _invoke(prompt: str, timeout: int) -> Dict[str, Any]:
                 [binary, "-p", prompt, "--permission-mode", "bypassPermissions"],
                 capture_output=True,
                 text=True,
+                # X posts are not cp1252. Without this, text=True decodes the CLI's
+                # stdout with the locale codec and a reader thread dies on the first
+                # emoji or smart quote, which surfaces as "no items parsed" rather
+                # than an error. Matches the auth-store read above.
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 cwd=workdir,
                 env=_subprocess_env(child_home),

--- a/tests/test_grok_x.py
+++ b/tests/test_grok_x.py
@@ -205,6 +205,24 @@ def test_resolved_binary_path_is_used_not_bare_name(monkeypatch):
     assert seen["cmd"][0] == "/opt/custom/grok"
 
 
+def test_subprocess_decodes_stdout_as_utf8_not_locale(monkeypatch):
+    """text=True with no explicit encoding decodes with the locale codec
+    (cp1252 on Windows). X post text is not cp1252, so a bare emoji or
+    smart quote in the CLI's stdout would otherwise crash the decode and
+    surface as "no items parsed" instead of a real error."""
+    seen = {}
+    monkeypatch.setattr(grok_x, "binary_path", lambda: "/usr/bin/grok")
+
+    def fake_run(cmd, **kwargs):
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, _block("2087568620465607078"), "")
+
+    monkeypatch.setattr(grok_x.subprocess, "run", fake_run)
+    grok_x.search_x("steipete", *WINDOW)
+    assert seen["kwargs"].get("encoding") == "utf-8"
+    assert seen["kwargs"].get("errors") == "replace"
+
+
 def test_missing_binary_returns_error_not_raises(monkeypatch):
     monkeypatch.setattr(grok_x, "binary_path", lambda: None)
     result = grok_x.search_x("steipete", *WINDOW)


### PR DESCRIPTION
## Summary

`_invoke()` runs the Grok CLI with `subprocess.run(..., text=True)` and no explicit `encoding`, so stdout is decoded with `locale.getpreferredencoding()` — cp1252 on Windows. X post text routinely contains emoji and smart quotes that aren't valid cp1252, so the decode raises and the grok X backend reports "no items parsed" instead of a real, diagnosable error. This adds `encoding="utf-8", errors="replace"`, matching the existing UTF-8 read of the auth token store a few lines above in the same file.

Found and fixed locally while updating a Windows install from v3.21.0 to v3.21.1; confirmed via the GitHub API that neither tag has this fix, so it isn't tracked upstream.

## Testing

- [x] `uv run pytest`
- [x] Added a regression test (`test_subprocess_decodes_stdout_as_utf8_not_locale` in `tests/test_grok_x.py`) that asserts `encoding="utf-8"` and `errors="replace"` are passed to `subprocess.run`

`uv run pytest tests/test_grok_x.py` passes clean (all green). The full suite has a number of pre-existing failures on this Windows dev box (POSIX file-permission bits, `os.killpg`, POSIX-only path checks) — verified identical with and without this change via `git stash`, so unrelated to this PR.

## Changelog

- [x] Added `changelog.d/+grok-x-windows-utf8-decode.fixed.md`

## Agent disclosure

### AI review

Written and verified by Claude Code. Checked: the encoding regression is real (traced `text=True` → `locale.getpreferredencoding()` on Windows → cp1252), the comment's claim about the auth-store read is accurate (same file, line ~236), and the fix doesn't change behavior on POSIX (UTF-8 there already). Ran the targeted test file and the full suite before/after to confirm no regressions beyond the pre-existing Windows-only failures noted above.

### Security

No input handling, command execution, path handling, auth, secrets, or dependency changes. Purely a decode-encoding fix on an existing subprocess call.

## Notes

Windows-specific; no behavior change on macOS/Linux where the locale codec is already UTF-8.

### Relationship to this change

- [x] None

## Related issues

N/A