### PR TITLE
fix(bird): pass only the vendored client's env surface to the subprocess

### DIFF
--- a/changelog.d/1063.fixed.md
+++ b/changelog.d/1063.fixed.md
@@ -1,0 +1,1 @@
+The vendored X-search subprocess no longer receives a copy of the full environment: `bird_x` now passes only the variables the client actually reads (runtime vars, X session cookies, `BIRD_*` flags, injected credentials), so unrelated ambient API keys and tokens cannot reach scan-excluded vendored code ([#1063](https://github.com/mvanhorn/last30days-skill/issues/1063)).

--- a/skills/last30days/scripts/lib/bird_x.py
+++ b/skills/last30days/scripts/lib/bird_x.py
@@ -54,22 +54,24 @@ DEPTH_CONFIG = {
 # Module-level credentials injected from .env config
 _credentials: Dict[str, str] = {}
 
-# The vendored bird-search client reads exactly this env surface: runtime vars
-# the node subprocess needs (PATH for executable lookup, HOME for user caches,
-# NODE_ENV), the X session cookies it resolves from the environment
-# (cookies.js readEnvCookie), and its browser-cookie disable flag. Ambient
+# The vendored bird-search client reads exactly this env surface, and the
+# node subprocess it spawns needs the node-runtime env (platform, locale,
+# TLS/proxy config) to run in every environment it runs in today. Ambient
 # BIRD_* vars pass through as well. Everything else in os.environ - unrelated
 # API keys, tokens, .env contents - must not reach the scan-excluded vendored
-# client (issue #1063).
+# client (issue #1063). Mirrors the platform-var surface grok_x keeps for its
+# node child (grok_x._subprocess_env).
 _SUBPROCESS_ENV_ALLOWLIST = (
-    "PATH",
-    "HOME",
-    "NODE_ENV",
+    # Runtime / platform vars the node subprocess needs (mirrors grok_x)
+    "PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "SystemRoot",
+    "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "SystemDrive", "COMSPEC",
+    "PATHEXT", "TEMP", "TMP",
+    # Node TLS / proxy / CA config for custom-CA and proxied environments
+    "NODE_ENV", "NODE_OPTIONS", "NODE_EXTRA_CA_CERTS",
+    "NODE_TLS_REJECT_UNAUTHORIZED", "NODE_USE_ENV_PROXY",
+    "SSL_CERT_FILE", "SSL_CERT_DIR", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
     # X session cookies the vendored client reads from the environment
-    "AUTH_TOKEN",
-    "CT0",
-    "TWITTER_AUTH_TOKEN",
-    "TWITTER_CT0",
+    "AUTH_TOKEN", "CT0", "TWITTER_AUTH_TOKEN", "TWITTER_CT0",
     # Browser-cookie disable flag the client reads (cookies.js envFlagEnabled)
     "LAST30DAYS_DISABLE_BROWSER_COOKIES",
 )
@@ -96,13 +98,10 @@ def _has_process_credentials() -> bool:
 def _subprocess_env() -> Dict[str, str]:
     """Build env dict for Node subprocesses, merging injected credentials.
 
-    The child env is limited to exactly the surface the vendored bird-search
-    client reads today (runtime vars, X session cookies, browser-cookie flags,
-    BIRD_* vars) plus the injected credentials. os.environ.copy() previously
-    handed every ambient variable - including unrelated API keys and tokens -
-    to scan-excluded vendored code (issue #1063); the allowlist shrinks the
-    blast radius to match the scan gap with no behavior change to the
-    ambient-credential lane.
+    The child env is limited to the vendored client's env surface (see
+    ``_SUBPROCESS_ENV_ALLOWLIST``) plus injected credentials, so unrelated
+    ambient secrets never reach scan-excluded vendored code (issue #1063).
+    The ambient-credential lane behaves exactly as before.
     """
     env = {
         name: os.environ[name]

--- a/skills/last30days/scripts/lib/bird_x.py
+++ b/skills/last30days/scripts/lib/bird_x.py
@@ -54,6 +54,26 @@ DEPTH_CONFIG = {
 # Module-level credentials injected from .env config
 _credentials: Dict[str, str] = {}
 
+# The vendored bird-search client reads exactly this env surface: runtime vars
+# the node subprocess needs (PATH for executable lookup, HOME for user caches,
+# NODE_ENV), the X session cookies it resolves from the environment
+# (cookies.js readEnvCookie), and its browser-cookie disable flag. Ambient
+# BIRD_* vars pass through as well. Everything else in os.environ - unrelated
+# API keys, tokens, .env contents - must not reach the scan-excluded vendored
+# client (issue #1063).
+_SUBPROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "NODE_ENV",
+    # X session cookies the vendored client reads from the environment
+    "AUTH_TOKEN",
+    "CT0",
+    "TWITTER_AUTH_TOKEN",
+    "TWITTER_CT0",
+    # Browser-cookie disable flag the client reads (cookies.js envFlagEnabled)
+    "LAST30DAYS_DISABLE_BROWSER_COOKIES",
+)
+
 
 def set_credentials(auth_token: Optional[str], ct0: Optional[str]):
     """Inject AUTH_TOKEN/CT0 from .env config so Node subprocesses can use them."""
@@ -74,8 +94,25 @@ def _has_process_credentials() -> bool:
 
 
 def _subprocess_env() -> Dict[str, str]:
-    """Build env dict for Node subprocesses, merging injected credentials."""
-    env = os.environ.copy()
+    """Build env dict for Node subprocesses, merging injected credentials.
+
+    The child env is limited to exactly the surface the vendored bird-search
+    client reads today (runtime vars, X session cookies, browser-cookie flags,
+    BIRD_* vars) plus the injected credentials. os.environ.copy() previously
+    handed every ambient variable - including unrelated API keys and tokens -
+    to scan-excluded vendored code (issue #1063); the allowlist shrinks the
+    blast radius to match the scan gap with no behavior change to the
+    ambient-credential lane.
+    """
+    env = {
+        name: os.environ[name]
+        for name in _SUBPROCESS_ENV_ALLOWLIST
+        if name in os.environ
+    }
+    env.update({
+        key: value for key, value in os.environ.items()
+        if key.startswith("BIRD_")
+    })
     env.update(_credentials)
     # Hard-disable browser-cookie fallback so normal pipeline runs never hit
     # Safari/Chrome Keychain prompts during source detection or search.

--- a/skills/last30days/scripts/lib/bird_x.py
+++ b/skills/last30days/scripts/lib/bird_x.py
@@ -70,6 +70,7 @@ _SUBPROCESS_ENV_ALLOWLIST = (
     "NODE_ENV", "NODE_OPTIONS", "NODE_EXTRA_CA_CERTS",
     "NODE_TLS_REJECT_UNAUTHORIZED", "NODE_USE_ENV_PROXY",
     "SSL_CERT_FILE", "SSL_CERT_DIR", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+    "http_proxy", "https_proxy", "no_proxy",
     # X session cookies the vendored client reads from the environment
     "AUTH_TOKEN", "CT0", "TWITTER_AUTH_TOKEN", "TWITTER_CT0",
     # Browser-cookie disable flag the client reads (cookies.js envFlagEnabled)

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -13,6 +13,78 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 VENDORED_BIRD = REPO_ROOT / "skills" / "last30days" / "scripts" / "lib" / "vendor" / "bird-search" / "bird-search.mjs"
 
 
+class TestSubprocessEnv(unittest.TestCase):
+    """_subprocess_env() passes only the vendored client's env surface (issue #1063)."""
+
+    def _ambient(self, **overrides):
+        base = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/test",
+            "NODE_ENV": "production",
+            "AUTH_TOKEN": "ambient-token",
+            "CT0": "ambient-ct0",
+            "TWITTER_AUTH_TOKEN": "ambient-tw-token",
+            "TWITTER_CT0": "ambient-tw-ct0",
+            "LAST30DAYS_DISABLE_BROWSER_COOKIES": "0",
+            "BIRD_QUERY_IDS_CACHE": "/tmp/ids.json",
+            "SCRAPECREATORS_API_KEY": "sc-secret",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+        }
+        base.update(overrides)
+        return base
+
+    def _call(self, ambient, credentials=None):
+        from lib import bird_x
+        old = bird_x._credentials
+        try:
+            bird_x._credentials = dict(credentials or {})
+            # None means "absent" - os.environ cannot hold None values.
+            patch_env = {k: v for k, v in ambient.items() if v is not None}
+            with mock.patch.dict(os.environ, patch_env, clear=True):
+                return bird_x._subprocess_env()
+        finally:
+            bird_x._credentials = old
+
+    def test_unrelated_ambient_secrets_are_excluded(self):
+        out = self._call(self._ambient())
+        self.assertNotIn("SCRAPECREATORS_API_KEY", out)
+        self.assertNotIn("AWS_SECRET_ACCESS_KEY", out)
+
+    def test_runtime_and_client_vars_pass_through(self):
+        out = self._call(self._ambient())
+        self.assertEqual("/usr/bin:/bin", out.get("PATH"))
+        self.assertEqual("/home/test", out.get("HOME"))
+        self.assertEqual("production", out.get("NODE_ENV"))
+        self.assertEqual("ambient-token", out.get("AUTH_TOKEN"))
+        self.assertEqual("ambient-ct0", out.get("CT0"))
+        self.assertEqual("ambient-tw-token", out.get("TWITTER_AUTH_TOKEN"))
+        self.assertEqual("ambient-tw-ct0", out.get("TWITTER_CT0"))
+        self.assertEqual("0", out.get("LAST30DAYS_DISABLE_BROWSER_COOKIES"))
+        self.assertEqual("/tmp/ids.json", out.get("BIRD_QUERY_IDS_CACHE"))
+
+    def test_absent_vars_are_omitted(self):
+        out = self._call(self._ambient(NODE_ENV=None))
+        self.assertNotIn("NODE_ENV", out)
+        out = self._call(self._ambient(LAST30DAYS_DISABLE_BROWSER_COOKIES=None))
+        self.assertNotIn("LAST30DAYS_DISABLE_BROWSER_COOKIES", out)
+
+    def test_injected_credentials_override_ambient(self):
+        out = self._call(self._ambient(), credentials={"AUTH_TOKEN": "injected", "CT0": "injected-ct0"})
+        self.assertEqual("injected", out.get("AUTH_TOKEN"))
+        self.assertEqual("injected-ct0", out.get("CT0"))
+
+    def test_disable_flag_always_hard_set(self):
+        out = self._call(self._ambient(), credentials={"AUTH_TOKEN": "t", "CT0": "c"})
+        self.assertEqual("1", out.get("BIRD_DISABLE_BROWSER_COOKIES"))
+        # ambient 0 is overridden to 1
+        out = self._call(self._ambient(BIRD_DISABLE_BROWSER_COOKIES="0"))
+        self.assertEqual("1", out.get("BIRD_DISABLE_BROWSER_COOKIES"))
+
+    def test_ambient_bird_vars_pass_through(self):
+        out = self._call(self._ambient(BIRD_FEATURES_PATH="/tmp/features.json"))
+        self.assertEqual("/tmp/features.json", out.get("BIRD_FEATURES_PATH"))
+
+
 class TestBirdXEngagementZero(unittest.TestCase):
     def test_zero_likes_preserved(self):
         tweets = [

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -105,6 +105,12 @@ class TestSubprocessEnv(unittest.TestCase):
                 text,
             ):
                 reads.add(m.group(1) or m.group(2))
+            # cookies.js reads via helpers with the keys passed as arguments:
+            # envFlagEnabled('NAME') and readEnvCookie(cookies, ['A', 'B'], ...).
+            for m in re.finditer(r"envFlagEnabled\(\s*['\"]([A-Z0-9_]+)['\"]\s*\)", text):
+                reads.add(m.group(1))
+            for m in re.finditer(r"readEnvCookie\(\s*\w+\s*,\s*\[([^\]]*)\]", text):
+                reads.update(re.findall(r"['\"]([A-Z0-9_]+)['\"]", m.group(1)))
         self.assertTrue(reads, "vendored client env reads not found")
         allowlist = set(bird_x._SUBPROCESS_ENV_ALLOWLIST)
         uncovered = {

--- a/tests/test_bird_x.py
+++ b/tests/test_bird_x.py
@@ -84,6 +84,35 @@ class TestSubprocessEnv(unittest.TestCase):
         out = self._call(self._ambient(BIRD_FEATURES_PATH="/tmp/features.json"))
         self.assertEqual("/tmp/features.json", out.get("BIRD_FEATURES_PATH"))
 
+    def test_allowlist_covers_vendored_client_env_reads(self):
+        """Every process.env name the vendored client reads is reachable.
+
+        Guards the allowlist against vendor drift: a future bird-search bump
+        that reads a new non-BIRD_ env var must either be added to the
+        allowlist or fail here, keeping the child env surface explicit
+        (issue #1063).
+        """
+        import re
+
+        from lib import bird_x
+
+        vendor_dir = REPO_ROOT / "skills" / "last30days" / "scripts" / "lib" / "vendor" / "bird-search"
+        reads = set()
+        for path in list(vendor_dir.rglob("*.js")) + list(vendor_dir.rglob("*.mjs")):
+            text = path.read_text(encoding="utf-8")
+            for m in re.finditer(
+                r"process\.env\[\s*['\"]([A-Z0-9_]+)['\"]\s*\]|process\.env\.([A-Z0-9_]+)",
+                text,
+            ):
+                reads.add(m.group(1) or m.group(2))
+        self.assertTrue(reads, "vendored client env reads not found")
+        allowlist = set(bird_x._SUBPROCESS_ENV_ALLOWLIST)
+        uncovered = {
+            name for name in reads
+            if not name.startswith("BIRD_") and name not in allowlist
+        }
+        self.assertEqual(set(), uncovered)
+
 
 class TestBirdXEngagementZero(unittest.TestCase):
     def test_zero_likes_preserved(self):


### PR DESCRIPTION
## Summary

The vendored X-search Node subprocess no longer receives a copy of the full environment. `bird_x._subprocess_env()` previously passed `os.environ.copy()` to scan-excluded vendored code, so every ambient variable - unrelated API keys, tokens, and `.env` contents - could leak to it if the vendored client were ever compromised (issue #1063). The child env is now built from an allowlist covering exactly what the client and the node runtime read today: runtime/platform vars (mirroring `grok_x`'s own child env), node TLS/proxy/CA config, the X session cookies the client resolves from the environment (`AUTH_TOKEN`/`CT0`/`TWITTER_*`), `LAST30DAYS_DISABLE_BROWSER_COOKIES`, ambient `BIRD_*` vars, injected credentials, and the hard-set `BIRD_DISABLE_BROWSER_COOKIES=1`. The ambient-credential auth lane and all three subprocess call sites behave exactly as before.

## Testing

- [x] `uv run pytest` — 4098 passed, 6 skipped, 66 subtests passed
- [x] Added 7 regression tests (red observed on the pre-fix code, then green): unrelated ambient secrets excluded, runtime/client/credential/flag vars pass through, absent vars omitted, injected-credentials override, hard-set flag, and a vendor-drift guard that parses the vendored client's `process.env` reads and asserts every non-`BIRD_` read stays covered
- [x] Coverage gate held: `uv run pytest --cov` — TOTAL 88.92% (fail_under 84%)

## Changelog

- [x] Added `changelog.d/1063.fixed.md` (`fixed` type)
- [ ] Skip changelog

## Agent disclosure

### AI review

This change was reviewed by a multi-lens agent review (correctness, project-standards, testing, adversarial). Main risks checked: ambient-credential auth lane preservation, node-runtime platform env (Windows homedir vars, TLS/proxy/CA config), and vendor-env-surface completeness. The review flagged one P1 finding (the initial allowlist dropped Windows homedir/platform vars, which can crash node `os.homedir()` on Windows and break custom-CA/proxied environments); it was independently validated and fixed in the same branch by mirroring `grok_x`'s platform surface and adding the vendor-drift guard test. Residual notes: the `BIRD_*` prefix passthrough is broader than the client's exact reads (deliberate), and no Windows runner exists to exercise the homedir path end-to-end.

### Security

The change shrinks the blast radius: unrelated ambient secrets no longer reach the scan-excluded vendored subprocess. Injected X session credentials and the client's own credential reads still pass through by design. Tests use dummy values only.

## Notes

Issue option 1 (dropping the `vendor/` scan exclusion) is intentionally deferred - it changes install-time scanning for every installer and needs Hermes scanner validation outside this PR's scope.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure: <!-- who / what relationship -->

## Related issues

Fixes #1063
