### PR TITLE
fix(instagram): unwrap user reels media envelopes

### DIFF
--- a/changelog.d/1017.fixed.md
+++ b/changelog.d/1017.fixed.md
@@ -1,0 +1,1 @@
+Instagram creator reels now unwrap ScrapeCreators `media` envelopes before parsing, preserving their metadata and date filtering.

--- a/skills/last30days/scripts/lib/instagram.py
+++ b/skills/last30days/scripts/lib/instagram.py
@@ -271,7 +271,15 @@ def _user_reels(
 
     raw_items = data.get("items") or data.get("reels") or data.get("data") or []
     _log(f"  -> {len(raw_items)} reels from @{handle}")
-    return raw_items
+
+    # User-reels responses wrap each reel in a ``media`` envelope, while
+    # other Instagram endpoints already return flat reel dictionaries.
+    return [
+        item["media"]
+        if isinstance(item, dict) and isinstance(item.get("media"), dict)
+        else item
+        for item in raw_items
+    ]
 
 
 def search_instagram(

--- a/tests/test_instagram.py
+++ b/tests/test_instagram.py
@@ -40,6 +40,37 @@ class TestInstagramOwnerTypeSafety(unittest.TestCase):
         self.assertEqual("fallbackuser", items[0]["author_name"])
 
 
+class TestInstagramUserReelsEnvelope(unittest.TestCase):
+    def test_wrapped_user_reel_is_parsed_with_its_fields(self):
+        from unittest.mock import patch
+        from lib import instagram
+
+        reel = {
+            "id": "reel-1017",
+            "code": "ABC1017",
+            "taken_at": "2026-08-01T12:34:56.000Z",
+            "caption": {"text": "Wrapped reel caption"},
+            "video_play_count": 123,
+            "like_count": 45,
+            "comment_count": 6,
+        }
+        response = {"items": [{"media": reel}]}
+
+        with patch.object(instagram.http, "get", return_value=response):
+            raw_items = instagram._user_reels("creator", token="test-token")
+
+        items = _parse_items(raw_items, "wrapped reel")
+
+        self.assertEqual(1, len(items))
+        self.assertEqual("reel-1017", items[0]["video_id"])
+        self.assertEqual("2026-08-01", items[0]["date"])
+        self.assertEqual("Wrapped reel caption", items[0]["text"])
+        self.assertEqual(
+            {"views": 123, "likes": 45, "comments": 6},
+            items[0]["engagement"],
+        )
+
+
 class TestInstagramComments(unittest.TestCase):
     """U1: Instagram comment fetching via ScrapeCreators."""
 


### PR DESCRIPTION
## Summary

Fix Instagram creator discovery dropping every reel returned by ScrapeCreators' `/v1/instagram/user/reels` endpoint. That endpoint wraps each reel in a `media` object, while the shared parser expects a flat reel mapping; the source now unwraps that envelope while preserving already-flat payloads.

## Testing

- [x] `uv run pytest tests/test_instagram.py -q` (12 passed)
- [x] `uv run pytest` (4078 passed, 5 skipped, 53 subtests passed)
- [x] Added a regression test covering parsed reel id, date, caption, and engagement from the wrapped response
- [x] `git diff --check` passed

## Changelog

- [x] Added `changelog.d/1017.fixed.md`
- [ ] Skip changelog - chore/internal only

## Agent disclosure

### AI review

The change was developed with AI assistance and independently reviewed for spec compliance, endpoint-shape handling, regression risk, scope, and security. The reviewers found no blocking logic or security concerns. The focused Instagram tests and full test suite pass.

### Security

N/A. This is a local response-shape normalization change. No command execution, path handling, authentication behavior, dependency, or secret-handling code was changed.

## Notes

The source-boundary normalization keeps `_parse_items()` on one flat payload shape and leaves already-flat Instagram search results unchanged.

### Relationship to this change

- [x] None
- [ ] Yes - disclosure: 

## Related issues

Fixes #1017
