### PR TITLE
fix(github): qualifier-only or empty topics are clean no-results, not ERROR (#953)

### DIFF
--- a/changelog.d/953.fixed.md
+++ b/changelog.d/953.fixed.md
@@ -1,0 +1,1 @@
+Empty or qualifier-only GitHub topics now report no-results instead of marking the source as failed.

--- a/changelog.d/954.fixed.md
+++ b/changelog.d/954.fixed.md
@@ -1,0 +1,1 @@
+GitHub qualifier-only rejections now truncate the topic in error detail and logs so a long planner query cannot spam stderr, the error envelope, and doctor hints on every subquery.

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -198,6 +198,17 @@ def strip_search_qualifiers(text: str) -> str:
     return " ".join(_QUALIFIER_RE.sub(" ", text).split())
 
 
+# Bound topic fragments in logs/error envelopes so fanout cannot blow them up (#954).
+_DIAGNOSTIC_TOPIC_LIMIT = 120
+
+
+def _truncate_diagnostic(text: str, limit: int = _DIAGNOSTIC_TOPIC_LIMIT) -> str:
+    """Cap a topic fragment used in logs or error envelopes."""
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
 def search_github(
     topic: str,
     from_date: str,
@@ -226,22 +237,27 @@ def search_github(
     count = DEPTH_LIMITS.get(depth, DEPTH_LIMITS["default"])
     core = extract_core_subject(topic)
     plain_core = strip_search_qualifiers(core)
-    if plain_core != core:
-        _log(f"Stripped search qualifiers: '{core}' -> '{plain_core}'")
     if not plain_core:
         # A qualifier-only (or empty) topic leaves nothing to search on.
         # Report it instead of querying an empty term, which would match the
         # whole site and then be discarded by the date filter as a bogus
-        # "no results" (issue #949).
+        # "no results" (issue #949). Truncate the topic; skip the strip log
+        # so this path does not repeat an unbounded core (issue #954).
         _log("Topic contained only search qualifiers or was empty; nothing to search")
+        shown = _truncate_diagnostic(topic)
         return {
             "items": [],
             "context": {"core": core, "from_date": from_date,
                         "to_date": to_date, "count": count},
             "error": (
-                f"GitHub topic contained only search qualifiers or was empty: {topic!r}"
+                f"GitHub topic contained only search qualifiers or was empty: {shown!r}"
             ),
         }
+    if plain_core != core:
+        _log(
+            "Stripped search qualifiers: "
+            f"'{_truncate_diagnostic(core)}' -> '{_truncate_diagnostic(plain_core)}'"
+        )
     core = plain_core
     resolved_token = _resolve_token(token)
     authed = bool(resolved_token)

--- a/skills/last30days/scripts/lib/github.py
+++ b/skills/last30days/scripts/lib/github.py
@@ -239,19 +239,16 @@ def search_github(
     plain_core = strip_search_qualifiers(core)
     if not plain_core:
         # A qualifier-only (or empty) topic leaves nothing to search on.
-        # Report it instead of querying an empty term, which would match the
-        # whole site and then be discarded by the date filter as a bogus
-        # "no results" (issue #949). Truncate the topic; skip the strip log
-        # so this path does not repeat an unbounded core (issue #954).
+        # Skip the network rather than querying an empty term, which would
+        # match the whole site (#949). Return a clean empty envelope, not an
+        # error, so the pipeline records NO_RESULTS instead of ERROR (#953)
+        # and GitHub is not marked as a failed attempt. The strip log below
+        # stays bounded by _truncate_diagnostic (#954).
         _log("Topic contained only search qualifiers or was empty; nothing to search")
-        shown = _truncate_diagnostic(topic)
         return {
             "items": [],
             "context": {"core": core, "from_date": from_date,
                         "to_date": to_date, "count": count},
-            "error": (
-                f"GitHub topic contained only search qualifiers or was empty: {shown!r}"
-            ),
         }
     if plain_core != core:
         _log(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -673,15 +673,14 @@ class TestSearchGithubQualifiers(unittest.TestCase):
         self.assertNotIn("is:pull-request", q)
 
     @patch.object(github, "_resolve_token", return_value="test-token")
-    def test_qualifier_only_topic_errors_without_network(self, mock_token):
+    def test_qualifier_only_topic_skips_network(self, mock_token):
         with patch.object(github, "_fetch_json") as mock_fetch:
             result = github.search_github(
                 "created:>2025-03-20", "2026-07-01", "2026-07-31",
             )
         mock_fetch.assert_not_called()
         self.assertEqual(result["items"], [])
-        self.assertIn("error", result)
-        self.assertIn("qualifier", result["error"].lower())
+        self.assertNotIn("error", result)
         self.assertEqual(result["context"]["from_date"], "2026-07-01")
 
     @patch.object(github, "_resolve_token", return_value="test-token")
@@ -712,12 +711,12 @@ class TestSearchGithubQualifiers(unittest.TestCase):
         self.assertNotIn("created:>2025-03-20", q)
 
     @patch.object(github, "_resolve_token", return_value="test-token")
-    def test_empty_topic_errors_without_network(self, mock_token):
+    def test_empty_topic_skips_network(self, mock_token):
         with patch.object(github, "_fetch_json") as mock_fetch:
             result = github.search_github("", "2026-07-01", "2026-07-31")
         mock_fetch.assert_not_called()
         self.assertEqual(result["items"], [])
-        self.assertIn("error", result)
+        self.assertNotIn("error", result)
 
     @patch.object(github, "_resolve_token", return_value="test-token")
     def test_glued_term_after_qualifier_value_reaches_query(self, mock_token):

--- a/tests/test_github_qualifier_only.py
+++ b/tests/test_github_qualifier_only.py
@@ -1,0 +1,70 @@
+"""Empty and qualifier-only GitHub topics must not be classified as ERROR (#953).
+
+Pre-#949, search_github('') built a site-wide created:> window query.
+The qualifier strip then returned an error envelope with no network call,
+and pipeline._result_outcome_artifact mapped that error to a failed attempt.
+"""
+
+from unittest.mock import patch
+
+from lib import github, pipeline, schema
+
+
+def _search(topic):
+    with patch.object(github, "_resolve_token", return_value="test-token"):
+        with patch.object(github, "_fetch_json") as mock_fetch:
+            result = github.search_github(topic, "2026-07-01", "2026-07-31")
+    return result, mock_fetch
+
+
+def _bundle_from_envelope(envelope):
+    artifact = pipeline._result_outcome_artifact("github", envelope)
+    bundle = schema.RetrievalBundle()
+    bundle.mark_attempted("github")
+    outcome = artifact.get("_source_outcome") if isinstance(artifact, dict) else None
+    if isinstance(outcome, dict):
+        bundle.record_failure(
+            "github",
+            outcome["state"],
+            outcome["detail"],
+            attempted=outcome.get("attempted", True),
+        )
+    items = github.parse_github_response(envelope)
+    bundle.add_items("primary", "github", items)
+    return artifact, bundle
+
+
+def test_empty_topic_is_clean_no_results_not_error():
+    result, mock_fetch = _search("")
+    mock_fetch.assert_not_called()
+    assert result["items"] == []
+    assert "error" not in result
+    artifact, bundle = _bundle_from_envelope(result)
+    assert artifact == {}
+    assert "github" not in bundle.errors_by_source
+    outcome = bundle.source_status["github"]
+    assert outcome.state == schema.NO_RESULTS
+    assert outcome.attempted is True
+
+
+def test_qualifier_only_topic_is_clean_no_results_not_error():
+    result, mock_fetch = _search("created:>2025-03-20")
+    mock_fetch.assert_not_called()
+    assert result["items"] == []
+    assert "error" not in result
+    artifact, bundle = _bundle_from_envelope(result)
+    assert artifact == {}
+    assert "github" not in bundle.errors_by_source
+    assert bundle.source_status["github"].state == schema.NO_RESULTS
+
+
+def test_noise_plus_qualifier_topic_is_clean_no_results_not_error():
+    # extract_core_subject('the best stars:>1000') -> 'stars:>1000' -> plain ''
+    result, mock_fetch = _search("the best stars:>1000")
+    mock_fetch.assert_not_called()
+    assert result["items"] == []
+    assert "error" not in result
+    artifact, bundle = _bundle_from_envelope(result)
+    assert artifact == {}
+    assert "github" not in bundle.errors_by_source
+    assert bundle.source_status["github"].state == schema.NO_RESULTS

--- a/tests/test_github_qualifier_spam.py
+++ b/tests/test_github_qualifier_spam.py
@@ -1,0 +1,78 @@
+"""Qualifier-only GitHub topics must not embed unbounded raw topics.
+
+Stream fanout calls ``search_github`` once per subquery. Before #954 the
+error envelope used ``{topic!r}`` and the strip log used the full core, so
+log volume, error-report volume, and doctor-hint size scaled with both
+fanout and topic length.
+"""
+
+from unittest.mock import patch
+
+from lib import github
+
+_FROM = "2026-07-01"
+_TO = "2026-07-31"
+# Wrapper text plus a ~120-char topic slice. The pre-fix error embedded
+# the entire raw topic (thousands of chars on a pathological planner query).
+_ERROR_BOUND = 300
+_STRIP_LOG_BOUND = 400
+
+
+def _long_qualifier_only_topic() -> str:
+    return "created:>2025-03-20 " + ("stars:>1 " * 400)
+
+
+def test_qualifier_only_error_detail_is_bounded():
+    topic = _long_qualifier_only_topic()
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch:
+        result = github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    error = result["error"]
+    assert "qualifier" in error.lower()
+    assert len(error) < _ERROR_BOUND
+    assert len(error) < len(topic)
+    assert "created:>2025-03-20" in error
+    assert "..." in error
+
+
+def test_short_qualifier_only_topic_is_fully_shown():
+    topic = "created:>2025-03-20"
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch:
+        result = github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    assert topic in result["error"]
+    assert "..." not in result["error"]
+
+
+def test_qualifier_only_logs_are_bounded_across_fanout():
+    topic = _long_qualifier_only_topic()
+    logs: list[str] = []
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json"
+    ) as fetch, patch.object(github, "_log", side_effect=lambda m: logs.append(m)):
+        for _ in range(5):
+            github.search_github(topic, _FROM, _TO)
+    fetch.assert_not_called()
+    assert logs
+    for msg in logs:
+        assert len(msg) < _ERROR_BOUND
+        assert topic not in msg
+
+
+def test_mixed_topic_strip_log_is_bounded():
+    subject = "open source ai " * 200
+    topic = subject + "stars:>1000 created:>2025-03-20"
+    logs: list[str] = []
+    with patch.object(github, "_resolve_token", return_value="t"), patch.object(
+        github, "_fetch_json", return_value={"items": []}
+    ), patch.object(github, "_log", side_effect=lambda m: logs.append(m)):
+        github.search_github(topic, _FROM, _TO)
+    strip_logs = [m for m in logs if m.startswith("Stripped search qualifiers:")]
+    assert strip_logs
+    for msg in strip_logs:
+        assert len(msg) < _STRIP_LOG_BOUND
+        assert subject not in msg

--- a/tests/test_github_qualifier_spam.py
+++ b/tests/test_github_qualifier_spam.py
@@ -22,30 +22,28 @@ def _long_qualifier_only_topic() -> str:
     return "created:>2025-03-20 " + ("stars:>1 " * 400)
 
 
-def test_qualifier_only_error_detail_is_bounded():
+def test_qualifier_only_topic_returns_clean_empty_envelope_without_network():
+    """#953 supersedes the #954 error bound: a qualifier-only topic is a clean
+    no-results envelope (no error key), so there is nothing to spam."""
     topic = _long_qualifier_only_topic()
     with patch.object(github, "_resolve_token", return_value="t"), patch.object(
         github, "_fetch_json"
     ) as fetch:
         result = github.search_github(topic, _FROM, _TO)
     fetch.assert_not_called()
-    error = result["error"]
-    assert "qualifier" in error.lower()
-    assert len(error) < _ERROR_BOUND
-    assert len(error) < len(topic)
-    assert "created:>2025-03-20" in error
-    assert "..." in error
+    assert result["items"] == []
+    assert "error" not in result
 
 
-def test_short_qualifier_only_topic_is_fully_shown():
+def test_short_qualifier_only_topic_is_also_clean_no_results():
     topic = "created:>2025-03-20"
     with patch.object(github, "_resolve_token", return_value="t"), patch.object(
         github, "_fetch_json"
     ) as fetch:
         result = github.search_github(topic, _FROM, _TO)
     fetch.assert_not_called()
-    assert topic in result["error"]
-    assert "..." not in result["error"]
+    assert result["items"] == []
+    assert "error" not in result
 
 
 def test_qualifier_only_logs_are_bounded_across_fanout():


### PR DESCRIPTION
Stacked on #1039 (#954): this branch includes that commit and adapts its two error-envelope tests, because #953 removes the error envelope #954 had only bounded. Merge #1039 first or merge this one and close #1039 — either order is fine.

Fixes #953

## Summary

Empty or qualifier-only GitHub topics no longer mark the source as failed. `search_github` still skips the network when stripping leaves nothing to search (the #949 site-wide guard), but it returns a clean empty envelope instead of an `error` key, so the pipeline records no-results rather than ERROR.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused (`uv run pytest tests/test_github_qualifier_only.py tests/test_github.py --tb=short`):
58 passed in 0.14s

Full (`uv run pytest -q --deselect tests/test_backend_descriptors.py::TestGrokExpiryStates::test_no_grok_cli_is_missing`):
4079 passed, 5 skipped, 1 deselected, 53 subtests passed in 151.19s (0:02:31)

New tests fail before the envelope change (they assert no `error` key and NO_RESULTS, not ERROR) and pass after.

## Changelog

- [x] Added `changelog.d/953.fixed.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

Implemented by Grok Build (xAI coding agent) under the author's supervision from a written contract; diff and tests reviewed by the author's Claude Code session before opening.

### AI review

Checked that omitting `error` does not restore a site-wide empty-term search (#949 still skips the network), that mixed subject-plus-qualifier topics still strip and query, and that a clean empty envelope is not written into `errors_by_source` (so `_retry_thin_sources` stays eligible). SKIPPED_UNCONFIGURED was rejected because GitHub is configured; NO_RESULTS is the honest state. `add_items` always sets attempted=True for an available source, which is correct once other subqueries have run.

### Security

No credentials, network, or path handling changed. Tests patch `_fetch_json` and use dummy tokens only.

## Notes

A qualifier-only subquery no longer poisons the whole GitHub source. Mixed topics such as `open source AI stars:>1000 created:>2025-03-20` are unchanged.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #953
