### PR TITLE
fix(hooks): use bare CLAUDE_PLUGIN_ROOT in SessionStart

### DIFF
--- a/changelog.d/1074.fixed.md
+++ b/changelog.d/1074.fixed.md
@@ -1,0 +1,3 @@
+SessionStart hook must use the bare ${CLAUDE_PLUGIN_ROOT} form so Claude Code's
+missing-plugin-root guard can match it. A default of `.` resolves relative to the
+session cwd and can execute a decoy check-config.sh from the user's project.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-${extensionPath:-.}}/hooks/scripts/check-config.sh\""
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-config.sh\""
           }
         ]
       }

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -126,5 +126,16 @@ class TestPluginContract(unittest.TestCase):
 
         self.assertEqual([], offenders)
 
+    def test_session_start_hook_uses_bare_claude_plugin_root(self) -> None:
+        # Claude Code's missing-plugin-root guard matches the exact literal
+        # ${CLAUDE_PLUGIN_ROOT}. Defaults like ${CLAUDE_PLUGIN_ROOT:-.} slip past
+        # that check and resolve relative to the session cwd (issue #1074).
+        hooks = _json(ROOT / "hooks" / "hooks.json")
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn("${CLAUDE_PLUGIN_ROOT}", command)
+        self.assertNotIn(":-", command)
+        self.assertNotIn("extensionPath", command)
+        self.assertNotIn(":-.}", command)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`hooks/hooks.json` SessionStart used a defaulting form for CLAUDE_PLUGIN_ROOT that does not contain the literal `${CLAUDE_PLUGIN_ROOT}`. Claude Code's missing-plugin-root guard matches that exact substring, so the guard never fired and the `.` default resolved relative to the session cwd (any repo with `hooks/scripts/check-config.sh` could run instead of the plugin's).

Preferred fix from #1074: bare `${CLAUDE_PLUGIN_ROOT}` so the platform guard applies again. `extensionPath` appears nowhere else in the tree; Gemini uses `GEMINI_EXTENSION_DIR` in gemini-extension.json, not this hook path.

## Testing

- [x] `uv run pytest tests/test_plugin_contract.py tests/test_check_config_env_safety.py`
- [x] New contract test fails if the old cwd-default form is restored (sabotage)
- [x] Shell repro: old form runs a cwd decoy; new form fails closed with both vars unset

## Changelog

- [x] Added changelog.d/1074.fixed.md

## Agent disclosure

- **Harness:** Hermes Agent (opensource-builder)
- **Model:** grok-composer-2.5-fast (xAI)

## Relationship

No paid relationship with the maintainer or competing products.

## Related issues

Closes #1074
