### PR TITLE
fix: continue research after optional X skip

### DIFF
--- a/changelog.d/+x-skip-continuation.fixed.md
+++ b/changelog.d/+x-skip-continuation.fixed.md
@@ -1,0 +1,1 @@
+Declining or skipping X/browser-cookie access now continues the requested research with available sources, and reports X only as an optional omission after useful results.

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -534,7 +534,9 @@ When both `LAST30DAYS_API_KEY` and `LAST30DAYS_API_BASE` are set, the engine run
 
 ## Step 0: First-Run Setup Wizard
 
-**CRITICAL: ALWAYS execute Step 0 BEFORE Step 1, even when the user provided a topic.** If the user typed `/last30days Mercer Island`, you MUST run the wizard BEFORE any research. The topic is preserved - research runs immediately after the wizard completes. Do NOT skip the wizard because a topic was provided. It takes about 30 seconds and only runs once, ever.
+**CRITICAL: ALWAYS execute Step 0 BEFORE Step 1, even when the user provided a topic.** If the user typed `/last30days Mercer Island`, preserve that topic while handling the first-run choice. The wizard may ask for browser-cookie consent, but declining or skipping X must never stop the requested research.
+
+**RESEARCH CONTINUATION OVERRIDE (dominates every optional onboarding step below):** When the invocation already includes a topic and the user declines X/browser-cookie access inside Auto setup, run the cookie-free setup path, then immediately research that topic with the sources that are available. When the user chooses Skip for now, mark setup complete and immediately research without running setup. In either case, skip the ScrapeCreators offer, source-tier prompt, retry prompt, and first-topic picker until after the useful research response. Do not ask another X question in the same run. After the findings, report X once as an optional omitted source without an unlock pitch. Browser-cookie reads still require explicit consent; a skip or no answer is never consent.
 
 **You are the conversational driver.** The Python setup script does only mechanical work (cookie reads, tool installs, the GitHub device-auth flow) - it CANNOT prompt the user, because it runs as a non-interactive subprocess. So consent happens HERE, in chat: you ask, the user answers, and you gate each subprocess call on the answer. Do NOT just run `setup` and report the result - that is the silent-onboarding regression this section exists to prevent.
 
@@ -555,7 +557,7 @@ When both `LAST30DAYS_API_KEY` and `LAST30DAYS_API_BASE` are set, the engine run
 
 ### Claude Code Modal Flow
 
-**Follow these steps IN ORDER. Do NOT skip ahead to research. The sequence is: (1) welcome (built into the setup modal) → (2) setup modal → (3) run setup if chosen → (4) ScrapeCreators offer modal → (5) source opt-in modal → (6) first-topic picker. Start at step 1.**
+**Follow these steps IN ORDER unless the Research Continuation Override routes a waiting topic directly to research.** The normal sequence is: (1) welcome (built into the setup modal) → (2) setup modal → (3) run setup if chosen → (4) ScrapeCreators offer modal → (5) source opt-in modal → (6) first-topic picker. Start at step 1.
 
 **Step 1 - Welcome.** The welcome pitch is delivered INSIDE the Step 2 setup modal, NOT as a separate message. Claude Code folds Bash/tool output behind "ctrl+o to expand", so a separate welcome message - or a `--welcome` command run - gets buried and the user never sees it. The AskUserQuestion modal is the only always-fully-visible surface, so the pitch lives in its question text. Do NOT run a separate `--welcome` command in this modal flow, and do NOT try to print the welcome as a chat message before the modal; go straight to Step 2. (The `--welcome` command still exists for the Non-Modal Prose Flow below, where there is no modal.)
 
@@ -573,7 +575,7 @@ Options:
 
 **Step 3 - Run setup based on the choice.**
 
-**If the user picks Skip for now:** write `SETUP_COMPLETE=true` to `~/.config/last30days/.env` (append-only; run `mkdir -p ~/.config/last30days && touch ~/.config/last30days/.env` first if the file does not exist) so the wizard does NOT re-fire on every subsequent run, then skip straight to Step 6 (the topic picker). Do not run any `setup` command - the always-on sources (Reddit, HN, Polymarket, GitHub, Web) need no setup.
+**If the user picks Skip for now:** write `SETUP_COMPLETE=true` to `~/.config/last30days/.env` (append-only; run `mkdir -p ~/.config/last30days && touch ~/.config/last30days/.env` first if the file does not exist) so the wizard does NOT re-fire on every subsequent run. Do not run any `setup` command - the always-on sources (Reddit, HN, Polymarket, GitHub, Web) need no setup. If the invocation already includes a topic, research it immediately and skip Steps 4-6 until after the useful response. Otherwise continue to Step 6.
 
 **If the user picks Auto setup:**
 
@@ -581,16 +583,16 @@ Get cookie consent first. Check if `BROWSER_CONSENT=true` already exists in `~/.
 Question: "Auto setup installs the free CLIs either way - yt-dlp (YouTube), Digg, arXiv, and Techmeme. The only thing that needs your OK is reading your browser's x.com cookies to authenticate X/Twitter search: I check Chrome first (a one-time macOS Keychain prompt may appear; click Always Allow), then Firefox and Safari. Cookies are read live, never saved to disk. Include X?"
 Options (give each option the description shown):
 - "Yes - X cookies + all CLIs" - description: "Read x.com cookies for X/Twitter search AND install yt-dlp (YouTube), Digg, arXiv, and Techmeme." Run `"${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup --allow-browser-cookies` (relative to the skill root). Append `BROWSER_CONSENT=true` to `.env` after setup completes.
-- "Skip X - just the CLIs" - description: "No cookie reads. Still installs yt-dlp (YouTube), Digg, arXiv, and Techmeme." Run `FROM_BROWSER=off "${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup`.
+- "Skip X - just the CLIs" - description: "No cookie reads. Still installs yt-dlp (YouTube), Digg, arXiv, and Techmeme." Run `FROM_BROWSER=off "${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup`. If the invocation already includes a topic, immediately research it with `--no-browser-cookies`; skip Steps 4-6 until after the useful response.
 - "xAI API key for X instead" - description: "Use an api.x.ai key for X search (no cookie read), plus install yt-dlp (YouTube), Digg, arXiv, and Techmeme." Ask them to paste it, write `XAI_API_KEY` to `.env`, then run `FROM_BROWSER=off "${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup`.
 
 **Grok CLI is an opt-in backup, not a setup-time recommendation.** Do NOT check for grok first or offer it as a primary option during setup. A leftover `~/.grok/auth.json` must never steal the X lane. If the user mentions having a Grok account, tell them: "You can use the Grok CLI by pinning `LAST30DAYS_X_BACKEND=grok` in your `.env` after running `grok login`. This is opt-in because a leftover grok login should not take over X automatically." Do not call it free — it needs a Grok plan.
 
 The consented `setup --allow-browser-cookies` run extracts cookies (Chrome/Chromium family first via the Keychain with no Full Disk Access, then Firefox and Safari as fallbacks; the winning browser is pinned for future runs only when it is Firefox or Safari, so Chrome never re-triggers the Keychain prompt on later runs) and best-effort installs yt-dlp (YouTube), the free keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; Digg activates only when the binary is on the **agent subprocess PATH**, typically `$HOME/.local/bin`; setup reports honestly if installed off-PATH; recommend-only if `npx` is unavailable), plus the free keyless arXiv and Techmeme CLIs. Show the user what was found and installed - including whether Digg landed on PATH (active) or off-PATH (installed but not yet active).
 
-**macOS Full Disk Access remediation (Safari fallback only).** Chrome and Firefox need no Full Disk Access; only the Safari fallback does. After the `setup` run, inspect its stderr. If it contains `Permission denied reading Cookies.binarycookies` and the platform is macOS, the OS blocked the Safari read - surface the fix instead of swallowing it: `macOS blocked the Safari cookie read. If your x.com login is in Chrome, you don't need this. To use Safari: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry of the `setup` command. If the user skips, continue.
+**macOS Full Disk Access remediation (Safari fallback only).** Chrome and Firefox need no Full Disk Access; only the Safari fallback does. After the `setup` run, inspect its stderr. If it contains `Permission denied reading Cookies.binarycookies` and the platform is macOS, the OS blocked the Safari read - surface the fix instead of swallowing it: `macOS blocked the Safari cookie read. If your x.com login is in Chrome, you don't need this. To use Safari: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry only when no research topic is waiting. If a topic is already waiting or the user skips, continue immediately with available sources.
 
-**Step 4: ScrapeCreators offer (every first run).** Show this as plain text, then a modal:
+**Step 4: ScrapeCreators offer (every first run unless the Research Continuation Override already started a waiting topic).** Show this as plain text, then a modal:
 
 ScrapeCreators adds TikTok and Instagram - posts AND top comments - plus YouTube comments, all on by default. 10,000 free calls, no credit card. Your key also backfills Reddit **search** when the free path returns no items (empty-only by default; Reddit comments already come free via shreddit), and backstops YouTube transcripts if yt-dlp gets throttled. (We don't get a cut.) You can widen coverage even further in the next step.
 
@@ -651,9 +653,9 @@ For hosts without interactive modal prompts (OpenClaw, Codex, Cursor, Gemini CLI
 
 **3. Cookie consent (ask BEFORE reading anything).** First check if `BROWSER_CONSENT=true` already exists in `~/.config/last30days/.env` (e.g. granted in a prior Claude Code session); if so, skip this prompt and run `setup --allow-browser-cookies` directly. Otherwise ask. Example: `I can read your browser cookies to unlock X/Twitter and other logged-in sources - I check Chrome first (a one-time macOS Keychain prompt may appear; click Always Allow), then Firefox and Safari. Want me to? (yes / no)` **Wait for the answer.**
    - On **yes** → run `"${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup --allow-browser-cookies` (and append `BROWSER_CONSENT=true` to `.env` after it completes). Extracts cookies (Chrome/Chromium family first via the Keychain with no Full Disk Access, then Firefox and Safari; only a Firefox/Safari winner is pinned for later runs, so Chrome never re-prompts) and best-effort installs yt-dlp (YouTube), the free keyless Digg CLI (`digg-pp-cli` via `@mvanhorn/printing-press-library install digg --cli-only`; activates only when on the agent subprocess PATH, typically `$HOME/.local/bin`; reports honestly if off-PATH; recommend-only if `npx` is unavailable), plus the free keyless arXiv and Techmeme CLIs.
-   - On **no** → run `FROM_BROWSER=off "${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup`. Skips all cookie reads; still installs yt-dlp (YouTube), Digg, arXiv, and Techmeme, still writes `SETUP_COMPLETE`.
+   - On **no** → run `FROM_BROWSER=off "${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup`. Skips all cookie reads; still installs yt-dlp (YouTube), Digg, arXiv, and Techmeme, still writes `SETUP_COMPLETE`. If the invocation already includes a topic, immediately research it with `--no-browser-cookies`; skip the remaining optional onboarding steps until after the useful response.
 
-**4. Full Disk Access remediation (macOS only).** After `setup`, inspect stderr. If it contains `Permission denied reading Cookies.binarycookies` on macOS, surface: `macOS blocked the cookie read. To enable X/Twitter: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry. If skipped, continue.
+**4. Full Disk Access remediation (macOS only).** After `setup`, inspect stderr. If it contains `Permission denied reading Cookies.binarycookies` on macOS, surface: `macOS blocked the cookie read. To enable X/Twitter: System Settings > Privacy & Security > Full Disk Access > enable your terminal (or the Claude app), then I can retry.` Offer ONE retry only when no research topic is waiting. If a topic is already waiting or the user skips, continue immediately with available sources.
 
 **5. ScrapeCreators signup offer (every first run, consent BEFORE launching the browser).** Explain it grants 10,000 free calls that add TikTok and Instagram, plus optional backups: Reddit search backfill when the free path returns no items (empty-only by default; thin-run / SC-primary are opt-in env knobs — see Reddit backend pin below), and a YouTube transcript fallback when yt-dlp is rate-limited or bot-gated. GitHub signup grants the full 10,000 free calls (more than the web form), and it opens a GitHub authorization page where you enter a short code. Ask, e.g.: `Want to unlock TikTok, Instagram, and more? I can sign you up for ScrapeCreators with GitHub (10,000 free calls, ~20-30s) - it opens a browser and you enter a short code. (yes / no)` **Wait for the answer.**
    - On **yes** → two commands. FIRST run `"${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup --github-start` in the FOREGROUND - it returns in ~1-2s with a `Your GitHub code: XXXX-XXXX` line plus a JSON blob, copies the code to the clipboard, and opens the browser. Read the `user_code` from that output and immediately tell the user: the code, that it's on their clipboard so they can just paste it (Cmd+V) on the GitHub page - do not make them hunt for it. (If `status == "already_registered"`, stop here - their existing key is active. If the output said the clipboard copy failed, tell them to type the code.) THEN run `"${LAST30DAYS_PYTHON:-python3}" skills/last30days/scripts/last30days.py setup --github-poll` (background with a 5-min timeout, or foreground) and parse the **LAST** JSON line of its stdout for the final status. On success the engine persists the key automatically and returns `"persisted": true` with a MASKED `api_key` (never ask for or echo the raw key). Confirm the paid sources are active.
@@ -859,8 +861,8 @@ Before running the engine, determine which flags apply to this topic and resolve
 
 | Flag | Resolved in | Applies when |
 |------|-------------|--------------|
-| `--x-handle={handle}` | Step 0.5 (Section A below) | Topic is a person, brand, product, or creator with an X presence |
-| `--x-related={h1,h2,...}` | Step 0.5 (Section A below) | Topic has associated entities (founders, commentators, spouse, collaborators, media handles) |
+| `--x-handle={handle}` | Step 0.5 (Section A below) | X is in `ACTIVE_SOURCES_LIST` and the topic is a person, brand, product, or creator with an X presence |
+| `--x-related={h1,h2,...}` | Step 0.5 (Section A below) | X is in `ACTIVE_SOURCES_LIST` and the topic has associated entities (founders, commentators, spouse, collaborators, media handles) |
 | `--github-user={user}` | Step 0.5b | Topic is a person who ships code (developer, engineer, CEO-who-codes, researcher) |
 | `--github-repo={owner/repo}` | Step 0.5c | Topic is a product / project / open-source tool |
 | `--trustpilot-domain={domain}` | Step 0.5d | Topic is a company / brand / service with a Trustpilot presence (passing the flag also auto-activates the opt-in Trustpilot source for this run) |
@@ -877,9 +879,9 @@ Before running the engine, determine which flags apply to this topic and resolve
 
 ---
 
-### Section A: Resolve X Handles (if topic could have X accounts)
+### Section A: Resolve X Handles (only when X is active and the topic could have X accounts)
 
-If TOPIC looks like it could have its own X/Twitter account - **people, creators, brands, products, tools, companies, communities** (e.g., "Dor Brothers", "Jason Calacanis", "Nano Banana Pro", "Seedance", "Midjourney"), do WebSearches to find handles in three categories:
+If `ACTIVE_SOURCES_LIST` contains `x` and TOPIC looks like it could have its own X/Twitter account - **people, creators, brands, products, tools, companies, communities** (e.g., "Dor Brothers", "Jason Calacanis", "Nano Banana Pro", "Seedance", "Midjourney"), do WebSearches to find handles in three categories. If X is not active, skip this section without prompting or trying to unlock it.
 
 **1. Primary handle** (the entity itself):
 ```
@@ -1391,7 +1393,7 @@ Only show lines for platforms where something was resolved. Skip empty lines. On
 
 **Rules for your plan:**
 - Emit 1 to 4 subqueries (more for complex/multi-faceted topics, fewer for simple ones)
-- **CRITICAL: Your PRIMARY subquery MUST include ALL of these sources: reddit, x, youtube, tiktok, instagram, hackernews, polymarket.** Never omit reddit (highest-signal discussion) or youtube (unique transcripts + official content). Secondary subqueries can target specific platforms.
+- **CRITICAL: Your PRIMARY subquery MUST include every applicable source from `ACTIVE_SOURCES_LIST` among reddit, x, youtube, tiktok, instagram, hackernews, polymarket.** Never invent an unavailable source. Preserve X whenever it is active; when it is unavailable, continue with the rest. Never omit active Reddit (highest-signal discussion) or active YouTube (unique transcripts + official content). Secondary subqueries can target specific platforms.
 - `search_query` should be concise and keyword-heavy - match how content is TITLED on platforms
 - `ranking_query` should read like a natural language question
 - **X disambiguation:** express your disambiguation intent in `ranking_query` (e.g., "What are people saying about Rome the city in Italy, not AS Roma or Rome Odunze?") — do not phrase-quote `search_query` for X or invent X operators; the engine handles X query compilation internally.
@@ -1406,7 +1408,7 @@ Only show lines for platforms where something was resolved. Skip empty lines. On
 - For how_to: prioritize YouTube (tutorials) and Reddit (guides)
 - Primary subquery weight = 1.0, secondary = 0.6-0.8, peripheral = 0.3-0.5
 
-**Available sources (include ALL in primary subquery):** reddit, x, youtube, tiktok, instagram, hackernews, polymarket. Optional: bluesky, truthsocial, threads, pinterest, grounding (web search - only if user has Brave/Exa/Serper key), digg (Digg clusters - only if `digg-pp-cli` is on PATH), amazon (buyer reviews - only if `brightdata` is on PATH and logged in; see Step 0.5e)
+**Available sources (include every active one in the primary subquery):** use the engine's `ACTIVE_SOURCES_LIST`. The normal candidates are reddit, x, youtube, tiktok, instagram, hackernews, and polymarket; X remains part of the normal set when active and is simply omitted when unavailable. Optional: bluesky, truthsocial, threads, pinterest, grounding (web search - only if user has Brave/Exa/Serper key), digg (Digg clusters - only if `digg-pp-cli` is on PATH), amazon (buyer reviews - only if `brightdata` is on PATH and logged in; see Step 0.5e)
 
 **Intent → freshness_mode mapping:**
 - breaking_news, prediction → `strict_recent`
@@ -2008,17 +2010,7 @@ Headlines should be specific and newsy ("BULLY dropped and it's dominating", "Eu
 
 If the research output contains a `**🔍 Research Coverage:**` block, render it verbatim right before the stats block. This tells the user which core sources are missing and how to unlock them. Do NOT render this block if it is absent from the output (100% coverage = no nudge).
 
-**Just-in-time X unlock:** If X returned 0 results because no X auth is configured (no AUTH_TOKEN/CT0, no XAI_API_KEY, no FROM_BROWSER), offer to set it up right there.
-
-**Call AskUserQuestion.** Question: "X/Twitter wasn't searched. Want to unlock it?"
-
-Default options (always presented first — cookie consent and paid keys are the primary X fix):
-- "Scan my browser cookies (free)" - Get consent, run cookie scan, write BROWSER_CONSENT=true + FROM_BROWSER=auto to .env
-- "I have AUTH_TOKEN and CT0 from my browser" - Ask them to paste each value, then write AUTH_TOKEN=<value>\nCT0=<value> to .env
-- "I have an xAI API key" - Ask them to paste it, write XAI_API_KEY to .env
-- "Skip for now"
-
-**Grok CLI is an opt-in backup, not a default prescription.** After showing the modal, add one line: "If you have a Grok account and prefer to use it: install the Grok CLI (`curl -fsSL https://x.ai/cli/install.sh | bash`), run `grok login`, then set `LAST30DAYS_X_BACKEND=grok` to enable it." Do not describe the Grok path as free — it needs a Grok plan. Do not put grok first or as a primary recommendation; a leftover `~/.grok/auth.json` must never steal the X lane.
+**Optional X omission:** If X was unavailable because no X authentication was configured, finish the useful findings first. The engine emits one short, non-blocking note: `Optional source omitted: X/Twitter was not enabled; research continued with the available sources.` Render that note once if present. Do not repeat it. Do not open a modal, ask another question, recommend a login, or provide cookie/API setup instructions unless the user explicitly asks to enable X.
 
 **THEN - Engine footer pass-through (right before invitation):**
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -1139,8 +1139,8 @@ def _missing_sources_for_promo(diag: dict[str, object]) -> str | None:
     missing = []
     if "reddit" not in available:
         missing.append("reddit")
-    if "x" not in available:
-        missing.append("x")
+    # X is optional. A successful run without X must reach the research output
+    # without an authentication or browser-cookie promo in front of it.
     # The web promo nudges toward a paid backend for higher-quality web search.
     # Grounding is now available keyless on non-native hosts, so key the promo on
     # the absence of a *paid* backend, not on grounding availability. Suppress it
@@ -1150,9 +1150,28 @@ def _missing_sources_for_promo(diag: dict[str, object]) -> str | None:
         missing.append("web")
     if not missing:
         return None
-    if "reddit" in missing and "x" in missing:
-        return "both"
     return missing[0]
+
+
+def _optional_x_omission_text(
+    diag: dict[str, object],
+    requested_sources: list[str] | None,
+) -> str | None:
+    """Return a non-blocking post-result note for a default run without X.
+
+    Explicit ``--search`` runs already define their intended source boundary,
+    so they do not need an omission note. Doctor/diagnose remains the place for
+    X setup or repair instructions.
+    """
+    if requested_sources is not None:
+        return None
+    available = set(diag.get("available_sources") or [])
+    if "x" in available:
+        return None
+    return (
+        "Optional source omitted: X/Twitter was not enabled; research "
+        "continued with the available sources."
+    )
 
 
 def _show_runtime_ui(
@@ -3817,6 +3836,7 @@ def _main(
             _yt_fetch_stats = _youtube_yt.get_transcript_fetch_stats()
             instagram_items = report.items_by_source.get("instagram") or []
             research_results = {
+                "active_sources": diag.get("available_sources") or [],
                 "youtube_videos_count": len(youtube_items),
                 "youtube_transcripts_count": sum(
                     1 for it in youtube_items
@@ -3864,7 +3884,13 @@ def _main(
     )
     report.artifacts["pre_research_flags_present"] = pre_research_flags_present
 
-    return _render_save_and_print(args, report, entity_reports, synthesis_md, config)
+    exit_code = _render_save_and_print(args, report, entity_reports, synthesis_md, config)
+    if args.emit in {"compact", "md", "brief"}:
+        x_omission = _optional_x_omission_text(diag, requested_sources)
+        if x_omission:
+            sys.stderr.write(f"\n{x_omission}\n")
+            sys.stderr.flush()
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/skills/last30days/scripts/lib/quality_nudge.py
+++ b/skills/last30days/scripts/lib/quality_nudge.py
@@ -1,6 +1,6 @@
 """Post-research quality score and upgrade nudge.
 
-Computes a quality score based on 5 core sources and builds
+Computes a quality score based on the non-blocking core sources and builds
 a nudge message describing what the user missed and how to fix it.
 
 Fix text comes from ``lib.prescriptions`` (the single remediation
@@ -13,7 +13,9 @@ from typing import List
 from . import prescriptions
 
 
-# The 5 core sources
+# Sources whose absence can justify a post-run quality repair. X remains a
+# supported source, but it is optional: declining cookie access must not turn a
+# successful multi-source run into a setup prompt or a lower quality grade.
 CORE_SOURCES = ["hn", "polymarket", "x", "youtube", "reddit"]
 
 # Labels for display
@@ -28,6 +30,8 @@ SOURCE_LABELS = {
 
 def _is_x_active(config: dict, research_results: dict) -> bool:
     """Check if X source is active (has credentials AND didn't error)."""
+    if "x" in (research_results.get("active_sources") or []):
+        return not bool(research_results.get("x_error"))
     has_creds = _has_x_credentials(config)
     if not has_creds:
         return False
@@ -149,7 +153,7 @@ def _is_instagram_silent_failure(config: dict, research_results: dict) -> bool:
 
 
 def compute_quality_score(config: dict, research_results: dict) -> dict:
-    """Compute research quality score based on 5 core sources.
+    """Compute research quality score from the non-blocking core sources.
 
     Args:
         config: Configuration dict from env.get_config()
@@ -163,9 +167,9 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
 
     Returns:
         {
-            "score_pct": 40-100,
+            "score_pct": 0-100,
             "core_active": ["hn", "polymarket", ...],
-            "core_missing": ["x", "youtube"],
+            "core_missing": ["youtube"],
             "core_errored": [],          # configured but errored at top level
             "core_degraded": [],         # configured and returned items but quality below threshold
             "bonus_errored": [],         # bonus sources (Instagram, etc.) configured but silent
@@ -183,14 +187,11 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
     core_active.append("polymarket")
     core_active.append("reddit")
 
-    # X
-    has_x_creds = _has_x_credentials(config)
+    optional_omitted: List[str] = []
     if _is_x_active(config, research_results):
         core_active.append("x")
     else:
-        core_missing.append("x")
-        if has_x_creds and research_results.get("x_error"):
-            core_errored.append("x")
+        optional_omitted.append("x")
 
     # YouTube
     has_ytdlp = _has_ytdlp()
@@ -225,7 +226,8 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
     if _is_instagram_silent_failure(config, research_results):
         bonus_errored.append("instagram")
 
-    score_pct = int(len(core_active) / 5 * 100)
+    scored_source_count = len(CORE_SOURCES) - len(optional_omitted)
+    score_pct = int(len(core_active) / scored_source_count * 100)
 
     has_sc = bool(config.get("SCRAPECREATORS_API_KEY"))
     active_sources = research_results.get("active_sources") or []
@@ -238,6 +240,7 @@ def compute_quality_score(config: dict, research_results: dict) -> dict:
         active_sources=active_sources,
         bonus_errored=bonus_errored,
         has_ytdlp=has_ytdlp,
+        core_total=scored_source_count,
     ) if (core_missing or core_degraded or bonus_errored) else None
 
     return {
@@ -260,6 +263,7 @@ def _build_nudge_text(
     active_sources: list = None,
     bonus_errored: List[str] = None,
     has_ytdlp: bool = False,
+    core_total: int | None = None,
 ) -> str:
     """Build human-readable nudge text describing what was missed or degraded.
 
@@ -280,8 +284,9 @@ def _build_nudge_text(
         else:
             missed_parts.append(label)
 
-    active_count = 5 - len(core_missing)
-    lines.append(f"Research quality: {active_count}/5 core sources.")
+    effective_total = core_total if core_total is not None else len(CORE_SOURCES)
+    active_count = effective_total - len(core_missing)
+    lines.append(f"Research quality: {active_count}/{effective_total} core sources.")
     if missed_parts:
         lines.append(f"Missing: {', '.join(missed_parts)}.")
     if core_degraded:
@@ -294,33 +299,6 @@ def _build_nudge_text(
 
     # Free suggestions
     free_suggestions: List[str] = []
-
-    if "x" in core_missing:
-        if "x" in core_errored:
-            x_fix = prescriptions.get("x", "cookies_expired")
-            free_suggestions.append(f"X/Twitter errored - {x_fix.fix_nl}.")
-        else:
-            x_fix = prescriptions.get("x", "cookies_missing")
-            # Pick by state: telling a user who already installed grok to
-            # install it again is the stale-shim reading the health layer
-            # exists to avoid. Mirrors _probe_grok's three-way split.
-            from . import grok_x as _grok_x
-            grok_key = (
-                "grok_not_authenticated"
-                if _grok_x.binary_path() and not _grok_x.has_stored_auth()
-                else "grok_cli_missing"
-            )
-            grok_fix = prescriptions.get("x", grok_key)
-            # Deliberately not described as free: grok needs no X credential,
-            # but it does need an installed, signed-in grok CLI drawing on a
-            # Grok plan. This block is headed "Free suggestions", so the
-            # precondition has to be stated inline rather than inherited.
-            free_suggestions.append(
-                "X/Twitter: real-time posts with likes and reposts - the fastest "
-                "signal for breaking topics. Easiest path if you have a Grok "
-                f"account: {grok_fix.fix_nl} (no X credential at all). "
-                f"Otherwise: {x_fix.fix_nl}."
-            )
 
     if "youtube" in core_missing:
         if "youtube" in core_errored:

--- a/skills/last30days/scripts/lib/setup_wizard.py
+++ b/skills/last30days/scripts/lib/setup_wizard.py
@@ -36,7 +36,6 @@ _WELCOME_TEXT = """Welcome to /last30days! I research any topic across Reddit, X
 I synthesize what people are actually saying right now across social, news, and market sources.
 
 Auto setup gives you the core sources free in about 30 seconds:
-- X/Twitter - reads your browser cookies to authenticate (read live each run, never saved to disk). I check Chrome first (fastest - a one-time macOS Keychain prompt may appear; click Always Allow), then Firefox and Safari.
 - Reddit with comments - free keyless discovery (RSS + shreddit), no API key needed.
 - YouTube search + transcripts - installs yt-dlp (open source, 190K+ GitHub stars).
 - Digg - trending news, GitHub stars, and pipeline feeds - installs the free, keyless Digg CLI.
@@ -44,6 +43,7 @@ Auto setup gives you the core sources free in about 30 seconds:
 - StockTwits - retail trader sentiment - auto-on when your topic is a ticker or crypto (e.g. "$NVDA earnings", "bitcoin"), off for everything else.
 - Trustpilot - brand/company review sentiment - opt-in (add trustpilot to INCLUDE_SOURCES), off by default.
 - Hacker News + Polymarket + GitHub (auto-on if the gh CLI is installed) - always on, zero config.
+- X/Twitter - optional. It stays available when you already configured it, or after you explicitly approve a browser-cookie read; skipping it never blocks research.
 
 Want TikTok and Instagram too? ScrapeCreators adds those (10,000 free calls, scrapecreators.com). No kickbacks, no affiliation.
 
@@ -73,6 +73,7 @@ def run_auto_setup(config: Dict[str, Any], *, allow_browser_cookies: bool = Fals
     Returns:
         Dict with keys:
           cookies_found: {source_name: browser_name} for each source where cookies were found
+          browser_cookie_scan_attempted: bool (True only after explicit consent)
           ytdlp_installed: bool
           ytdlp_action: already_installed | installed | install_failed | no_homebrew
           digg_installed: bool (True when the engine can resolve digg-pp-cli on PATH)
@@ -154,6 +155,7 @@ def run_auto_setup(config: Dict[str, Any], *, allow_browser_cookies: bool = Fals
 
     results: Dict[str, Any] = {
         "cookies_found": cookies_found,
+        "browser_cookie_scan_attempted": allow_browser_cookies,
         "ytdlp_installed": ytdlp_installed,
         "ytdlp_action": ytdlp_action,
         "digg_installed": digg_installed,
@@ -653,11 +655,9 @@ def get_setup_status_text(results: Dict[str, Any]) -> str:
     lines.append("")
 
     cookies_found = results.get("cookies_found", {})
-    if cookies_found:
+    if results.get("browser_cookie_scan_attempted") and cookies_found:
         for source, browser in cookies_found.items():
             lines.append(f"  - {source.upper()} cookies found in {browser}")
-    else:
-        lines.append("  - No browser cookies found for X/Twitter")
 
     ytdlp_action = results.get("ytdlp_action", "")
     if ytdlp_action == "installed":

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -489,9 +489,9 @@ class CliV3Tests(unittest.TestCase):
     def test_ensure_supported_python_allows_supported_interpreter(self):
         cli.ensure_supported_python((3, 12, 0))
 
-    def test_missing_sources_for_promo_prefers_reddit_x_then_web(self):
+    def test_missing_sources_for_promo_treats_x_as_optional(self):
         self.assertEqual(
-            "both",
+            "reddit",
             cli._missing_sources_for_promo({"available_sources": ["youtube"]}),
         )
         self.assertEqual(
@@ -504,6 +504,31 @@ class CliV3Tests(unittest.TestCase):
             cli._missing_sources_for_promo(
                 {"available_sources": ["reddit", "x", "grounding"], "native_web_backend": "brave"}
             ),
+        )
+
+    def test_optional_x_omission_is_post_result_copy_for_default_runs(self):
+        note = cli._optional_x_omission_text(
+            {"available_sources": ["reddit", "youtube", "grounding"]},
+            None,
+        )
+        self.assertEqual(
+            "Optional source omitted: X/Twitter was not enabled; research "
+            "continued with the available sources.",
+            note,
+        )
+
+    def test_optional_x_omission_is_suppressed_when_x_active_or_search_explicit(self):
+        self.assertIsNone(
+            cli._optional_x_omission_text(
+                {"available_sources": ["reddit", "x", "youtube"]},
+                None,
+            )
+        )
+        self.assertIsNone(
+            cli._optional_x_omission_text(
+                {"available_sources": ["reddit", "youtube"]},
+                ["reddit", "youtube"],
+            )
         )
         # ...or suppressed entirely on a native-search host.
         self.assertIsNone(
@@ -785,7 +810,7 @@ class CliV3Tests(unittest.TestCase):
             source_counts={"grounding": 0},
             display_sources=["grounding"],
         )
-        fake_progress.show_promo.assert_called_once_with("both", diag=diag)
+        fake_progress.show_promo.assert_called_once_with("reddit", diag=diag)
         self.assertIn("# rendered", stdout.getvalue())
 
     def test_main_writes_rendered_output_to_explicit_file(self):

--- a/tests/test_grok_surfacing.py
+++ b/tests/test_grok_surfacing.py
@@ -34,13 +34,10 @@ def test_doctor_mentions_grok_as_opt_in():
     assert "opt-in" in src.lower()
 
 
-def test_quality_nudge_offers_grok_but_does_not_call_it_free():
+def test_quality_nudge_does_not_turn_optional_x_into_a_grok_prompt():
     src = inspect.getsource(quality_nudge)
-    assert "grok_cli_missing" in src
-    assert "no X credential at all" in src
-    # The block is headed "Free suggestions"; grok needs a Grok plan, so the
-    # precondition must be stated inline rather than inherited from the header.
-    assert "if you have a Grok" in src
+    assert "grok_cli_missing" not in src
+    assert 'core_missing.append("x")' not in src
 
 
 def test_configuration_documents_the_grok_path_as_opt_in():
@@ -103,19 +100,19 @@ def test_skill_md_presents_grok_as_opt_in_backup():
     assert "LAST30DAYS_X_BACKEND=grok" in text
 
 
-def test_skill_md_just_in_time_unlock_defaults():
-    """Just-in-time X unlock presents cookies and keys first."""
+def test_skill_md_replaces_just_in_time_unlock_with_optional_omission():
+    """A useful report ends without a second X consent or key prompt."""
     text = _skill_md()
-    section = text[text.index("Just-in-time X unlock"):][:3000]
-    # Default options should be cookies and keys, not grok.
-    assert "Scan my browser cookies" in section
-    assert "xAI API key" in section
+    assert "Just-in-time X unlock" not in text
+    section = text[text.index("Optional X omission"):][:1200]
+    assert "finish the useful findings first" in section
+    assert "Do not open a modal" in section
 
 
-def test_skill_md_does_not_call_the_grok_path_free():
+def test_skill_md_keeps_grok_paid_caveat_in_explicit_setup_path():
     text = _skill_md()
-    section = text[text.index("Just-in-time X unlock"):][:3000]
-    assert "Do not describe the Grok path as free" in section or "Do not call it free" in section
+    section = text[text.index("Grok CLI is an opt-in backup"):][:1200]
+    assert "Do not call it free" in section
 
 
 # --- Doctor grok-only unpinned behavior (R3/R8) -----------------------------

--- a/tests/test_onboarding_contract.py
+++ b/tests/test_onboarding_contract.py
@@ -50,6 +50,30 @@ class TestOnboardingContract(unittest.TestCase):
         """The erosion-resistant gate that orphaned the wizard in #659 is restored."""
         self.assertIn("ALWAYS execute Step 0 BEFORE Step 1", self.step0)
 
+    def test_waiting_topic_continues_after_x_decline_or_setup_skip(self):
+        """Declining optional X access must never strand the requested topic."""
+        self.assertIn("RESEARCH CONTINUATION OVERRIDE", self.step0)
+        self.assertIn("declining or skipping X must never stop", self.step0)
+        self.assertIn("immediately research it with `--no-browser-cookies`", self.modal)
+        self.assertIn("immediately research it with `--no-browser-cookies`", self.prose)
+        self.assertIn("a skip or no answer is never consent", self.step0)
+
+    def test_waiting_topic_defers_optional_prompts_and_x_retry(self):
+        self.assertIn("skip the ScrapeCreators offer", self.step0)
+        self.assertIn("Do not ask another X question in the same run", self.step0)
+        self.assertIn("Offer ONE retry only when no research topic is waiting", self.modal)
+        self.assertIn("Offer ONE retry only when no research topic is waiting", self.prose)
+
+    def test_x_handle_resolution_and_plan_follow_active_sources(self):
+        self.assertIn("If `ACTIVE_SOURCES_LIST` contains `x`", self.text)
+        self.assertIn("every applicable source from `ACTIVE_SOURCES_LIST`", self.text)
+        self.assertIn("Preserve X whenever it is active", self.text)
+
+    def test_post_report_x_note_is_non_blocking(self):
+        self.assertNotIn("Just-in-time X unlock", self.text)
+        self.assertIn("Optional X omission", self.text)
+        self.assertIn("finish the useful findings first", self.text)
+
     # --- Modal flow: the restored NUX, stages in order ---
 
     def test_modal_flow_stage_order(self):

--- a/tests/test_prescriptions.py
+++ b/tests/test_prescriptions.py
@@ -149,20 +149,19 @@ def _nudge(config_overrides=None, result_overrides=None, ytdlp_installed=False):
 
 
 class TestSharedWithQualityNudge:
-    def test_x_cookie_expired_nudge_is_built_from_the_registry_entry(self):
-        entry = prescriptions.get("x", "cookies_expired")
+    def test_x_cookie_expiry_is_an_optional_omission_not_a_nudge(self):
         q = _nudge(
             config_overrides={"AUTH_TOKEN": "tok123"},
             result_overrides={"x_error": "401 unauthorized"},
             ytdlp_installed=True,
         )
-        assert q["nudge_text"] is not None
-        assert entry.fix_nl in q["nudge_text"]
+        assert q["nudge_text"] is None
+        assert q["core_missing"] == []
 
-    def test_x_cookie_missing_nudge_is_built_from_the_registry_entry(self):
-        entry = prescriptions.get("x", "cookies_missing")
+    def test_x_cookie_missing_is_an_optional_omission_not_a_nudge(self):
         q = _nudge(ytdlp_installed=True)
-        assert entry.fix_nl in q["nudge_text"]
+        assert q["nudge_text"] is None
+        assert q["core_missing"] == []
 
     def test_ytdlp_missing_nudge_uses_registry_cli(self):
         entry = prescriptions.get("youtube", "ytdlp_missing")

--- a/tests/test_quality_nudge.py
+++ b/tests/test_quality_nudge.py
@@ -1,7 +1,8 @@
 """Tests for post-research quality score and upgrade nudge.
 
-Reddit is always a core source (free public JSON). The 5 core sources are:
-HN, Polymarket, Reddit (always active), X, YouTube.
+Reddit is always a core source (free public JSON). X remains supported when
+active, but its absence is optional and must not lower the quality grade or
+trigger an authentication nudge.
 ScrapeCreators adds TikTok + Instagram as bonus sources, not core.
 """
 
@@ -54,11 +55,11 @@ def _compute(config_overrides=None, result_overrides=None, ytdlp_installed=False
 
 
 class TestBaseline:
-    """HN + Polymarket + Reddit always active (no X, no YT) -> 60%."""
+    """HN + Polymarket + Reddit active; X omitted and YouTube missing."""
 
-    def test_score_60(self):
+    def test_score_75(self):
         q = _compute()
-        assert q["score_pct"] == 60
+        assert q["score_pct"] == 75
 
     def test_active_sources(self):
         q = _compute()
@@ -67,9 +68,10 @@ class TestBaseline:
         assert "reddit" in q["core_active"]
         assert len(q["core_active"]) == 3
 
-    def test_missing_x_and_youtube(self):
+    def test_only_youtube_is_missing(self):
         q = _compute()
-        assert set(q["core_missing"]) == {"x", "youtube"}
+        assert q["core_missing"] == ["youtube"]
+        assert "x" not in q["core_active"]
 
     def test_reddit_not_in_missing(self):
         """Reddit is always active - never appears in missing."""
@@ -77,11 +79,11 @@ class TestBaseline:
         assert "reddit" not in q["core_missing"]
         assert "reddit_comments" not in q["core_missing"]
 
-    def test_nudge_mentions_x_and_youtube(self):
+    def test_nudge_mentions_youtube_not_x(self):
         q = _compute()
         assert q["nudge_text"] is not None
-        assert "X/Twitter" in q["nudge_text"]
         assert "YouTube" in q["nudge_text"]
+        assert "X/Twitter" not in q["nudge_text"]
 
     def test_nudge_does_not_mention_reddit(self):
         """Reddit is free - nudge should not tell user to get SC for it."""
@@ -101,6 +103,10 @@ class TestXCookies:
         assert "YouTube" in q["nudge_text"]
         assert "X/Twitter" not in q["nudge_text"]
 
+    def test_x_remains_active_when_configured(self):
+        q = _compute(config_overrides={"AUTH_TOKEN": "tok123"})
+        assert "x" in q["core_active"]
+
 
 class TestXquikKey:
     """+Xquik key -> 80% without browser-cookie or xAI credentials."""
@@ -114,6 +120,14 @@ class TestXquikKey:
         q = _compute(config_overrides={"XQUIK_API_KEY": "xq_test"})
         assert "YouTube" in q["nudge_text"]
         assert "X/Twitter" not in q["nudge_text"]
+
+
+class TestActiveSourceX:
+    """The runtime active-source list preserves X without legacy credentials."""
+
+    def test_active_x_is_counted(self):
+        q = _compute(result_overrides={"active_sources": ["reddit", "x", "youtube"]})
+        assert "x" in q["core_active"]
 
 
 class TestXPlusYtdlp:
@@ -162,26 +176,24 @@ class TestFullCoverageWithSC:
 class TestSCDoesNotAffectCoreScore:
     """SC key should not change core score - it only adds bonus sources."""
 
-    def test_sc_alone_still_60(self):
-        """SC key without X or yt-dlp is still 60% (3/5 core)."""
+    def test_sc_alone_still_75(self):
+        """SC key without yt-dlp is still 75% of non-optional core."""
         q = _compute(config_overrides={"SCRAPECREATORS_API_KEY": "sc_key"})
-        assert q["score_pct"] == 60
+        assert q["score_pct"] == 75
 
-    def test_sc_plus_ytdlp_is_80(self):
+    def test_sc_plus_ytdlp_is_100(self):
         q = _compute(
             config_overrides={"SCRAPECREATORS_API_KEY": "sc_key"},
             ytdlp_installed=True,
         )
-        assert q["score_pct"] == 80
+        assert q["score_pct"] == 100
 
-    def test_nudge_suggests_browser_cookies(self):
+    def test_no_x_cookie_nudge_after_complete_available_source_run(self):
         q = _compute(
             config_overrides={"SCRAPECREATORS_API_KEY": "sc_key"},
             ytdlp_installed=True,
         )
-        assert q["nudge_text"] is not None
-        assert "x.com" in q["nudge_text"].lower()
-        assert "XQUIK_API_KEY" in q["nudge_text"]
+        assert q["nudge_text"] is None
 
 
 class TestYouTubeFallbackProvider:
@@ -237,7 +249,8 @@ class TestYouTubeFallbackProvider:
         assert "youtube" in q["core_missing"]
         assert "youtube" not in q["core_active"]
         assert "youtube" not in q["core_degraded"]
-        assert "Missing: X/Twitter, YouTube" in q["nudge_text"]
+        assert "Missing: YouTube" in q["nudge_text"]
+        assert "X/Twitter" not in q["nudge_text"]
 
 
 class TestDisclaimerAlwaysPresent:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -79,6 +79,7 @@ class TestRunAutoSetup:
         assert results["ytdlp_installed"] is True
         assert results["ytdlp_action"] == "already_installed"
         assert results["env_written"] is False
+        assert results["browser_cookie_scan_attempted"] is True
 
     @patch("lib.cookie_extract.extract_cookies_with_source")
     @patch("shutil.which")
@@ -93,6 +94,7 @@ class TestRunAutoSetup:
 
         assert results["cookies_found"] == {}
         mock_extract.assert_not_called()
+        assert results["browser_cookie_scan_attempted"] is False
         assert results["ytdlp_installed"] is False
         assert results["ytdlp_action"] == "no_homebrew"
 
@@ -107,6 +109,7 @@ class TestRunAutoSetup:
         results = setup_wizard.run_auto_setup(config, allow_browser_cookies=True)
 
         assert results["cookies_found"] == {}
+        assert results["browser_cookie_scan_attempted"] is True
 
     @patch("lib.cookie_extract.extract_cookies_with_source")
     @patch("shutil.which")
@@ -687,6 +690,7 @@ class TestGetSetupStatusText:
         """Status text mentions found cookies and yt-dlp."""
         results = {
             "cookies_found": {"x": "chrome"},
+            "browser_cookie_scan_attempted": True,
             "ytdlp_installed": True,
             "ytdlp_action": "already_installed",
             "env_written": True,
@@ -696,17 +700,31 @@ class TestGetSetupStatusText:
         assert "yt-dlp already installed" in text
         assert "Configuration saved" in text
 
-    def test_with_no_cookies_no_ytdlp(self):
-        """Status text shows no cookies and suggests yt-dlp install."""
+    def test_skipped_cookie_scan_does_not_claim_x_is_missing(self):
+        """A consent-safe skip reports setup work without an X unlock nudge."""
         results = {
             "cookies_found": {},
+            "browser_cookie_scan_attempted": False,
             "ytdlp_installed": False,
             "ytdlp_action": "no_homebrew",
             "env_written": False,
         }
         text = setup_wizard.get_setup_status_text(results)
-        assert "No browser cookies found" in text
+        assert "browser cookies" not in text.lower()
+        assert "X/Twitter" not in text
         assert "Install Homebrew first" in text
+
+    def test_consented_scan_with_no_match_stays_non_promotional(self):
+        results = {
+            "cookies_found": {},
+            "browser_cookie_scan_attempted": True,
+            "ytdlp_installed": True,
+            "ytdlp_action": "already_installed",
+            "env_written": False,
+        }
+        text = setup_wizard.get_setup_status_text(results)
+        assert "browser cookies" not in text.lower()
+        assert "X/Twitter" not in text
 
     def test_status_text_installed(self):
         """Status text for freshly installed yt-dlp."""


### PR DESCRIPTION
## Summary

Declining or skipping X/browser-cookie access no longer strands a supplied research topic. The skill continues with available sources, preserves explicit cookie consent, retains configured X when active, and reports an unavailable X lane only after useful results.

## Testing

- [ ] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Focused regression set: 275 passed. Full suite: 4,106 collected, 4,099 passed, 6 skipped, and 1 unrelated host-sensitive failure in `tests/test_backend_descriptors.py::TestGrokExpiryStates::test_no_grok_cli_is_missing`; this machine has Grok at `/opt/homebrew/bin/grok` while the subprocess PATH omits that directory, and the fixture expects Grok to be entirely absent. Python compilation and `git diff --check` passed.

## Changelog

- [x] Added `changelog.d/+x-skip-continuation.fixed.md`
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Codex and delegated agents checked consent handling, first-run fall-through, active-source planning, X-active preservation, post-result messaging, setup status copy, quality scoring, and genuine error-reporting paths. The review found stale X repair-prompt expectations in two existing test areas; those expectations were updated, and a report-shape cleanup removed an unnecessary new return field before the final focused run.

### Security

Browser-cookie reads remain gated by explicit consent. The no-cookie path passes `--no-browser-cookies`, does not add credential writes, and does not change command execution or dependency behavior. Added lines were checked for credential patterns.

## Notes

This does not remove or disable X. Configured X remains an active source. It changes only the behavior when X is optional and unavailable or declined: continue the supported research first, then report the omission without another setup prompt.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

N/A
