### PR TITLE
test: keep Amazon date fixture portable on Windows

### DIFF
--- a/tests/test_amazon.py
+++ b/tests/test_amazon.py
@@ -45,7 +45,10 @@ def search_record(**over):
 
 
 def review_record(days_ago: int, rating: int, **over):
-    posted = (TODAY - timedelta(days=days_ago)).strftime("%B %-d, %Y")
+    review_date = TODAY - timedelta(days=days_ago)
+    # ``%-d`` is POSIX-only and raises on Windows.  Build the day component
+    # from the datetime so this fixture exercises the same payload everywhere.
+    posted = f"{review_date.strftime('%B')} {review_date.day}, {review_date.year}"
     base = {
         "review_id": f"R{days_ago}{rating}",
         # Live shape: the date is doubled and prose-wrapped.

--- a/tests/test_amazon.py
+++ b/tests/test_amazon.py
@@ -619,7 +619,9 @@ class _Item:
 
 
 class TestSourceItemEnrichment:
-    def test_reviews_and_stats_land_on_item_metadata(self):
+    def test_reviews_and_stats_land_on_item_metadata(self, monkeypatch):
+        # Review records are relative to the fixture date, not the wall clock.
+        monkeypatch.setattr(amazon, "_today", lambda: TODAY)
         items = [_Item("B000000001"), _Item("B000000002")]
         amazon.enrich_source_items(
             items, depth="default", keyword="bentgo lunch box",


### PR DESCRIPTION
## Summary

Make the Amazon review fixture format its day component without the POSIX-only %-d strftime directive. This keeps the existing payload shape and makes the fixture run on Windows as well as Unix.

## Testing

- [x] uv run pytest -q tests/test_amazon.py (88 passed)
- [ ] uv run pytest (the updated Amazon failure is gone; the full run reaches an unrelated Windows failure because tests/test_changelog_workflow.py invokes bash, which is unavailable in this environment)
- [x] Added or updated tests that would catch a regression: the existing Amazon suite now executes through its review parsing tests on Windows.

## Changelog

- [x] Skip changelog - test-only portability fix with no shipped behavior change.

## Agent disclosure

### AI review

Audited the repository manifests, skill instructions, source/test layout, command and path boundaries, and recent issue/PR state. The change is limited to a deterministic test fixture; no production code, dependency, API, CI, or architecture is changed.

### Security

N/A. No input handling, command execution, path handling, auth, secrets, or dependency behavior was changed. The repository security hygiene and vendored-code boundaries were reviewed.

## Notes

The fix replaces a platform-specific date directive with the datetime day/year fields while preserving the same human-readable Amazon date payload.

### Relationship to this change

- [x] None
- [ ] Yes - disclosure: N/A

## Related issues

N/A