### PR TITLE
fix(grok): parse CLI JSON output so X search is not empty (#1051)

### DIFF
--- a/changelog.d/1051.fixed.md
+++ b/changelog.d/1051.fixed.md
@@ -1,0 +1,1 @@
+Grok X backend now requests `--output-format json` and parses the JSON array Grok CLI 1.0.5 actually emits, so searches no longer die as "no items parsed". `--json-schema` is still not passed.

--- a/skills/last30days/scripts/lib/grok_x.py
+++ b/skills/last30days/scripts/lib/grok_x.py
@@ -17,6 +17,10 @@ Two invocation constraints, both measured, both load-bearing:
   4 calls, `--json-schema` on 1 of 4.
 * **Never pass `--tools`.** Two runs produced no output in 7 minutes and were
   killed; the identical prompts without it completed normally.
+* **Do pass `--output-format json`.** Grok CLI 1.0.5 narrates tool use and
+  then fences a JSON array; the field-block parser treats that as empty
+  (``no items parsed``). JSON stdout is the CLI's supported way to skip the
+  preamble without constrained decoding. See #1051.
 
 Because retrieval is performed by a language model rather than an API client,
 its output can be *confidently wrong* in a way no other backend's can. Every
@@ -501,6 +505,11 @@ _FIELD_LINE = re.compile(
 # below one with 500 literal likes.
 _INT_RE = re.compile(r"(-?\d[\d,]*(?:\.\d+)?)\s*([KMB])?", re.I)
 _SUFFIX_MULTIPLIER = {"k": 1_000, "m": 1_000_000, "b": 1_000_000_000}
+_STATUS_URL_RE = re.compile(
+    r"(?:x\.com|twitter\.com)/([A-Za-z0-9_]{1,15})/status/(\d+)",
+    re.I,
+)
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.I | re.S)
 
 
 def _as_int(value: str) -> Optional[int]:
@@ -528,6 +537,146 @@ def _parse_date(value: str) -> Optional[str]:
         return datetime.fromisoformat(value.replace("Z", "+00:00")).strftime("%Y-%m-%d")
     except (TypeError, ValueError):
         return None
+
+
+def _fields_from_json_obj(obj: Any) -> Optional[Dict[str, Any]]:
+    """Map one JSON object onto the field-block shape, or None if unusable."""
+    if not isinstance(obj, dict):
+        return None
+    url = str(obj.get("url") or obj.get("link") or "")
+    post_id = obj.get("id") or obj.get("post_id") or obj.get("status_id") or obj.get("tweet_id")
+    handle: Any = (
+        obj.get("handle")
+        or obj.get("author_handle")
+        or obj.get("username")
+        or obj.get("author")
+        or obj.get("user")
+    )
+    if isinstance(handle, dict):
+        handle = (
+            handle.get("username")
+            or handle.get("screen_name")
+            or handle.get("handle")
+            or ""
+        )
+    match = _STATUS_URL_RE.search(url)
+    if match:
+        handle = handle or match.group(1)
+        post_id = post_id or match.group(2)
+    post_id_s = str(post_id or "").strip()
+    if not post_id_s.isdigit():
+        return None
+    text = obj.get("text") or obj.get("full_text") or ""
+    # `content` is often the CLI wrapper payload, not post text.
+    if not text and "content" in obj and not isinstance(obj.get("content"), (dict, list)):
+        text = obj.get("content") or ""
+    return {
+        "post_id": post_id_s,
+        "author_handle": str(handle or "").strip().lstrip("@"),
+        "text": str(text or ""),
+        "likes": obj.get("likes") if obj.get("likes") is not None else obj.get("favorite_count"),
+        "reposts": obj.get("reposts") if obj.get("reposts") is not None else obj.get("retweets"),
+        "replies": obj.get("replies"),
+        "quotes": obj.get("quotes"),
+        "created_at": obj.get("created_at") or obj.get("timestamp") or "",
+    }
+
+
+def _extract_json_values(text: str) -> List[Any]:
+    """Yield JSON values from raw stdout, fenced blocks, or embedded payloads."""
+    values: List[Any] = []
+    text = text or ""
+    try:
+        values.append(json.loads(text))
+    except (json.JSONDecodeError, TypeError):
+        pass
+    for match in _JSON_FENCE_RE.finditer(text):
+        blob = (match.group(1) or "").strip()
+        try:
+            values.append(json.loads(blob))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    if values:
+        return values
+    decoder = json.JSONDecoder()
+    idx = 0
+    while idx < len(text):
+        starts = [i for i in (text.find("[", idx), text.find("{", idx)) if i >= 0]
+        if not starts:
+            break
+        start = min(starts)
+        try:
+            value, end = decoder.raw_decode(text, start)
+            values.append(value)
+            idx = end
+        except json.JSONDecodeError:
+            idx = start + 1
+        if len(values) >= 8:
+            break
+    return values
+
+
+def _posts_from_json_value(value: Any, *, depth: int = 0) -> List[Dict[str, Any]]:
+    if depth > 4:
+        return []
+    if isinstance(value, list):
+        posts = []
+        for item in value:
+            fields = _fields_from_json_obj(item)
+            if fields:
+                posts.append(fields)
+        return posts
+    if isinstance(value, str):
+        for nested in _extract_json_values(value):
+            posts = _posts_from_json_value(nested, depth=depth + 1)
+            if posts:
+                return posts
+        return []
+    if not isinstance(value, dict):
+        return []
+    direct = _fields_from_json_obj(value)
+    if direct:
+        return [direct]
+    for key in ("posts", "items", "results", "data", "tweets"):
+        if key in value:
+            posts = _posts_from_json_value(value[key], depth=depth + 1)
+            if posts:
+                return posts
+    for key in ("content", "message", "result", "text", "output"):
+        inner = value.get(key)
+        if isinstance(inner, (str, list, dict)):
+            posts = _posts_from_json_value(inner, depth=depth + 1)
+            if posts:
+                return posts
+    return []
+
+
+def _fields_from_json_text(text: str) -> List[Dict[str, Any]]:
+    for value in _extract_json_values(text):
+        posts = _posts_from_json_value(value)
+        if posts:
+            return posts
+    return []
+
+
+def _fields_from_blocks(text: str) -> List[Dict[str, Any]]:
+    raw: List[Dict[str, Any]] = []
+    for block in _split_blocks(text):
+        fields: Dict[str, Any] = {}
+        for line in block.splitlines():
+            match = _FIELD_LINE.match(line)
+            if not match:
+                continue
+            key = _FIELD_ALIASES.get(match.group(1).strip().lower())
+            if key and key not in fields:
+                value = match.group(2).strip()
+                # Field values arrive with varying markdown decoration
+                # (`- **id:** 123`), so strip emphasis and code marks.
+                value = value.strip("*").strip().strip("`").strip()
+                fields[key] = value
+        if fields.get("post_id"):
+            raw.append(fields)
+    return raw
 
 
 def _split_blocks(text: str) -> List[str]:
@@ -567,22 +716,23 @@ def parse_x_response(
         _log(f"error: {response['error']}")
         return []
 
-    raw: List[Dict[str, Any]] = []
-    for block in _split_blocks(response.get("text") or ""):
-        fields: Dict[str, Any] = {}
-        for line in block.splitlines():
-            match = _FIELD_LINE.match(line)
-            if not match:
-                continue
-            key = _FIELD_ALIASES.get(match.group(1).strip().lower())
-            if key and key not in fields:
-                value = match.group(2).strip()
-                # Field values arrive with varying markdown decoration
-                # (`- **id:** 123`), so strip emphasis and code marks.
-                value = value.strip("*").strip().strip("`").strip()
-                fields[key] = value
-        if fields.get("post_id"):
-            raw.append(fields)
+    text = response.get("text") or ""
+    raw = _fields_from_json_text(text)
+    if not raw:
+        probe = text
+        try:
+            loaded = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            loaded = None
+        if isinstance(loaded, dict):
+            for key in ("content", "message", "result", "text", "output"):
+                inner = loaded.get(key)
+                if isinstance(inner, str) and inner.strip():
+                    probe = inner
+                    raw = _fields_from_json_text(probe)
+                    break
+        if not raw:
+            raw = _fields_from_blocks(probe)
 
     kept, reason = _validate_items(raw, from_date, to_date) if from_date else (raw, "")
     if reason:
@@ -690,7 +840,15 @@ def _invoke(prompt: str, timeout: int) -> Dict[str, Any]:
         with tempfile.TemporaryDirectory(prefix="last30days-grok-") as workdir:
             child_home = _stage_child_home(workdir)
             result = subprocess.run(
-                [binary, "-p", prompt, "--permission-mode", "bypassPermissions"],
+                [
+                    binary,
+                    "-p",
+                    prompt,
+                    "--permission-mode",
+                    "bypassPermissions",
+                    "--output-format",
+                    "json",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=timeout,

--- a/tests/test_grok_x.py
+++ b/tests/test_grok_x.py
@@ -6,6 +6,7 @@ rather than an API client, so the module's job is as much rejecting confident
 fabrication as it is parsing.
 """
 
+import json
 import re
 import subprocess
 
@@ -112,6 +113,44 @@ def test_narration_around_blocks_is_tolerated():
     assert len(grok_x.parse_x_response({"text": text}, "steipete", *WINDOW)) == 1
 
 
+def test_json_array_with_url_fields_is_parsed():
+    """Grok CLI 1.0.5 emits a JSON array of {url, text, likes} instead of
+    the prompted id:/handle: field blocks (#1051)."""
+    text = json.dumps([
+        {
+            "url": "https://x.com/steipete/status/2087568620465607078",
+            "text": "cli was a year ago.",
+            "likes": 2041,
+        }
+    ])
+    items = grok_x.parse_x_response({"text": text}, "steipete", *WINDOW)
+    assert len(items) == 1
+    assert items[0]["author_handle"] == "steipete"
+    assert items[0]["url"].endswith("/2087568620465607078")
+    assert items[0]["engagement"]["likes"] == 2041
+
+
+def test_fenced_json_preamble_is_parsed():
+    """Without --output-format json the CLI narrates, then fences the array."""
+    text = (
+        "I'll search X for Seedance posts from the last 7 days and return "
+        "only the JSON array.\n"
+        "Checking the X search workflow first.\n"
+        "```json\n"
+        + json.dumps([
+            {
+                "url": "https://x.com/steipete/status/2087568620465607078",
+                "text": "cli was a year ago.",
+                "likes": 1462,
+            }
+        ])
+        + "\n```\n"
+    )
+    items = grok_x.parse_x_response({"text": text}, "steipete", *WINDOW)
+    assert len(items) == 1
+    assert items[0]["author_handle"] == "steipete"
+
+
 def test_markdown_decorated_fields_are_parsed():
     text = (
         "- **id:** 2087568620465607078\n"
@@ -150,6 +189,11 @@ def test_invocation_omits_json_schema_and_tools(monkeypatch):
     assert "--json-schema" not in seen["cmd"]
     assert "--tools" not in seen["cmd"]
     assert "--permission-mode" in seen["cmd"]
+    # Grok 1.0.5 narrates before the payload unless stdout is JSON (#1051).
+    # --json-schema is still forbidden: constrained decoding skips the tool.
+    assert "--output-format" in seen["cmd"]
+    fmt_idx = seen["cmd"].index("--output-format")
+    assert seen["cmd"][fmt_idx + 1] == "json"
 
 
 def test_subprocess_runs_in_an_isolated_empty_directory(monkeypatch):


### PR DESCRIPTION
## Summary

Grok CLI 1.0.5 narrates, then emits a fenced JSON array of `{url, text, likes}` instead of the prompted `id:`/`handle:` field blocks. The field-block parser treated that as empty (`no items parsed`), so `LAST30DAYS_X_BACKEND=grok` returned 0 posts.

This PR:

- Passes `--output-format json` so the CLI skips the preamble (still **never** `--json-schema` or `--tools` — constrained decoding skips the search tool).
- Parses JSON arrays and fenced JSON as a second path, mapping `url` → handle + snowflake id, then the existing provenance checks.

## Testing

- [x] `uv run pytest tests/test_grok_x.py` — 61 passed
- [x] Added tests that fail on current main:
  - JSON `{url,text,likes}` array
  - narrated fenced JSON (the 1.0.5 shape)
  - argv includes `--output-format json` and still omits `--json-schema` / `--tools`
- [x] Full `uv run pytest` — the 4 remaining failures are pre-existing on this host (doctor grok pin / xurl) and reproduce on unmodified `main`

## Changelog

- [x] Added `changelog.d/1051.fixed.md`
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Checked invocation contract (no `--json-schema` / `--tools`), provenance still keyed on snowflake id + handle, and JSON parse falls back to field blocks so existing fixtures stay valid. Did not live-run `grok` (binary not on this PATH); tests pin the 1.0.5 payload from #1051.

### Security

Untrusted CLI stdout is still parsed, not executed. JSON walking is depth-capped. No secrets, no `shell=True`.

## Notes

`--json-schema` is intentionally **not** added. The module measured it as competing with tool use (search does not run; model fills schema from training data).

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #1051