### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,3 +41,8 @@ uv.lock            export-ignore
 .clawhubignore  export-ignore
 .gitignore      export-ignore
 .gitattributes  export-ignore
+
+# Normalize line endings to LF in the repository.
+# Without this, contributors on Windows checkouts commit CRLF, which turns
+# routine edits into whole-file diffs and hides the real change in review.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

Adds `* text=auto eol=lf` to `.gitattributes`. The file already exists for `git archive` packaging but carries no `text`/`eol` rules, so files edited in a Windows checkout are committed with CRLF and later show as fully modified on macOS/Linux. In one checkout that surfaced as 235 files / 57,202 lines changed, with `git diff --ignore-cr-at-eol` completely empty — none of it a real change.

## Testing

- [ ] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Not run locally: `uv` isn't installed on this machine, and I didn't want to install toolchains as a side effect of a one-line config PR. CI runs the suite on this PR.

No tests added — the change adds no Python and is a git-level attribute; there's no runtime behaviour a test could assert against. What I verified instead, on a full checkout:

- Adding the rule produced **zero** renormalization. `git status` stayed clean and no tracked file went dirty, because every tracked file is already LF in the index. So this is preventative, not a mass rewrite, and no follow-up `git add --renormalize` commit is needed.
- The diff is 5 insertions, 0 deletions. All 21 existing `export-ignore` entries are untouched, so `scripts/build-skill.sh` packaging is unaffected.
- The 6 files git already tracks as `-text` stay binary — `text=auto` detects binary by content, and `export-ignore` sets a different attribute, so the two rule sets don't interact.

## Changelog

- [ ] Added `changelog.d/<pr-or-issue>.<type>.md`
- [x] Skip changelog — chore/internal only (also add the `skip-changelog` label)

Repo hygiene with no user-visible effect. Happy to add a `changed` fragment if you'd rather it appear in the notes.

## Agent disclosure

### AI review

Opened with Claude Code. The risk I checked hardest was whether this would trigger a repo-wide renormalization and bury maintainers in a phantom diff — that's the usual failure mode when `text=auto` lands on a repo with mixed endings. Confirmed it doesn't here: the index is already uniformly LF, so the rule matches the existing state and `git status` stays clean after applying it.

The second risk was clobbering the existing `export-ignore` block, which the skill build depends on. The change is an append, verified as 5 insertions / 0 deletions with the `export-ignore` count unchanged at 21.

I also confirmed the 235-file diff that motivated this was purely carriage returns before trusting that reading — `git diff -w` was empty, but `-w` also swallows genuine whitespace edits, so I re-ran with `--ignore-cr-at-eol`, which isolates CR and was also empty.

### Security

N/A. No input handling, command execution, path handling, auth, secrets, or dependency changes. One config line.

## Notes

Placement is at the end of the file, after the packaging rules. Order doesn't matter functionally here since `export-ignore` and `text`/`eol` are different attributes, but move it to the top if you prefer broad-rule-first.

Contributors with existing CRLF working copies will see those files as modified once this lands; `git add --renormalize .` or a fresh checkout clears it. That's a one-time cost per affected checkout, and only for contributors who already have the problem this prevents.

### Relationship to this change

- [x] None

## Related issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
