### PR TITLE
fix(github): bound qualifier-only topic fragments in errors and logs so fanout cannot spam them (#954)

### DIFF
--- a/changelog.d/954.fixed.md
+++ b/changelog.d/954.fixed.md
@@ -1,0 +1,1 @@
+GitHub qualifier-only rejections now truncate the topic in error detail and logs so a long planner query cannot spam stderr, the error envelope, and doctor hints on every subquery.

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -198,6 +198,17 @@ def strip_search_qualifiers(text: str) -> str:
     return " ".join(_QUALIFIER_RE.sub(" ", text).split())
 
 
+# Bound topic fragments in logs/error envelopes so fanout cannot blow them up (#954).
+_DIAGNOSTIC_TOPIC_LIMIT = 120
+
+
+def _truncate_diagnostic(text: str, limit: int = _DIAGNOSTIC_TOPIC_LIMIT) -> str:
+    """Cap a topic fragment used in logs or error envelopes."""
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
 def search_github(
     topic: str,
     from_date: str,
@@ -226,22 +237,27 @@ def search_github(
     count = DEPTH_LIMITS.get(depth, DEPTH_LIMITS["default"])
     core = extract_core_subject(topic)
     plain_core = strip_search_qualifiers(core)
-    if plain_core != core:
-        _log(f"Stripped search qualifiers: '{core}' -> '{plain_core}'")
     if not plain_core:
         # A qualifier-only (or empty) topic leaves nothing to search on.
         # Report it instead of querying an empty term, which would match the
         # whole site and then be discarded by the date filter as a bogus
-        # "no results" (issue #949).
+        # "no results" (issue #949). Truncate the topic; skip the strip log
+        # so this path does not repeat an unbounded core (issue #954).
         _log("Topic contained only search qualifiers or was empty; nothing to search")
+        shown = _truncate_diagnostic(topic)
         return {
             "items": [],
             "context": {"core": core, "from_date": from_date,
                         "to_date": to_date, "count": count},
             "error": (
-                f"GitHub topic contained only search qualifiers or was empty: {topic!r}"
+                f"GitHub topic contained only search qualifiers or was empty: {shown!r}"
             ),
         }
+    if plain_core != core:
+        _log(
+            "Stripped search qualifiers: "
+            f"'{_truncate_diagnostic(core)}' -> '{_truncate_diagnostic(plain_core)}'"
+        )
     core = plain_core
     resolved_token = _resolve_token(token)
     authed = bool(resolved_token)

--- a/tests/test_github_qualifier_spam.py
+++ b/tests/test_github_qualifier_spam.py
@@ -1,0 +1,78 @@
+"""Qualifier-only GitHub topics must not embed unbounded raw topics.
+
+Stream fanout calls ``search_github`` once per subquery. Before #954 the
+error envelope used ``{topic!r}`` and the strip log used the full core, so
+log volume, error-report volume, and doctor-hint size scaled with both
+fanout and topic length.
+"""
+
+from unittest.mock import patch
+
+from lib import github
+
+_FROM = "2026-07-01"
+_TO = "2026-07-31"
+# Wrapper text plus a ~120-char topic slice. The pre-fix error embedded
+# the entire raw topic (thousands of chars on a pathological planner query).
+_ERROR_BOUND = 300
+_STRIP_LOG_BOUND = 400
+
+
+def _long_qualifier_only_topic() -> str:
+    return "created:>2025-03-20 " + ("stars:>1 " * 400)
+
+
+def test_qualifier_only_error_detail_is_bounded():
+    topic = _long_qualifier_only_topic()
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch:
+        result = github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    error = result["error"]
+    assert "qualifier" in error.lower()
+    assert len(error) < _ERROR_BOUND
+    assert len(error) < len(topic)
+    assert "created:>2025-03-20" in error
+    assert "..." in error
+
+
+def test_short_qualifier_only_topic_is_fully_shown():
+    topic = "created:>2025-03-20"
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch:
+        result = github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    assert topic in result["error"]
+    assert "..." not in result["error"]
+
+
+def test_qualifier_only_logs_are_bounded_across_fanout():
+    topic = _long_qualifier_only_topic()
+    logs: list[str] = []
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch, patch.object(github, "_log", side_effect=lambda m: logs.append(m)):
+        for _ in range(5):
+            github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    assert logs
+    for msg in logs:
+        assert len(msg) < _ERROR_BOUND
+        assert topic not in msg
+
+
+def test_mixed_topic_strip_log_is_bounded():
+    subject = "open source ai " * 200
+    topic = subject + "stars:>1000 created:>2025-03-20"
+    logs: list[str] = []
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json", return_value={"items": []}
+    ), patch.object(github, "_log", side_effect=lambda m: logs.append(m)):
+        github.search_github(topic, _FROM, _TO)
+    strip_logs = [m for m in logs if m.startswith("Stripped search qualifiers:")]
+    assert strip_logs
+    for msg in strip_logs:
+        assert len(msg) < _STRIP_LOG_BOUND
+        assert subject not in msg


### PR DESCRIPTION
Fixes #954

## Summary

GitHub qualifier-only rejections no longer embed the entire raw topic in the error envelope or the strip log. Stream fanout calls `search_github` once per subquery, so `{topic!r}` made log volume, error-report volume, and doctor-hint size scale with both fanout and topic length. Diagnostic fragments are now capped at 120 characters, and the empty-core path skips the redundant strip log.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused (`uv run pytest tests/test_github_qualifier_spam.py tests/test_github.py --tb=no -ra`):

```
...........................................................              [100%]
59 passed in 0.23s
```

Full (`uv run pytest -q --tb=no -ra --deselect tests/test_backend_descriptors.py::TestGrokExpiryStates::test_no_grok_cli_is_missing`):

```
..................................                                       [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_digg.py:455: LAST30DAYS_DIGG_LIVE not set or digg-pp-cli missing
SKIPPED [1] tests/test_digg.py:465: LAST30DAYS_DIGG_LIVE not set or digg-pp-cli missing
SKIPPED [1] tests/test_digg.py:474: LAST30DAYS_DIGG_LIVE not set or digg-pp-cli missing
SKIPPED [1] tests/test_digg.py:483: LAST30DAYS_DIGG_LIVE not set or digg-pp-cli missing
SKIPPED [1] tests/test_new_sources_eval.py:99: set LAST30DAYS_EVAL_LIVE=1 to run live source exploration
```

Exit 0. 4085 collected, 1 deselected, 5 skipped (live-only). New tests failed before the cap (`len(error) == 3682`, strip logs 3655 / 6066) and passed after.

## Changelog

- [x] Added `changelog.d/954.fixed.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Checked that the qualifier-only early return still skips the network, that existing `test_github.py` assertions on `"qualifier"` in the error still hold, and that short topics remain fully visible. Truncation is display-only: mixed topics still search on the full stripped core. Did not change pipeline fanout; each subquery still calls GitHub, but each envelope and log line is bounded.

### Security

Planner/user topic strings are untrusted input. Bounding them in logs and error envelopes reduces log-injection and oversized-payload risk. No credentials, path handling, or command execution changed.

## Notes

Pipeline-level dedup of qualifier-only GitHub calls was not done: fanout submits every (subquery, source) pair up front, so a skip would need shared mutable state or serial GitHub. The 120-char cap is enough for this P3.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #954