### PR TITLE
fix(xquik): include posts from the requested end date

### DIFF
--- a/changelog.d/+xquik-inclusive-end-date.fixed.md
+++ b/changelog.d/+xquik-inclusive-end-date.fixed.md
@@ -1,0 +1,1 @@
+Xquik-backed X searches now include posts published on the requested end date.

--- a/skills/last30days/scripts/lib/xquik.py
+++ b/skills/last30days/scripts/lib/xquik.py
@@ -30,9 +30,13 @@ _BASE_URL = "https://xquik.com/api/v1"
 def _with_date_window(query: str, from_date: str, to_date: str) -> str:
     """Apply the engine's inclusive date window to an X search query."""
     try:
-        exclusive_until = (date.fromisoformat(to_date) + timedelta(days=1)).isoformat()
+        end_date = date.fromisoformat(to_date)
     except (TypeError, ValueError):
         exclusive_until = to_date
+    else:
+        if end_date == date.max:
+            return f"{query} since:{from_date}"
+        exclusive_until = (end_date + timedelta(days=1)).isoformat()
     return f"{query} since:{from_date} until:{exclusive_until}"
 
 

--- a/skills/last30days/scripts/lib/xquik.py
+++ b/skills/last30days/scripts/lib/xquik.py
@@ -7,7 +7,7 @@ bookmarks). Requires an API key from xquik.com.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from . import http, log
@@ -25,6 +25,15 @@ DEPTH_CONFIG = {
 }
 
 _BASE_URL = "https://xquik.com/api/v1"
+
+
+def _with_date_window(query: str, from_date: str, to_date: str) -> str:
+    """Apply the engine's inclusive date window to an X search query."""
+    try:
+        exclusive_until = (date.fromisoformat(to_date) + timedelta(days=1)).isoformat()
+    except (TypeError, ValueError):
+        exclusive_until = to_date
+    return f"{query} since:{from_date} until:{exclusive_until}"
 
 
 def _log(msg: str):
@@ -100,7 +109,7 @@ def search_xquik(
     seen_ids: set[str] = set()
 
     for query_text in queries:
-        q = f"{query_text} since:{from_date} until:{to_date}"
+        q = _with_date_window(query_text, from_date, to_date)
         items, auth_error = _execute_search(
             q, cfg["limit"], token,
             label=query_text, id_prefix="XQ",
@@ -209,7 +218,7 @@ def search_handles(
         handle = str(raw).lstrip("@").strip()
         if not handle:
             continue
-        q = f"from:{handle} since:{from_date} until:{to_date}"
+        q = _with_date_window(f"from:{handle}", from_date, to_date)
         got, auth_error = _execute_search(
             q, count_per, token,
             label=f"from:{handle}", id_prefix="XF",
@@ -244,7 +253,7 @@ def search_mentions(
         handle = str(raw).lstrip("@").strip()
         if not handle:
             continue
-        q = f"@{handle} since:{from_date} until:{to_date}"
+        q = _with_date_window(f"@{handle}", from_date, to_date)
         got, auth_error = _execute_search(
             q, count_per, token,
             label=f"@{handle}", id_prefix="XA",

--- a/tests/test_xquik.py
+++ b/tests/test_xquik.py
@@ -222,6 +222,7 @@ class TestSearchXquik(unittest.TestCase):
         for to_date, exclusive_until in (
             ("2026-08-20", "2026-08-21"),
             ("2026-12-31", "2027-01-01"),
+            ("9999-12-31", None),
         ):
             with self.subTest(to_date=to_date):
                 mock_get.reset_mock()
@@ -233,7 +234,10 @@ class TestSearchXquik(unittest.TestCase):
                     token="test-key",
                 )
                 url = mock_get.call_args[0][0]
-                self.assertIn(f"until%3A{exclusive_until}", url)
+                if exclusive_until:
+                    self.assertIn(f"until%3A{exclusive_until}", url)
+                else:
+                    self.assertNotIn("until%3A", url)
 
     @patch("lib.xquik.http.get")
     def test_deduplicates_across_queries(self, mock_get):

--- a/tests/test_xquik.py
+++ b/tests/test_xquik.py
@@ -217,6 +217,24 @@ class TestSearchXquik(unittest.TestCase):
         self.assertEqual(result["items"][0]["engagement"]["likes"], 50)
         self.assertNotIn("error", result)
 
+    @patch("lib.xquik.http.get", return_value={"tweets": []})
+    def test_search_includes_requested_end_date(self, mock_get):
+        for to_date, exclusive_until in (
+            ("2026-08-20", "2026-08-21"),
+            ("2026-12-31", "2027-01-01"),
+        ):
+            with self.subTest(to_date=to_date):
+                mock_get.reset_mock()
+                search_xquik(
+                    "AI agents",
+                    "2026-08-01",
+                    to_date,
+                    depth="quick",
+                    token="test-key",
+                )
+                url = mock_get.call_args[0][0]
+                self.assertIn(f"until%3A{exclusive_until}", url)
+
     @patch("lib.xquik.http.get")
     def test_deduplicates_across_queries(self, mock_get):
         tweet = {
@@ -307,6 +325,7 @@ class TestFromLane(unittest.TestCase):
         url = m.call_args[0][0]
         self.assertIn("from%3Aelonmusk", url)        # from:elonmusk url-encoded
         self.assertIn("since%3A2026-05-19", url)
+        self.assertIn("until%3A2026-06-19", url)
         self.assertNotIn("Grok", url)                 # topic must NOT be AND'd into query
         self.assertEqual(1, len(items))
         self.assertEqual("XF1", items[0]["id"])       # FROM-lane id prefix
@@ -345,6 +364,7 @@ class TestAboutLane(unittest.TestCase):
                                           topic="Grok 4", count_per=5, token="k")
         url = m.call_args[0][0]
         self.assertIn("%40elonmusk", url)             # @elonmusk url-encoded
+        self.assertIn("until%3A2026-06-19", url)
         authors = {it["author_handle"] for it in items}
         self.assertIn("fan", authors)
         self.assertNotIn("elonmusk", authors)         # own tweet dropped


### PR DESCRIPTION
## Summary

The engine treats `to_date` as inclusive, but Xquik searches passed it directly to X's exclusive `until:` operator. A run ending today could therefore omit every Xquik result published today.

Advance the exclusive bound by 1 calendar day for topic, author, and mention lanes. At `9999-12-31`, omit the unrepresentable upper bound so the final ISO date remains included. This preserves the existing start date, ranking mode, authentication, and backend failover behavior.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression

Validation results:

- 4,044 tests passed, 5 skipped, and 56 subtests passed.
- Repository coverage reached 88.84% against the 84% gate.
- 337 affected backend, pipeline, date, and normalization tests passed with 7 subtests.
- Regressions cover a normal end date, year rollover, `date.max`, and all 3 Xquik lanes.
- `git diff --check` passed.

## Changelog

- [x] Added `changelog.d/+xquik-inclusive-end-date.fixed.md`
- [ ] Skip changelog

## Agent disclosure

### AI review

The review traced date generation through `dates.get_date_range`, verified inclusive filtering in `normalize`, and compared the adapter with the committed Xquik search contract. It checked all 3 query lanes, month and year rollover behavior, `date.max`, malformed legacy input, authentication handling, backend selection, failover, and duplicate open work. The implementation uses one shared helper to prevent lane drift.

### Security

No credential, command, path, or dependency behavior changes. The existing API key header remains unchanged. Date parsing operates on the engine-provided ISO date and preserves the prior query if legacy input is malformed.

## Notes

X's `until:` bound is exclusive. Advancing it by 1 day makes the query match the engine's inclusive end-date contract. Since no date follows `9999-12-31`, that one boundary omits `until:` instead.

### Relationship to this change

- [ ] None
- [x] Yes - disclosure: I maintain Xquik, the existing optional backend affected by this fix.

## Related issues

N/A. No open issue or pull request covered this boundary defect.
