### PR TITLE
fix(grounding): keep undated keyed-web results instead of dropping the whole response (#928)

### DIFF
--- a/changelog.d/928.fixed.md
+++ b/changelog.d/928.fixed.md
@@ -1,0 +1,1 @@
+Keyed web backends (Brave, Exa, Serper, Parallel) no longer drop organic results that omit a parseable date, so a valid API response no longer collapses to zero items.

--- a/skills/last30days/scripts/lib/grounding.py
+++ b/skills/last30days/scripts/lib/grounding.py
@@ -64,7 +64,7 @@ def brave_search(
     for i, r in enumerate((data.get("web", {}).get("results", []))[:count]):
         raw_date = r.get("page_age") or ""
         pub_date = _normalize_date(raw_date[:10]) if raw_date else None
-        if not _in_date_range(pub_date, date_range):
+        if _known_date_out_of_range(pub_date, date_range):
             continue
         items.append({
             "id": f"WB{i + 1}",
@@ -109,7 +109,7 @@ def exa_search(
             continue
         raw_date = r.get("publishedDate") or ""
         pub_date = _normalize_date(raw_date.split("T")[0] if "T" in raw_date else raw_date[:10]) if raw_date else None
-        if not _in_date_range(pub_date, date_range):
+        if _known_date_out_of_range(pub_date, date_range):
             continue
         items.append({
             "id": f"WE{i + 1}",
@@ -146,7 +146,7 @@ def serper_search(
     for i, r in enumerate((data.get("organic", []))[:count]):
         raw_date = r.get("date") or ""
         pub_date = _parse_serper_date(raw_date)
-        if not _in_date_range(pub_date, date_range):
+        if _known_date_out_of_range(pub_date, date_range):
             continue
         items.append({
             "id": f"WS{i + 1}",
@@ -187,7 +187,7 @@ def parallel_search(
             continue
         raw_date = r.get("publish_date") or ""
         pub_date = _normalize_date(raw_date[:10]) if raw_date else None
-        if not _in_date_range(pub_date, date_range):
+        if _known_date_out_of_range(pub_date, date_range):
             continue
         items.append({
             "id": f"WP{i + 1}",
@@ -363,6 +363,11 @@ def _in_date_range(pub_date: str | None, date_range: tuple[str, str]) -> bool:
     if not pub_date:
         return False
     return date_range[0] <= pub_date <= date_range[1]
+
+
+def _known_date_out_of_range(pub_date: str | None, date_range: tuple[str, str]) -> bool:
+    """True when a parseable date falls outside the window. Unknown dates stay."""
+    return pub_date is not None and not _in_date_range(pub_date, date_range)
 
 
 def _domain(url: str) -> str:

--- a/tests/test_grounding_v3.py
+++ b/tests/test_grounding_v3.py
@@ -24,17 +24,19 @@ class BraveSearchTests(unittest.TestCase):
                     {
                         "title": "Undated Article",
                         "url": "https://example.com/undated",
-                        "description": "Should also be filtered",
+                        "description": "Kept because date is unknown",
                     }
                 ]
             }
         }
         with patch("lib.grounding.http.request", return_value=mock_response) as mock_req:
             items, artifact = grounding.brave_search("test", ("2026-02-25", "2026-03-27"), "fake-key")
-            self.assertEqual(1, len(items))
+            self.assertEqual(2, len(items))
             self.assertEqual("Test Article", items[0]["title"])
             self.assertEqual("https://example.com/article", items[0]["url"])
             self.assertEqual("2026-03-10", items[0]["date"])
+            self.assertEqual("Undated Article", items[1]["title"])
+            self.assertIsNone(items[1]["date"])
             self.assertEqual("brave", artifact["label"])
             call_url = mock_req.call_args.args[1]
             self.assertIn("freshness=2026-02-25to2026-03-27", call_url)
@@ -59,15 +61,17 @@ class SerperSearchTests(unittest.TestCase):
                 {
                     "title": "Undated Result",
                     "link": "https://example.com/undated",
-                    "snippet": "Should also be filtered",
+                    "snippet": "Kept because date is unknown",
                 }
             ]
         }
         with patch("lib.grounding.http.request", return_value=mock_response):
             items, artifact = grounding.serper_search("test", ("2026-02-25", "2026-03-27"), "fake-key")
-            self.assertEqual(1, len(items))
+            self.assertEqual(2, len(items))
             self.assertEqual("Serper Result", items[0]["title"])
             self.assertEqual("2026-03-15", items[0]["date"])
+            self.assertEqual("Undated Result", items[1]["title"])
+            self.assertIsNone(items[1]["date"])
             self.assertEqual("serper", artifact["label"])
 
 
@@ -92,19 +96,21 @@ class ExaSearchTests(unittest.TestCase):
                 {
                     "title": "Undated Exa Result",
                     "url": "https://example.com/undated-exa",
-                    "text": "No date means filtered",
+                    "text": "Kept because date is unknown",
                 },
             ]
         }
         with patch("lib.grounding.http.request", return_value=mock_response) as mock_req:
             items, artifact = grounding.exa_search("test", ("2026-02-25", "2026-03-27"), "fake-exa-key")
-            self.assertEqual(1, len(items))
+            self.assertEqual(2, len(items))
             self.assertEqual("Exa Result", items[0]["title"])
             self.assertEqual("https://example.com/exa", items[0]["url"])
             self.assertEqual("2026-03-15", items[0]["date"])
+            self.assertEqual("Undated Exa Result", items[1]["title"])
+            self.assertIsNone(items[1]["date"])
             self.assertTrue(items[0]["id"].startswith("WE"))
             self.assertEqual("exa", artifact["label"])
-            self.assertEqual(1, artifact["resultCount"])
+            self.assertEqual(2, artifact["resultCount"])
             # Verify API call
             call_args = mock_req.call_args
             self.assertEqual("POST", call_args.args[0])
@@ -137,7 +143,7 @@ class ParallelSearchTests(unittest.TestCase):
                 {
                     "title": "Undated Parallel Result",
                     "url": "https://example.com/undated-parallel",
-                    "snippet": "Should also be filtered",
+                    "snippet": "Kept because date is unknown",
                 },
             ]
         }
@@ -145,13 +151,15 @@ class ParallelSearchTests(unittest.TestCase):
             items, artifact = grounding.parallel_search(
                 "test", ("2026-02-25", "2026-03-27"), "fake-parallel-key"
             )
-            self.assertEqual(1, len(items))
+            self.assertEqual(2, len(items))
             self.assertEqual("Parallel Result", items[0]["title"])
             self.assertEqual("https://example.com/parallel", items[0]["url"])
             self.assertEqual("2026-03-15", items[0]["date"])
+            self.assertEqual("Undated Parallel Result", items[1]["title"])
+            self.assertIsNone(items[1]["date"])
             self.assertTrue(items[0]["id"].startswith("WP"))
             self.assertEqual("parallel", artifact["label"])
-            self.assertEqual(1, artifact["resultCount"])
+            self.assertEqual(2, artifact["resultCount"])
             self.assertEqual("POST", mock_req.call_args.args[0])
             self.assertEqual("https://api.parallel.ai/v1/search", mock_req.call_args.args[1])
             self.assertEqual(

--- a/tests/test_keyed_web_date_filter.py
+++ b/tests/test_keyed_web_date_filter.py
@@ -1,0 +1,228 @@
+"""Keyed web backends must not drop undated organic results (issue #928).
+
+Brave freshness, Exa published-date bounds, and Serper ``tbs=cdr`` already
+constrain the query server-side. Organic results often omit a parseable
+date; treating that as out-of-range emptied the backend. Only a known date
+outside the window is dropped.
+"""
+
+from unittest.mock import patch
+
+from lib import grounding
+
+DATE_RANGE = ("2026-02-25", "2026-03-27")
+
+
+def _titles(items):
+    return [item["title"] for item in items]
+
+
+class TestSerperKeepsUndatedOrganicResults:
+    def test_all_undated_organic_results_are_returned(self):
+        payload = {
+            "organic": [
+                {"title": "A", "link": "https://a.example/1", "snippet": "a"},
+                {"title": "B", "link": "https://b.example/2", "snippet": "b"},
+                {"title": "C", "link": "https://c.example/3", "snippet": "c"},
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.serper_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["A", "B", "C"]
+        assert artifact["resultCount"] == 3
+        assert all(item["date"] is None for item in items)
+
+    def test_drops_only_known_out_of_range_dates(self):
+        payload = {
+            "organic": [
+                {"title": "Undated A", "link": "https://a.example/1", "snippet": "a"},
+                {
+                    "title": "Out of range",
+                    "link": "https://b.example/2",
+                    "snippet": "b",
+                    "date": "Apr 28, 2025",
+                },
+                {"title": "Undated C", "link": "https://c.example/3", "snippet": "c"},
+                {
+                    "title": "In range",
+                    "link": "https://d.example/4",
+                    "snippet": "d",
+                    "date": "Mar 15, 2026",
+                },
+                {"title": "Undated E", "link": "https://e.example/5", "snippet": "e"},
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.serper_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["Undated A", "Undated C", "In range", "Undated E"]
+        assert artifact["resultCount"] == 4
+        assert items[2]["date"] == "2026-03-15"
+        assert items[0]["date"] is None
+
+    def test_unparseable_date_is_kept(self):
+        payload = {
+            "organic": [
+                {
+                    "title": "Garbage date",
+                    "link": "https://a.example/1",
+                    "snippet": "a",
+                    "date": "not a date",
+                },
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.serper_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["Garbage date"]
+        assert artifact["resultCount"] == 1
+        assert items[0]["date"] is None
+
+
+class TestBraveKeepsUndatedResults:
+    def test_all_undated_results_are_returned(self):
+        payload = {
+            "web": {
+                "results": [
+                    {
+                        "title": "U",
+                        "url": "https://u.example/",
+                        "description": "u",
+                    }
+                ]
+            }
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.brave_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["U"]
+        assert artifact["resultCount"] == 1
+        assert items[0]["date"] is None
+
+    def test_drops_only_known_out_of_range_dates(self):
+        payload = {
+            "web": {
+                "results": [
+                    {
+                        "title": "In range",
+                        "url": "https://example.com/article",
+                        "description": "ok",
+                        "page_age": "2026-03-10T00:00:00",
+                    },
+                    {
+                        "title": "Old",
+                        "url": "https://example.com/old",
+                        "description": "old",
+                        "page_age": "2025-12-10T00:00:00",
+                    },
+                    {
+                        "title": "Undated",
+                        "url": "https://example.com/undated",
+                        "description": "no date",
+                    },
+                ]
+            }
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.brave_search(
+                "test", DATE_RANGE, "fake-key"
+            )
+        assert _titles(items) == ["In range", "Undated"]
+        assert artifact["resultCount"] == 2
+
+
+class TestExaKeepsUndatedResults:
+    def test_all_undated_results_are_returned(self):
+        payload = {
+            "results": [
+                {"title": "U", "url": "https://u.example/", "text": "u"},
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.exa_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["U"]
+        assert artifact["resultCount"] == 1
+        assert items[0]["date"] is None
+
+    def test_drops_only_known_out_of_range_dates(self):
+        payload = {
+            "results": [
+                {
+                    "title": "In range",
+                    "url": "https://example.com/exa",
+                    "text": "ok",
+                    "publishedDate": "2026-03-15T00:00:00.000Z",
+                },
+                {
+                    "title": "Old",
+                    "url": "https://example.com/old-exa",
+                    "text": "old",
+                    "publishedDate": "2025-12-01T00:00:00.000Z",
+                },
+                {
+                    "title": "Undated",
+                    "url": "https://example.com/undated-exa",
+                    "text": "no date",
+                },
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.exa_search("test", DATE_RANGE, "fake-key")
+        assert _titles(items) == ["In range", "Undated"]
+        assert artifact["resultCount"] == 2
+
+
+class TestParallelKeepsUndatedResults:
+    def test_all_undated_results_are_returned(self):
+        payload = {
+            "results": [
+                {
+                    "title": "U",
+                    "url": "https://u.example/",
+                    "excerpts": ["u"],
+                }
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.parallel_search(
+                "OpenAI", DATE_RANGE, "fake-key", count=5
+            )
+        assert _titles(items) == ["U"]
+        assert artifact["resultCount"] == 1
+        assert items[0]["date"] is None
+
+    def test_drops_only_known_out_of_range_dates(self):
+        payload = {
+            "results": [
+                {
+                    "title": "In range",
+                    "url": "https://example.com/parallel",
+                    "excerpts": ["ok"],
+                    "publish_date": "2026-03-15T00:00:00Z",
+                },
+                {
+                    "title": "Old",
+                    "url": "https://example.com/old-parallel",
+                    "excerpts": ["old"],
+                    "publish_date": "2025-12-01T00:00:00Z",
+                },
+                {
+                    "title": "Undated",
+                    "url": "https://example.com/undated-parallel",
+                    "excerpts": ["no date"],
+                },
+            ]
+        }
+        with patch("lib.grounding.http.request", return_value=payload):
+            items, artifact = grounding.parallel_search(
+                "test", DATE_RANGE, "fake-key"
+            )
+        assert _titles(items) == ["In range", "Undated"]
+        assert artifact["resultCount"] == 2


### PR DESCRIPTION
## Summary

Keyed web backends (Brave, Exa, Serper, Parallel) no longer drop organic results whose date is missing or unparseable. The client-side window filter now drops only results whose **known** date is out of range, so a valid API response no longer collapses to zero items.

Fixes #928

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused (`tests/test_keyed_web_date_filter.py` + `tests/test_grounding_v3.py`): 38 passed in 0.09s.

Full suite: `uv run pytest -q --deselect tests/test_backend_descriptors.py::TestGrokExpiryStates::test_no_grok_cli_is_missing` → 4085 passed, 5 skipped, 1 deselected, 53 subtests passed in 175.95s.

New `tests/test_keyed_web_date_filter.py` failed on all 9 cases before the fix (undated results emptied the backend) and passes after. Known out-of-range dates still drop. Existing grounding tests were updated to match the keep-undated contract.

## Changelog

- [x] Added `changelog.d/928.fixed.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Checked that undated and unparseable dates are kept, and that a known date outside the window still drops. Confirmed Brave freshness, Exa published-date bounds, and Serper `tbs=cdr` still go out on the request. Parallel still has no server-side date param; it gets the same keep-undated rule the issue asked for. Dummy keys only; HTTP mocked; no real network.

### Security

N/A. No new input handling, command execution, path handling, auth, secrets, or dependencies.

## Notes

Parallel does not send a date constraint on the API request. Known out-of-range Parallel dates still drop. Unknown dates are kept, matching the other three backends.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure: <!-- who / what relationship -->

## Related issues

Fixes #928
