### PR TITLE
fix(reddit): pace the keyless bucket at 1 req/s with an env knob and retry 429'd sub-requests once (#985)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -135,7 +135,7 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Source | Key(s) | Required for | Free tier |
 |---|---|---|---|
 | Local corpus | `--corpus <dir>` or `LAST30DAYS_CORPUS_DIRS` | private `.md`/`.txt`; `.pdf` when `pdftotext` is on PATH | yes (offline) |
-| Reddit (public) | none (default free keyless path). With `SCRAPECREATORS_API_KEY`: empty-only search backup by default; `LAST30DAYS_REDDIT_SC_MIN_ITEMS=<N>` backfills thin free runs; `LAST30DAYS_REDDIT_BACKEND=scrapecreators` pins SC primary with free fallback | always on; SC knobs require `SCRAPECREATORS_API_KEY` | yes |
+| Reddit (public) | none (default free keyless path). With `SCRAPECREATORS_API_KEY`: empty-only search backup by default; `LAST30DAYS_REDDIT_SC_MIN_ITEMS=<N>` backfills thin free runs; `LAST30DAYS_REDDIT_BACKEND=scrapecreators` pins SC primary with free fallback. `LAST30DAYS_REDDIT_KEYLESS_RATE` paces unauthenticated reddit.com requests (default `1` req/sec) | always on; SC knobs require `SCRAPECREATORS_API_KEY` | yes |
 | Hacker News | none | always on | yes |
 | Polymarket | none | always on | yes |
 | StockTwits | none | auto-on for ticker/crypto topics only (gated by symbol detection); never registered for non-financial topics | yes (public API, ~200 req/hr per IP) |
@@ -165,6 +165,8 @@ python3 skills/last30days/scripts/last30days.py "MCP servers" \
 | Jobs / careers pages | none for public ATS pages; web backend improves fallback discovery | `--hiring-signals` and strong Hiring Signals in standard company reports | yes |
 | Apify (alternate scraper) | `APIFY_API_TOKEN` | fallback for Reddit/TikTok/Instagram when ScrapeCreators is exhausted | yes (limited) |
 
+**Reddit keyless pacing.** Unauthenticated reddit.com requests (RSS, listing partials, shreddit) share one token bucket. The default is `1` request per second with a burst of 2, slow enough that engine fan-out does not trip HTTP 429 on a typical home IP. Set `LAST30DAYS_REDDIT_KEYLESS_RATE` to a float req/sec to trade wall-clock for coverage: higher finishes faster and loses more sub-requests to 429; lower is safer and slower. Invalid or non-positive values fall back to `1`. A 429'd RSS or listing sub-request is retried once after a short jittered pause, still through the limiter. This does not change ScrapeCreators routing (`LAST30DAYS_REDDIT_BACKEND` / `LAST30DAYS_REDDIT_SC_MIN_ITEMS`).
+
 **YouTube transcript tuning.** `LAST30DAYS_YT_SUB_LANGS` controls the comma-separated caption-language priority passed to yt-dlp and defaults to `en,es,pt`. When `SCRAPECREATORS_API_KEY` is available, yt-dlp uses one fast attempt before the paid fallback; set `LAST30DAYS_YT_TRANSCRIPT_FAST_TIMEOUT` to the number of seconds allowed for that attempt when a throttled host needs longer than the 12-second default. A VTT completed before the timeout is reused rather than discarded. `LAST30DAYS_YT_SEARCH_TIMEOUT` sets the per-search yt-dlp deadline (default 120s). Comparison-mode fan-out also caps concurrent yt-dlp processes process-wide and caches identical searches within a run so redundant `ytsearch` calls do not self-throttle the same IP.
 
 **X backend priority (bird first).** The default X backend chain is bird (browser cookies) → xai (API key) → xurl (OAuth2 CLI) → xquik (API key). Cookies beat `XAI_API_KEY` when both are present. A leftover grok login never steals the X lane; see below.
@@ -185,6 +187,7 @@ BRAVE_API_KEY=<your-brave-key>
 # Optional sources
 SCRAPECREATORS_API_KEY=<your-scrapecreators-key>
 INCLUDE_SOURCES=tiktok,instagram
+# LAST30DAYS_REDDIT_KEYLESS_RATE=1  # keyless reddit.com req/sec; lower = fewer 429s, slower runs
 # Xiaohongshu is requested-only: run with --search xhs after starting a local
 # browser-session service. Defaults probe localhost, then host.docker.internal.
 # XIAOHONGSHU_API_BASE=http://localhost:18060

--- a/changelog.d/985.fixed.md
+++ b/changelog.d/985.fixed.md
@@ -1,0 +1,1 @@
+Keyless Reddit now paces unauthenticated reddit.com requests at 1 req/sec (configurable via `LAST30DAYS_REDDIT_KEYLESS_RATE`) and retries a 429'd RSS or listing sub-request once, so routine runs no longer drop those lanes as `partial` HTTP 429.

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -471,6 +471,9 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         ('LAST30DAYS_X_MODEL', None),
         ('LAST30DAYS_X_BACKEND', None),
         ('LAST30DAYS_REDDIT_BACKEND', None),
+        # Keyless reddit.com token-bucket rate (req/sec). http.py reads it
+        # from os.environ on each acquire, so .env values are exported below.
+        ('LAST30DAYS_REDDIT_KEYLESS_RATE', None),
         # Doctor cache freshness window in seconds (doctor --cached).
         ('LAST30DAYS_DOCTOR_TTL', None),
         # Per-source deadline (seconds) for doctor --probe live checks.
@@ -599,6 +602,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         'LAST30DAYS_YT_SUB_LANGS',
         'LAST30DAYS_YT_TRANSCRIPT_FAST_TIMEOUT',
         'LAST30DAYS_YT_SEARCH_TIMEOUT',
+        'LAST30DAYS_REDDIT_KEYLESS_RATE',
     ):
         if config.get(key):
             os.environ.setdefault(key, config[key])

--- a/skills/last30days/scripts/lib/http.py
+++ b/skills/last30days/scripts/lib/http.py
@@ -1,7 +1,9 @@
 """HTTP utilities for last30days skill (stdlib only)."""
 
 import json
+import math
 import os
+import random
 import re
 import socket
 import sys
@@ -934,7 +936,62 @@ class RateLimiter:
 # Shared across all keyless Reddit tiers (RSS, listing, shreddit) so their
 # combined fan-out is throttled as one family. Burst lets the parallel
 # enrichment workers proceed; sustained rate caps the stampede.
-REDDIT_KEYLESS_LIMITER = RateLimiter(rate_per_sec=5.0, burst=5)
+# 1 req/sec is slow enough that home IPs survive RSS + listing + shreddit
+# fan-out; raise LAST30DAYS_REDDIT_KEYLESS_RATE to trade 429s for wall-clock.
+REDDIT_KEYLESS_RATE_ENV = "LAST30DAYS_REDDIT_KEYLESS_RATE"
+DEFAULT_REDDIT_KEYLESS_RATE = 1.0
+DEFAULT_REDDIT_KEYLESS_BURST = 2
+_REDDIT_429_RETRY_SLEEP_SEC = 1.0
+_REDDIT_429_RETRY_JITTER_SEC = 0.5
+
+
+def parse_reddit_keyless_rate(raw: Optional[str]) -> float:
+    """Parse LAST30DAYS_REDDIT_KEYLESS_RATE; invalid/non-positive -> default."""
+    text = (raw or "").strip()
+    if not text:
+        return DEFAULT_REDDIT_KEYLESS_RATE
+    try:
+        rate = float(text)
+    except (TypeError, ValueError):
+        return DEFAULT_REDDIT_KEYLESS_RATE
+    if not math.isfinite(rate) or rate <= 0:
+        return DEFAULT_REDDIT_KEYLESS_RATE
+    return rate
+
+
+def make_reddit_keyless_limiter(
+    environ: Optional[Dict[str, str]] = None,
+) -> RateLimiter:
+    envmap = os.environ if environ is None else environ
+    return RateLimiter(
+        rate_per_sec=parse_reddit_keyless_rate(envmap.get(REDDIT_KEYLESS_RATE_ENV)),
+        burst=DEFAULT_REDDIT_KEYLESS_BURST,
+    )
+
+
+REDDIT_KEYLESS_LIMITER = make_reddit_keyless_limiter()
+
+
+def _sync_reddit_keyless_rate() -> None:
+    """Apply a process-env override without resetting in-flight tokens."""
+    rate = parse_reddit_keyless_rate(os.environ.get(REDDIT_KEYLESS_RATE_ENV))
+    if REDDIT_KEYLESS_LIMITER.rate != rate:
+        REDDIT_KEYLESS_LIMITER.rate = rate
+
+
+def _failures_are_429(failures: list[HTTPError]) -> bool:
+    if not failures:
+        return False
+    last = failures[-1]
+    return last.status_code == 429 or last.outcome_state == health.RATE_LIMITED
+
+
+def _sleep_reddit_429_retry() -> None:
+    """Short jittered pause before the single in-lane 429 retry."""
+    time.sleep(
+        _REDDIT_429_RETRY_SLEEP_SEC
+        + random.uniform(0.0, _REDDIT_429_RETRY_JITTER_SEC)
+    )
 
 
 def reddit_keyless_get_text(
@@ -950,8 +1007,47 @@ def reddit_keyless_get_text(
     requests via :data:`REDDIT_KEYLESS_LIMITER` so a broad multi-query run does
     not stampede Reddit's keyless endpoints and trip blocks.
     """
+    _sync_reddit_keyless_rate()
     REDDIT_KEYLESS_LIMITER.acquire()
     return get_text(url, timeout=timeout, retries=retries, accept=accept, headers=headers)
+
+
+def reddit_keyless_get_text_retry_429(
+    url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    accept: str = "*/*",
+    headers: Optional[Dict[str, str]] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Limiter-throttled GET with one extra limiter-respecting retry on 429.
+
+    Returns ``(body, error)``. The first attempt is captured locally so a
+    recovered 429 is not left in the pipeline sink. A second 429, or any
+    non-429 miss, is recorded as before. Internal ``get_text`` retries are
+    skipped (``retries=1``) so the in-lane retry is the one that re-acquires
+    the bucket.
+    """
+    kwargs: Dict[str, Any] = {
+        "timeout": timeout,
+        "retries": 1,
+        "accept": accept,
+        "headers": headers,
+    }
+    with capture_failures() as first:
+        text = reddit_keyless_get_text(url, **kwargs)
+    if text is not None:
+        return text, None
+    if _failures_are_429(first):
+        _sleep_reddit_429_retry()
+        with tee_failures() as second:
+            text = reddit_keyless_get_text(url, **kwargs)
+        if text is not None:
+            return text, None
+        err = second[-1] if second else (first[-1] if first else None)
+        return None, str(err) if err is not None else "no response"
+    for err in first:
+        _record_failure(err)
+    err = first[-1] if first else None
+    return None, str(err) if err is not None else "no response"
 
 
 def scrapecreators_headers(token: str) -> Dict[str, str]:

--- a/skills/last30days/scripts/lib/reddit_listing.py
+++ b/skills/last30days/scripts/lib/reddit_listing.py
@@ -189,16 +189,16 @@ def _fetch_one_with_status(
     timeframe: str = TIMEFRAME,
 ) -> tuple[List[Dict[str, Any]], Optional[str]]:
     try:
-        # tee_failures, not capture_failures: the latter would replace the
-        # pipeline's sink and hide this failure from it. get_text launders a
-        # terminal HTTP failure into None, so the tee is how this lane recovers
-        # the status code it needs to report (issue #899).
-        with http.tee_failures() as swallowed:
-            text = http.reddit_keyless_get_text(_listing_url(subreddit, sort, timeframe), timeout=LISTING_TIMEOUT,
-                                                accept="text/html")
+        # retry_429 records a terminal miss into the pipeline sink (issue #899)
+        # and retries a 429 once through the limiter (issue #985). An empty
+        # body ("") is a real empty listing; None never is.
+        text, error = http.reddit_keyless_get_text_retry_429(
+            _listing_url(subreddit, sort, timeframe),
+            timeout=LISTING_TIMEOUT,
+            accept="text/html",
+        )
         if text is None:
-            # An empty body ("") is a real empty listing; None never is.
-            return [], (str(swallowed[-1]) if swallowed else "no response")
+            return [], (error or "no response")
         return parse_cards(text, query), None
     except Exception as e:
         _log(f"listing fetch failed r/{subreddit} {sort}: {e}")

--- a/skills/last30days/scripts/lib/reddit_rss.py
+++ b/skills/last30days/scripts/lib/reddit_rss.py
@@ -171,9 +171,11 @@ def _build_urls(query: str, depth: str, subreddits: Optional[List[str]]) -> List
 
 
 def _fetch_feed(url: str, query: str) -> List[Dict[str, Any]]:
-    """Fetch and parse one feed. Never raises."""
+    """Fetch and parse one feed. Never raises. One limiter-respecting 429 retry."""
     try:
-        text = http.reddit_keyless_get_text(url, timeout=FEED_TIMEOUT, accept="application/atom+xml")
+        text, _error = http.reddit_keyless_get_text_retry_429(
+            url, timeout=FEED_TIMEOUT, accept="application/atom+xml"
+        )
         return _parse_feed(text, query) if text else []
     except Exception as e:  # defensive: a single bad feed must not sink the run
         _log(f"feed fetch failed for {url}: {e}")

--- a/skills/last30days/scripts/lib/render.py
+++ b/skills/last30days/scripts/lib/render.py
@@ -2532,7 +2532,15 @@ def _format_outcome(outcome: schema.SourceOutcome) -> str:
     state = outcome.state
     if state == schema.PARTIAL:
         noun = "item" if outcome.items_returned == 1 else "items"
-        summary = f"partial after {outcome.items_returned} {noun}"
+        summary = f"partial — {outcome.items_returned} {noun} returned"
+        detail_l = detail.lower()
+        if (
+            "429" in detail_l
+            or "rate-limited" in detail_l
+            or "rate limit" in detail_l
+            or "too many requests" in detail_l
+        ):
+            summary += ", some requests rate-limited"
     elif state == schema.NO_RESULTS:
         summary = "no results"
     else:

--- a/tests/test_reddit_keyless_backoff.py
+++ b/tests/test_reddit_keyless_backoff.py
@@ -1,8 +1,9 @@
-"""Tests for the shared keyless-Reddit throttle (U4)."""
+"""Tests for the shared keyless-Reddit throttle (U4) and 429 in-lane retry."""
 
+import os
 from unittest import mock
 
-from lib import http, reddit_rss
+from lib import http, reddit_listing, reddit_rss, render, schema
 
 
 class TestRateLimiter:
@@ -53,3 +54,211 @@ class TestRedditKeylessGetText:
         with mock.patch.object(reddit_rss.http, "reddit_keyless_get_text", return_value=None) as throttled:
             reddit_rss.search_rss("test query")
         assert throttled.called
+
+
+class TestRedditKeylessRateKnob:
+    def test_default_rate_is_one_per_sec_small_burst(self):
+        limiter = http.make_reddit_keyless_limiter(environ={})
+        assert limiter.rate == 1.0
+        assert limiter.capacity == 2
+
+    def test_env_override(self):
+        limiter = http.make_reddit_keyless_limiter(
+            environ={http.REDDIT_KEYLESS_RATE_ENV: "0.25"}
+        )
+        assert limiter.rate == 0.25
+        assert limiter.capacity == 2
+
+    def test_invalid_and_nonpositive_fall_back_to_default(self):
+        for raw in ("fast", "", "-1", "0", "nan", "inf"):
+            limiter = http.make_reddit_keyless_limiter(
+                environ={http.REDDIT_KEYLESS_RATE_ENV: raw}
+            )
+            assert limiter.rate == http.DEFAULT_REDDIT_KEYLESS_RATE, raw
+
+    def test_process_env_syncs_onto_shared_limiter(self, monkeypatch):
+        monkeypatch.setattr(http.REDDIT_KEYLESS_LIMITER, "rate", 1.0)
+        monkeypatch.setenv(http.REDDIT_KEYLESS_RATE_ENV, "0.5")
+        with mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http, "get_text", return_value="ok"):
+            http.reddit_keyless_get_text("https://www.reddit.com/x.rss")
+        assert http.REDDIT_KEYLESS_LIMITER.rate == 0.5
+
+    def test_env_file_value_is_exported_for_limiter(self, tmp_path, monkeypatch):
+        from lib import env
+
+        config_file = tmp_path / ".env"
+        config_file.write_text(f"{http.REDDIT_KEYLESS_RATE_ENV}=0.25\n", encoding="utf-8")
+        config_file.chmod(0o600)
+        monkeypatch.setattr(env, "CONFIG_DIR", tmp_path)
+        monkeypatch.setattr(env, "CONFIG_FILE", config_file)
+        monkeypatch.setenv("LAST30DAYS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv(http.REDDIT_KEYLESS_RATE_ENV, raising=False)
+        monkeypatch.chdir(tmp_path)
+        with mock.patch.object(env, "_load_keychain", return_value={}), \
+             mock.patch.object(env, "_load_pass", return_value={}):
+            config = env.get_config()
+        assert config[http.REDDIT_KEYLESS_RATE_ENV] == "0.25"
+        assert http.parse_reddit_keyless_rate(
+            config[http.REDDIT_KEYLESS_RATE_ENV]
+        ) == 0.25
+        assert os.environ.get(http.REDDIT_KEYLESS_RATE_ENV) == "0.25"
+
+
+def _record_status(code: int, reason: str) -> None:
+    http._record_failure(http.HTTPError(f"HTTP {code}: {reason}", code))
+
+
+class TestRedditKeyless429Retry:
+    def test_429_then_200_recovers_via_single_retry(self):
+        bodies = [None, "<feed xmlns='http://www.w3.org/2005/Atom'/>"]
+
+        def fake_get(*_args, **_kwargs):
+            val = bodies.pop(0)
+            if val is None:
+                _record_status(429, "Too Many Requests")
+            return val
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get), \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire") as acq, \
+             mock.patch.object(http.time, "sleep") as slept, \
+             mock.patch.object(http.random, "uniform", return_value=0.0):
+            text, err = http.reddit_keyless_get_text_retry_429(
+                "https://www.reddit.com/search.rss"
+            )
+        assert text.startswith("<feed")
+        assert err is None
+        assert acq.call_count == 2
+        slept.assert_called_once()
+        assert bodies == []
+
+    def test_429_then_429_records_failure_and_stops(self):
+        def fake_get(*_args, **_kwargs):
+            _record_status(429, "Too Many Requests")
+            return None
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get) as gt, \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http.time, "sleep"), \
+             mock.patch.object(http.random, "uniform", return_value=0.0), \
+             http.capture_failures() as failures:
+            text, err = http.reddit_keyless_get_text_retry_429(
+                "https://www.reddit.com/search.rss"
+            )
+        assert text is None
+        assert err is not None and "429" in err
+        assert gt.call_count == 2
+        assert any(f.status_code == 429 for f in failures)
+
+    def test_non_429_miss_is_not_retried(self):
+        def fake_get(*_args, **_kwargs):
+            _record_status(403, "Forbidden")
+            return None
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get) as gt, \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http.time, "sleep") as slept, \
+             http.capture_failures() as failures:
+            text, err = http.reddit_keyless_get_text_retry_429(
+                "https://www.reddit.com/search.rss"
+            )
+        assert text is None
+        assert "403" in (err or "")
+        assert gt.call_count == 1
+        slept.assert_not_called()
+        assert any(f.status_code == 403 for f in failures)
+
+    def test_rss_fetch_feed_recovers_after_one_429(self):
+        feed = (
+            '<feed xmlns="http://www.w3.org/2005/Atom"><entry>'
+            "<title>Recovered</title>"
+            '<link href="https://www.reddit.com/r/test/comments/abc/x/" />'
+            "<updated>2026-05-20T00:00:00+00:00</updated></entry></feed>"
+        )
+        bodies = [None, feed]
+
+        def fake_get(*_args, **_kwargs):
+            val = bodies.pop(0)
+            if val is None:
+                _record_status(429, "Too Many Requests")
+            return val
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get), \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http.time, "sleep"):
+            posts = reddit_rss._fetch_feed(
+                "https://www.reddit.com/search.rss", "Recovered"
+            )
+        assert len(posts) == 1
+        assert posts[0]["title"] == "Recovered"
+
+    def test_listing_fetch_recovers_after_one_429(self):
+        from pathlib import Path
+
+        html = (
+            Path(__file__).resolve().parent.parent
+            / "fixtures"
+            / "reddit_listing_cards_sample.html"
+        ).read_text(encoding="utf-8")
+        bodies = [None, html]
+
+        def fake_get(*_args, **_kwargs):
+            val = bodies.pop(0)
+            if val is None:
+                _record_status(429, "Too Many Requests")
+            return val
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get), \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http.time, "sleep"):
+            items, error = reddit_listing._fetch_one_with_status(
+                "technology", "hot", "netherlands"
+            )
+        assert error is None
+        assert items
+        assert bodies == []
+
+    def test_listing_fetch_records_double_429(self):
+        def fake_get(*_args, **_kwargs):
+            _record_status(429, "Too Many Requests")
+            return None
+
+        with mock.patch.object(http, "get_text", side_effect=fake_get) as gt, \
+             mock.patch.object(http.REDDIT_KEYLESS_LIMITER, "acquire"), \
+             mock.patch.object(http.time, "sleep"), \
+             http.capture_failures() as failures:
+            items, error = reddit_listing._fetch_one_with_status(
+                "technology", "hot", "x"
+            )
+        assert items == []
+        assert error is not None and "429" in error
+        assert gt.call_count == 2
+        assert any(f.status_code == 429 for f in failures)
+
+
+class TestPartialOutcomeWording:
+    def test_rate_limited_partial_does_not_read_as_cutoff(self):
+        outcome = schema.SourceOutcome(
+            source="reddit",
+            state=schema.PARTIAL,
+            items_returned=8,
+            detail="HTTP 429: Too Many Requests",
+        )
+        text = render._format_outcome(outcome)
+        assert "partial after" not in text
+        assert "8 items returned" in text
+        assert "some requests rate-limited" in text
+        assert "HTTP 429" in text
+
+    def test_non_rate_limit_partial_keeps_count_without_429_claim(self):
+        outcome = schema.SourceOutcome(
+            source="instagram",
+            state=schema.PARTIAL,
+            items_returned=1,
+            detail="HTTP 400: Bad Request",
+        )
+        text = render._format_outcome(outcome)
+        assert "partial after" not in text
+        assert "1 item returned" in text
+        assert "rate-limited" not in text
+        assert "HTTP 400" in text

--- a/tests/test_reddit_rss.py
+++ b/tests/test_reddit_rss.py
@@ -3,7 +3,15 @@
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from lib import reddit_rss
+
+
+@pytest.fixture(autouse=True)
+def _no_keyless_throttle():
+    with mock.patch.object(reddit_rss.http.REDDIT_KEYLESS_LIMITER, "acquire"):
+        yield
 
 FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "reddit_search_rss_sample.xml"
 


### PR DESCRIPTION
Fixes #985.

## Summary

Unauthenticated reddit.com traffic (RSS, listing, shreddit) shared one token bucket at 5 req/sec with burst 5. Engine fan-out on a typical home IP tripped HTTP 429 and those sub-requests were dropped; the partial outcome then read as `partial after N items`, which sounds like a cutoff rather than a rate limit.

The shared limiter now defaults to 1 req/sec with burst 2; `LAST30DAYS_REDDIT_KEYLESS_RATE` overrides the rate (invalid or non-positive values fall back to 1). RSS and listing fetch through `reddit_keyless_get_text_retry_429`, which retries a 429 once after a short jittered pause and re-acquires the bucket; a recovered 429 is not left in the pipeline sink. Partial outcomes that mention 429 or rate limiting now read `partial — N items returned, some requests rate-limited`. ScrapeCreators routing is unchanged.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

New coverage in `tests/test_reddit_keyless_backoff.py`: `TestRedditKeylessRateKnob` (default 1/sec burst 2, env override, invalid fallback, process-env sync, `.env` export), `TestRedditKeyless429Retry` (429-then-200 recovers with two acquires; double 429 records and stops; non-429 is not retried; RSS and listing recover after one 429; listing records double 429), `TestPartialOutcomeWording`. `tests/test_reddit_rss.py` autouses a limiter-acquire patch so RSS unit tests do not sleep. Full suite green on this branch (one environment-dependent test, `TestGrokExpiryStates::test_no_grok_cli_is_missing`, deselected locally because this host has the grok CLI installed).

## Changelog

- [x] Added `changelog.d/985.fixed.md`
- [ ] Skip changelog

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Reviewed the limiter default change, env parse/export, the in-lane 429 retry (local `capture_failures` so a recovered 429 is not recorded, then `tee_failures` on the retry), and the RSS/listing call sites. No credential paths touched.

### Security

Env parsing rejects non-finite and non-positive rates and falls back to 1. No new credential handling. The retry sleep is bounded (1s plus up to 0.5s jitter). Tests use dummy HTML/RSS fixtures, not live reddit.com.

## Notes

`CONFIGURATION.md` documents `LAST30DAYS_REDDIT_KEYLESS_RATE`. `LAST30DAYS_REDDIT_BACKEND` and `LAST30DAYS_REDDIT_SC_MIN_ITEMS` are unchanged. The 1 req/sec default trades wall-clock for fewer 429s; raise the knob on IPs with more headroom.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #985.
