### PR TITLE
fix(reddit): prioritize most-commented threads for enrichment slots

### DIFF
--- a/changelog.d/906.fixed.md
+++ b/changelog.d/906.fixed.md
@@ -1,0 +1,1 @@
+Keyless Reddit comment-enrichment slots now go to the most-commented threads within each entity-priority tier, so a high-discussion thread no longer misses `## Top Community Comments` coverage while near-empty threads consume the scarce slots ([#906](https://github.com/mvanhorn/last30days-skill/issues/906)).

--- a/skills/last30days/scripts/lib/reddit_keyless.py
+++ b/skills/last30days/scripts/lib/reddit_keyless.py
@@ -256,6 +256,21 @@ def _enrich(posts: List[Dict[str, Any]], depth: str) -> List[Dict[str, Any]]:
     return enriched + rest
 
 
+def _by_comments(posts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Stable-sort posts by comment count descending for enrichment slots.
+
+    Ties (equal counts, including unknown counts treated as 0) preserve the
+    incoming order, which search_and_enrich's provisional score-first sort
+    establishes. Mirrors _relevance_rank_key's `or 0` guard so a present-but-
+    None count is treated as 0 rather than raising.
+    """
+    def _comment_count(post: Dict[str, Any]) -> int:
+        eng = post.get("engagement") or {}
+        return eng.get("num_comments") or post.get("num_comments") or 0
+
+    return sorted(posts, key=_comment_count, reverse=True)
+
+
 def _slot_priority(topic: str, posts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Order posts for enrichment slots: entity-matching posts first.
 
@@ -268,9 +283,11 @@ def _slot_priority(topic: str, posts: List[Dict[str, Any]]) -> List[Dict[str, An
     post text) so slots go to posts likely to survive final ranking — keying
     on the same head token keeps the two paths from diverging. Falls back to
     token-overlap relevance when the topic yields no usable primary entity.
-    Within each tier the incoming
-    (score-first) order is preserved. Never raises; on any failure the
-    incoming order is returned unchanged.
+    Within each tier posts are ordered by comment count descending (stable:
+    equal or unknown counts preserve the incoming score-first order), so the
+    scarce slots go to the threads with the most discussion rather than to
+    near-empty threads that merely ranked higher by score. Never raises; on
+    any failure the incoming order is returned unchanged.
     """
     try:
         from . import relevance, rerank
@@ -292,7 +309,7 @@ def _slot_priority(topic: str, posts: List[Dict[str, Any]]) -> List[Dict[str, An
         misses: List[Dict[str, Any]] = []
         for post in posts:
             (matches if _matches(post) else misses).append(post)
-        return matches + misses
+        return _by_comments(matches) + _by_comments(misses)
     except Exception:
         return posts
 
@@ -349,7 +366,8 @@ def search_and_enrich(
         _log(f"Relevance floor dropped {before - len(posts)} off-topic posts")
 
     # Provisional score-first order so enrichment-slot selection has a stable
-    # within-tier order to preserve.
+    # within-tier tiebreak order to preserve: within each entity tier, slots go
+    # to the most-commented threads first, and equal counts keep score order.
     posts.sort(
         key=lambda p: (
             p.get("engagement", {}).get("score", 0) or 0,
@@ -359,9 +377,10 @@ def search_and_enrich(
         reverse=True,
     )
 
-    # Enrichment slot selection is relevance-aware: entity-matching posts
-    # claim the scarce comment slots first (score order preserved within
-    # each tier).
+    # Enrichment slot selection is comment-aware within entity tiers:
+    # entity-matching posts claim the scarce comment slots first, and within
+    # each tier the most-commented threads get slots first (score order is the
+    # stable tiebreak for equal counts).
     posts = _enrich(_slot_priority(topic, posts), depth)
 
     # Final display order ranks relevance-first with a bounded engagement bonus,

--- a/tests/test_reddit_keyless.py
+++ b/tests/test_reddit_keyless.py
@@ -333,6 +333,38 @@ class TestSlotPriority:
         assert posts[2]["url"] not in enriched_urls   # 4-comment thread above it skipped
         assert len(enriched_urls) == reddit_keyless.ENRICH_LIMITS["default"]
 
+    def test_miss_tier_orders_by_comments_for_leftover_slots(self):
+        # Review finding #1 (validated): when the entity-match tier is smaller
+        # than ENRICH_LIMITS, leftover slots are filled from the miss tier in
+        # comment-count order. 1 match + 4 misses at quick depth (limit 3): the
+        # two most-commented misses get slots, the least-commented miss does not.
+        # Score order deliberately differs from comment order so this test
+        # discriminates the miss-tier sort from the old score-first order.
+        posts = [
+            self._titled_nc(1, "openclaw thread", score=100, ncmt=2),
+            self._titled_nc(2, "Gemma thread A", score=5, ncmt=30),
+            self._titled_nc(3, "Gemma thread B", score=40, ncmt=9),
+            self._titled_nc(4, "Gemma thread C", score=30, ncmt=2),
+            self._titled_nc(5, "Gemma thread D", score=20, ncmt=1),
+        ]
+        enriched_urls = []
+
+        def _capture(url):
+            enriched_urls.append(url)
+            return {"top_comments": [], "comment_insights": [], "num_comments": None}
+
+        with mock.patch.object(reddit_keyless, "_discover", return_value=posts), \
+             mock.patch.object(reddit_keyless.reddit_shreddit, "fetch_comments",
+                               side_effect=_capture):
+            reddit_keyless.search_and_enrich(
+                "openclaw", "2026-05-01", "2026-05-31", depth="quick")
+        assert posts[0]["url"] in enriched_urls       # entity match always slotted
+        assert posts[1]["url"] in enriched_urls       # 30-comment miss (top miss)
+        assert posts[2]["url"] in enriched_urls       # 9-comment miss
+        assert posts[3]["url"] not in enriched_urls   # 2-comment miss below the cut
+        assert posts[4]["url"] not in enriched_urls   # 1-comment miss below the cut
+        assert len(enriched_urls) == reddit_keyless.ENRICH_LIMITS["quick"]
+
 
 class TestScoredListingsFallback:
     """_scored_listings falls back to the arctic-shift archive when the

--- a/tests/test_reddit_keyless.py
+++ b/tests/test_reddit_keyless.py
@@ -259,6 +259,80 @@ class TestSlotPriority:
             out = reddit_keyless._slot_priority("openclaw", posts)
         assert out == posts
 
+    @staticmethod
+    def _titled_nc(i, title, score=0, ncmt=0, selftext=""):
+        """_titled variant that also sets a real comment count (both surfaces)."""
+        p = TestSlotPriority._titled(i, title, score=score, selftext=selftext)
+        p["num_comments"] = ncmt
+        p["engagement"]["num_comments"] = ncmt
+        return p
+
+    def test_comment_count_orders_within_match_tier(self):
+        # Two entity-matching posts: the low-score high-comment thread wins the slot.
+        high_comments = self._titled_nc(1, "openclaw thread with lots of discussion", score=1, ncmt=45)
+        low_comments = self._titled_nc(2, "openclaw thread, quiet", score=900, ncmt=3)
+        out = reddit_keyless._slot_priority("openclaw", [low_comments, high_comments])
+        assert out[0] is high_comments
+        assert out[1] is low_comments
+
+    def test_entity_match_tier_beats_comment_count(self):
+        # Entity priority is preserved: a miss with 100 comments still follows a
+        # match with 1 comment, regardless of discussion volume.
+        match = self._titled_nc(1, "openclaw tips", score=10, ncmt=1)
+        miss = self._titled_nc(2, "Gemma news", score=100, ncmt=100)
+        out = reddit_keyless._slot_priority("openclaw", [miss, match])
+        assert out[0] is match
+        assert out[1] is miss
+
+    def test_equal_comment_counts_preserve_incoming_order_stable(self):
+        # Stable tiebreak: equal comment counts preserve the incoming order. The
+        # score-first order is established by search_and_enrich's provisional
+        # sort before _slot_priority runs; _slot_priority must not re-sort ties.
+        p1 = self._titled_nc(1, "openclaw thread a", score=100, ncmt=5)
+        p2 = self._titled_nc(2, "openclaw thread b", score=50, ncmt=5)
+        out = reddit_keyless._slot_priority("openclaw", [p2, p1])
+        assert out[0] is p2
+        assert out[1] is p1
+
+    def test_unknown_comment_count_ties_with_zero(self):
+        # Missing/None comment count is treated as 0: it ties with a known-zero
+        # post (stable) and sorts below any positive-count post in its tier.
+        unknown = self._titled_nc(1, "openclaw unknown", score=100, ncmt=None)
+        positive = self._titled_nc(2, "openclaw positive", score=10, ncmt=3)
+        known_zero = self._titled_nc(3, "openclaw zero", score=5, ncmt=0)
+        out = reddit_keyless._slot_priority("openclaw", [known_zero, unknown, positive])
+        assert out[0] is positive
+        assert out[1:] == [known_zero, unknown]
+
+    def test_richest_thread_gets_slot_when_score_ranked_low(self):
+        # Issue #906 regression: a 45-comment thread ranked 7th by score must get
+        # an enrichment slot at default depth (limit 5) while a 4-comment thread
+        # above it in score order does not. All posts are in the same entity tier.
+        posts = [
+            self._titled_nc(1, "openclaw thread one", score=1000, ncmt=4),
+            self._titled_nc(2, "openclaw thread two", score=900, ncmt=4),
+            self._titled_nc(3, "openclaw thread three", score=800, ncmt=4),
+            self._titled_nc(4, "openclaw thread four", score=700, ncmt=4),
+            self._titled_nc(5, "openclaw thread five", score=600, ncmt=6),
+            self._titled_nc(6, "openclaw thread six", score=500, ncmt=5),
+            self._titled_nc(7, "openclaw thread seven", score=300, ncmt=4),
+            self._titled_nc(8, "openclaw thread eight", score=77, ncmt=45),
+        ]
+        enriched_urls = []
+
+        def _capture(url):
+            enriched_urls.append(url)
+            return {"top_comments": [], "comment_insights": [], "num_comments": None}
+
+        with mock.patch.object(reddit_keyless, "_discover", return_value=posts), \
+             mock.patch.object(reddit_keyless.reddit_shreddit, "fetch_comments",
+                               side_effect=_capture):
+            reddit_keyless.search_and_enrich(
+                "openclaw", "2026-05-01", "2026-05-31", depth="default")
+        assert posts[7]["url"] in enriched_urls      # 45-comment thread enriched
+        assert posts[2]["url"] not in enriched_urls   # 4-comment thread above it skipped
+        assert len(enriched_urls) == reddit_keyless.ENRICH_LIMITS["default"]
+
 
 class TestScoredListingsFallback:
     """_scored_listings falls back to the arctic-shift archive when the


### PR DESCRIPTION
## Summary

Keyless Reddit comment-enrichment slots (`ENRICH_LIMITS` 3/5/8 per depth) now go to the most-commented threads within each entity-priority tier. Previously the slots were allocated in score-first order, so a high-discussion thread ranked low by score could miss `## Top Community Comments` coverage entirely while near-empty threads consumed the scarce slots (reported in #906 with a 45-comment thread ranked 7th missing every slot). The entity-match tier still claims slots first, ties keep the stable score-first order, and the final display sort key (`_relevance_rank_key`) is untouched, so user-visible ranking semantics are unchanged.

## Testing

- [x] `uv run pytest` — 4097 passed, 6 skipped, 66 subtests passed
- [x] Added 6 regression tests (red observed on the pre-fix code, then green) covering: highest-comment thread gets a slot at default depth, comment-count ordering within the match tier, entity-tier priority over comment counts, stable ties, unknown counts treated as 0, and leftover slots in the miss tier ordered by comments
- [x] Coverage gate held: `uv run pytest --cov` — TOTAL 88.93% (fail_under 84%)

## Changelog

- [x] Added `changelog.d/906.fixed.md` (`fixed` type)
- [ ] Skip changelog

## Agent disclosure

### AI review

This change was reviewed by a multi-lens agent review (correctness, project-standards, testing, learnings, adversarial). Main risks checked: entity-tier priority preservation, stable tie-break behavior, the `or 0` None guard on comment counts, and display-order invariance. The review flagged one test gap (miss-tier ordering when the entity-match tier does not fill the slot budget); that finding was independently validated and the regression test was added in the same branch. Advisory notes carried forward: slot ordering uses discovery-time comment counts (inherent to the signal), and comment-first ordering front-loads slower comment fetches into the existing 45s enrichment budget.

### Security

N/A — no input handling, command execution, path handling, auth, secrets, or dependency changes. Tests use dummy values only.

## Notes

Entity-miss threads with many comments still lose slots to entity matches with few comments; that is the intended entity-priority contract, not a regression. Follow-up work is tracked in #986/#1020 (Instagram) separately — unrelated to this change.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure: <!-- who / what relationship -->

## Related issues

Fixes #906
