### PR TITLE
fix(cookies): parse Windows Firefox profiles.ini as UTF-16

### DIFF
--- a/changelog.d/1067.fixed.md
+++ b/changelog.d/1067.fixed.md
@@ -1,0 +1,1 @@
+Windows Firefox `FROM_BROWSER` X auth no longer dies on a UTF-16 `profiles.ini` (`UnicodeDecodeError` used to skip the fallback and kill the only keyless X route).

--- a/skills/last30days/scripts/lib/cookie_extract.py
+++ b/skills/last30days/scripts/lib/cookie_extract.py
@@ -86,6 +86,16 @@ def _get_firefox_profiles_dir() -> Optional[Path]:
     return path if path.is_dir() else None
 
 
+def _load_profiles_ini(ini_path: Path) -> configparser.ConfigParser:
+    """Parse Firefox profiles.ini, retrying UTF-16 LE used on Windows (#1067)."""
+    config = configparser.ConfigParser()
+    try:
+        config.read(str(ini_path), encoding="utf-8")
+    except UnicodeDecodeError:
+        config.read(str(ini_path), encoding="utf-16")
+    return config
+
+
 def _find_default_profile(profiles_dir: Path) -> Optional[Path]:
     """Parse profiles.ini to find the default profile directory.
 
@@ -96,8 +106,7 @@ def _find_default_profile(profiles_dir: Path) -> Optional[Path]:
 
     if ini_path.is_file():
         try:
-            config = configparser.ConfigParser()
-            config.read(str(ini_path), encoding="utf-8")
+            config = _load_profiles_ini(ini_path)
 
             # First pass: Install* section (Firefox >= 67 format, takes priority)
             for section in config.sections():
@@ -118,7 +127,7 @@ def _find_default_profile(profiles_dir: Path) -> Optional[Path]:
                     resolved = _resolve_profile_path(profiles_dir, config, section)
                     if resolved and resolved.is_dir():
                         return resolved
-        except (configparser.Error, OSError) as exc:
+        except (configparser.Error, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse profiles.ini: %s", exc)
 
     # Fallback: scan directory for anything that looks like a profile

--- a/tests/test_cookie_extract.py
+++ b/tests/test_cookie_extract.py
@@ -281,6 +281,39 @@ class TestExtractFirefoxCookies:
         assert result is not None
         assert result["auth_token"] == "fallback_token"
 
+    def test_utf16_profiles_ini_uses_install_default(self, mock_firefox_env):
+        """Firefox on Windows writes UTF-16 LE profiles.ini (#1067)."""
+        default_profile = "en3ndvop.default-release"
+        decoy = "aaa111.decoy"
+        profiles_dir = mock_firefox_env(
+            default_profile=default_profile,
+            profiles={
+                decoy: [
+                    (".x.com", "auth_token", "decoy_token"),
+                ],
+                default_profile: [
+                    (".x.com", "auth_token", "utf16_token"),
+                    (".x.com", "ct0", "utf16_ct0"),
+                ],
+            },
+        )
+        ini = textwrap.dedent(f"""\
+            [Install308046B0AF4A39CB]
+            Default={default_profile}
+            Locked=1
+        """)
+        (profiles_dir / "profiles.ini").write_bytes(ini.encode("utf-16"))
+
+        with patch(
+            "lib.cookie_extract._get_firefox_profiles_dir",
+            return_value=profiles_dir,
+        ):
+            result = extract_firefox_cookies(".x.com", ["auth_token", "ct0"])
+
+        assert result is not None
+        assert result["auth_token"] == "utf16_token"
+        assert result["ct0"] == "utf16_ct0"
+
     def test_non_default_profile_with_cookies(self, mock_firefox_env):
         """Falls back to non-default profile when default has no X cookies."""
         profiles_dir = mock_firefox_env(


### PR DESCRIPTION
## Summary

Firefox on Windows writes `profiles.ini` as UTF-16 LE. `_find_default_profile()` read it as UTF-8, `UnicodeDecodeError` was not in the `except` tuple, and `FROM_BROWSER` X auth died before the documented profile fallback.

Retry UTF-16 on decode failure so the Install/Default profile is used, and treat leftover decode errors as malformed-ini (fallback), not a crash.

## Testing

- [x] `uv run pytest`
- [x] Added `test_utf16_profiles_ini_uses_install_default` (UTF-16 fixture; decoy profile would win if we only widened the except)
- Sabotage: dropping the UTF-16 retry makes that test fail (`decoy_token` vs `utf16_token`)

## Changelog

- [x] Added `changelog.d/1067.fixed.md`
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Checked encoding fallback vs silent fallback to `sorted()` first profile, sibling `encoding="utf-8"` sites (only this one), and that cookie DB handling is unchanged. Independent review subagent was not dispatched for this small parse change.

### Security

Cookie files are still read only after a valid profile path; this change only how `profiles.ini` is decoded. No new network, subprocess, or secret logging. N/A beyond that.

## Notes

Does not change Chrome/Chromium cookie paths. Does not surface the decode failure in `--diagnose` (called out on the issue; out of scope).

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

Fixes #1067
