### PR TITLE
fix(youtube): keep transcribed videos when the date window is empty

### DIFF
--- a/changelog.d/1043.fixed.md
+++ b/changelog.d/1043.fixed.md
@@ -1,0 +1,1 @@
+Keep YouTube videos that already had transcripts fetched when the hard date window would otherwise empty the source (#1043). Search already kept out-of-window results when fewer than 3 were recent.

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -98,13 +98,18 @@ def normalize_source_items(
         return filtered
     # YouTube search already keeps out-of-window videos when fewer than 3
     # are recent, then pays for transcripts. A second hard date filter here
-    # dropped those transcribed items to zero (#1043). Keep the retrieved
-    # set instead of paying for transcripts that never appear in the brief.
+    # dropped those transcribed items to zero (#1043). Keep transcript-backed
+    # retrieved items instead of paying for transcripts that never appear in
+    # the brief. Metadata-only / caption-failed videos are not that rescue.
     if source == "youtube" and normalized:
-        if require_date:
-            dated = [item for item in normalized if item.published_at]
-            return dated or normalized
-        return normalized
+        transcribed = [
+            item for item in normalized if str(item.snippet or "").strip()
+        ]
+        if transcribed:
+            if require_date:
+                dated = [item for item in transcribed if item.published_at]
+                return dated or transcribed
+            return transcribed
     if freshness_mode == "evergreen_ok" and source == "youtube":
         if require_date:
             return [item for item in normalized if item.published_at]

--- a/skills/last30days/scripts/lib/normalize.py
+++ b/skills/last30days/scripts/lib/normalize.py
@@ -96,6 +96,15 @@ def normalize_source_items(
     )
     if filtered:
         return filtered
+    # YouTube search already keeps out-of-window videos when fewer than 3
+    # are recent, then pays for transcripts. A second hard date filter here
+    # dropped those transcribed items to zero (#1043). Keep the retrieved
+    # set instead of paying for transcripts that never appear in the brief.
+    if source == "youtube" and normalized:
+        if require_date:
+            dated = [item for item in normalized if item.published_at]
+            return dated or normalized
+        return normalized
     if freshness_mode == "evergreen_ok" and source == "youtube":
         if require_date:
             return [item for item in normalized if item.published_at]

--- a/tests/test_normalize_v3.py
+++ b/tests/test_normalize_v3.py
@@ -248,5 +248,30 @@ class NormalizeV3Tests(unittest.TestCase):
         )
         self.assertEqual([], normalized)
 
+    def test_youtube_keeps_older_items_when_date_window_is_empty_even_without_evergreen(self):
+        """#1043: search kept out-of-window videos so transcripts could run; normalize must not drop them."""
+        items = [
+            {
+                "video_id": "vid-old",
+                "title": "Informa TechTarget overview",
+                "url": "https://youtube.com/watch?v=vid-old",
+                "channel_name": "Example",
+                "date": "2025-01-10",
+                "transcript_snippet": "Fetched transcript about Informa TechTarget.",
+                "engagement": {"views": 1000, "likes": 50, "comments": 10},
+            }
+        ]
+        normalized = normalize.normalize_source_items(
+            "youtube",
+            items,
+            "2026-02-15",
+            "2026-03-17",
+            freshness_mode="balanced_recent",
+        )
+        self.assertEqual(1, len(normalized))
+        self.assertEqual("vid-old", normalized[0].item_id)
+        self.assertIn("Fetched transcript", normalized[0].snippet)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_normalize_v3.py
+++ b/tests/test_normalize_v3.py
@@ -272,6 +272,56 @@ class NormalizeV3Tests(unittest.TestCase):
         self.assertEqual("vid-old", normalized[0].item_id)
         self.assertIn("Fetched transcript", normalized[0].snippet)
 
+    def test_youtube_empty_window_fallback_keeps_only_transcribed_items(self):
+        """#1043 rescue is transcript-backed evidence, not stale metadata-only videos."""
+        items = [
+            {
+                "video_id": "vid-meta",
+                "title": "Old video without captions",
+                "url": "https://youtube.com/watch?v=vid-meta",
+                "channel_name": "Example",
+                "date": "2025-01-10",
+                "engagement": {"views": 1000, "likes": 50, "comments": 10},
+            },
+            {
+                "video_id": "vid-old",
+                "title": "Informa TechTarget overview",
+                "url": "https://youtube.com/watch?v=vid-old",
+                "channel_name": "Example",
+                "date": "2025-01-10",
+                "transcript_snippet": "Fetched transcript about Informa TechTarget.",
+                "engagement": {"views": 1000, "likes": 50, "comments": 10},
+            },
+        ]
+        normalized = normalize.normalize_source_items(
+            "youtube",
+            items,
+            "2026-02-15",
+            "2026-03-17",
+            freshness_mode="balanced_recent",
+        )
+        self.assertEqual(1, len(normalized))
+        self.assertEqual("vid-old", normalized[0].item_id)
+
+    def test_youtube_empty_window_fallback_drops_all_transcript_free_videos(self):
+        items = [
+            {
+                "video_id": "vid-meta",
+                "title": "Old video without captions",
+                "url": "https://youtube.com/watch?v=vid-meta",
+                "channel_name": "Example",
+                "date": "2025-01-10",
+            }
+        ]
+        normalized = normalize.normalize_source_items(
+            "youtube",
+            items,
+            "2026-02-15",
+            "2026-03-17",
+            freshness_mode="strict_recent",
+        )
+        self.assertEqual([], normalized)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

YouTube search keeps older videos when fewer than 3 fall in the date window, then fetches transcripts. `normalize_source_items` then hard-filtered those same items to zero, so logs showed `Got transcripts for 6/6` and the brief showed `YouTube: 0 videos`.

Keep the retrieved YouTube set when the date window is empty (all freshness modes, not only `evergreen_ok`).

Fixes #1043

## Testing

- [x] `uv run pytest tests/test_normalize_v3.py`

## Changelog

- [x] Added `changelog.d/1043.fixed.md`

## Agent disclosure

### AI review

Checked that search already has a soft date fallback; the second filter was the drop. Grounding still requires dates.

### Security

N/A

### Relationship to this change

- [x] None

## Related issues

Fixes #1043
