### PR TITLE
fix(bluesky): return actionable error after refresh retry fails

### DIFF
--- a/changelog.d/6037.fixed.md
+++ b/changelog.d/6037.fixed.md
@@ -1,0 +1,1 @@
+- Return an actionable error when Bluesky search still receives `401 Unauthorized` after the one-time session refresh.

--- a/skills/last30days/scripts/lib/bluesky.py
+++ b/skills/last30days/scripts/lib/bluesky.py
@@ -259,6 +259,11 @@ def search_bluesky(
     if error_msg == "refresh":
         _log("Session expired; recreating token and retrying once")
         response, error_msg = _auth_and_search()
+        if error_msg == "refresh":
+            error_msg = (
+                "Bluesky session appears expired; failed after token refresh; "
+                "check credentials or app password"
+            )
     if error_msg:
         return {"posts": [], "error": error_msg}
     if response is None:

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -208,6 +208,26 @@ class TestSearchBlueskyAuth(unittest.TestCase):
         self.assertEqual(mock_request.call_count, 4)
         self.assertEqual(mock_request.call_args_list[3].kwargs.get("headers", {}), {"Authorization": "Bearer tok-new"})
 
+    @patch("lib.bluesky.http.request")
+    def test_second_401_returns_actionable_refresh_error(self, mock_request):
+        from lib.http import HTTPError
+
+        mock_request.side_effect = [
+            {"accessJwt": "tok-old", "refreshJwt": "ref-old"},
+            HTTPError("HTTP 401: Unauthorized", 401, ""),
+            {"accessJwt": "tok-new", "refreshJwt": "ref-new"},
+            HTTPError("HTTP 401: Unauthorized", 401, ""),
+        ]
+        config = {"BSKY_HANDLE": "user.bsky.social", "BSKY_APP_PASSWORD": "pw"}
+
+        result = bluesky.search_bluesky("test", "2026-01-01", "2026-03-09", config=config)
+
+        self.assertEqual(result["posts"], [])
+        self.assertEqual(mock_request.call_count, 4)
+        self.assertNotEqual(result["error"], "refresh")
+        self.assertIn("failed after token refresh", result["error"])
+        self.assertIn("check credentials or app password", result["error"])
+
 
 class TestSearchEndpointHostResolution(unittest.TestCase):
     """The default search host moved from `public.api.bsky.app` (the


### PR DESCRIPTION
## Summary

- replace the internal `refresh` sentinel with an actionable error after a second Bluesky `401 Unauthorized`
- add regression coverage for old token / 401 / refreshed token / 401
- add a changelog fragment

## Validation

- `uv run pytest tests/test_bluesky.py` — 47 passed
- `uv run pytest --cov --cov-report=term-missing` — 4092 passed, 6 skipped, 88.92% coverage
- `git diff --check`

Generated with Codex.