### PR TITLE
fix(transcribe): send the skill User-Agent in _post_audio so Groq's Cloudflare edge stops returning 403 (#983)

### DIFF
--- a/changelog.d/+groq-transcribe-user-agent.fixed.md
+++ b/changelog.d/+groq-transcribe-user-agent.fixed.md
@@ -1,0 +1,1 @@
+Audio transcription posts the skill's canonical User-Agent instead of Python-urllib, so Groq's Cloudflare edge no longer 403s the request with error 1010.

--- a/skills/last30days/scripts/lib/transcribe.py
+++ b/skills/last30days/scripts/lib/transcribe.py
@@ -24,7 +24,7 @@ import tempfile
 from dataclasses import dataclass, field
 from typing import Optional
 
-from . import env, health, subproc
+from . import env, health, http, log, subproc
 
 # Whisper's documented upload ceiling. We compress to stay under it and chunk
 # when a single clip still exceeds it.
@@ -177,7 +177,11 @@ def _transcribe_chunk(
     for name, key in providers:
         try:
             text = _post_audio(name, path, key, timeout=timeout)
-        except Exception:  # noqa: BLE001 - any provider failure -> try the next
+        except Exception as exc:  # noqa: BLE001 - any provider failure -> try the next
+            # Surface the failing provider + error (e.g. Groq's Cloudflare 403,
+            # "error code: 1010") under LAST30DAYS_DEBUG instead of silently
+            # degrading to an empty transcript (#983).
+            log.debug(f"transcribe: provider {name} failed on a chunk: {exc!r}")
             text = None
         if text is not None:
             return text, name
@@ -214,6 +218,10 @@ def _post_audio(provider: str, path: str, api_key: str, timeout: float) -> Optio
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": f"multipart/form-data; boundary={boundary}",
+            # A plain-urllib UA is fingerprinted and 403'd by Cloudflare-style
+            # edges (Groq returns "error code: 1010", #983). Send the skill's
+            # canonical identity instead, same as lib/http.py's get/post.
+            "User-Agent": http.USER_AGENT,
         },
         method="POST",
     )

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -2,7 +2,7 @@
 
 from unittest import mock
 
-from lib import health, transcribe
+from lib import health, http, transcribe
 
 
 class TestPrerequisites:
@@ -91,3 +91,58 @@ class TestTranscribeFlow:
             result = transcribe.transcribe_media("https://x/v", {"GROQ_API_KEY": "k"})
         assert result.ok is False
         assert "all providers failed" in result.reason
+
+
+class TestPostAudioUserAgent:
+    """_post_audio must send a real User-Agent, not Python-urllib/3.x.
+
+    Groq's Cloudflare edge 403s the default urllib fingerprint with
+    "error code: 1010" (#983); a plain-urllib UA is a liability on every
+    provider this helper serves.
+    """
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"text": "hello"}'
+
+    def _capture_headers(self, tmp_path):
+        captured = {}
+
+        def _capture(req, timeout=None):
+            # urllib stores header keys capitalized ("User-agent").
+            captured.update({k.lower(): v for k, v in req.headers.items()})
+            return self._Resp()
+
+        audio = tmp_path / "audio.mp3"
+        audio.write_bytes(b"fake-audio")
+        with mock.patch("urllib.request.urlopen", side_effect=_capture):
+            transcribe._post_audio("groq", str(audio), "key", timeout=5.0)
+        return captured
+
+    def test_user_agent_is_canonical_skill_ua(self, tmp_path):
+        captured = self._capture_headers(tmp_path)
+        assert "user-agent" in captured
+        assert captured["user-agent"] == http.USER_AGENT
+
+    def test_user_agent_not_urllib_default(self, tmp_path):
+        captured = self._capture_headers(tmp_path)
+        assert not captured["user-agent"].startswith("Python-urllib")
+
+    def test_user_agent_sent_for_openai_too(self, tmp_path):
+        captured = {}
+
+        def _capture(req, timeout=None):
+            captured.update({k.lower(): v for k, v in req.headers.items()})
+            return self._Resp()
+
+        audio = tmp_path / "audio.mp3"
+        audio.write_bytes(b"fake-audio")
+        with mock.patch("urllib.request.urlopen", side_effect=_capture):
+            transcribe._post_audio("openai", str(audio), "key", timeout=5.0)
+        assert captured.get("user-agent") == http.USER_AGENT


### PR DESCRIPTION
Fixes #983.

## Summary

`_post_audio` posted multipart audio with `Authorization` and `Content-Type` but no `User-Agent`, so urllib sent `Python-urllib/3.x`. Groq's Cloudflare edge 403s that fingerprint with `error code: 1010`, and the chunk loop swallowed the exception, so Groq silently degraded to the next provider or an empty transcript.

The request now sends `http.USER_AGENT` (the same identity `lib/http.py` already uses for get/post). Provider failures are logged at debug under `LAST30DAYS_DEBUG` instead of being dropped, so the next person sees which provider failed and why.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

New class `TestPostAudioUserAgent` in `tests/test_transcribe.py`: `test_user_agent_is_canonical_skill_ua`, `test_user_agent_not_urllib_default`, `test_user_agent_sent_for_openai_too`. Full suite green on this branch (one environment-dependent test, `TestGrokExpiryStates::test_no_grok_cli_is_missing`, deselected locally because this host has the grok CLI installed).

## Changelog

- [x] Added `changelog.d/+groq-transcribe-user-agent.fixed.md`
- [ ] Skip changelog

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Reviewed `_post_audio` header construction and the chunk-loop except path: the new `User-Agent` is the static skill identity already used by `lib/http.py`, `Authorization` is unchanged, and the debug line records `{exc!r}` (the urllib/HTTP error), never the bearer token.

### Security

No new input handling. The User-Agent is a compile-time string; API keys stay in the `Authorization` header only. Tests use dummy keys and a mocked `urlopen`.

## Notes

The same UA is sent for OpenAI so a later edge fingerprint there does not regress the helper. Debug lines appear only with `LAST30DAYS_DEBUG`.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #983.
