### PR TITLE
fix(discover): treat a bot-gated river listing as schema-drift, not no-results (#940)

### DIFF
--- a/changelog.d/940.fixed.md
+++ b/changelog.d/940.fixed.md
@@ -1,0 +1,1 @@
+A bot-gated Reddit r/all (or empty HN/Digg river) on `--discover` is no longer a clean `no-results`: a successful fetch with nothing parseable is `schema-drift` with the HTTP status in `detail`, so a blocked river cannot vote "quiet."

--- a/skills/last30days/scripts/lib/hackernews.py
+++ b/skills/last30days/scripts/lib/hackernews.py
@@ -185,6 +185,14 @@ def fetch_discovery_listings(
         unique_hits.append(hit)
 
     items = parse_hackernews_response({"hits": unique_hits}, query="")
+    # Front page + best-in-window cannot both be legitimately empty; a
+    # successful transport with nothing parseable is a gated river, not a
+    # quiet day (issue #940).
+    if not unique_hits and not errors:
+        errors.append(
+            "HTTP 200: HN front page returned no hits "
+            "(likely bot-gated interstitial)"
+        )
     return {"items": items, "errors": errors}
 
 

--- a/skills/last30days/scripts/lib/pipeline.py
+++ b/skills/last30days/scripts/lib/pipeline.py
@@ -468,6 +468,32 @@ def _matches_discovery_domain(domain: str, text: str) -> bool:
     return bool((anchors or domain_terms) & terms(text))
 
 
+_DISCOVERY_RIVER_SOURCES = frozenset({"reddit", "hackernews", "digg"})
+_EMPTY_RIVER_DETAIL = (
+    "HTTP 200: river listing returned no parseable items "
+    "(likely bot-gated interstitial)"
+)
+
+
+def _empty_river_error(
+    source: str,
+    items: list[dict[str, Any]],
+    error: str | None,
+    *,
+    keyword_gate: bool,
+) -> str | None:
+    """Keep a blocked river from voting quiet on a global sweep.
+
+    Keyword-scoped zero after a domain gate is a real no-results. r/all, the
+    HN front page, and the Digg feed cannot be legitimately empty (issue #940).
+    """
+    if error:
+        return error
+    if keyword_gate or items or source not in _DISCOVERY_RIVER_SOURCES:
+        return None
+    return _EMPTY_RIVER_DETAIL
+
+
 def _fetch_discovery_source(
     source: str,
     plan: schema.DiscoveryPlan,
@@ -503,7 +529,12 @@ def _fetch_discovery_source(
                     f"{item.get('title') or ''} {item.get('selftext') or ''}",
                 )
             ]
-        return items, "; ".join(result.get("errors") or []) or None
+        return items, _empty_river_error(
+            "reddit",
+            items,
+            "; ".join(result.get("errors") or []) or None,
+            keyword_gate=keyword_gate,
+        )
     if source == "hackernews":
         result = hackernews.fetch_discovery_listings(from_date, to_date, depth=depth)
         items = result.get("items") or []
@@ -520,7 +551,12 @@ def _fetch_discovery_source(
                 if _matches_discovery_domain(plan.domain, str(item.get("title") or ""))
             ]
         errors = result.get("errors") or []
-        return items, "; ".join(errors) or None
+        return items, _empty_river_error(
+            "hackernews",
+            items,
+            "; ".join(errors) or None,
+            keyword_gate=keyword_gate,
+        )
     if source == "digg":
         result = digg.search_digg(plan.domain, from_date, to_date, depth=depth)
         items = digg.parse_digg_response(result, query=plan.domain)
@@ -531,7 +567,12 @@ def _fetch_discovery_source(
                 item for item in items
                 if _matches_discovery_domain(plan.domain, str(item.get("title") or ""))
             ]
-        return items, result.get("error")
+        return items, _empty_river_error(
+            "digg",
+            items,
+            result.get("error"),
+            keyword_gate=keyword_gate,
+        )
     if source == "x":
         # Discovery uses domain directly as query (no planner search_query)
         query = plan.domain

--- a/skills/last30days/scripts/lib/reddit_listing.py
+++ b/skills/last30days/scripts/lib/reddit_listing.py
@@ -101,6 +101,41 @@ def _post_id(permalink: str) -> str:
 
 _ERROR_PATTERN = re.compile(r"^r/(\S+)\s+(\S+):", re.IGNORECASE)
 
+# Challenge/block pages arrive as HTTP 200 HTML with no <shreddit-post> cards.
+# A dedicated-sub shreddit partial can legitimately be a small empty fragment;
+# r/all cannot, and a full HTML document without cards is never a listing.
+_BLOCK_MARKERS = (
+    "verify you are human",
+    "confirm you are a human",
+    "just a moment",
+    "attention required",
+    "cf-browser-verification",
+    "enable javascript and reload",
+    "whoa there",
+)
+
+
+def _listing_gate_error(subreddit: str, text: str) -> Optional[str]:
+    """Return an error when an empty parse is a gate, not a quiet listing."""
+    sub = subreddit.removeprefix("r/").strip().lower()
+    body = text or ""
+    if sub == "all" or _unparseable_listing_body(body):
+        return (
+            f"HTTP 200: no parseable listing cards ({len(body)} bytes; "
+            "likely bot-gated interstitial)"
+        )
+    return None
+
+
+def _unparseable_listing_body(text: str) -> bool:
+    if not text.strip():
+        return False
+    lowered = text.lower()
+    if any(marker in lowered for marker in _BLOCK_MARKERS):
+        return True
+    stripped = text.lstrip().lower()
+    return stripped.startswith(("<!doctype html", "<html"))
+
 
 def _shreddit_error_recovered(error: str, successes: Set[tuple[str, str]]) -> bool:
     """Return True if the error's (sub, sort) pair is in the successes set.
@@ -199,7 +234,10 @@ def _fetch_one_with_status(
         if text is None:
             # An empty body ("") is a real empty listing; None never is.
             return [], (str(swallowed[-1]) if swallowed else "no response")
-        return parse_cards(text, query), None
+        posts = parse_cards(text, query)
+        if posts:
+            return posts, None
+        return [], _listing_gate_error(subreddit, text)
     except Exception as e:
         _log(f"listing fetch failed r/{subreddit} {sort}: {e}")
         return [], str(e)

--- a/tests/test_discover_river_gated.py
+++ b/tests/test_discover_river_gated.py
@@ -1,0 +1,150 @@
+"""River listings must not report a bot-gate as a clean no-results.
+
+Issue #940: a global ``--discover --nominate-only`` sweep treated Reddit's
+r/all as quiet when the listing fetch returned HTTP 200 with a large HTML
+block page and zero ``<shreddit-post>`` cards. r/all, the HN front page, and
+the Digg feed cannot be legitimately empty; a successful transport with
+nothing parseable is a gated/degraded outcome, and the HTTP status belongs
+in ``source_status.detail``. Keyword-scoped zero after a domain gate is
+still a real no-results.
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+from lib import hackernews, pipeline, reddit_listing, schema
+
+
+BLOCK_HTML = (
+    "<!DOCTYPE html><html><head><title>Just a moment</title></head>"
+    "<body>" + ("x" * 180_000) + "<p>Please wait while we verify you are human</p>"
+    "</body></html>"
+)
+
+
+def _html_response(body: str, status: int = 200):
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body.encode()
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _nominate_reddit(*, domain: str, urlopen_side_effect):
+    with mock.patch.object(pipeline, "available_sources", return_value=["reddit"]), \
+         mock.patch("lib.http.time.sleep"), \
+         mock.patch("lib.http.urllib.request.urlopen", side_effect=urlopen_side_effect):
+        return pipeline.run_discover_nominate(
+            domain=domain,
+            config={},
+            as_of_date="2026-07-10",
+        )
+
+
+def test_global_r_all_block_page_is_not_reported_as_no_results():
+    result = _nominate_reddit(domain="", urlopen_side_effect=lambda *a, **k: _html_response(BLOCK_HTML))
+
+    outcome = result.source_status["reddit"]
+    assert outcome.state != schema.NO_RESULTS
+    assert outcome.state == schema.SCHEMA_DRIFT
+    assert outcome.items_returned == 0
+    assert outcome.attempted is True
+    assert "200" in (outcome.detail or "")
+
+
+def test_keyword_scoped_r_all_block_page_is_not_reported_as_no_results():
+    # Uncategorized domains still sweep r/all; an empty parse is a gate, not
+    # a quiet topic.
+    result = _nominate_reddit(
+        domain="urban gardening",
+        urlopen_side_effect=lambda *a, **k: _html_response(BLOCK_HTML),
+    )
+
+    outcome = result.source_status["reddit"]
+    assert outcome.state != schema.NO_RESULTS
+    assert "200" in (outcome.detail or "")
+
+
+def test_fetch_discovery_listings_records_r_all_block_page():
+    with mock.patch("lib.http.time.sleep"), mock.patch(
+        "lib.http.urllib.request.urlopen",
+        side_effect=lambda *a, **k: _html_response(BLOCK_HTML),
+    ):
+        result = reddit_listing.fetch_discovery_listings(["all"], query="")
+
+    assert result["items"] == []
+    assert result["errors"]
+    assert any("200" in error for error in result["errors"])
+
+
+def test_dedicated_sub_empty_partial_is_a_real_empty_listing():
+    with mock.patch.object(
+        reddit_listing.http, "reddit_keyless_get_text", return_value="<div></div>"
+    ):
+        items, error = reddit_listing._fetch_one_with_status("tea", "hot", "matcha")
+
+    assert items == []
+    assert error is None
+
+
+def test_dedicated_sub_html_block_page_is_gated():
+    with mock.patch.object(
+        reddit_listing.http, "reddit_keyless_get_text", return_value=BLOCK_HTML
+    ):
+        items, error = reddit_listing._fetch_one_with_status("tea", "hot", "matcha")
+
+    assert items == []
+    assert error is not None
+    assert "200" in error
+
+
+def test_keyword_gate_dropping_every_card_is_still_no_results():
+    payload = {
+        "items": [
+            {"title": "OpenAI ships a new frontier model", "selftext": ""},
+            {"title": "Anthropic updates its agent SDK", "selftext": ""},
+        ],
+        "errors": [],
+    }
+    plan = schema.DiscoveryPlan(
+        domain="urban gardening", category=None, subreddits=["all"], sources=["reddit"],
+    )
+    with mock.patch.object(reddit_listing, "fetch_discovery_listings", return_value=payload):
+        items, error = pipeline._fetch_discovery_source(
+            "reddit", plan,
+            from_date="2026-06-10", to_date="2026-07-10",
+            depth="default", mock=False, config={}, keyword_gate=True,
+        )
+
+    assert items == []
+    assert error is None
+
+
+def test_hn_front_page_empty_parse_is_not_a_clean_empty_feed():
+    def fake_request(method, url, **_kwargs):
+        assert method == "GET"
+        return {"hits": []}
+
+    with mock.patch.object(hackernews.http, "request", side_effect=fake_request):
+        result = hackernews.fetch_discovery_listings("2026-06-10", "2026-07-10", depth="quick")
+
+    assert result["items"] == []
+    assert result["errors"]
+    assert any("200" in error for error in result["errors"])
+
+
+def test_global_digg_empty_river_is_not_reported_as_no_results():
+    plan = schema.DiscoveryPlan(
+        domain="", category=None, subreddits=["all"], sources=["digg"],
+    )
+    with mock.patch.object(pipeline.digg, "search_digg", return_value={"results": []}):
+        items, error = pipeline._fetch_discovery_source(
+            "digg", plan,
+            from_date="2026-06-10", to_date="2026-07-10",
+            depth="default", mock=False, config={}, keyword_gate=False,
+        )
+
+    assert items == []
+    assert error
+    assert "200" in error


### PR DESCRIPTION
## Summary

`--discover` no longer treats a bot-gated Reddit r/all (or an empty HN/Digg river) as a clean `no-results`. A successful listing fetch with nothing parseable is `schema-drift`, and `source_status.detail` carries the HTTP status, so a blocked river cannot vote "quiet." Keyword-scoped zero after a domain gate is unchanged.

Fixes #940

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused: `uv run pytest tests/test_discover_river_gated.py -q` → 8 passed in 0.34s.

Full: `uv run pytest -q --deselect tests/test_backend_descriptors.py::TestGrokExpiryStates::test_no_grok_cli_is_missing` → 4084 passed, 5 skipped, exit 0.

New coverage in `tests/test_discover_river_gated.py` failed on HEAD before the adapter/pipeline change (200 HTML block page reported `no-results` with empty detail) and passes after.

## Changelog

- [x] Added `changelog.d/940.fixed.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Checked that urllib 403/429 still classify as `auth-failed`/`rate-limited` (#899), that a quiet dedicated-sub shreddit fragment stays a real empty listing, and that keyword-scoped zero after a domain gate stays `no-results`. The 200 HTML block-page path is the hole this PR closes; challenge markers and a full HTML document without cards are treated as gated.

### Security

N/A. No new network, auth, or command-execution surface. Tests mock `urlopen` / `get_text` with fixture HTML only.

## Notes

`/r/all/hot.json` is still permanently 403 keyless and is not fetched. The engine's r/all river uses HTML listing pages, which can return 200 with a challenge body. HN and Digg get the same empty-river rule on a global sweep.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #940
