### PR TITLE
docs: flexible window, artifacts, troubleshooting

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,14 +1,14 @@
 {
-  "name": "last30days-skill",
+  "name": "obsidian2date",
   "interface": {
-    "displayName": "last30days"
+    "displayName": "obsidian2date"
   },
   "plugins": [
     {
-      "name": "last30days",
+      "name": "obsidian2date",
       "source": {
         "source": "url",
-        "url": "https://github.com/mvanhorn/last30days-skill.git"
+        "url": "https://github.com/pauleschwarz/obsidian2date.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "obsidian2date",
-      "description": "Research any topic from the last 30 days across multiple sources, then write durable Obsidian run notes, briefings, and related wikilinks.",
+      "description": "Research any topic over any recent window across multiple sources, then write durable Obsidian run notes, briefings, and related wikilinks.",
       "version": "0.1.0",
       "author": {
         "name": "Paul Schwarz",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,24 +1,24 @@
 {
-  "name": "last30days-skill",
+  "name": "obsidian2date",
   "owner": {
-    "name": "Matt Van Horn",
-    "url": "https://github.com/mvanhorn"
+    "name": "Paul Schwarz",
+    "url": "https://github.com/pauleschwarz"
   },
   "metadata": {
-    "description": "Marketplace hosting the last30days research plugin."
+    "description": "Research current topics, then keep the useful evidence in linked Obsidian notes."
   },
   "plugins": [
     {
-      "name": "last30days",
-      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
-      "version": "3.21.1",
+      "name": "obsidian2date",
+      "description": "Research any topic from the last 30 days across multiple sources, then write durable Obsidian run notes, briefings, and related wikilinks.",
+      "version": "0.1.0",
       "author": {
-        "name": "Matt Van Horn",
-        "url": "https://github.com/mvanhorn"
+        "name": "Paul Schwarz",
+        "url": "https://github.com/pauleschwarz"
       },
       "source": "./",
-      "category": "productivity",
-      "homepage": "https://github.com/mvanhorn/last30days-skill"
+      "category": "research",
+      "homepage": "https://github.com/pauleschwarz/obsidian2date"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research any topic across Reddit, X, YouTube, HN, GitHub and more — then write durable Obsidian run notes, briefings, and related-note links. Fork of last30days.",
+  "description": "Research any topic from the last 30 days, then write durable Obsidian run notes, briefings, and related-note links.",
   "author": {
     "name": "Paul Schwarz",
     "url": "https://github.com/pauleschwarz"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research any topic from the last 30 days, then write durable Obsidian run notes, briefings, and related-note links.",
+  "description": "Research any topic over any recent window, then write durable Obsidian run notes, briefings, and related-note links.",
   "author": {
     "name": "Paul Schwarz",
     "url": "https://github.com/pauleschwarz"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,30 +1,25 @@
 {
-  "name": "last30days",
-  "version": "3.21.1",
-  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+  "name": "obsidian2date",
+  "version": "0.1.0",
+  "description": "Research any topic across Reddit, X, YouTube, HN, GitHub and more — then write durable Obsidian run notes, briefings, and related-note links. Fork of last30days.",
   "author": {
-    "name": "Matt Van Horn",
-    "email": "mvanhorn@gmail.com",
-    "url": "https://github.com/mvanhorn"
+    "name": "Paul Schwarz",
+    "url": "https://github.com/pauleschwarz"
   },
-  "homepage": "https://github.com/mvanhorn/last30days-skill",
-  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "homepage": "https://github.com/pauleschwarz/obsidian2date",
+  "repository": "https://github.com/pauleschwarz/obsidian2date",
   "license": "MIT",
   "keywords": [
-    "competitor research",
+    "obsidian",
     "research",
+    "briefing",
+    "vault",
     "reddit",
     "twitter",
     "youtube",
-    "tiktok",
-    "instagram",
-    "trends",
-    "prompts",
-    "polymarket",
+    "hacker-news",
     "github",
-    "perplexity",
-    "threads",
-    "pinterest",
-    "hacker-news"
+    "last30days",
+    "multi-source"
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,50 +1,44 @@
 {
-  "name": "last30days",
-  "version": "3.21.1",
-  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and the web.",
+  "name": "obsidian2date",
+  "version": "0.1.0",
+  "description": "Research any topic across Reddit, X, YouTube, HN, GitHub and more — then write durable Obsidian notes and briefings. Fork of last30days.",
   "author": {
-    "name": "Matt Van Horn",
-    "email": "mvanhorn@gmail.com",
-    "url": "https://github.com/mvanhorn"
+    "name": "Paul Schwarz",
+    "url": "https://github.com/pauleschwarz"
   },
-  "homepage": "https://github.com/mvanhorn/last30days-skill",
-  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "homepage": "https://github.com/pauleschwarz/obsidian2date",
+  "repository": "https://github.com/pauleschwarz/obsidian2date",
   "license": "MIT",
   "keywords": [
-    "competitor research",
+    "obsidian",
     "research",
+    "briefing",
+    "vault",
     "reddit",
     "twitter",
     "youtube",
-    "tiktok",
-    "instagram",
-    "trends",
-    "prompts",
-    "polymarket",
+    "hacker-news",
     "github",
-    "perplexity",
-    "threads",
-    "pinterest",
-    "hacker-news"
+    "last30days"
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "last30days",
-    "shortDescription": "Research what people are saying about a topic now.",
-    "longDescription": "last30days adds a Codex skill for researching any topic based on recent discussion and engagement signals across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and the web.",
-    "developerName": "Matt Van Horn",
+    "displayName": "obsidian2date",
+    "shortDescription": "Research a topic and land it in Obsidian.",
+    "longDescription": "obsidian2date keeps the last30days multi-source research engine and adds vault-native export: durable run notes, briefings, related wikilinks, index and dashboard.",
+    "developerName": "Paul Schwarz",
     "category": "Research",
     "capabilities": [
       "Interactive",
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/mvanhorn/last30days-skill",
+    "websiteURL": "https://github.com/pauleschwarz/obsidian2date",
     "defaultPrompt": [
-      "TikTok shop trends",
-      "Codex vs Cursor",
-      "best travel credit cards"
+      "local LLM agent frameworks",
+      "obsidian plugins 2026",
+      "rust async runtime"
     ],
-    "brandColor": "#6F42C1"
+    "brandColor": "#0F766E"
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research any topic from the last 30 days, then write durable Obsidian notes and briefings.",
+  "description": "Research any topic over any recent window, then write durable Obsidian notes and briefings.",
   "author": {
     "name": "Paul Schwarz",
     "url": "https://github.com/pauleschwarz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research any topic across Reddit, X, YouTube, HN, GitHub and more — then write durable Obsidian notes and briefings. Fork of last30days.",
+  "description": "Research any topic from the last 30 days, then write durable Obsidian notes and briefings.",
   "author": {
     "name": "Paul Schwarz",
     "url": "https://github.com/pauleschwarz"
@@ -25,7 +25,7 @@
   "interface": {
     "displayName": "obsidian2date",
     "shortDescription": "Research a topic and land it in Obsidian.",
-    "longDescription": "obsidian2date keeps the last30days multi-source research engine and adds vault-native export: durable run notes, briefings, related wikilinks, index and dashboard.",
+    "longDescription": "obsidian2date researches current topics, then adds vault-native export: durable run notes, briefings, related wikilinks, index and dashboard.",
     "developerName": "Paul Schwarz",
     "category": "Research",
     "capabilities": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "obsidian2date",
-      "description": "Research any topic from the last 30 days across social sources and the web, then write durable Obsidian run notes, briefings, and related wikilinks.",
+      "description": "Research any topic over any recent window across social sources and the web, then write durable Obsidian run notes, briefings, and related wikilinks.",
       "version": "0.1.0",
       "category": "research",
       "source": {

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,24 +1,27 @@
 {
-  "name": "last30days-skill",
+  "name": "obsidian2date",
   "owner": {
-    "name": "Matt Van Horn",
-    "url": "https://github.com/mvanhorn"
+    "name": "Paul Schwarz",
+    "url": "https://github.com/pauleschwarz"
   },
-  "description": "Marketplace for the last30days research plugin",
+  "description": "Research current topics, then keep the useful evidence in linked Obsidian notes.",
   "plugins": [
     {
-      "name": "last30days",
-      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
-      "version": "3.21.1",
-      "category": "productivity",
+      "name": "obsidian2date",
+      "description": "Research any topic from the last 30 days across social sources and the web, then write durable Obsidian run notes, briefings, and related wikilinks.",
+      "version": "0.1.0",
+      "category": "research",
       "source": {
         "source": "url",
-        "url": "https://github.com/mvanhorn/last30days-skill.git"
+        "url": "https://github.com/pauleschwarz/obsidian2date.git"
       },
-      "homepage": "https://github.com/mvanhorn/last30days-skill",
+      "homepage": "https://github.com/pauleschwarz/obsidian2date",
       "keywords": [
-        "last30days",
-        "last 30 days"
+        "obsidian",
+        "research",
+        "briefing",
+        "vault",
+        "last30days"
       ]
     }
   ]

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,18 +1,26 @@
 {
-  "name": "last30days",
-  "version": "3.21.1",
-  "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+  "name": "obsidian2date",
+  "version": "0.1.0",
+  "description": "Research any topic from the last 30 days, then write durable Obsidian notes, briefings, and related wikilinks.",
   "author": {
-    "name": "Matt Van Horn",
-    "email": "mvanhorn@gmail.com",
-    "url": "https://github.com/mvanhorn"
+    "name": "Paul Schwarz",
+    "url": "https://github.com/pauleschwarz"
   },
-  "homepage": "https://github.com/mvanhorn/last30days-skill",
-  "repository": "https://github.com/mvanhorn/last30days-skill",
+  "homepage": "https://github.com/pauleschwarz/obsidian2date",
+  "repository": "https://github.com/pauleschwarz/obsidian2date",
   "license": "MIT",
   "keywords": [
+    "obsidian",
+    "research",
+    "briefing",
+    "vault",
+    "reddit",
+    "twitter",
+    "youtube",
+    "hacker-news",
+    "github",
     "last30days",
-    "last 30 days"
+    "multi-source"
   ],
   "skills": "./skills/"
 }

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research any topic from the last 30 days, then write durable Obsidian notes, briefings, and related wikilinks.",
+  "description": "Research any topic over any recent window, then write durable Obsidian notes, briefings, and related wikilinks.",
   "author": {
     "name": "Paul Schwarz",
     "url": "https://github.com/pauleschwarz"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 Matt Van Horn
+Copyright (c) 2026 Paul Schwarz (obsidian2date fork / Obsidian export path)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.de.md
+++ b/README.de.md
@@ -1,38 +1,28 @@
-# /last30days
+# /obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | Deutsch | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 <p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
+  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="obsidian2date - aktuelle Recherche als verknuepfte Obsidian-Notizen" />
 </p>
 
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
+**Recherche der letzten 30 Tage, als verknuepftes Wissen in Obsidian.**
 
-**Eine von einem KI-Agenten gesteuerte Suchmaschine, die nach Upvotes, Likes und echtem Geld gewichtet – nicht nach Redaktionen.**
+Dieses README beschreibt die aktuelle obsidian2date-Pipeline. Die Laufzeitspezifikation der Skill liegt in [skills/obsidian2date/SKILL.md](skills/obsidian2date/SKILL.md) und ist maßgeblich für das aktuelle Verhalten von Befehlen und Setup.
 
-Dieses README beschreibt die aktuelle v3-Pipeline. Die Laufzeitspezifikation der Skill liegt in [skills/last30days/SKILL.md](skills/last30days/SKILL.md) und ist maßgeblich für das aktuelle Verhalten von Befehlen und Setup.
-
-**Claude Code (empfohlen – automatische Updates über den Marketplace):**
+**Claude Code:**
 ```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
+/plugin marketplace add pauleschwarz/obsidian2date
+/plugin install obsidian2date
 ```
 
 **Codex, Cursor, Copilot, Gemini CLI oder einer von 50+ [Agent Skills](https://agentskills.io)-Hosts:**
 ```
-npx skills add mvanhorn/last30days-skill -g
+npx skills add pauleschwarz/obsidian2date -g
 ```
 (`-g` installiert global für deinen Benutzer, also in allen Projekten verfügbar. Lass das Flag weg, wenn du die Installation auf ein Projekt beschränken willst.)
 
-Weitere Installationswege (claude.ai im Browser, OpenClaw, manuell) findest du unten im Abschnitt [Installation](#installation).
+Weitere Installationswege (claude.ai im Browser, OpenClaw, manuell) findest du unten im Abschnitt [Installation](#installation). Für den direkten Start aus einem Checkout siehe das englische [README](README.md).
 
 Null Konfiguration. Reddit, HN, Polymarket und GitHub funktionieren sofort. Führe die Skill einmal aus, und der Setup-Assistent schaltet X, YouTube, TikTok, arXiv, Techmeme und mehr in 30 Sekunden frei.
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,373 +1,197 @@
-# /obsidian2date
+# obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | Deutsch | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="obsidian2date - aktuelle Recherche als verknuepfte Obsidian-Notizen" />
-</p>
+**Recherchiere jedes beliebige Zeitfenster. Behalte das Nützliche in Obsidian.**
 
-**Recherche der letzten 30 Tage, als verknuepftes Wissen in Obsidian.**
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
 
-Dieses README beschreibt die aktuelle obsidian2date-Pipeline. Die Laufzeitspezifikation der Skill liegt in [skills/obsidian2date/SKILL.md](skills/obsidian2date/SKILL.md) und ist maßgeblich für das aktuelle Verhalten von Befehlen und Setup.
+`obsidian2date` recherchiert, was Menschen tatsächlich zu einem Thema sagen —
+auf Reddit, X, YouTube, HN, GitHub, Polymarket und im Web — über jedes
+Zeitfenster deiner Wahl (letzte Woche, letzte 7 Tage, letzte 90 Tage; 30 Tage
+sind nur der Standard) — und macht aus jedem Lauf dauerhafte, verknüpfte
+Obsidian-Notizen.
 
-**Claude Code:**
-```
-/plugin marketplace add pauleschwarz/obsidian2date
-/plugin install obsidian2date
-```
+Jeder Lauf erzeugt:
 
-**Codex, Cursor, Copilot, Gemini CLI oder einer von 50+ [Agent Skills](https://agentskills.io)-Hosts:**
-```
-npx skills add pauleschwarz/obsidian2date -g
-```
-(`-g` installiert global für deinen Benutzer, also in allen Projekten verfügbar. Lass das Flag weg, wenn du die Installation auf ein Projekt beschränken willst.)
+- eine quellenbasierte **Run-Notiz**
+- ein kompaktes **Briefing**
+- `[[Wikilinks]]` zu verwandten Läufen
+- einen aktualisierten **Index** und ein **Dashboard**
 
-Weitere Installationswege (claude.ai im Browser, OpenClaw, manuell) findest du unten im Abschnitt [Installation](#installation). Für den direkten Start aus einem Checkout siehe das englische [README](README.md).
+Kein Tracking. MIT. Öffentlicher Fork von
+[last30days-skill](https://github.com/mvanhorn/last30days-skill); die
+Upstream-Research-Engine bleibt mergebar. Benötigt Python 3.12+ und ein
+Obsidian-Vault; Quellen und API-Keys sind optional — siehe
+[CONFIGURATION.md](CONFIGURATION.md).
 
-Null Konfiguration. Reddit, HN, Polymarket und GitHub funktionieren sofort. Führe die Skill einmal aus, und der Setup-Assistent schaltet X, YouTube, TikTok, arXiv, Techmeme und mehr in 30 Sekunden frei.
+## Als Slash-Command benutzen (Hauptpfad)
 
----
+`obsidian2date` ist ein Agent Skill: installiere das Repo einmal und tippe
+dann `/obsidian2date <topic>` in deinen Agenten. Der Skill startet die
+Research-Engine, löst deinen Vault auf, schreibt die Notizen und meldet die
+Pfade. Keine Flags zum Auswendiglernen — sag "letzte Woche" oder "über die
+letzten 90 Tage" in der Anfrage, und der Skill übersetzt das in die richtigen
+Engine-Flags.
 
-Upvotes von Reddit. Likes von X. YouTube-Transkripte. TikTok-Engagement. Polymarket-Quoten, gedeckt durch echtes Geld und Insiderwissen. Das sind Millionen Menschen, die jeden Tag mit ihrer Aufmerksamkeit und ihrem Geldbeutel abstimmen. /last30days durchsucht all das parallel, gewichtet nach dem, womit echte Menschen tatsächlich interagieren, und ein KI-Agent fasst es als Juror zu einem einzigen Briefing zusammen.
+| Host | Installation | Danach |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y` (oder dieses Repo als `.claude-plugin` hinzufügen) | `/obsidian2date <topic>` |
+| Codex | Repo bringt `.codex-plugin/plugin.json` mit | `/obsidian2date <topic>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <topic>` |
+| Gemini CLI | Repo bringt `gemini-extension.json` mit | `/obsidian2date <topic>` |
+| OpenClaw / agents.md-Hosts | Repo bringt `.agents/`-Manifest mit | `/obsidian2date <topic>` |
+| pi / jeder skill-fähige Agent | `skills/obsidian2date/` ins Skills-Verzeichnis des Agenten symlinken oder kopieren | `/obsidian2date <topic>` |
 
-Google aggregiert Redaktionen. /last30days durchsucht Menschen.
+Was der Skill bei jedem Lauf tut (siehe
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — die
+kanonische Laufzeitspezifikation, die das Modell liest):
 
-Diese Suche bekommst du nirgendwo sonst, weil keine einzelne KI Zugriff auf alles hat. Google erfasst weder Reddit-Kommentare noch X-Beiträge. ChatGPT hat einen Deal mit Reddit, kann aber weder X noch TikTok durchsuchen. Gemini hat YouTube, aber kein Reddit. Claude hat nichts davon nativ. Jede Plattform ist ein abgeschotteter Garten mit eigener API, eigenen Tokens, eigener Authentifizierung. Aber du kannst deine eigenen Schlüssel und Browser-Sessions mitbringen – und plötzlich durchsucht ein KI-Agent alle gleichzeitig, wägt sie gegeneinander ab und sagt dir, was wirklich zählt.
+1. deinen Vault auflösen (einmal fragen, dann für die Session merken)
+2. das Zeitfenster aus deiner Anfrage ableiten (Standard: 30 Tage)
+3. die Research-Engine mit `--emit=obsidian` ausführen
+4. Briefing-Pfad, Run-Notiz-Pfad und alle partiellen oder nicht erreichbaren Quellen ehrlich melden
 
-Das ist der eigentliche Durchbruch. Keine bessere Suchmaschine, sondern ein Dutzend getrennter Plattformen, die ein Agent miteinander verbindet.
+## Schnellstart (CLI-Fallback)
 
-```
-/last30days Peter Steinberger
-```
-
-Du hast morgen ein Meeting. Du googelst die Person. Du bekommst ihr LinkedIn-Profil von 2023. /last30days zeigt dir, was sie diesen Monat wirklich macht: bei OpenAI eingestiegen, um an Codex zu arbeiten, kämpft gegen Anthropics Verbot von Drittanbieter-Agenten, hat 23 PRs mit 85 % Merge-Rate geliefert, baut „LobsterOS“ für geräteübergreifende Agentensteuerung – und ein Thread in r/ClaudeCode kam auf 569 Upvotes bei der Frage, ob sie ein Held oder „unerträglich“ ist. Verteilt über X-Beiträge, Reddit-Threads, YouTube-Transkripte und GitHub-Commits. Nichts davon stand bei Google.
-
-## Warum es das gibt
-
-Ich habe es gebaut, um bei KI Schritt zu halten. Alles ändert sich täglich, und die Nerds auf Reddit und X wissen es immer zuerst. Ich brauchte bessere Prompts, und die Trainingsdaten lagen immer Monate hinter dem, was die Community längst herausgefunden hatte.
-
-Daraus wurde etwas Größeres. Heute lasse ich es vor einem Sales-Call laufen, um die Wahrheit der letzten 30 Tage über ein Unternehmen zu kennen. Vor einem Meeting, um die aktuellen Tweets und Podcast-Transkripte meines Gegenübers zu lesen. Vor einer Reise nach Disney World, um zu wissen, welche Attraktionen geschlossen sind und was die Community über Genie+ sagt. Bevor ich irgendetwas baue, um zu wissen, an welchen Problemen die Leute wirklich hängen.
-
-Wenn du dich mit einem CEO triffst: Hast du alle Tweets und YouTube-Transkripte der letzten 30 Tage gelesen? Ich schon.
-
-## Quellen, gewichtet von den Menschen
-
-| Quelle | Was dir die Menschen sagen |
-|--------|--------------------------|
-| **Reddit** | Die ungefilterte Meinung. Top-Kommentare mit echten Upvote-Zahlen, kostenlos, ohne API-Schlüssel. Die echten Meinungen, die Google vergräbt. |
-| **X / Twitter** | Die spontane Einschätzung, der Experten-Thread, die erste Reaktion auf eine Eilmeldung. Zuerst informiert, zuerst am Streiten. |
-| **YouTube** | Die 45-minütige Tiefenanalyse. Vollständige Transkripte, durchsucht nach den 5 zitierfähigen Sätzen, auf die es ankommt. |
-| **TikTok** | Der Creator, der 3,6 Millionen Menschen mit einer Sichtweise erreicht, die du bei Google nie findest. |
-| **Instagram Reels** | Die Perspektive der Influencer, inklusive Transkript des Gesprochenen. Das Signal der visuellen Kultur. |
-| **Hacker News** | Der Konsens der Entwickler. 825 Punkte, 899 Kommentare. Wo technische Leute wirklich streiten. |
-| **Polymarket** | Keine Meinungen. Quoten. Gedeckt durch echtes Geld. 96 % Wahrscheinlichkeit bei Albumverkäufen. 4 % bei einer Übernahme. |
-| **GitHub** | Für Personen: PR-Tempo, Top-Repos nach Sternen, Release Notes. Für Themen: Issues und Discussions. |
-| **Digg** | Kuratierte Story-Cluster aus Diggs AI-1000-Leaderboard (rund 1000 KI-Accounts mit hohem Signal auf X), mit zuordenbaren Inline-Zitaten und ganz ohne X-Authentifizierung. Wird automatisch aktiv, sobald `digg-pp-cli` im PATH liegt. |
-| **arXiv** | Die Fachartikel hinter dem Hype. Neue Forschung im Zeitfenster, kostenlos, ohne API-Schlüssel. Wird automatisch aktiv, sobald `arxiv-pp-cli` im PATH liegt (das Erst-Setup installiert es). |
-| **Techmeme** | Die redaktionelle Ebene der Tech-News, begrenzt auf dein 30-Tage-Fenster. Kostenlos, ohne API-Schlüssel. Wird automatisch aktiv, sobald `techmeme-pp-cli` im PATH liegt (das Erst-Setup installiert es). |
-| **LinkedIn** | Das berufliche Signal. Beiträge und Artikel, wobei Artikel als starkes Signal gewichtet werden. |
-| **StockTwits** | Die Stimmung der Trader. Aktiviert sich automatisch, wenn dein Thema ein Ticker oder eine Kryptowährung ist. |
-| **Threads** | Die Textebene nach Twitter. Gespräche von Creators und Marken. |
-| **Pinterest** | Visuelle Entdeckung. Pins, gespeicherte Beiträge und Kommentare zu Produkten und Ideen. |
-| **Xiaohongshu (RED)** | Chinesische Signale zu Lifestyle, Produkten und Creators. Wird ausdrücklich mit `--search xhs` angefordert, wenn lokal ein eingeloggtes x-mcp-Browser-Plugin oder ein `xiaohongshu-mcp`-Dienst läuft. |
-| **Bluesky** | Die dezentrale soziale Ebene. AT-Protocol-Beiträge aus der Abwanderung nach Twitter. |
-| **Perplexity** | Gesteuerte Agent-API-Synthese, OpenRouter-Sonar-Fallback, Rohtreffer der Search API und explizite Deep Research. |
-| **Web** | Die redaktionelle Berichterstattung, die Blog-Vergleiche. Ein Signal von vielen, nicht das einzige. |
-
-Die Community steuert laufend weitere bei. Truth Social und andere Nischenquellen stecken bereits in der Engine, weitere folgen.
-
-Ein Reddit-Thread mit 1.500 Upvotes ist ein stärkeres Signal als ein Blogbeitrag, den niemand gelesen hat. Ein TikTok mit 3,6 Millionen Aufrufen sagt mehr darüber aus, was kulturell relevant ist, als jede Pressemitteilung. Polymarket-Quoten mit 66.000 $ Handelsvolumen dahinter lassen sich schwerer wegdiskutieren als die Vermutung eines Kommentators.
-
-Die Synthese sortiert nach dem, womit echte Menschen tatsächlich interagiert haben. Soziale Relevanz, nicht SEO-Relevanz.
-
-## Wofür die Leute es wirklich nutzen
-
-**Vor einem Meeting.** `/last30days Peter Steinberger` – beim Codex-Team von OpenAI eingestiegen, kämpft gegen Anthropics Verbot von Drittanbieter-Agenten, 23 PRs mit 85 % Merge-Rate auf GitHub gemergt, baut LobsterOS für geräteübergreifende Agentensteuerung. r/ClaudeCode: „Seit OpenClaw erschienen ist, war allgemein bekannt: Wer es über etwas anderes als die API laufen lässt, fliegt irgendwann raus“ (227 Upvotes). Das steht so nicht auf LinkedIn.
-
-**Um Hiring-Signale zu lesen.** `/last30days Listen Labs --hiring-signals` – aktuelle Stellenanzeigen und Karriereseiten werden zu zitierten Belegen für Schwerpunktverschiebungen: Einstellungen in Enterprise Security, Customer Success, Infrastruktur oder Produktausbau. Der Bericht sagt, was das Hiring zu signalisieren scheint, nicht was die Roadmap liefern wird.
-
-**Um ein Thema vor seinem Höhepunkt zu finden.** Frag `/last30days what's exploding in AI agents?`, und die Skill wechselt in den Discovery-Modus: Die Engine durchkämmt Reddit-Kategorielisten, die Front- und Best-Stories von Hacker News, Diggs AI-1000-Feed und X, sofern du authentifiziert bist. Dein Agent bewertet die Vorschläge (Namen, Müllfilterung, inhaltliche Relevanz) und schreibt Podcast- und X-Artikel-Ansätze. Am Ende bekommst du 5 bis 10 nach Velocity sortierte Themen. Jedes Ergebnis enthält quellenübergreifende Zahlen, ein Momentum-Label und einen startklaren Folgebefehl `/last30days "<topic>"`.
-
-**Wenn etwas erscheint.** `/last30days Kanye West` – Großbritannien hat sein Visum blockiert, das Wireless Festival wurde abgesagt, die Sponsoren sind abgesprungen. Aber BULLY stieg auf Platz 2 der Billboard-Charts ein. Fantano kam aus seinem „Yay sabbatical“ zurück, um es zu rezensieren (653.000 Aufrufe). Beim SoFi Homecoming holte er Lauryn Hill und Travis Scott für 44 Songs auf die Bühne. Polymarket: „Wird Kanye wieder twittern?“ 86 % Ja. 23 Reddit-Threads, 17 YouTube-Videos, 86.000 Upvotes.
-
-**Um Tools zu vergleichen.** `/last30days OpenClaw vs Hermes vs Paperclip` – „Das sind keine Konkurrenten, das sind Schichten.“ OpenClaw ist die ausführende Ebene (351.000 GitHub-Sterne, produktiv), Hermes ist das sich selbst verbessernde Gehirn (31.000 Sterne), Paperclip ist das Organigramm (49.000 Sterne). Die Sternzahlen kommen live aus der GitHub-API, nicht aus veralteten Blogbeiträgen. Vergleichstabelle mit Architektur, Speicher, Sicherheit und idealem Einsatzzweck. Laut @IMJustinBrooke: „OpenClaw = Glumanda, Hermes = Glurak.“
-
-**Um die Welt zu verstehen.** `/last30days Iran vs USA` – Tag 38 des Krieges. Trumps Ultimatum bis Dienstag, damit der Iran die Straße von Hormus wieder öffnet. Zwei US-Kampfjets abgeschossen. Öl bei 126 $ pro Barrel. Die IEA nannte es „die größte Versorgungsstörung in der Geschichte des globalen Ölmarkts“. Polymarket: Waffenstillstand bis zum 31. Dezember bei 74 %. 27 X-Beiträge, 10 YouTube-Videos, 20 Prognosemärkte.
-
-**Vor einer Reise.** `/last30days Universal Epic Universe` – die Erweiterung ist bereits im Bau. Baugenehmigung „Project 680“ eingereicht. Eine Feuerwerksshow ist über die Infrastruktur belegt, aber noch nicht angekündigt. Wartezeiten: Mine-Cart Madness im Schnitt 148 Minuten. Noch keine Jahreskarte, und die Einheimischen sind genervt. Stardust Racers steht bis zum 5. April wegen Renovierung still.
-
-**Um schnell etwas zu lernen.** `/last30days Nano Banana Pro prompting` – JSON-strukturierte Prompts lösen den Tag-Wildwuchs ab. Das verschachtelte Format von @pictsbyai verhindert „Concept Bleeding“. Bearbeiten schlägt neu generieren. Und danach schreibt dir die Skill einen produktionsreifen Prompt, der genau das umsetzt, was die Community als funktionierend beschrieben hat.
-
-## Was neu ist
-
-Seit der Ankündigung von v3.3 im Mai und mit Stand v3.11.1 (Juli 2026): 175 gemergte PRs – 122 davon von 52 Beitragenden aus der Community – verteilt auf 15 Releases. Das ist gelandet.
-
-### Erstklassig auf OpenAI Codex
-
-/last30days ist jetzt ein natives Codex-Plugin mit geführtem Setup – keine Portierung, sondern ein vollwertiger Bürger. Renderer-bewusste Zitate sorgen dafür, dass die Codex-Ausgabe sich wie ein Briefing liest und nicht wie eine URL-Suppe (#694), und dieselbe Engine läuft auf Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw und 50+ Agent-Skills-Hosts. Codex-Plugin-Manifest von [@rfoust](https://github.com/rfoust) (#686), Codex-Auth-Fix von [@tmchow](https://github.com/tmchow) (#698).
-
-### arXiv, Techmeme und Digg – kostenlos, ohne API-Schlüssel
-
-arXiv liefert die Fachartikel hinter dem Hype, Techmeme die redaktionelle Tech-News-Ebene – kostenlos, ohne einen einzigen Schlüssel, und das Erst-Setup installiert ihre CLIs, sodass sie sich von selbst aktivieren (#709). Diggs AI-1000-Story-Cluster kommen genauso ohne X-Authentifizierung an: Das Setup installiert dir die kostenlose Digg-CLI (#590). Trustpilot ist optional zuschaltbar für Recherchen zu Consumer-Marken.
-
-### Reddit gratis, mit echten Scores und Top-Kommentaren
-
-Reddits öffentliche .json-API ist gestorben; der kostenlose Weg kam stärker zurück. Schlüsselloses RSS plus Shreddit-Scraping (#457), gezielte Subreddit-Suche mit echten Upvote-Zahlen über arctic-shift (#696) und eine Relevanzschwelle, damit ein viraler Off-Topic-Beitrag dein Briefing nicht kapert (#488, danke [@rzachsmith](https://github.com/rzachsmith)). Kein API-Schlüssel. Echte Scores. Top-Kommentare inklusive.
-
-### Die besten Kommentare in jedem Briefing
-
-Kommentare sind jetzt eine quellenübergreifend standardmäßig aktive Ebene: Instagram-Kommentare mit rangbasierter Vielfalt, damit fünf zugespitzte Meinungen nicht alle aus einem einzigen Beitrag stammen (#751), YouTube-Kommentare plus ein Transkript-Backup über ScrapeCreators, falls yt-dlp scheitert (#637), und von der Community hochgevotete Kommentare, die in die Best-Takes-Wertung einfließen, damit die witzigsten Zeilen die Bewertung überleben (#592, #608).
-
-### Ein einziger doctor-Befehl
-
-Bitte um einen Health-Check: doctor prüft jede Quelle und verschreibt dann die genauen Korrekturen – welcher Schlüssel fehlt, welche CLI nicht im PATH liegt, welches Cookie abgelaufen ist (#753). Kein Rätselraten mehr, warum X so wenig geliefert hat.
-
-### Die X-Suche, neu gebaut
-
-Die X-Pipeline wurde von Grund auf überarbeitet: FROM- und ABOUT-Lanes, damit sowohl die eigenen Beiträge einer Person als auch das Gespräch über sie einsortiert werden (#610), personenbezogene Auflösung mehrdeutiger Unterabfragen (#611), Verifizierung der Urheberschaft aus erster Hand samt Ranking nach Interaktionssignalen (#613) und eine einzige X-Quelle mit automatischem Backend-Failover (#622). Dazu ein ehrliches `--diagnose`, das die Authentifizierung wirklich prüft (#609).
-
-### Weitere Quellen sind dazugekommen
-
-LinkedIn über ScrapeCreators, mit Artikeln als starkem Signal ([@ravstr](https://github.com/ravstr), #702). StockTwits aktiviert sich automatisch bei Ticker- und Krypto-Themen ([@wtiwana](https://github.com/wtiwana), #658). Perplexity hat direkte API-Modi und asynchrone Deep Research dazubekommen ([@sk-holmes](https://github.com/sk-holmes), #629).
-
-### Von der Community gehärtet
-
-Die Sicherheitswelle war fast vollständig Community-Arbeit: Fixes für Stored XSS im HTML-Renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), abgesicherte temporäre Cookie-Dateien, eine gegen Supply-Chain-Angriffe gehärtete CI mit OpenSSF Scorecard und Build-Provenance-Attestierung ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep- und OSV-Scanner-Scans plus ein Dependency-Review-Gate für jeden PR ([@23241a6749](https://github.com/23241a6749)), eine Mindestgrenze für die Testabdeckung, eingeführt bei 60 % und inzwischen auf 84 % angehoben ([@gourab5139014](https://github.com/gourab5139014)), und ein Hermes-Sicherheitsscan, der inzwischen keinen einzigen CRITICAL-Befund mehr enthält (#768).
-
-### Reicht weiter
-
-Hebräisch und andere nichtlateinische Sprachen ([@dudyme](https://github.com/dudyme)). CJK-taugliche Tokenisierung für chinesische Quellen ([@An-idd](https://github.com/An-idd)). Eine Welle an Windows-Kompatibilität. Cookie-Extraktion für die gesamte Chromium-Familie – Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) – plus macOS Keychain und pass(1) unter Linux als Quellen für Zugangsdaten. Historischer Rückblick mit `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Automatisch bereitgestelltes Python 3.12 über uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` zum Auslesen der Stellenseiten eines Unternehmens. Watchlist-Deltas zwischen zwei Durchläufen.
-
-### Weiterhin ab Werk dabei seit v3
-
-Die Grundlagen aus v3 sind alle noch da: das Pre-Research-Hirn, das die richtigen Handles, Subreddits und Hashtags ermittelt, bevor ein einziger API-Aufruf rausgeht (gebaut von [@j-sperling](https://github.com/j-sperling)); die Best-Takes-Wertung, die Humor und Viralität neben Relevanz berücksichtigt; quellenübergreifendes Cluster-Merging; Vergleiche in einem Durchgang („CLI vs MCP“ in 3 Minuten statt 12); automatisch gefundene `--competitors`-Vergleiche; der GitHub-Personenmodus (`--github-user=steipete`); der ELI5-Modus („eli5 on“ nach jedem Durchlauf); und teilbare, in sich geschlossene HTML-Briefings (`--emit=html`). Die Konfigurationsschalter stehen in [CONFIGURATION.md](CONFIGURATION.md).
-
-## Installation
-
-| Umgebung | Installation | Updates |
-|---------|---------|---------|
-| **Claude Code** (empfohlen) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatisch über den Marketplace, oder `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill`, dann `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI oder einer von 50+ [Agent Skills](https://agentskills.io)-Hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (Browser) | [`last30days.skill` herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) und über claude.ai > Customize > Skills > + > Create skill > Upload a skill hochladen | Neu herunterladen und erneut hochladen |
-| **Claude Desktop** | [Die `.mcpb` für deine Plattform herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest) und in Settings > Extensions ziehen | Neu herunterladen und das neue Bundle hineinziehen |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code (empfohlen)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Empfohlen, weil der Claude-Code-Marketplace die Updates für dich übernimmt: Der Plugin-Cache ist versioniert und aktualisiert sich automatisch, sobald ein neues Release erscheint. Mit `claude plugin update last30days@last30days-skill` erzwingst du eine Prüfung.
-
-Wenn du lieber den Agent-Skills-Installationsweg unter Claude Code nutzt, wird auch der unterstützt:
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-Das native Plugin und die `npx skills`-Installation können nebeneinander existieren. Beachte aber: Claude Code dedupliziert nicht über Installationsmethoden hinweg. Wenn sowohl das Marketplace-Plugin als auch die `npx skills`-Kopie aktiv sind, taucht `/last30days` doppelt auf. Nutze pro Rechner eine Installationsmethode.
-
-### Grok (xAI Build CLI)
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installiert last30days als natives Plugin. Die direkte Installation folgt dem Repository:
+Für Skripte, Cron oder Dev-Zeit-Engine-Tests rufst du die CLI direkt auf.
+Das ist der Fallback-Pfad, nicht der Hauptpfad — der Slash-Command oben ist
+das Produkt.
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /pfad/zu/deinem/vault
 ```
 
-Oder füge dieses Repository als Marketplace-Quelle hinzu und installiere anschließend über den Plugin-Namen:
+Oder den Vault einmal konfigurieren:
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/pfad/zu/deinem/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-Mit `--trust` überspringst du die Installationsbestätigung. Aktualisieren kannst du mit `grok plugin update last30days`. Grok liest aus Kompatibilitätsgründen auch die Claude-Code-Manifeste; das native `.grok-plugin/`-Paar ist der bevorzugte Weg – und genau darauf verweist ein offizieller Eintrag im [xAI-Marketplace](https://github.com/xai-org/plugin-marketplace). `npx skills add` bleibt ein gültiger Fallback über alle Hosts hinweg.
+### Zeitfenster
 
-### Codex, Cursor, Copilot, Gemini CLI und weitere Agent-Skills-Hosts
-
-Installiere über die offene [Agent Skills](https://agentskills.io)-CLI – sie unterstützt 50+ Hosts, darunter `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` und weitere (vollständige Liste im [Repository vercel-labs/skills](https://github.com/vercel-labs/skills)).
+`30` Tage sind nur der Standard. Frag nach allem Möglichen:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # letzte Woche
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # Quartals-Sweep
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-Das Flag `-g` (global) installiert in dein Benutzerverzeichnis, sodass die Skill in allen Projekten verfügbar ist. Ohne `-g` installiert `npx skills` projektlokal nach `./.skills/` (und wird mit dem Repository eingecheckt). Für ein Werkzeug, mit dem du die ganze Welt recherchierst, willst du die globale Installation.
+Im Slash-Command sagst du es einfach: "recherchiere die letzten 7 Tage zu AI
+video tools".
 
-Codex Desktop und andere Hosts, die auf Ordnerebene arbeiten, funktionieren sowohl in gewöhnlichen Ordnern als auch in Git-Repositories. Bitte den Host-Agenten vor der ersten Recherche, das mitgelieferte `scripts/last30days.py --preflight` aus dem geladenen Skill-Verzeichnis auszuführen; in einem Checkout des Quellcodes lautet der entsprechende Befehl `python3 skills/last30days/scripts/last30days.py --preflight`. Er zeigt dir, woher die Konfiguration stammt, welche Browser-Cookies gelesen würden, welche Dateien geschrieben würden, welche optionalen Befehle es gibt und welche Projektkonfiguration ignoriert wird – ohne Cookies zu lesen, Dateien zu schreiben oder eine Recherche zu starten.
+### Vault-Auflösung
 
-Standardmäßig wird für den Host installiert, den `npx skills` erkennt. Um gezielt einen (oder mehrere) anzusprechen:
+Das Export-Ziel wird in dieser Reihenfolge aufgelöst:
+
+1. `--obsidian-vault PATH` (ein explizit fehlender Pfad wird für den Export angelegt)
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. ein vorhandenes `~/Desktop/brain-paul`
+
+Umgebungs- und Desktop-Kandidaten müssen bereits Verzeichnisse sein. Ein
+vorhandener leerer oder nur aus Whitespace bestehender Vault-Umgebungswert
+deaktiviert absichtlich alle impliziten Fallbacks. Wenn nichts aufgelöst
+wird, stoppt der Befehl mit:
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+Verwende `~/...` oder absolute Pfade in `.env`-Dateien; `$HOME` wird dort
+nicht expandiert. Vorhandene Notizen werden nie überschrieben;
+Dateinamen-Kollisionen erhalten ein numerisches Suffix.
+
+## Was geschrieben wird
+
+Standard-Layout unter dem Vault-Root:
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Notizen werden nie überschrieben. Kollisionen am selben Tag erhalten
+numerische Suffixe. Verwandte frühere Läufe werden über Obsidian
+`[[Wikilinks]]` verknüpft, wenn Token-Überlappung erkannt wird.
+
+## Quellen & Keys
+
+Gleicher Standard wie Upstream:
+
+- **Ohne Keys standardmäßig:** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Optional:** X (Browser-Cookies / Backends), YouTube (`yt-dlp`),
+  TikTok/IG (ScrapeCreators), plus weitere bezahlte/opt-in Backends
+
+Siehe [`CONFIGURATION.md`](CONFIGURATION.md) für die vollständige Matrix und
+das Key-Setup.
+
+## Sichere Diagnose
+
+Vor der Recherche einen reinen Rechte-Check ausführen:
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` ist sicher: Er läuft **ohne Cookies zu lesen, Dateien zu
+schreiben oder Recherche zu starten**. Zur Fehlerbehebung von Quellen oder
+installierten Backends nutze stattdessen den Health-Check:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-Später aktualisieren mit:
+## Upstream-Modi funktionieren weiterhin
 
 ```bash
-npx skills update last30days -g
+# ursprüngliche kompakte Synthese-Ausgabe
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# Agent-JSON
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# Production-Brief
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-Oder aktualisiere alles, was du global über `npx skills` installiert hast:
+## Verhältnis zu Upstream
+
+| Aspekt | Richtlinie |
+| --- | --- |
+| Research-Engine | Mergebar mit `upstream/main` bleiben |
+| Obsidian-Export | Additiv-Modul: `lib/obsidian_export.py` |
+| Branding / Skill | `obsidian2date` |
+| Lizenz | MIT; Upstream-Copyright-Hinweise erhalten |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-Auflisten und entfernen kannst du mit `npx skills list -g` und `npx skills remove last30days -g`.
+## Credits
 
-### claude.ai (Browser)
+- Upstream-Research-Engine: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Obsidian-Export-Pfad + öffentliches Fork-Packaging: [pauleschwarz](https://github.com/pauleschwarz)
 
-1. [`last30days.skill` herunterladen](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) – aus dem neuesten Release
-2. Geh zu [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Klicke im Skills-Panel auf `+`, dann auf `Create skill` > `Upload a skill`, und wähle die Datei aus oder zieh sie hinein
+## Lizenz
 
-Aktiviere vorher unter Capabilities die Option „Code execution and file creation“ – ohne sie laufen Skills nicht.
-
-### Claude Desktop
-
-Claude Desktop installiert `/last30days` als MCP-Server über ein `.mcpb`-Bundle (ein Model-Context-Protocol-Paket zum Ein-Klick-Installieren).
-
-1. Öffne das [neueste Release](https://github.com/mvanhorn/last30days-skill/releases/latest) und lade die `.mcpb` für deine Plattform herunter:
-   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Öffne Claude Desktop, geh zu Settings > Extensions und zieh die Datei hinein.
-3. Füge auf Nachfrage die API-Schlüssel für die Quellen ein, die du aktivieren willst. Jedes Feld ist optional – überspringst du alle, fällt die Engine auf den reinen Web-Modus zurück. Die Schlüssel landen im Schlüsselbund deines Betriebssystems.
-4. Starte Claude Desktop neu. Bitte Claude, „zu Peter Steinberger zu recherchieren“ oder zu einem beliebigen anderen Thema, und es ruft das Tool `research` auf.
-
-**Voraussetzung auf dem Host:** Python 3.12+ im PATH. Das Bundle bringt den Quellcode der Engine mit, nutzt aber deinen lokalen Python-Interpreter. Unter Windows installierst du ihn von [python.org](https://www.python.org/downloads/); macOS und die meisten Linux-Distributionen bringen bereits eine kompatible Version mit.
-
-**Die Schlüssel werden nicht mit der Claude-Code-Skill geteilt.** Claude Desktop und Claude Code halten bewusst getrennte Speicher für Zugangsdaten. Wenn du `~/.config/last30days/.env` bereits für die Claude-Code-Skill eingerichtet hast, gibst du dieselben Schlüssel hier einmalig erneut ein.
-
-Windows-Unterstützung ist zurückgestellt, bis die plattformspezifischen Einstiegspunkte im Manifest geklärt sind; verfolgt wird das in einem eigenen Issue.
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-Für X/Twitter-Aktionen außerhalb der `/last30days`-Recherche – Tweets oder
-Antworten posten, Follower exportieren, Medien verwalten, Accounts beobachten
-und Verlosungen auswerten – nutzt du [TweetClaw](https://github.com/Xquik-dev/tweetclaw)
-als ergänzendes OpenClaw-Plugin. TweetClaw wird von Xquik-dev gepflegt und ist
-hier nur als optionale Ergänzung aufgeführt, nicht als Abhängigkeit oder
-Empfehlung von last30days.
-
-### Manuell (für Entwickler)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-Der Symlink hält die Installation beim Bearbeiten mit deinem Arbeitsverzeichnis synchron – erneutes Kopieren entfällt. Für `claude.ai` baust du die `.skill`-Datei aus dem Quellcode: `bash skills/last30days/scripts/build-skill.sh` erzeugt `dist/last30days.skill`.
-
-Reddit (mit Kommentaren), Hacker News, Polymarket und GitHub funktionieren sofort. Null Konfiguration. Führe `/last30days` einmal aus, und der Setup-Assistent schaltet in 30 Sekunden weitere Quellen frei, darunter die kostenlosen CLIs für arXiv und Techmeme.
-
-## Bring deine eigenen Schlüssel mit
-
-Diese Plattformen haben nichts miteinander zu tun. X weiß nicht, was Reddit denkt. YouTube sieht TikTok nicht. Aber du kannst deine eigenen API-Schlüssel und Browser-Tokens mitbringen – und hast auf einen Schlag Zugriff auf alle gleichzeitig.
-
-| Quellen | Was du brauchst | Kosten |
-|---------|---------------|------|
-| Reddit (mit Kommentaren) + HN + Polymarket + GitHub + StockTwits | Nichts | Kostenlos |
-| arXiv + Techmeme | Kostenlose CLIs, die das Erst-Setup automatisch installiert | Kostenlos |
-| X / Twitter | In einem beliebigen Browser bei x.com anmelden, oder `XQUIK_API_KEY` / `XAI_API_KEY` setzen | Browser-Cookies sind kostenlos; Schlüssel hängen vom Anbieter ab |
-| YouTube | `brew install yt-dlp` | Kostenlos |
-| Bluesky | App-Passwort von bsky.app | Kostenlos |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube-Kommentare | Ein ScrapeCreators-Schlüssel | 10.000 kostenlose Aufrufe, danach nutzungsabhängig |
-| Xiaohongshu (RED) | Ein eingeloggtes x-mcp-Browser-Plugin oder einen `xiaohongshu-mcp`-Dienst laufen lassen und die Quelle mit `--search xhs` pro Durchlauf oder `INCLUDE_SOURCES=xiaohongshu` in `.env` zuschalten; last30days probiert automatisch `http://localhost:18060` und danach `http://host.docker.internal:18060`, oder du setzt `XIAOHONGSHU_API_BASE` für eine eigene URL | Kein last30days-API-Schlüssel nötig; hängt von deinem lokalen Browser-Session-Dienst ab |
-| DripStack (Premium-Finanznewsletter) | Zuschaltbar: `--search dripstack` pro Durchlauf, oder `INCLUDE_SOURCES=dripstack` in `.env` | Kein Schlüssel; kostenlose öffentliche Such-API |
-| Perplexity Agent API / Search API / Deep Research | Ein Perplexity-Schlüssel, oder ein OpenRouter-Schlüssel als Sonar-Fallback | Nutzungsabhängig; ein direkter Schlüssel aktiviert Agent API und Deep Research im Hintergrund |
-| Websuche | Ein Brave-Search-Schlüssel | 2.000 kostenlose Anfragen pro Monat |
-
-### macOS Keychain (optional)
-
-Unter macOS kannst du Schlüssel im System-Schlüsselbund statt in einer `.env`-Datei ablegen. Die Skill liest sie automatisch aus, allerdings mit der niedrigsten Priorität – bei einer Kollision gewinnen weiterhin `.env`-Dateien und die Prozessumgebung.
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-Die Einträge werden für den aktuellen Benutzer unter dem Dienstnamen `last30days-<KEY>` gespeichert. Auf Nicht-Darwin-Plattformen tut der Loader nichts, für Linux- und Windows-Nutzer ändert sich also am Verhalten nichts.
-
-Du hast bereits Schlüssel unter anderen Keychain-Dienstnamen? Dann setz das nicht geheime Mapping `LAST30DAYS_KEYCHAIN_ALIASES`, das in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) beschrieben ist, statt Geheimnisse zu kopieren.
-
-Die vollständige Schlüsselmatrix pro Quelle, die Priorität der Reasoning-Anbieter und die Priorität der Websuche-Backends stehen in [CONFIGURATION.md](CONFIGURATION.md).
-
-## Konfiguration
-
-Zwei Dinge, die du vermutlich schon am ersten Tag wissen willst:
-
-**Wo die Rechercheergebnisse landen.** `LAST30DAYS_MEMORY_DIR` zeigt standardmäßig auf `~/Documents/Last30Days/` (unter Windows: `C:\Users\<you>\Documents\Last30Days\`). Überschreib das, indem du die Umgebungsvariable in deiner Shell auf einen beliebigen Pfad setzt, oder mit `--save-dir <path>` pro Durchlauf. Nutze `--output <file>`, wenn du das gerenderte Ergebnis an einem exakten Pfad brauchst – im Format, das `--emit` vorgibt. Mit `--save-suffix=<name>` hältst du mehrere Varianten desselben Themas auseinander (etwa pro Kunde). Jeder Durchlauf mit `--save-dir` erzeugt `<slug>-raw[-suffix].md`. Mit `python3 skills/last30days/scripts/last30days.py --preflight` siehst du vor einer Recherche, welche Dateien geschrieben würden.
-
-**Strukturierte Ausgabe für Agenten und Workflows.** Bitte `/last30days` um maschinenlesbares JSON, dann bekommst du das stabile, versionierte Agentenprofil. Für den direkten Einsatz der Engine in Skripten oder in der Entwicklung führst du `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` aus; `--json-profile=raw` brauchst du nur, wenn du den unversionierten internen `Report`-Dump willst. Siehe die [Feldreferenz des JSON-Exports samt Versionierungsrichtlinie](docs/reference/json-export.md).
-
-**Discovery ohne festes Thema.** Frag `/last30days what's trending in AI agents?`, um ein sortiertes Discovery-Briefing zu bekommen, statt ein Thema zu recherchieren, das du ohnehin kennst. Auf einem Agenten-Host läuft dafür das dreistufige, vom Host bewertete Protokoll (das Modell benennt Themen, filtert Müll heraus, bewertet ihre Relevanz und schreibt die inhaltlichen Ansätze). Für den direkten Einsatz der Engine in Skripten oder per Cron führst du `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` aus (einmaliger Lauf: deterministische Themennamen, keine Ansätze); mit `--emit=json` bekommst du den versionierten Discovery-Vertrag. Discovery schließt ein positionsbasiertes Thema und `--drill` gegenseitig aus.
-
-**Trendbeobachtung über mehrere Durchläufe.** Der Standardmodus erzeugt pro Durchlauf einen frischen Markdown-Snapshot. Um Erkenntnisse über die Zeit zu sammeln, hängst du `--store` an, damit sie in einer SQLite-Datenbank landen, und nutzt dann [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) für geplante Durchläufe (auf Wunsch mit Zustellung per Slack oder Webhook bei neuen Funden) sowie [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) für tägliche oder wöchentliche Zusammenfassungen. Das vollständige Taktmuster steht in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
-
-**Eine abonnierbare Recherche-Bibliothek.** Bitte `/last30days`, deinen Bibliotheks-Feed zu bauen, oder nutze für Skripting und Entwicklung direkt `python3 skills/last30days/scripts/last30days.py library feed`. Das verwandelt gespeicherte Briefings in eine `index.html`, ein lokales Atom-`feed.xml` und lesbare Briefing-Seiten. Hänge `--publish` nur an, wenn der HTML-Index und die Briefing-Seiten gehostet werden sollen; das Veröffentlichen ist eine bewusste Entscheidung und standardmäßig öffentlich. Damit der Atom-Feed wirklich abonnierbar wird, hoste das erzeugte Ausgabeverzeichnis bei einem statischen Anbieter wie GitHub Pages.
-
-**Durchsuche alles, was du schon recherchiert hast.** Frag `/last30days search my library for MCP servers` oder `/last30days have I researched MCP servers before?`. Für den direkten Einsatz der Engine führst du `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` aus. Die Suche läuft offline und deterministisch: Sie indexiert nach und nach dieselben gespeicherten Briefings, die auch der Bibliotheks-Feed nutzt, führt passende Treffer aus dem Store je Durchlauf zusammen und gruppiert die Ergebnisse nach Thema und Datum. Neue Durchläufe blenden außerdem einen kompakten Abschnitt **From your library** („aus deiner Bibliothek“) ein, wenn frühere Recherchen das aktuelle Thema überschneiden; mit `LAST30DAYS_LIBRARY_CONTEXT=off` schaltest du diesen passiven Kontext ab.
-
-Wrapper-Skripte pro Kunde, eigene Kategorie-Subreddits und der experimentelle Beta-Kanal für Anpassungen in Arbeit sind ebenfalls in [CONFIGURATION.md](CONFIGURATION.md) dokumentiert.
-
-## Showcase: Recherche-Feeds aus der Community
-
-Du hast mit last30days ein wiederkehrendes KI-Update, eine Marktbeobachtung oder eine herrlich spezielle Obsession veröffentlicht? Teil die URL deiner öffentlichen Bibliothek – oder die Atom-URL, sobald `feed.xml` bei einem statischen Anbieter liegt – im [Showcase-Thread der Community](https://github.com/mvanhorn/last30days-skill/issues/532). Community-Feeds werden hier verlinkt, sobald ihre Besitzer sie einreichen; bis dahin ist der Thread die Sammelstelle.
-
-## So funktioniert es
-
-1. **Du tippst ein Thema ein.** Person, Unternehmen, Produkt, Technologie, „X vs Y“. Alles ist möglich.
-2. **Der Agent klärt, wer zählt.** Er findet X-Handles (auch die von Gründerinnen und Gründern), GitHub-Repos, Subreddits, TikTok-Hashtags und YouTube-Kanäle. Bei „Kanye West“ weiß er, dass r/hiphopheads, @kanyewest und „bully review“ auf YouTube dazugehören. Bei „OpenClaw“ löst er openclaw/openclaw auf GitHub auf und holt die aktuellen Sternzahlen.
-3. **Alle Quellen werden parallel durchsucht.** Erweiterung über mehrere Suchanfragen. Ergebnisse gewichtet nach Engagement, Relevanz und Aktualität.
-4. **Die Tiefe, die sonst niemand hat.** Vollständige YouTube-Transkripte aus Reaktionsvideos. Die besten Reddit-Kommentare samt Upvote-Zahlen. TikTok-Captions. Polymarket-Quoten. Nicht nur Titel und Links.
-5. **Dieselbe Geschichte, zusammengeführt.** Das Wireless Festival auf Reddit angekündigt, auf X diskutiert, Ticketpreise auf TikTok – das ergibt einen Cluster, nicht drei getrennte Einträge.
-6. **Zu einem Briefing verdichtet.** Auf konkreten Daten fußend. Nach Quelle belegt. Sortiert nach dem, womit Menschen wirklich interagieren. Nicht „hier ist, was ich gefunden habe“, sondern „hier ist, was zählt“.
-7. **Danach wird es dein Experte.** Nach einem einzigen Durchlauf weiß deine Claude-Sitzung alles, was die Community weiß. Stell Rückfragen. Lass sie Prompts schreiben, E-Mails entwerfen, Reisen planen, Systeme entwerfen – immer verankert in dem, was gerade wirklich stimmt.
-
-## Was die Leute sagen
-
-> „Ich habe eine Claude-Code-Skill gefunden, die zu jedem Thema die letzten 30 Tage auf Reddit, X, YouTube und HN recherchiert. Und dann schreibt sie dir die Prompts. Vor jedem Text, den ich schreibe, habe ich das bisher von Hand auf Reddit und X gemacht. Tab für Tab. Thread für Thread. Genau das ist der Teil, der 90 Minuten frisst. Der fällt jetzt weg.“ – @itsjasonai
-
-> „Diese eine Skill hat meinen kompletten Recherche-Workflow ersetzt. Du gibst ihr ein Thema, sie holt sich von Reddit, X und dem Web, worüber die Leute wirklich reden. Keine alten Blogbeiträge. Echte Gespräche aus den letzten 30 Tagen.“ – @itswilsoncharles
-
-> „5 der 10 Trending-Repos heute auf GitHub sind Claude-Tools. Nummer 1: mvanhorn/last30days-skill“ – @yieldhunter95
-
-## Open Source
-
-MIT-Lizenz. Kein Tracking. Keine Analytics. Deine Recherche bleibt auf deinem Rechner. Über 2.700 Tests.
-
-Gebaut mit Python 3.12+, yt-dlp, Node.js (mitgelieferter Bird-Client für die X-Suche) und der ScrapeCreators-API. Architektur der v3-Engine von [@j-sperling](https://github.com/j-sperling).
-
-Wie du einen PR aufmachst, steht in [CONTRIBUTING.md](CONTRIBUTING.md), die vollständige Liste der Community-Beitragenden in [CONTRIBUTORS.md](CONTRIBUTORS.md) und die Versionshistorie in [CHANGELOG.md](CHANGELOG.md).
-
-## Sternverlauf
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT. Siehe [LICENSE](LICENSE).

--- a/README.es.md
+++ b/README.es.md
@@ -1,383 +1,196 @@
-# /last30days
+# obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | Español | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
-</p>
-
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
-
-**Un buscador dirigido por un agente de IA que puntúa por votos positivos, likes y dinero real, no por redacciones.**
-
-Este README documenta el pipeline v3 actual. La especificación de ejecución de la skill vive en [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que es la referencia definitiva sobre el comportamiento de los comandos y la configuración.
-
-**Claude Code (recomendado — actualizaciones automáticas vía marketplace):**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
-
-**Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ hosts de [Agent Skills](https://agentskills.io):**
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-(`-g` instala de forma global para tu usuario, así que la tienes disponible en todos tus proyectos. Omite ese flag si prefieres limitar la instalación a un proyecto.)
-
-Más formas de instalarlo (claude.ai web, OpenClaw, manual) en la sección [Instalación](#instalación) de más abajo.
-
-Cero configuración. Reddit, HN, Polymarket y GitHub funcionan de inmediato. Ejecútalo una vez y el asistente de configuración desbloquea X, YouTube, TikTok, arXiv, Techmeme y más en 30 segundos.
-
----
-
-Los votos positivos de Reddit. Los likes de X. Las transcripciones de YouTube. La interacción en TikTok. Las cuotas de Polymarket, respaldadas por dinero real y por información privilegiada. Eso son millones de personas votando cada día con su atención y su cartera. /last30days lo busca todo en paralelo, lo puntúa según aquello con lo que la gente interactúa de verdad, y un agente de IA hace de juez para sintetizarlo en un único informe.
-
-Google agrega redacciones. /last30days busca personas.
-
-Esta búsqueda no la consigues en ningún otro sitio, porque ninguna IA tiene acceso a todo. Google no toca los comentarios de Reddit ni las publicaciones de X. ChatGPT tiene un acuerdo con Reddit, pero no puede buscar en X ni en TikTok. Gemini tiene YouTube, pero no Reddit. Claude no tiene ninguno de forma nativa. Cada plataforma es un jardín amurallado con su propia API, sus propios tokens y su propia autenticación. Pero tú puedes aportar tus claves y tus sesiones de navegador y, de golpe, un agente de IA las consulta todas a la vez, las compara entre sí y te dice qué importa de verdad.
-
-Ese es el desbloqueo. No se trata de un buscador mejor, sino de una docena de plataformas incomunicadas que un agente conecta entre sí.
-
-```
-/last30days Peter Steinberger
-```
-
-Mañana tienes una reunión. Buscas a la persona en Google. Te sale su LinkedIn de 2023. /last30days te da lo que está haciendo de verdad este mes: se ha incorporado a OpenAI para trabajar en Codex, pelea contra el veto de Anthropic a los agentes de terceros, ha entregado 23 PR con un 85 % de tasa de merge, construye «LobsterOS» para controlar agentes entre dispositivos, y un hilo de r/ClaudeCode llegó a 569 votos positivos debatiendo si es un héroe o un «insoportable». Todo repartido entre publicaciones de X, hilos de Reddit, transcripciones de YouTube y commits de GitHub. Nada de eso estaba en Google.
-
-## Por qué existe esto
-
-Lo construí para no quedarme atrás en IA. Todo cambia cada día y los frikis de Reddit y de X siempre se enteran primero. Necesitaba mejores prompts, y los datos de entrenamiento siempre iban meses por detrás de lo que la comunidad ya había averiguado.
-
-Pero acabó siendo algo más grande. Ahora lo lanzo antes de una llamada comercial, para conocer la verdad de los últimos 30 días sobre una empresa. Antes de una reunión, para leer los tuits recientes y las transcripciones de podcasts de la otra persona. Antes de un viaje a Disney World, para saber qué atracciones están cerradas y qué opina la comunidad sobre Genie+. Antes de construir nada, para saber con qué problemas se está encontrando la gente de verdad.
-
-Si te vas a reunir con un CEO, ¿te has leído todos sus tuits y todas sus transcripciones de YouTube de los últimos 30 días? Yo sí.
-
-## Fuentes, puntuadas por la gente
-
-| Fuente | Lo que te dice la gente |
-|--------|--------------------------|
-| **Reddit** | La opinión sin filtros. Los mejores comentarios con su recuento real de votos positivos, gratis y sin clave de API. Las opiniones reales que Google entierra. |
-| **X / Twitter** | La reacción en caliente, el hilo del experto, la primera respuesta a una noticia de última hora. Los primeros en enterarse, los primeros en discutir. |
-| **YouTube** | El análisis a fondo de 45 minutos. Transcripciones completas, rastreadas para sacar las 5 frases citables que importan. |
-| **TikTok** | El creador que llega a 3,6 millones de personas con una lectura que nunca encontrarás en Google. |
-| **Instagram Reels** | La mirada de los influencers, con transcripción de lo que dicen. La señal de la cultura visual. |
-| **Hacker News** | El consenso de los desarrolladores. 825 puntos, 899 comentarios. Donde la gente técnica discute de verdad. |
-| **Polymarket** | No son opiniones. Son cuotas. Respaldadas por dinero real. 96 % de probabilidad en ventas de un álbum. 4 % en una adquisición. |
-| **GitHub** | Para personas: ritmo de PR, mejores repositorios por estrellas, notas de versión. Para temas: issues y discusiones. |
-| **Digg** | Grupos de noticias seleccionados del ranking AI 1000 de Digg (unas 1000 cuentas de IA con mucha señal en X), con citas atribuibles integradas y sin necesidad de autenticarte en X. Se activa solo cuando `digg-pp-cli` está en el PATH. |
-| **arXiv** | Los artículos científicos que hay detrás del ruido. Investigación nueva dentro de la ventana, gratis y sin clave de API. Se activa solo cuando `arxiv-pp-cli` está en el PATH (la configuración inicial lo instala). |
-| **Techmeme** | La capa editorial de la actualidad tecnológica, acotada a tu ventana de 30 días. Gratis y sin clave de API. Se activa solo cuando `techmeme-pp-cli` está en el PATH (la configuración inicial lo instala). |
-| **LinkedIn** | La señal profesional. Publicaciones y artículos, con los artículos ponderados como señal fuerte. |
-| **StockTwits** | El sentimiento de los traders. Se activa automáticamente cuando tu tema es un ticker o una criptomoneda. |
-| **Threads** | La capa de texto posterior a Twitter. Conversaciones de creadores y marcas. |
-| **Pinterest** | Descubrimiento visual. Pines, guardados y comentarios sobre productos e ideas. |
-| **Xiaohongshu (RED)** | Señales chinas sobre estilo de vida, productos y creadores. Se pide de forma explícita con `--search xhs` cuando tienes corriendo en local un plugin de navegador x-mcp con sesión iniciada o un servicio `xiaohongshu-mcp`. |
-| **Bluesky** | La capa social descentralizada. Publicaciones de AT Protocol surgidas de la migración posterior a Twitter. |
-| **Perplexity** | Síntesis controlada con la Agent API, alternativa Sonar mediante OpenRouter, resultados en bruto de la Search API y Deep Research explícita. |
-| **Web** | La cobertura editorial, las comparativas de los blogs. Una señal entre muchas, no la única. |
-
-La comunidad no para de sumar fuentes. Truth Social y otras fuentes de nicho ya están en el motor, y vienen más.
-
-Un hilo de Reddit con 1.500 votos positivos es una señal más fuerte que una entrada de blog que no leyó nadie. Un TikTok con 3,6 millones de visualizaciones dice más sobre lo que es culturalmente relevante que cualquier nota de prensa. Unas cuotas de Polymarket respaldadas por 66.000 dólares de volumen son más difíciles de rebatir que la corazonada de un tertuliano.
-
-La síntesis ordena según aquello con lo que la gente real ha interactuado de verdad. Relevancia social, no relevancia SEO.
-
-## Para qué lo usa la gente en realidad
-
-**Antes de una reunión.** `/last30days Peter Steinberger` — se ha incorporado al equipo de Codex de OpenAI, pelea contra el veto de Anthropic a los agentes de terceros, 23 PR mergeadas con un 85 % de tasa de merge en GitHub, construye LobsterOS para controlar agentes entre dispositivos. r/ClaudeCode: «Desde que salió OpenClaw, todo el mundo sabía que, si lo pasabas por algo que no fuera la API, acabarías baneado» (227 votos positivos). Eso no está en LinkedIn.
-
-**Para leer señales de contratación.** `/last30days Listen Labs --hiring-signals` — las ofertas de empleo y las páginas de carreras actuales se convierten en pruebas citadas de un cambio de prioridades: contratación en seguridad para empresa, customer success, infraestructura o expansión de producto. El informe dice lo que la contratación parece señalar, no lo que la hoja de ruta va a entregar.
-
-**Para encontrar el tema antes de su pico.** Pregunta `/last30days what's exploding in AI agents?` y la skill cambia a modo descubrimiento: el motor barre los listados por categoría de Reddit, la portada y las mejores historias de Hacker News, el feed AI 1000 de Digg y X si estás autenticado; tu agente evalúa las candidaturas (nombres, filtrado de ruido, interés real) y escribe enfoques para pódcast o para un artículo en X; después obtienes entre 5 y 10 temas ordenados por velocidad. Cada resultado incluye cifras de varias fuentes, una etiqueta de impulso y un comando `/last30days "<topic>"` listo para lanzar.
-
-**Cuando sale algo nuevo.** `/last30days Kanye West` — el Reino Unido le bloqueó el visado, el Wireless Festival se canceló, los patrocinadores huyeron. Pero BULLY debutó en el número 2 del Billboard. Fantano volvió de su «Yay sabbatical» para reseñarlo (653.000 visualizaciones). En el SoFi Homecoming sacó al escenario a Lauryn Hill y a Travis Scott para 44 canciones. Polymarket: «¿Volverá Kanye a tuitear?» 86 % sí. 23 hilos de Reddit, 17 vídeos de YouTube, 86.000 votos positivos.
-
-**Para comparar herramientas.** `/last30days OpenClaw vs Hermes vs Paperclip` — «No son competidores, son capas.» OpenClaw es la capa de ejecución (351.000 estrellas en GitHub, en producción), Hermes es el cerebro que se mejora a sí mismo (31.000 estrellas), Paperclip es el organigrama (49.000 estrellas). El número de estrellas se saca en directo de la API de GitHub, no de entradas de blog caducadas. Tabla comparativa con arquitectura, memoria, seguridad y caso de uso ideal. Según @IMJustinBrooke: «OpenClaw = Charmander, Hermes = Charizard.»
-
-**Para entender el mundo.** `/last30days Iran vs USA` — día 38 de la guerra. El ultimátum de Trump, con plazo hasta el martes, para que Irán reabra el estrecho de Ormuz. Dos aviones de combate estadounidenses derribados. El petróleo a 126 dólares el barril. La AIE lo calificó como «la mayor interrupción de suministro de la historia del mercado mundial del petróleo». Polymarket: alto el fuego antes del 31 de diciembre al 74 %. 27 publicaciones de X, 10 vídeos de YouTube, 20 mercados de predicción.
-
-**Antes de un viaje.** `/last30days Universal Epic Universe` — la ampliación ya está en obras. Licencia «Project 680» presentada. El espectáculo de fuegos artificiales está confirmado por la infraestructura, pero sin anunciar. Tiempos de espera: Mine-Cart Madness promedia 148 minutos. Todavía no hay pase anual, y los vecinos están hartos. Stardust Racers cerrada por reforma hasta el 5 de abril.
-
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` — los prompts estructurados en JSON están sustituyendo al amontonamiento de etiquetas. El formato anidado de @pictsbyai evita el «concept bleeding». Editar gana a regenerar. Y después te escribe un prompt de producción aplicando exactamente lo que la comunidad ha dicho que funciona.
-
-## Novedades
-
-Desde el anuncio de la v3.3 en mayo y hasta la v3.11.1 (julio de 2026): 175 PR mergeadas —122 de ellas de 52 colaboradores de la comunidad— repartidas en 15 versiones. Esto es lo que ha entrado.
-
-### Ciudadano de primera en OpenAI Codex
-
-/last30days ya es un plugin nativo de Codex con configuración guiada: no es un port, es un ciudadano de primera. Las citas tienen en cuenta el renderizador, así que la salida en Codex se lee como un informe y no como una sopa de URL (#694), y el mismo motor funciona en Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw y 50+ hosts de Agent Skills. Manifiesto del plugin de Codex por [@rfoust](https://github.com/rfoust) (#686), corrección de autenticación en Codex por [@tmchow](https://github.com/tmchow) (#698).
-
-### arXiv, Techmeme y Digg: gratis y sin claves de API
-
-arXiv aporta los artículos científicos que hay detrás del ruido y Techmeme la capa editorial de la actualidad tecnológica: gratis, sin una sola clave, y la configuración inicial instala sus CLI para que se activen solas (#709). Los grupos de noticias AI 1000 de Digg llegan igual, sin autenticarte en X: la configuración instala por ti la CLI gratuita de Digg (#590). Trustpilot está disponible como opción para investigar marcas de consumo.
-
-### Reddit gratis, con puntuaciones reales y mejores comentarios
-
-La API pública .json de Reddit desapareció; la vía gratuita volvió más fuerte. RSS sin clave y scraping de shreddit (#457), descubrimiento de subreddits específicos con recuentos reales de votos positivos vía arctic-shift (#696), y un umbral de relevancia para que una publicación viral fuera de tema no secuestre tu informe (#488, gracias [@rzachsmith](https://github.com/rzachsmith)). Sin clave de API. Puntuaciones reales. Con los mejores comentarios incluidos.
-
-### Los mejores comentarios en cada informe
-
-Los comentarios son ya una capa activada por defecto en todas las fuentes: comentarios de Instagram con diversidad basada en el ranking, para que cinco opiniones rotundas no salgan todas de la misma publicación (#751), comentarios de YouTube más un respaldo de transcripción vía ScrapeCreators para cuando yt-dlp falla (#637), y comentarios votados por la comunidad ponderados dentro de Best Takes, para que las mejores frases sobrevivan a la puntuación (#592, #608).
-
-### Un único comando doctor
-
-Pide una revisión y doctor comprueba todas las fuentes y receta los arreglos exactos: qué clave falta, qué CLI no está en el PATH, qué cookie ha caducado (#753). Se acabó adivinar por qué X ha devuelto tan poco.
-
-### La búsqueda en X, reconstruida
-
-El pipeline de X se rehízo de arriba abajo: carriles FROM y ABOUT para que se posicionen tanto las publicaciones de una persona como la conversación sobre ella (#610), desambiguación de subconsultas según la persona buscada (#611), verificación de la autoría de primera mano con ranking por señales de interacción (#613), y una única fuente X con conmutación automática entre backends (#622). Además, un `--diagnose` honesto que comprueba de verdad la autenticación (#609).
-
-### Se han sumado más fuentes
-
-LinkedIn vía ScrapeCreators, con los artículos como señal fuerte ([@ravstr](https://github.com/ravstr), #702). StockTwits se activa automáticamente en temas de tickers y cripto ([@wtiwana](https://github.com/wtiwana), #658). Perplexity ha ganado modos de API directos y Deep Research asíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
-
-### Endurecido por la comunidad
-
-La oleada de seguridad fue casi por completo trabajo de la comunidad: correcciones de XSS almacenado en el renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), archivos temporales de cookies blindados, CI endurecida frente a ataques a la cadena de suministro con OpenSSF Scorecard y atestación de procedencia de las builds ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), análisis con Semgrep y OSV-Scanner más un control de revisión de dependencias en cada PR ([@23241a6749](https://github.com/23241a6749)), un mínimo de cobertura de pruebas fijado al 60 % y elevado desde entonces al 84 % ([@gourab5139014](https://github.com/gourab5139014)), y un análisis de seguridad de Hermes que ya no arroja ningún hallazgo CRITICAL (#768).
-
-### Llega más lejos
-
-Hebreo y otros idiomas no latinos ([@dudyme](https://github.com/dudyme)). Tokenización adaptada a CJK para las fuentes chinas ([@An-idd](https://github.com/An-idd)). Una oleada de compatibilidad con Windows. Extracción de cookies en toda la familia Chromium —Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov))— además del llavero de macOS y pass(1) en Linux como orígenes de credenciales. Consulta histórica hacia atrás con `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Instalación automática de Python 3.12 mediante uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para leer las páginas de empleo de una empresa. Diferencias de la lista de seguimiento entre ejecuciones.
-
-### Lo que ya venía de serie desde la v3
-
-Los cimientos de la v3 siguen todos aquí: el cerebro previo a la investigación, que identifica las cuentas, subreddits y hashtags correctos antes de que salga una sola llamada a la API (obra de [@j-sperling](https://github.com/j-sperling)); la puntuación Best Takes, que valora el humor y la viralidad además de la relevancia; la fusión de clústeres entre fuentes; las comparativas en una sola pasada («CLI vs MCP» en 3 minutos, no en 12); las comparativas `--competitors` descubiertas de forma automática; el modo persona de GitHub (`--github-user=steipete`); el modo ELI5 («eli5 on» después de cualquier ejecución); y los informes HTML autocontenidos y compartibles (`--emit=html`). Los ajustes de configuración están en [CONFIGURATION.md](CONFIGURATION.md).
-
-## Instalación
-
-| Entorno | Instalación | Actualizaciones |
-|---------|---------|---------|
-| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automáticas vía marketplace, o `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` y después `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI, o cualquiera de los 50+ hosts de [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Descarga `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) y súbelo desde claude.ai > Customize > Skills > + > Create skill > Upload a skill | Volver a descargar y volver a subir |
-| **Claude Desktop** | [Descarga el `.mcpb` de tu plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) y arrástralo a Settings > Extensions | Volver a descargar y arrastrar el nuevo paquete |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code (recomendado)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Es la opción recomendada porque el marketplace de Claude Code se encarga de las actualizaciones por ti: la caché del plugin está versionada y se refresca sola cuando se publica una versión nueva. Ejecuta `claude plugin update last30days@last30days-skill` para forzar una comprobación.
-
-Si prefieres usar la vía de instalación de Agent Skills en Claude Code, también está soportada:
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-El plugin nativo y la instalación con `npx skills` pueden convivir. Ojo: Claude Code no deduplica entre métodos de instalación. Si tienes activos a la vez el plugin del marketplace y la copia de `npx skills`, `/last30days` aparecerá dos veces. Usa un solo método de instalación por máquina.
-
-### Grok (xAI Build CLI)
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala last30days como plugin nativo. La instalación directa sigue el repositorio:
+**Investiga cualquier ventana reciente. Guarda lo útil en Obsidian.**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
+
+`obsidian2date` investiga lo que la gente dice realmente sobre un tema en
+Reddit, X, YouTube, HN, GitHub, Polymarket y la web — sobre la ventana que
+pidas (la semana pasada, los últimos 7 días, los últimos 90 días; 30 días es
+solo el valor por defecto) — y convierte cada ejecución en notas de Obsidian
+duraderas y enlazadas.
+
+Cada ejecución produce:
+
+- una **nota de ejecución** respaldada por fuentes
+- un **briefing** compacto
+- `[[wikilinks]]` a ejecuciones relacionadas
+- un **Índice** y un **Dashboard** actualizados
+
+Sin seguimiento. MIT. Fork público de
+[last30days-skill](https://github.com/mvanhorn/last30days-skill); el motor de
+investigación ascendente sigue siendo fusionable. Requiere Python 3.12+ y un
+vault de Obsidian; las fuentes y las claves de API son opcionales — ver
+[CONFIGURATION.md](CONFIGURATION.md).
+
+## Úsalo como comando de barra (camino principal)
+
+`obsidian2date` es un Agent Skill: instala el repositorio una vez y escribe
+`/obsidian2date <tema>` en tu agente. El skill ejecuta el motor de
+investigación, resuelve tu vault, escribe las notas e informa de las rutas.
+Sin flags que memorizar — di "la semana pasada" o "los últimos 90 días" en la
+petición y el skill lo traduce a los flags correctos del motor.
+
+| Host | Instalación | Después |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y` (o añade este repo como `.claude-plugin`) | `/obsidian2date <tema>` |
+| Codex | el repo incluye `.codex-plugin/plugin.json` | `/obsidian2date <tema>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <tema>` |
+| Gemini CLI | el repo incluye `gemini-extension.json` | `/obsidian2date <tema>` |
+| OpenClaw / hosts agents.md | el repo incluye el manifiesto `.agents/` | `/obsidian2date <tema>` |
+| pi / cualquier agente con skills | enlaza o copia `skills/obsidian2date/` en el directorio de skills del agente | `/obsidian2date <tema>` |
+
+Qué hace el skill en cada ejecución (ver
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — la
+especificación canónica de ejecución que lee el modelo):
+
+1. resolver tu vault (preguntar una vez, recordarlo para la sesión)
+2. derivar la ventana de tu petición (por defecto 30 días)
+3. ejecutar el motor de investigación con `--emit=obsidian`
+4. informar del briefing, la nota de ejecución y las fuentes parciales o no disponibles con honestidad
+
+## Inicio rápido (fallback CLI)
+
+Para scripting, cron o pruebas del motor en desarrollo, llama a la CLI
+directamente. Este es el camino de respaldo, no el principal — el comando de
+barra de arriba es el producto.
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /ruta/a/tu/vault
 ```
 
-O añade este repositorio como fuente de marketplace y luego instálalo por nombre de plugin:
+O configura el vault una vez:
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/ruta/a/tu/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-Añade `--trust` para saltarte la confirmación de instalación. Actualiza con `grok plugin update last30days`. Grok también lee los manifiestos de Claude Code por compatibilidad; el par nativo `.grok-plugin/` es la vía principal, y es a lo que apunta una entrada oficial en el [marketplace de xAI](https://github.com/xai-org/plugin-marketplace). `npx skills add` sigue siendo una alternativa válida para cualquier host.
+### Ventana temporal
 
-### Codex, Cursor, Copilot, Gemini CLI y otros hosts de Agent Skills
-
-Instálalo con la CLI abierta de [Agent Skills](https://agentskills.io): soporta 50+ hosts, entre ellos `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` y más (lista completa en el [repositorio vercel-labs/skills](https://github.com/vercel-labs/skills)).
+`30` días es solo el valor por defecto. Pide lo que quieras:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # la semana pasada
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # barrido trimestral
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-El flag `-g` (global) instala en tu directorio de usuario, de modo que la skill queda disponible en todos los proyectos. Sin `-g`, `npx skills` instala solo en el proyecto, dentro de `./.skills/` (y se versiona con el repositorio). Para una herramienta que sirve para investigar el mundo entero, lo que quieres es la instalación global.
+En el comando de barra, solo dilo: "investiga los últimos 7 días de AI video
+tools".
 
-Codex de escritorio y otros hosts que trabajan a nivel de carpeta funcionan tanto en carpetas normales como en repositorios Git. Antes de la primera investigación, pídele al agente anfitrión que ejecute el `scripts/last30days.py --preflight` incluido desde el directorio de la skill cargada; en un clon del código fuente, el comando equivalente es `python3 skills/last30days/scripts/last30days.py --preflight`. Te muestra de dónde sale la configuración, qué cookies del navegador se leerían, qué archivos se escribirían, qué comandos opcionales hay y qué configuración de proyecto se ignora, todo ello sin leer cookies, sin escribir archivos y sin lanzar ninguna investigación.
+### Resolución del vault
 
-Por defecto se instala para el host que detecte `npx skills`. Para apuntar a uno concreto (o a varios):
+El destino de exportación se resuelve en este orden:
+
+1. `--obsidian-vault PATH` (una ruta explícita inexistente se crea para la exportación)
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. un `~/Desktop/brain-paul` existente
+
+Los candidatos de entorno y escritorio deben ser directorios ya existentes.
+Un valor de entorno de vault presente pero vacío o solo con espacios
+desactiva intencionadamente los fallbacks implícitos. Si nada se resuelve,
+el comando se detiene con:
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+Usa `~/...` o una ruta absoluta en archivos `.env`; `$HOME` no se expande
+allí. Las notas existentes nunca se sobrescriben; las colisiones de nombre
+de archivo reciben un sufijo numérico.
+
+## Qué se escribe
+
+Disposición por defecto bajo la raíz del vault:
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Las notas nunca se sobrescriben. Las colisiones del mismo día reciben
+sufijos numéricos. Las ejecuciones anteriores relacionadas se enlazan vía
+`[[wikilinks]]` de Obsidian cuando se detecta superposición de tokens.
+
+## Fuentes y claves
+
+El mismo suelo que upstream:
+
+- **Sin claves por defecto:** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Opcionales:** X (cookies de navegador / backends), YouTube (`yt-dlp`),
+  TikTok/IG (ScrapeCreators), además de otros backends de pago/opt-in
+
+Ver [`CONFIGURATION.md`](CONFIGURATION.md) para la matriz completa y la
+configuración de claves.
+
+## Diagnóstico seguro
+
+Ejecuta una comprobación de solo permisos antes de investigar:
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` es seguro: se ejecuta **sin leer cookies, escribir archivos ni
+iniciar la investigación**. Para depurar fuentes o backends instalados, usa
+en su lugar la comprobación de salud:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-Para actualizar más adelante:
+## Los modos de upstream siguen funcionando
 
 ```bash
-npx skills update last30days -g
+# envoltorio de síntesis compacta original
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# JSON para agentes
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# brief de producción
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-O actualiza todo lo que hayas instalado globalmente con `npx skills`:
+## Relación con upstream
+
+| Aspecto | Política |
+| --- | --- |
+| Motor de investigación | Mantenerlo fusionable con `upstream/main` |
+| Exportación a Obsidian | Módulo aditivo: `lib/obsidian_export.py` |
+| Marca / skill | `obsidian2date` |
+| Licencia | MIT; conservar los avisos de copyright de upstream |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-Puedes listarlo y desinstalarlo con `npx skills list -g` y `npx skills remove last30days -g`.
+## Créditos
 
-### claude.ai (web)
+- Motor de investigación upstream: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Ruta de exportación a Obsidian + empaquetado del fork público: [pauleschwarz](https://github.com/pauleschwarz)
 
-1. [Descarga `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) de la última versión publicada
-2. Entra en [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Pulsa el botón `+` del panel de Skills, luego `Create skill` > `Upload a skill`, y busca o arrastra el archivo
+## Licencia
 
-Activa antes «Code execution and file creation» en Capabilities: sin eso, las skills no se ejecutan.
-
-### Claude Desktop
-
-Claude Desktop instala `/last30days` como servidor MCP mediante un paquete `.mcpb` (un paquete de Model Context Protocol de un solo clic).
-
-1. Entra en la [última versión publicada](https://github.com/mvanhorn/last30days-skill/releases/latest) y descarga el `.mcpb` de tu plataforma:
-   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abre Claude Desktop, ve a Settings > Extensions y arrastra el archivo ahí.
-3. Cuando te las pida, pega las claves de API de las fuentes que quieras activar. Todos los campos son opcionales: si los saltas todos, el motor se queda en modo solo web. Las claves se guardan en el llavero de tu sistema operativo.
-4. Reinicia Claude Desktop. Pídele a Claude que «investigue a Peter Steinberger», o cualquier otro tema, y llamará a la herramienta `research`.
-
-**Requisito del anfitrión:** Python 3.12+ en el PATH. El paquete incluye el código del motor, pero usa tu intérprete de Python local. En Windows, instálalo desde [python.org](https://www.python.org/downloads/); macOS y la mayoría de distribuciones de Linux ya traen una versión compatible.
-
-**Las claves no se comparten con la skill de Claude Code.** Claude Desktop y Claude Code mantienen almacenes de credenciales separados a propósito. Si ya configuraste `~/.config/last30days/.env` para la skill de Claude Code, aquí tendrás que introducir esas mismas claves una vez.
-
-La compatibilidad con Windows queda aplazada hasta resolver los puntos de entrada por plataforma del manifiesto; el seguimiento se hace en una incidencia aparte.
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-Para flujos de acción en X/Twitter fuera de la investigación de `/last30days` —publicar
-tuits o respuestas, exportar seguidores, gestionar medios, monitorizar cuentas y
-resolver sorteos— usa [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como
-plugin complementario de OpenClaw. TweetClaw lo mantiene Xquik-dev y aparece aquí
-únicamente como opción complementaria: no es una dependencia ni una recomendación
-de last30days.
-
-### Manual (para desarrolladores)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-El enlace simbólico mantiene la instalación sincronizada con tu copia de trabajo a medida que editas, sin necesidad de volver a copiar nada. Para `claude.ai`, compila el archivo `.skill` desde el código fuente: `bash skills/last30days/scripts/build-skill.sh` genera `dist/last30days.skill`.
-
-Reddit (con comentarios), Hacker News, Polymarket y GitHub funcionan de inmediato. Cero configuración. Ejecuta `/last30days` una vez y el asistente de configuración desbloquea más fuentes en 30 segundos, incluidas las CLI gratuitas de arXiv y Techmeme.
-
-## Aporta tus propias claves
-
-Estas plataformas no tienen ninguna relación entre sí. X no sabe lo que piensa Reddit. YouTube no ve TikTok. Pero tú puedes aportar tus claves de API y tus tokens de navegador y, de golpe, tienes acceso a todas a la vez.
-
-| Fuentes | Lo que necesitas | Coste |
-|---------|---------------|------|
-| Reddit (con comentarios) + HN + Polymarket + GitHub + StockTwits | Nada | Gratis |
-| arXiv + Techmeme | CLI gratuitas, instaladas automáticamente por la configuración inicial | Gratis |
-| X / Twitter | Inicia sesión en x.com en cualquier navegador, o define `XQUIK_API_KEY` / `XAI_API_KEY` | Las cookies del navegador son gratis; las claves dependen del proveedor |
-| YouTube | `brew install yt-dlp` | Gratis |
-| Bluesky | Una contraseña de aplicación de bsky.app | Gratis |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentarios de YouTube | Una clave de ScrapeCreators | 10.000 llamadas gratis y luego pago por uso |
-| Xiaohongshu (RED) | Ten corriendo un plugin de navegador x-mcp con sesión iniciada o un servicio `xiaohongshu-mcp`, y activa la fuente con `--search xhs` por ejecución o con `INCLUDE_SOURCES=xiaohongshu` en `.env`; last30days prueba automáticamente `http://localhost:18060` y después `http://host.docker.internal:18060`, o usa `XIAOHONGSHU_API_BASE` para una URL propia | No hace falta clave de API de last30days; depende de tu servicio local de sesión de navegador |
-| DripStack (boletines financieros premium) | Opcional: `--search dripstack` por ejecución, o `INCLUDE_SOURCES=dripstack` en `.env` | Sin clave; API de búsqueda pública y gratuita |
-| Perplexity Agent API / Search API / Deep Research | Una clave de Perplexity, o una clave de OpenRouter como alternativa para Sonar | Pago por uso; una clave directa habilita la Agent API y Deep Research en segundo plano |
-| Búsqueda web | Una clave de Brave Search | 2.000 consultas gratis al mes |
-
-### Llavero de macOS (opcional)
-
-En macOS puedes guardar las claves en el llavero del sistema en lugar de en un archivo `.env`. La skill las recoge automáticamente como la fuente de menor prioridad: si hay conflicto, siguen ganando los archivos `.env` y el entorno del proceso.
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-Las entradas se guardan con el nombre de servicio `last30days-<KEY>` para el usuario actual. En plataformas que no son Darwin el cargador no hace nada, así que para quienes usan Linux o Windows no cambia el comportamiento.
-
-¿Ya tienes claves guardadas con otros nombres de servicio en el llavero? Define el mapeo no secreto `LAST30DAYS_KEYCHAIN_ALIASES` que se describe en [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), en lugar de copiar secretos.
-
-Consulta [CONFIGURATION.md](CONFIGURATION.md) para ver la matriz completa de claves por fuente, el orden de prioridad de los proveedores de razonamiento y el de los backends de búsqueda web.
-
-## Configuración
-
-Dos cosas que seguramente querrás saber desde el primer día:
-
-**Dónde se guardan los archivos de investigación.** `LAST30DAYS_MEMORY_DIR` apunta por defecto a `~/Documents/Last30Days/` (en Windows: `C:\Users\<you>\Documents\Last30Days\`). Puedes cambiarlo definiendo esa variable de entorno en tu shell con la ruta que quieras, o con `--save-dir <path>` en una ejecución concreta. Usa `--output <file>` cuando necesites el resultado renderizado en una ruta exacta, con el formato que elijas en `--emit`. Usa `--save-suffix=<name>` para mantener separadas varias variantes del mismo tema (por cliente, por ejemplo). Cada ejecución con `--save-dir` genera `<slug>-raw[-suffix].md`. Ejecuta `python3 skills/last30days/scripts/last30days.py --preflight` para revisar qué se va a escribir antes de lanzar una investigación.
-
-**Salida estructurada para agentes y flujos de trabajo.** Pídele a `/last30days` JSON legible por máquina y obtendrás el perfil de agente estable y versionado. Para usar el motor directamente en scripts o en desarrollo, ejecuta `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; añade `--json-profile=raw` solo si necesitas el volcado interno sin versionar de `Report`. Consulta la [referencia de campos de la exportación JSON y la política de versionado](docs/reference/json-export.md).
-
-**Descubrimiento sin tema.** Pregunta `/last30days what's trending in AI agents?` para obtener un informe de descubrimiento ordenado, en lugar de investigar un tema que ya conoces. En un host con agente esto ejecuta el protocolo de tres comandos arbitrado por el host (el modelo propone los temas, filtra el ruido, puntúa lo que merece la pena y escribe los enfoques de contenido). Para usar el motor directamente en scripts o en cron, ejecuta `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (una sola pasada: nombres de tema deterministas, sin enfoques); añade `--emit=json` para el contrato de descubrimiento versionado. El descubrimiento es incompatible con un tema posicional y con `--drill`.
-
-**Seguimiento de tendencias entre ejecuciones.** El modo por defecto genera una instantánea Markdown nueva en cada ejecución. Para ir acumulando hallazgos con el tiempo, añade `--store` y se guardarán en una base de datos SQLite; después usa [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para ejecuciones programadas (con envío opcional por Slack o webhook cuando aparezcan hallazgos nuevos) y [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resúmenes diarios o semanales. El patrón de cadencia completo está en [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
-
-**Una biblioteca de investigación a la que suscribirse.** Pídele a `/last30days` que genere el feed de tu biblioteca, o usa directamente `python3 skills/last30days/scripts/last30days.py library feed` para scripting y desarrollo. Convierte los informes guardados en un `index.html`, un `feed.xml` Atom local y páginas de informe legibles. Añade `--publish` solo cuando quieras alojar el índice HTML y las páginas de informe; publicar es una decisión explícita y por defecto es público. Para que el feed Atom se pueda seguir de verdad, aloja el directorio de salida generado en un alojamiento estático como GitHub Pages.
-
-**Busca en todo lo que ya has investigado.** Pregunta `/last30days search my library for MCP servers` o `/last30days have I researched MCP servers before?`. Para usar el motor directamente, ejecuta `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La búsqueda es offline y determinista: indexa de forma incremental los mismos informes guardados que usa el feed de la biblioteca, fusiona las coincidencias registradas en el almacén de cada ejecución y agrupa los resultados por tema y fecha. Las ejecuciones nuevas muestran además una sección compacta **From your library** («desde tu biblioteca») cuando una investigación anterior se solapa con el tema actual; define `LAST30DAYS_LIBRARY_CONTEXT=off` para desactivar ese contexto pasivo.
-
-Los scripts envoltorio por cliente, los subreddits de categoría personalizados y el canal beta experimental para personalizaciones en curso también están documentados en [CONFIGURATION.md](CONFIGURATION.md).
-
-## Escaparate: feeds de investigación de la comunidad
-
-¿Has publicado con last30days una actualización periódica sobre IA, un seguimiento de mercado o una obsesión maravillosamente específica? Comparte la URL de tu biblioteca pública —o la URL de Atom, una vez alojado `feed.xml` en un alojamiento estático— en [el hilo de escaparate de la comunidad](https://github.com/mvanhorn/last30days-skill/issues/532). Los feeds de la comunidad se irán enlazando aquí a medida que sus autores los envíen; mientras tanto, el hilo es el punto de recogida.
-
-## Cómo funciona
-
-1. **Escribes un tema.** Una persona, una empresa, un producto, una tecnología, «X vs Y». Lo que sea.
-2. **El agente averigua quién importa.** Encuentra las cuentas de X (incluidas las de fundadores), los repositorios de GitHub, los subreddits, los hashtags de TikTok y los canales de YouTube. Para «Kanye West» sabe que hay que mirar r/hiphopheads, @kanyewest y «bully review» en YouTube. Para «OpenClaw» resuelve openclaw/openclaw en GitHub y trae el número de estrellas en directo.
-3. **Todas las fuentes se consultan en paralelo.** Expansión con varias consultas. Resultados puntuados por interacción, relevancia y frescura.
-4. **La profundidad que no tiene nadie más.** Transcripciones completas de YouTube de vídeos de reacción. Los mejores comentarios de Reddit con su recuento de votos positivos. Los textos de los TikTok. Las cuotas de Polymarket. No solo títulos y enlaces.
-5. **La misma historia, fusionada.** El Wireless Festival anunciado en Reddit, comentado en X y con los precios de las entradas en TikTok: un solo clúster, no tres entradas distintas.
-6. **Sintetizado en un único informe.** Anclado en datos concretos. Citado por fuente. Ordenado según aquello con lo que la gente interactúa de verdad. No es «esto es lo que he encontrado», es «esto es lo que importa».
-7. **Y después se convierte en tu experto.** Tras una sola ejecución, tu sesión de Claude sabe todo lo que sabe la comunidad. Haz preguntas de seguimiento. Pídele que escriba prompts, redacte correos, planifique viajes o diseñe arquitecturas, todo anclado en lo que es real ahora mismo.
-
-## Lo que dice la gente
-
-> «He encontrado una skill de Claude Code que investiga cualquier tema en Reddit, X, YouTube y HN de los últimos 30 días. Y luego te escribe los prompts. Antes de cada contenido que escribo, hacía esa búsqueda a mano en Reddit y X. Pestaña a pestaña. Hilo a hilo. Esa es la parte que se lleva 90 minutos. Esto la elimina.» —@itsjasonai
-
-> «Esta única skill ha sustituido todo mi flujo de investigación. Le das un tema y rastrea Reddit, X y la web para sacar de qué está hablando la gente de verdad. Nada de entradas de blog viejas. Conversaciones reales de los últimos 30 días.» —@itswilsoncharles
-
-> «5 de los 10 repos en tendencia hoy en GitHub son herramientas de Claude. El número 1: mvanhorn/last30days-skill» —@yieldhunter95
-
-## Código abierto
-
-Licencia MIT. Sin rastreo. Sin analíticas. Tu investigación se queda en tu máquina. Más de 2.700 pruebas.
-
-Construido con Python 3.12+, yt-dlp, Node.js (cliente Bird incorporado para la búsqueda en X) y la API de ScrapeCreators. Arquitectura del motor v3 de [@j-sperling](https://github.com/j-sperling).
-
-Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para abrir un PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para la lista completa de colaboradores de la comunidad y [CHANGELOG.md](CHANGELOG.md) para el historial de versiones.
-
-## Evolución de las estrellas
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT. Ver [LICENSE](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,383 +1,197 @@
-# /last30days
+# obsidian2date
 
 [English](README.md) | Français | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
-</p>
-
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
-
-**Un moteur de recherche piloté par un agent IA, qui classe les résultats selon les upvotes, les likes et l'argent réel — pas selon des rédacteurs.**
-
-Ce README décrit le pipeline v3 actuel. La spécification d'exécution de la skill se trouve dans [skills/last30days/SKILL.md](skills/last30days/SKILL.md), qui fait référence pour le comportement des commandes et de la configuration.
-
-**Claude Code (recommandé — mises à jour automatiques via la marketplace) :**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
-
-**Codex, Cursor, Copilot, Gemini CLI, ou l'un des 50+ hôtes [Agent Skills](https://agentskills.io) :**
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-(`-g` installe la skill globalement pour votre utilisateur, donc disponible dans tous vos projets. Omettez ce flag pour une installation limitée au projet.)
-
-D'autres options d'installation (claude.ai web, OpenClaw, manuelle) dans la section [Installation](#installation) ci-dessous.
-
-Zéro configuration. Reddit, HN, Polymarket et GitHub fonctionnent immédiatement. Lancez la skill une fois : l'assistant de configuration débloque X, YouTube, TikTok, arXiv, Techmeme et d'autres sources en 30 secondes.
-
----
-
-Les upvotes de Reddit. Les likes de X. Les transcriptions YouTube. L'engagement TikTok. Les cotes Polymarket, adossées à de l'argent réel et à des informations d'initiés. Ce sont des millions de personnes qui votent chaque jour avec leur attention et leur portefeuille. /last30days interroge tout cela en parallèle, classe les résultats selon ce avec quoi les gens interagissent vraiment, et un agent IA joue le rôle de juge pour en tirer un seul brief.
-
-Google agrège des rédactions. /last30days interroge les gens.
-
-Cette recherche est introuvable ailleurs, parce qu'aucune IA n'a accès à l'ensemble. Google ne touche ni aux commentaires Reddit ni aux posts X. ChatGPT a un accord avec Reddit mais ne sait chercher ni sur X ni sur TikTok. Gemini a YouTube mais pas Reddit. Claude n'a nativement accès à aucun des trois. Chaque plateforme est un jardin clos, avec son API, ses tokens et son authentification. Mais vous pouvez apporter vos propres clés et vos sessions de navigateur : d'un coup, un agent IA peut toutes les interroger en même temps, les comparer entre elles et vous dire ce qui compte vraiment.
-
-C'est ça, le déclic. Pas un meilleur moteur de recherche. Une douzaine de plateformes cloisonnées, reliées par un agent.
-
-```
-/last30days Peter Steinberger
-```
-
-Vous avez une réunion demain. Vous cherchez la personne sur Google. Vous tombez sur son LinkedIn de 2023. /last30days vous donne ce qu'elle fait vraiment ce mois-ci : elle a rejoint OpenAI pour travailler sur Codex, elle conteste l'interdiction des agents tiers décrétée par Anthropic, elle a livré 23 PR avec un taux de merge de 85 %, elle construit « LobsterOS » pour piloter des agents entre appareils, et un fil r/ClaudeCode a atteint 569 upvotes en débattant de savoir si elle est un héros ou « insupportable ». Le tout dispersé entre des posts X, des fils Reddit, des transcriptions YouTube et des commits GitHub. Rien de tout ça n'était sur Google.
-
-## Pourquoi ce projet existe
-
-Je l'ai construit pour suivre le rythme de l'IA. Tout change chaque jour, et les passionnés de Reddit et de X sont toujours au courant les premiers. J'avais besoin de meilleurs prompts, et les données d'entraînement avaient toujours plusieurs mois de retard sur ce que la communauté avait déjà compris.
-
-Mais c'est devenu quelque chose de plus large. Aujourd'hui je le lance avant un rendez-vous commercial, pour connaître la vérité des 30 derniers jours sur une entreprise. Avant une réunion, pour lire les tweets récents et les transcriptions de podcasts de mon interlocuteur. Avant un séjour à Disney World, pour savoir quelles attractions sont fermées et ce que la communauté pense de Genie+. Avant de construire quoi que ce soit, pour savoir sur quels problèmes les gens butent réellement.
-
-Si vous rencontrez un PDG, avez-vous lu tous ses tweets et toutes ses transcriptions YouTube des 30 derniers jours ? Moi, oui.
-
-## Les sources, classées par les gens
-
-| Source | Ce que les gens vous disent |
-|--------|--------------------------|
-| **Reddit** | L'avis brut. Les meilleurs commentaires avec leur vrai nombre d'upvotes, gratuit, sans clé API. Les vraies opinions que Google enterre. |
-| **X / Twitter** | La réaction à chaud, le fil d'expert, la première réaction à l'actualité. Premiers informés, premiers à débattre. |
-| **YouTube** | L'analyse approfondie de 45 minutes. Des transcriptions complètes, fouillées pour en extraire les 5 phrases citables qui comptent. |
-| **TikTok** | Le créateur qui touche 3,6 millions de personnes avec un angle que vous ne trouverez jamais sur Google. |
-| **Instagram Reels** | Le regard des influenceurs, avec la transcription de ce qui est dit. Le signal de la culture visuelle. |
-| **Hacker News** | Le consensus des développeurs. 825 points, 899 commentaires. Là où les gens techniques débattent vraiment. |
-| **Polymarket** | Pas des opinions. Des cotes. Adossées à de l'argent réel. 96 % de probabilité sur des ventes d'album. 4 % sur une acquisition. |
-| **GitHub** | Pour les personnes : rythme des PR, meilleurs dépôts par étoiles, notes de version. Pour les sujets : issues et discussions. |
-| **Digg** | Des groupes d'articles sélectionnés depuis le classement AI 1000 de Digg (environ 1000 comptes IA à fort signal sur X), avec des citations attribuables intégrées (sans authentification X). Activé automatiquement quand `digg-pp-cli` est présent dans le PATH. |
-| **arXiv** | Les articles scientifiques derrière le battage médiatique. La recherche publiée dans la fenêtre, gratuit, sans clé API. Activé automatiquement quand `arxiv-pp-cli` est présent dans le PATH (la configuration initiale l'installe). |
-| **Techmeme** | La couche éditoriale de l'actu tech, restreinte à votre fenêtre de 30 jours. Gratuit, sans clé API. Activé automatiquement quand `techmeme-pp-cli` est présent dans le PATH (la configuration initiale l'installe). |
-| **LinkedIn** | Le signal professionnel. Posts et articles, les articles étant pondérés comme signal fort. |
-| **StockTwits** | Le sentiment des traders. S'active automatiquement quand votre sujet est un ticker ou une crypto. |
-| **Threads** | La couche texte de l'après-Twitter. Les conversations des créateurs et des marques. |
-| **Pinterest** | La découverte visuelle. Épingles, enregistrements et commentaires sur des produits et des idées. |
-| **Xiaohongshu (RED)** | Les signaux chinois sur le lifestyle, les produits et les créateurs. À demander explicitement avec `--search xhs` quand un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp` tourne en local. |
-| **Bluesky** | La couche sociale décentralisée. Les posts AT Protocol issus de la migration post-Twitter. |
-| **Perplexity** | Une synthèse contrôlée avec l’Agent API, un repli Sonar via OpenRouter, les résultats bruts de la Search API et Deep Research explicite. |
-| **Web** | La couverture éditoriale, les comparatifs de blogs. Un signal parmi d'autres, pas le seul. |
-
-La communauté en ajoute sans cesse. Truth Social et d'autres sources de niche sont déjà dans le moteur, et d'autres arrivent.
-
-Un fil Reddit à 1 500 upvotes est un signal plus fort qu'un billet de blog que personne n'a lu. Un TikTok à 3,6 millions de vues en dit plus sur ce qui compte culturellement qu'un communiqué de presse. Des cotes Polymarket adossées à 66 000 $ de volume sont plus difficiles à contester que l'intuition d'un éditorialiste.
-
-La synthèse classe selon ce avec quoi de vraies personnes ont vraiment interagi. La pertinence sociale, pas la pertinence SEO.
-
-## Ce que les gens en font vraiment
-
-**Avant une réunion.** `/last30days Peter Steinberger` — a rejoint l'équipe Codex d'OpenAI, conteste l'interdiction des agents tiers décrétée par Anthropic, 23 PR mergées avec un taux de merge de 85 % sur GitHub, construit LobsterOS pour piloter des agents entre appareils. r/ClaudeCode : « Depuis la sortie d'OpenClaw, tout le monde savait que si vous passiez par autre chose que l'API, vous finiriez par être banni » (227 upvotes). Ça, ce n'est pas sur LinkedIn.
-
-**Pour lire les signaux de recrutement.** `/last30days Listen Labs --hiring-signals` — les offres d'emploi et les pages carrières actuelles deviennent des preuves citées de changements de priorités : recrutements en sécurité entreprise, customer success, infrastructure ou expansion produit. Le rapport dit ce que le recrutement semble signaler, pas ce que la roadmap va livrer.
-
-**Pour repérer un sujet avant son pic.** Demandez `/last30days what's exploding in AI agents?` et la skill bascule en mode découverte : le moteur balaie les listings de catégories Reddit, la une et les meilleures histoires de Hacker News, le flux AI 1000 de Digg, et X si vous êtes authentifié ; votre agent évalue les candidats (noms, filtrage du bruit, intérêt réel) et rédige des angles pour un podcast ou un article X ; vous obtenez ensuite 5 à 10 sujets classés par vélocité. Chaque résultat comprend des chiffres multi-sources, une étiquette de momentum et une commande `/last30days "<topic>"` prête à lancer.
-
-**Quand quelque chose sort.** `/last30days Kanye West` — le Royaume-Uni a bloqué son visa, le Wireless Festival est annulé, les sponsors ont fui. Mais BULLY est entré n° 2 au Billboard. Fantano est revenu de son « Yay sabbatical » pour le chroniquer (653 000 vues). SoFi Homecoming a fait monter Lauryn Hill et Travis Scott sur scène pour 44 titres. Polymarket : « Kanye tweetera-t-il de nouveau ? » 86 % de oui. 23 fils Reddit, 17 vidéos YouTube, 86 000 upvotes.
-
-**Pour comparer des outils.** `/last30days OpenClaw vs Hermes vs Paperclip` — « Ce ne sont pas des concurrents, ce sont des couches. » OpenClaw est la couche d'exécution (351 000 étoiles GitHub, en production), Hermes est le cerveau qui s'améliore tout seul (31 000 étoiles), Paperclip est l'organigramme (49 000 étoiles). Nombres d'étoiles récupérés en direct via l'API GitHub, pas repris de billets de blog périmés. Tableau comparatif avec architecture, mémoire, sécurité et cas d'usage idéal. Selon @IMJustinBrooke : « OpenClaw = Salamèche, Hermes = Dracaufeu. »
-
-**Pour comprendre le monde.** `/last30days Iran vs USA` — 38e jour de guerre. Ultimatum de Trump, fixé à mardi, pour que l'Iran rouvre le détroit d'Ormuz. Deux avions de combat américains abattus. Le pétrole à 126 $ le baril. L'AIE parle de « la plus grande perturbation d'approvisionnement de l'histoire du marché pétrolier mondial ». Polymarket : cessez-le-feu avant le 31 décembre à 74 %. 27 posts X, 10 vidéos YouTube, 20 marchés de prédiction.
-
-**Avant un voyage.** `/last30days Universal Epic Universe` — l'extension est déjà en construction. Permis « Project 680 » déposé. Spectacle de feux d'artifice confirmé par les travaux mais toujours pas annoncé. Temps d'attente : Mine-Cart Madness à 148 minutes en moyenne. Toujours pas de pass annuel, et les habitants s'agacent. Stardust Racers fermé pour rénovation jusqu'au 5 avril.
-
-**Pour apprendre vite.** `/last30days Nano Banana Pro prompting` — les prompts structurés en JSON remplacent l'empilement de tags. Le format imbriqué de @pictsbyai évite le « concept bleeding ». Mieux vaut éditer que régénérer. Et ensuite, la skill vous écrit un prompt de production en appliquant exactement ce que la communauté a validé.
-
-## Nouveautés
-
-Depuis l'annonce de la v3.3 en mai, et jusqu'à la v3.11.1 (juillet 2026) : 175 PR mergées — dont 122 venant de 52 contributeurs de la communauté — réparties sur 15 versions. Voici ce qui a atterri.
-
-### Citoyen de première classe sur OpenAI Codex
-
-/last30days est désormais un plugin Codex natif avec configuration guidée : pas un portage, un vrai citoyen de première classe. Les citations tiennent compte du rendu, ce qui fait que la sortie Codex se lit comme un brief et non comme une soupe d'URL (#694), et le même moteur tourne sur Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw et 50+ hôtes Agent Skills. Manifeste du plugin Codex par [@rfoust](https://github.com/rfoust) (#686), correctif d'authentification Codex par [@tmchow](https://github.com/tmchow) (#698).
-
-### arXiv, Techmeme et Digg — gratuits, sans clé API
-
-arXiv apporte les articles scientifiques derrière le battage médiatique et Techmeme la couche éditoriale de l'actu tech — gratuits, sans aucune clé, et la configuration initiale installe leurs CLI pour qu'ils s'activent tout seuls (#709). Les groupes d'articles AI 1000 de Digg arrivent de la même façon, sans authentification X : la configuration installe pour vous la CLI Digg gratuite (#590). Trustpilot est disponible en option pour la recherche sur les marques grand public.
-
-### Reddit gratuit, avec de vrais scores et les meilleurs commentaires
-
-L'API .json publique de Reddit a disparu ; la voie gratuite est revenue plus forte. Flux RSS sans clé et scraping de shreddit (#457), découverte de subreddits dédiés avec de vrais décomptes d'upvotes via arctic-shift (#696), et un seuil de pertinence pour qu'un post viral hors sujet ne détourne pas votre brief (#488, merci [@rzachsmith](https://github.com/rzachsmith)). Pas de clé API. De vrais scores. Les meilleurs commentaires inclus.
-
-### Les meilleurs commentaires dans chaque brief
-
-Les commentaires sont maintenant une couche activée par défaut sur toutes les sources : commentaires Instagram avec une diversité fondée sur le rang, pour que cinq avis tranchés ne viennent pas tous du même post (#751), commentaires YouTube plus une récupération de transcription via ScrapeCreators quand yt-dlp échoue (#637), et commentaires plébiscités par la communauté intégrés au scoring Best Takes, pour que les meilleures punchlines survivent au classement (#592, #608).
-
-### Une seule commande doctor
-
-Demandez un diagnostic : doctor teste chaque source, puis prescrit les correctifs exacts — quelle clé manque, quelle CLI est absente du PATH, quel cookie a expiré (#753). Fini de deviner pourquoi X est revenu à vide.
-
-### La recherche X, reconstruite
-
-Le pipeline X a été repensé de fond en comble : des voies FROM et ABOUT pour que les posts d'une personne et la conversation à son sujet soient classés tous les deux (#610), désambiguïsation des sous-requêtes selon la personne visée (#611), vérification de la paternité des posts avec classement par signaux d'interaction (#613), et une source X unique avec bascule automatique entre backends (#622). Plus un `--diagnose` honnête qui teste vraiment l'authentification (#609).
-
-### De nouvelles sources
-
-LinkedIn via ScrapeCreators, avec les articles comme signal fort ([@ravstr](https://github.com/ravstr), #702). StockTwits s'active automatiquement sur les sujets liés aux tickers et aux cryptos ([@wtiwana](https://github.com/wtiwana), #658). Perplexity a gagné des modes API directs et Deep Research en asynchrone ([@sk-holmes](https://github.com/sk-holmes), #629).
-
-### Durci par la communauté
-
-La vague sécurité est presque entièrement le fait de la communauté : correctifs XSS stocké dans le rendu HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), fichiers temporaires de cookies verrouillés, CI durcie contre les attaques de chaîne d'approvisionnement avec OpenSSF Scorecard et attestation de provenance des builds ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), analyses Semgrep et OSV-Scanner plus un contrôle de revue des dépendances sur chaque PR ([@23241a6749](https://github.com/23241a6749)), un seuil plancher de couverture de tests instauré à 60 % puis relevé à 84 % ([@gourab5139014](https://github.com/gourab5139014)), et un audit de sécurité Hermes désormais sans aucune finding CRITICAL (#768).
-
-### Une portée plus large
-
-L'hébreu et les langues non latines ([@dudyme](https://github.com/dudyme)). Une tokenisation adaptée au CJK pour les sources chinoises ([@An-idd](https://github.com/An-idd)). Une vague d'améliorations sur Windows. L'extraction des cookies sur toute la famille Chromium — Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) — plus le trousseau macOS et pass(1) sous Linux comme sources d'identifiants. Le retour en arrière historique avec `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). L'installation automatique de Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` pour lire les pages emploi d'une entreprise. Les écarts de watchlist d'une exécution à l'autre.
-
-### Toujours livré depuis la v3
-
-Les fondations de la v3 sont toujours là : le cerveau de pré-recherche qui identifie les bons comptes, subreddits et hashtags avant le moindre appel API (construit par [@j-sperling](https://github.com/j-sperling)) ; le scoring Best Takes, qui prend en compte l'humour et la viralité en plus de la pertinence ; la fusion de clusters entre sources ; les comparaisons en une seule passe (« CLI vs MCP » en 3 minutes, pas 12) ; les comparaisons `--competitors` découvertes automatiquement ; le mode personne de GitHub (`--github-user=steipete`) ; le mode ELI5 (« eli5 on » après n'importe quelle exécution) ; et des briefs HTML autonomes et partageables (`--emit=html`). Les options de configuration sont détaillées dans [CONFIGURATION.md](CONFIGURATION.md).
-
-## Installation
-
-| Environnement | Installation | Mises à jour |
-|---------|---------|---------|
-| **Claude Code** (recommandé) | `/plugin marketplace add mvanhorn/last30days-skill` | Automatiques via la marketplace, ou `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` puis `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI, ou l'un des 50+ hôtes [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) et envoyez-le via claude.ai > Customize > Skills > + > Create skill > Upload a skill | Retélécharger et renvoyer |
-| **Claude Desktop** | [Téléchargez le `.mcpb` de votre plateforme](https://github.com/mvanhorn/last30days-skill/releases/latest) et glissez-le dans Settings > Extensions | Retélécharger et glisser le nouveau bundle |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code (recommandé)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Recommandé parce que la marketplace Claude Code gère les mises à jour pour vous : le cache du plugin est versionné et se rafraîchit automatiquement à chaque nouvelle version publiée. Lancez `claude plugin update last30days@last30days-skill` pour forcer une vérification.
-
-Si vous préférez passer par le chemin d'installation Agent Skills sur Claude Code, c'est également pris en charge :
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-Le plugin natif et l'installation `npx skills` peuvent coexister. Attention : Claude Code ne déduplique pas entre méthodes d'installation. Si le plugin de la marketplace et la copie `npx skills` sont actifs tous les deux, `/last30days` apparaîtra en double. Utilisez une seule méthode d'installation par machine.
-
-### Grok (xAI Build CLI)
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installe last30days comme plugin natif. L'installation directe suit le dépôt :
+**Recherchez n'importe quelle fenêtre récente. Gardez l'essentiel dans Obsidian.**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
+
+`obsidian2date` recherche ce que les gens disent réellement d'un sujet sur
+Reddit, X, YouTube, HN, GitHub, Polymarket et le web — sur la fenêtre que
+vous demandez (la semaine dernière, les 7 derniers jours, les 90 derniers
+jours ; 30 jours n'est que la valeur par défaut) — et transforme chaque
+exécution en notes Obsidian durables et liées entre elles.
+
+Chaque exécution produit :
+
+- une **note d'exécution** sourcée
+- un **briefing** compact
+- des `[[wikilinks]]` vers les exécutions liées
+- un **Index** et un **Dashboard** mis à jour
+
+Pas de suivi. MIT. Fork public de
+[last30days-skill](https://github.com/mvanhorn/last30days-skill) ; le moteur
+de recherche amont reste fusionnable. Requiert Python 3.12+ et un coffre
+(vault) Obsidian ; les sources et les clés API sont optionnelles — voir
+[CONFIGURATION.md](CONFIGURATION.md).
+
+## Utiliser comme commande slash (voie principale)
+
+`obsidian2date` est un Agent Skill : installez le dépôt une fois, puis
+tapez `/obsidian2date <sujet>` dans votre agent. Le skill lance le moteur de
+recherche, résout votre coffre, écrit les notes et signale les chemins.
+Aucun flag à mémoriser — dites « la semaine dernière » ou « sur les 90
+derniers jours » dans la demande, et le skill le traduit en flags moteur
+appropriés.
+
+| Hôte | Installation | Ensuite |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y` (ou ajoutez ce dépôt comme `.claude-plugin`) | `/obsidian2date <sujet>` |
+| Codex | le dépôt fournit `.codex-plugin/plugin.json` | `/obsidian2date <sujet>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <sujet>` |
+| Gemini CLI | le dépôt fournit `gemini-extension.json` | `/obsidian2date <sujet>` |
+| OpenClaw / hôtes agents.md | le dépôt fournit le manifeste `.agents/` | `/obsidian2date <sujet>` |
+| pi / tout agent compatible skills | liez ou copiez `skills/obsidian2date/` dans le dossier de skills de l'agent | `/obsidian2date <sujet>` |
+
+Ce que le skill fait à chaque exécution (voir
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — la
+spécification d'exécution canonique que lit le modèle) :
+
+1. résoudre votre coffre (demander une fois, s'en souvenir pour la session)
+2. déduire la fenêtre de votre demande (30 jours par défaut)
+3. lancer le moteur de recherche avec `--emit=obsidian`
+4. signaler honnêtement le chemin du briefing, de la note d'exécution et toute source partielle ou indisponible
+
+## Démarrage rapide (fallback CLI)
+
+Pour le scripting, cron ou les tests du moteur en développement, appelez la
+CLI directement. C'est la voie de secours, pas la principale — la commande
+slash ci-dessus est le produit.
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /chemin/vers/votre/vault
 ```
 
-Ou ajoutez ce dépôt comme source de marketplace, puis installez par nom de plugin :
+Ou configurez le coffre une fois :
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/chemin/vers/votre/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-Ajoutez `--trust` pour sauter la confirmation d'installation. Mettez à jour avec `grok plugin update last30days`. Grok lit aussi les manifestes Claude Code par compatibilité ; la paire native `.grok-plugin/` reste la voie principale, et c'est elle que pointe une entrée officielle dans la [marketplace xAI](https://github.com/xai-org/plugin-marketplace). `npx skills add` reste une solution de repli valable, tous hôtes confondus.
+### Fenêtre temporelle
 
-### Codex, Cursor, Copilot, Gemini CLI et autres hôtes Agent Skills
-
-Installez via la CLI ouverte [Agent Skills](https://agentskills.io) — elle prend en charge 50+ hôtes, dont `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` et d'autres (liste complète sur le [dépôt vercel-labs/skills](https://github.com/vercel-labs/skills)).
+`30` jours n'est que la valeur par défaut. Demandez ce que vous voulez :
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # la semaine dernière
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # balayage trimestriel
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-Le flag `-g` (global) installe dans votre répertoire utilisateur, ce qui rend la skill disponible dans tous vos projets. Sans `-g`, `npx skills` installe localement dans `./.skills/` (versionné avec le dépôt). Pour un outil qui sert à explorer le monde entier, c'est bien l'installation globale que vous voulez.
+Dans la commande slash, dites-le simplement : « recherche les 7 derniers
+jours d'AI video tools ».
 
-Codex desktop et les autres hôtes qui travaillent au niveau du dossier fonctionnent aussi bien dans un dossier ordinaire que dans un dépôt Git. Avant la première recherche, demandez à l'agent hôte de lancer le `scripts/last30days.py --preflight` fourni depuis le répertoire de la skill chargée ; dans un clone du dépôt source, la commande équivalente est `python3 skills/last30days/scripts/last30days.py --preflight`. Elle affiche l'origine de la configuration, le plan de lecture des cookies de navigateur, les fichiers qui seront écrits, les commandes optionnelles et la configuration projet ignorée — sans lire de cookies, sans écrire de fichier et sans lancer de recherche.
+### Résolution du coffre
 
-Par défaut, l'installation cible l'hôte que `npx skills` détecte. Pour en viser un en particulier (ou plusieurs) :
+La cible d'export est résolue dans cet ordre :
+
+1. `--obsidian-vault PATH` (un chemin explicite inexistant est créé pour l'export)
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. un `~/Desktop/brain-paul` existant
+
+Les candidats d'environnement et de bureau doivent déjà être des
+répertoires. Une valeur d'environnement de coffre présente mais vide ou
+composée d'espaces désactive délibérément les replis implicites. Si rien ne
+se résout, la commande s'arrête avec :
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+Utilisez `~/...` ou un chemin absolu dans les fichiers `.env` ; `$HOME` n'y
+est pas développé. Les notes existantes ne sont jamais écrasées ; les
+collisions de noms de fichiers reçoivent un suffixe numérique.
+
+## Ce qui est écrit
+
+Disposition par défaut sous la racine du coffre :
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Les notes ne s'écrasent jamais. Les collisions le même jour reçoivent des
+suffixes numériques. Les exécutions antérieures liées sont connectées via
+les `[[wikilinks]]` Obsidian lorsqu'un chevauchement de tokens est détecté.
+
+## Sources et clés
+
+Le même socle que l'amont :
+
+- **Sans clé par défaut :** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Optionnelles :** X (cookies de navigateur / backends), YouTube
+  (`yt-dlp`), TikTok/IG (ScrapeCreators), plus d'autres backends payants/opt-in
+
+Voir [`CONFIGURATION.md`](CONFIGURATION.md) pour la matrice complète et la
+configuration des clés.
+
+## Diagnostics sûrs
+
+Exécutez une vérification des seules permissions avant la recherche :
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` est sûr : il s'exécute **sans lire les cookies, écrire des
+fichiers ni lancer de recherche**. Pour dépanner des sources ou des backends
+installés, utilisez plutôt la vérification de santé :
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-Pour mettre à jour plus tard :
+## Les modes amont fonctionnent toujours
 
 ```bash
-npx skills update last30days -g
+# enveloppe de synthèse compacte d'origine
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# JSON pour agents
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# brief de production
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-Ou mettez à jour tout ce que vous avez installé globalement via `npx skills` :
+## Relation avec l'amont
+
+| Sujet | Politique |
+| --- | --- |
+| Moteur de recherche | Rester fusionnable avec `upstream/main` |
+| Export Obsidian | Module additif : `lib/obsidian_export.py` |
+| Marque / skill | `obsidian2date` |
+| Licence | MIT ; conserver les mentions de copyright amont |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-Listez et désinstallez avec `npx skills list -g` et `npx skills remove last30days -g`.
+## Crédits
 
-### claude.ai (web)
+- Moteur de recherche amont : [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Chemin d'export Obsidian + packaging du fork public : [pauleschwarz](https://github.com/pauleschwarz)
 
-1. [Téléchargez `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) depuis la dernière version publiée
-2. Allez sur [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Cliquez sur le bouton `+` du panneau Skills, puis sur `Create skill` > `Upload a skill`, et déposez le fichier
+## Licence
 
-Activez d'abord « Code execution and file creation » dans Capabilities — sans cela, les skills ne s'exécutent pas.
-
-### Claude Desktop
-
-Claude Desktop installe `/last30days` comme serveur MCP via un bundle `.mcpb` (un paquet Model Context Protocol en un clic).
-
-1. Ouvrez la [dernière version publiée](https://github.com/mvanhorn/last30days-skill/releases/latest) et téléchargez le `.mcpb` correspondant à votre plateforme :
-   - macOS Apple Silicon : `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel : `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64 : `last30days-pp-mcp-linux-amd64.mcpb`
-2. Ouvrez Claude Desktop, allez dans Settings > Extensions et glissez-y le fichier.
-3. Quand l'application vous les demande, collez les clés API des sources que vous voulez activer. Tous les champs sont facultatifs : si vous les ignorez tous, le moteur se rabat sur le mode web uniquement. Les clés sont stockées dans le trousseau de votre système.
-4. Redémarrez Claude Desktop. Demandez à Claude de « faire des recherches sur Peter Steinberger », ou sur n'importe quel sujet, et il appellera l'outil `research`.
-
-**Prérequis côté hôte :** Python 3.12+ dans le PATH. Le bundle embarque le code du moteur mais utilise votre interpréteur Python local. Installez-le depuis [python.org](https://www.python.org/downloads/) sous Windows ; macOS et la plupart des distributions Linux fournissent déjà une version compatible.
-
-**Les clés ne sont pas partagées avec la skill Claude Code.** Claude Desktop et Claude Code maintiennent délibérément des stockages d'identifiants distincts. Si vous avez déjà configuré `~/.config/last30days/.env` pour la skill Claude Code, il faudra ressaisir les mêmes clés ici, une fois.
-
-La prise en charge de Windows est reportée le temps de régler les points d'entrée par plateforme dans le manifeste ; le suivi se fait dans une issue dédiée.
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-Pour les workflows d'action sur X/Twitter en dehors des recherches `/last30days` —
-publier des tweets ou des réponses, exporter des abonnés, gérer les médias,
-surveiller des comptes, organiser des tirages au sort — utilisez
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw), le plugin OpenClaw
-complémentaire. TweetClaw est maintenu par Xquik-dev et n'est mentionné que comme
-option complémentaire : ce n'est ni une dépendance ni une recommandation de last30days.
-
-### Installation manuelle (développeurs)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-Le lien symbolique garde l'installation synchronisée avec votre copie de travail au fil de vos modifications — inutile de recopier quoi que ce soit. Pour `claude.ai`, construisez le fichier `.skill` depuis les sources : `bash skills/last30days/scripts/build-skill.sh` produit `dist/last30days.skill`.
-
-Reddit (avec les commentaires), Hacker News, Polymarket et GitHub fonctionnent immédiatement. Zéro configuration. Lancez `/last30days` une fois : l'assistant de configuration débloque d'autres sources en 30 secondes, dont les CLI gratuites arXiv et Techmeme.
-
-## Apportez vos propres clés
-
-Ces plateformes n'ont aucune relation entre elles. X ignore ce que pense Reddit. YouTube ne voit pas TikTok. Mais vous pouvez apporter vos propres clés API et vos tokens de navigateur, et vous avez soudain accès à toutes en même temps.
-
-| Sources | Ce qu'il vous faut | Coût |
-|---------|---------------|------|
-| Reddit (avec les commentaires) + HN + Polymarket + GitHub + StockTwits | Rien | Gratuit |
-| arXiv + Techmeme | Des CLI gratuites, installées automatiquement à la configuration initiale | Gratuit |
-| X / Twitter | Connectez-vous à x.com dans n'importe quel navigateur, ou définissez `XQUIK_API_KEY` / `XAI_API_KEY` | Les cookies de navigateur sont gratuits ; les clés dépendent du fournisseur |
-| YouTube | `brew install yt-dlp` | Gratuit |
-| Bluesky | Un mot de passe d'application depuis bsky.app | Gratuit |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + commentaires YouTube | Une clé ScrapeCreators | 10 000 appels gratuits, puis paiement à l'usage |
-| Xiaohongshu (RED) | Faites tourner un plugin de navigateur x-mcp connecté ou un service `xiaohongshu-mcp`, puis activez la source avec `--search xhs` pour une exécution ou `INCLUDE_SOURCES=xiaohongshu` dans `.env` ; last30days teste automatiquement `http://localhost:18060` puis `http://host.docker.internal:18060`, ou utilisez `XIAOHONGSHU_API_BASE` pour une URL personnalisée | Aucune clé API last30days ; dépend de votre service local de session de navigateur |
-| DripStack (newsletters financières premium) | Sur activation : `--search dripstack` pour une exécution, ou `INCLUDE_SOURCES=dripstack` dans `.env` | Aucune clé ; API de recherche publique et gratuite |
-| Perplexity Agent API / Search API / Deep Research | Une clé Perplexity, ou une clé OpenRouter en repli pour Sonar | Paiement à l'usage ; une clé directe active l’Agent API et Deep Research en arrière-plan |
-| Recherche web | Une clé Brave Search | 2 000 requêtes gratuites par mois |
-
-### Trousseau macOS (facultatif)
-
-Sous macOS, vous pouvez stocker vos clés dans le trousseau système plutôt que dans un fichier `.env`. La skill les récupère automatiquement, comme source de plus faible priorité : en cas de conflit, les fichiers `.env` et les variables d'environnement du processus l'emportent toujours.
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-Les entrées sont enregistrées sous le nom de service `last30days-<KEY>` pour l'utilisateur courant. Sur les plateformes non Darwin, le chargeur ne fait rien : aucun changement de comportement pour les utilisateurs Linux et Windows.
-
-Vous avez déjà des clés sous d'autres noms de service dans le trousseau ? Définissez la correspondance non secrète `LAST30DAYS_KEYCHAIN_ALIASES` décrite dans [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), plutôt que de recopier vos secrets.
-
-Voir [CONFIGURATION.md](CONFIGURATION.md) pour la matrice complète des clés par source, l'ordre de priorité des fournisseurs de raisonnement et celui des backends de recherche web.
-
-## Configuration
-
-Deux choses que vous voudrez sans doute savoir dès le premier jour :
-
-**Où sont enregistrés les fichiers de recherche.** `LAST30DAYS_MEMORY_DIR` vaut par défaut `~/Documents/Last30Days/` (sous Windows : `C:\Users\<you>\Documents\Last30Days\`). Redéfinissez cette variable d'environnement dans votre shell pour pointer ailleurs, ou passez `--save-dir <path>` sur une exécution. Utilisez `--output <file>` quand vous voulez le résultat rendu à un chemin précis, dans le format choisi par `--emit`. Utilisez `--save-suffix=<name>` pour garder séparées plusieurs variantes d'un même sujet (par client, par exemple). Chaque exécution avec `--save-dir` produit `<slug>-raw[-suffix].md`. Lancez `python3 skills/last30days/scripts/last30days.py --preflight` pour vérifier les écritures prévues avant une recherche.
-
-**Sortie structurée pour les agents et les workflows.** Demandez à `/last30days` du JSON exploitable par une machine pour obtenir le profil d'agent stable et versionné. Pour un usage direct du moteur en script ou en développement, lancez `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` ; n'ajoutez `--json-profile=raw` que si vous avez besoin du dump interne non versionné de `Report`. Voir la [référence des champs de l'export JSON et la politique de versionnement](docs/reference/json-export.md).
-
-**Découverte sans sujet imposé.** Demandez `/last30days what's trending in AI agents?` pour obtenir un brief de découverte classé, au lieu de rechercher un sujet que vous connaissez déjà. Sur un hôte agentique, cela déclenche le protocole en trois commandes arbitré par l'hôte (le modèle propose les sujets, écarte le bruit, note leur intérêt et rédige les angles éditoriaux). Pour un usage direct du moteur en script ou en cron, lancez `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (en une passe : noms de sujets déterministes, sans angles) ; ajoutez `--emit=json` pour le contrat de découverte versionné. La découverte est incompatible avec un sujet positionnel et avec `--drill`.
-
-**Suivi des tendances d'une exécution à l'autre.** Le mode par défaut produit un instantané Markdown à chaque exécution. Pour accumuler les résultats dans le temps, ajoutez `--store` afin de les conserver dans une base SQLite, puis utilisez [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) pour les exécutions planifiées (avec envoi facultatif sur Slack ou via webhook à chaque nouveau résultat) et [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) pour des synthèses quotidiennes ou hebdomadaires. Le schéma de cadence complet est dans [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
-
-**Une bibliothèque de recherche à laquelle s'abonner.** Demandez à `/last30days` de générer le flux de votre bibliothèque, ou utilisez directement `python3 skills/last30days/scripts/last30days.py library feed` pour vos scripts et vos développements. La commande transforme les briefs enregistrés en un `index.html`, un `feed.xml` Atom local et des pages de brief lisibles. N'ajoutez `--publish` que si vous voulez héberger l'index HTML et les pages de brief ; la publication est un choix explicite, et publique par défaut. Pour rendre le flux Atom réellement abonnable, hébergez le répertoire de sortie généré sur un hébergeur statique comme GitHub Pages.
-
-**Cherchez dans tout ce que vous avez déjà recherché.** Demandez `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Pour un usage direct du moteur, lancez `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. La recherche est hors ligne et déterministe : elle indexe au fil de l'eau les mêmes briefs enregistrés que le flux de bibliothèque, y fusionne les occurrences correspondantes conservées dans le store, et regroupe les résultats par sujet et par date. Les nouvelles exécutions affichent aussi une section compacte **From your library** (« depuis votre bibliothèque ») quand des recherches antérieures recoupent le sujet en cours ; définissez `LAST30DAYS_LIBRARY_CONTEXT=off` pour désactiver ce contexte passif.
-
-Les scripts d'encapsulation par client, les subreddits de catégorie personnalisés et le canal bêta expérimental pour les personnalisations en cours sont également documentés dans [CONFIGURATION.md](CONFIGURATION.md).
-
-## Vitrine : les flux de recherche de la communauté
-
-Vous avez publié une veille IA récurrente, un suivi de marché ou une obsession merveilleusement pointue avec last30days ? Partagez l'URL de votre bibliothèque publique — ou l'URL Atom une fois `feed.xml` hébergé sur un hébergeur statique — dans [le fil vitrine de la communauté](https://github.com/mvanhorn/last30days-skill/issues/532). Les flux communautaires seront listés ici au fur et à mesure que leurs auteurs les proposeront ; en attendant, le fil sert de point de collecte.
-
-## Comment ça marche
-
-1. **Vous saisissez un sujet.** Une personne, une entreprise, un produit, une technologie, « X vs Y ». N'importe quoi.
-2. **L'agent identifie qui compte.** Il trouve les comptes X (y compris ceux des fondateurs), les dépôts GitHub, les subreddits, les hashtags TikTok, les chaînes YouTube. Pour « Kanye West », il sait qu'il faut r/hiphopheads, @kanyewest et « bully review » sur YouTube. Pour « OpenClaw », il identifie openclaw/openclaw sur GitHub et récupère le nombre d'étoiles en direct.
-3. **Toutes les sources interrogées en parallèle.** Expansion multi-requêtes. Résultats classés selon l'engagement, la pertinence et la fraîcheur.
-4. **Une profondeur que personne d'autre n'a.** Les transcriptions YouTube complètes des vidéos de réaction. Les meilleurs commentaires Reddit avec leur nombre d'upvotes. Les légendes TikTok. Les cotes Polymarket. Pas seulement des titres et des liens.
-5. **Une même histoire, fusionnée.** Le Wireless Festival annoncé sur Reddit, commenté sur X, avec le prix des billets sur TikTok : un seul cluster, pas trois entrées distinctes.
-6. **Synthétisé en un seul brief.** Ancré dans des données précises. Sourcé. Classé selon ce avec quoi les gens interagissent vraiment. Pas « voilà ce que j'ai trouvé », mais « voilà ce qui compte ».
-7. **Ensuite, la skill devient votre experte.** Après une seule exécution, votre session Claude sait tout ce que sait la communauté. Posez vos questions de suivi. Faites-lui écrire des prompts, rédiger des e-mails, planifier des voyages, concevoir des architectures — le tout ancré dans la réalité du moment.
-
-## Ce que les gens en disent
-
-> « J'ai trouvé une skill Claude Code qui fait des recherches sur n'importe quel sujet à travers Reddit, X, YouTube et HN sur les 30 derniers jours. Et elle écrit les prompts à votre place. Avant chaque contenu que j'écris, je faisais ces recherches à la main sur Reddit et X. Onglet par onglet. Fil par fil. C'est la partie qui prend 90 minutes. Elle disparaît. » — @itsjasonai
-
-> « Cette seule skill a remplacé tout mon workflow de recherche. Vous lui donnez un sujet, elle récupère sur Reddit, X et le web ce dont les gens parlent vraiment. Pas de vieux billets de blog. De vraies conversations des 30 derniers jours. » — @itswilsoncharles
-
-> « 5 des 10 dépôts tendance du jour sur GitHub sont des outils Claude. N° 1 : mvanhorn/last30days-skill » — @yieldhunter95
-
-## Open source
-
-Licence MIT. Aucun tracking. Aucune analytics. Vos recherches restent sur votre machine. Plus de 2 700 tests.
-
-Construit avec Python 3.12+, yt-dlp, Node.js (client Bird intégré pour la recherche X) et l'API ScrapeCreators. Architecture du moteur v3 par [@j-sperling](https://github.com/j-sperling).
-
-Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour ouvrir une PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) pour la liste complète des contributeurs de la communauté, et [CHANGELOG.md](CHANGELOG.md) pour l'historique des versions.
-
-## Évolution des étoiles
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT. Voir [LICENSE](LICENSE).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,382 +1,195 @@
-# /last30days
+# obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | 日本語 | [简体中文](README.zh-CN.md)
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
-</p>
-
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
-
-**編集者ではなく、アップボート・いいね・実際に動いたお金でランク付けする、AIエージェント主導の検索エンジンです。**
-
-このREADMEは現行のv3パイプラインについて説明しています。実行時のスキル仕様は [skills/last30days/SKILL.md](skills/last30days/SKILL.md) にあり、コマンドとセットアップの挙動についてはそちらが最新かつ正式なものです。
-
-**Claude Code(推奨 — マーケットプレイス経由で自動更新):**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
-
-**Codex、Cursor、Copilot、Gemini CLI、その他50以上の [Agent Skills](https://agentskills.io) ホスト:**
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-(`-g` を付けるとユーザー単位でグローバルにインストールされ、すべてのプロジェクトで使えます。プロジェクト単位に限定したい場合はこのフラグを外してください。)
-
-その他のインストール方法(claude.aiのウェブ版、OpenClaw、手動)は下の [インストール](#インストール) セクションにあります。
-
-設定は不要です。Reddit、HN、Polymarket、GitHub はすぐに使えます。一度実行すれば、セットアップウィザードが30秒で X、YouTube、TikTok、arXiv、Techmeme などを有効にします。
-
----
-
-Reddit のアップボート。X のいいね。YouTube の文字起こし。TikTok のエンゲージメント。実際のお金とインサイダー情報に裏打ちされた Polymarket のオッズ。つまり、毎日何百万人もの人が自分の注意と財布で投票しているということです。/last30days はそのすべてを並行して検索し、実際に人々が反応したかどうかでスコアを付け、AIエージェントが判定役となって1本のブリーフにまとめます。
-
-Google は編集者を束ねます。/last30days は人を検索します。
-
-この検索は他のどこでも手に入りません。単独のAIがすべてにアクセスできないからです。Google の検索は Reddit のコメントにも X の投稿にも届きません。ChatGPT は Reddit と提携していますが、X も TikTok も検索できません。Gemini には YouTube がありますが Reddit がありません。Claude はそのどれもネイティブには持っていません。どのプラットフォームも、独自のAPI・独自のトークン・独自の認証を備えた閉じた庭です。しかし自分のキーとブラウザセッションを持ち込めば、AIエージェントが一度にすべてを検索し、互いに突き合わせてスコアを付け、本当に重要なことを教えてくれるようになります。
-
-そこが突破口です。優れた検索エンジンが1つ増えるという話ではありません。断絶していた十数のプラットフォームを、エージェントが橋渡しするのです。
-
-```
-/last30days Peter Steinberger
-```
-
-明日、打ち合わせがあるとします。その人を Google で調べると、出てくるのは2023年の LinkedIn です。/last30days なら、その人が今月実際にやっていることが分かります。Codex に取り組むため OpenAI に参加し、サードパーティ製エージェントを禁じた Anthropic の方針と争い、23本のPRをマージ率85%で送り、デバイスをまたいでエージェントを操作する「LobsterOS」を作っていて、さらに r/ClaudeCode では彼が英雄なのか「鼻につく」のかという議論が569アップボートを集めている。それらは X の投稿、Reddit のスレッド、YouTube の文字起こし、GitHub のコミットに散らばっていて、どれも Google には出てきませんでした。
-
-## なぜ作ったのか
-
-AIの動きに追いつくために作りました。何もかもが日々変わり、Reddit と X の濃い人たちがいつも真っ先に把握しています。もっと良いプロンプトが必要でしたが、学習データはコミュニティがすでに突き止めたことより常に数か月遅れていました。
-
-ただ、そこからもっと大きなものになりました。今では商談の前に走らせて、その会社について直近30日間の実情を押さえます。打ち合わせの前には、相手の最近のツイートやポッドキャストの文字起こしを読むために。ディズニー・ワールドに行く前には、どのアトラクションが休止中で、Genie+ についてコミュニティが何と言っているかを知るために。何かを作り始める前には、人々が実際にどんな問題にぶつかっているかを知るために。
-
-CEOと会うとして、直近30日間のツイートと YouTube の文字起こしを全部読んできましたか。私は読んでいます。
-
-## 人々がスコアを付けた情報源
-
-| 情報源 | 人々が教えてくれること |
-|--------|--------------------------|
-| **Reddit** | フィルターのかかっていない本音。実際のアップボート数付きのトップコメントが、無料・APIキーなしで手に入ります。Google が埋もれさせてしまう本当の意見です。 |
-| **X / Twitter** | 勢いのある一言、専門家のスレッド、速報への最初の反応。誰よりも早く知り、誰よりも早く議論が始まります。 |
-| **YouTube** | 45分の掘り下げ。文字起こし全文を検索し、引用に値する5つの文だけを取り出します。 |
-| **TikTok** | Google では絶対に見つからない切り口で360万人に届いているクリエイター。 |
-| **Instagram Reels** | 話した内容の文字起こし付きで届く、インフルエンサーの視点。ビジュアル文化のシグナルです。 |
-| **Hacker News** | 開発者の総意。825ポイント、899コメント。技術寄りの人たちが本気で議論している場所です。 |
-| **Polymarket** | 意見ではなく、オッズ。実際のお金が裏付けています。アルバムの売上に96%、買収に4%といった具合です。 |
-| **GitHub** | 人物について: PRの勢い、スター数の多いリポジトリ、リリースノート。トピックについて: Issue と Discussion。 |
-| **Digg** | Digg の AI 1000 リーダーボード(X 上でシグナルの強いAI関連アカウント約1000件)から集めたストーリークラスター。出典をたどれるインライン引用付きで、X の認証は不要です。`digg-pp-cli` が PATH にあると自動的に有効になります。 |
-| **arXiv** | 話題の裏側にある論文。対象期間に出た新しい研究が、無料・APIキーなしで手に入ります。`arxiv-pp-cli` が PATH にあると自動的に有効になります(初回セットアップでインストールされます)。 |
-| **Techmeme** | テックニュースの編集レイヤーを、対象の30日間に絞って取得します。無料・APIキーなし。`techmeme-pp-cli` が PATH にあると自動的に有効になります(初回セットアップでインストールされます)。 |
-| **LinkedIn** | ビジネス面のシグナル。投稿と記事を拾い、記事は強いシグナルとして重み付けします。 |
-| **StockTwits** | トレーダーの温度感。調べる対象が銘柄コードや暗号資産のときに自動で有効になります。 |
-| **Threads** | Twitter 以後のテキストの層。クリエイターやブランドの会話です。 |
-| **Pinterest** | ビジュアル起点の発見。プロダクトやアイデアに対するピン・保存・コメント。 |
-| **Xiaohongshu(RED)** | 中国のライフスタイル・プロダクト・クリエイターのシグナル。ログイン済みの x-mcp ブラウザプラグイン、または `xiaohongshu-mcp` サービスがローカルで動いているときに、`--search xhs` で明示的に指定して使います。 |
-| **Bluesky** | 分散型のソーシャル層。Twitter 以後の移住で生まれた AT Protocol の投稿です。 |
-| **Perplexity** | 制御された Agent API の統合、OpenRouter の Sonar フォールバック、Search API の生の結果、明示的な Deep Research。 |
-| **Web** | 編集記事や、ブログの比較記事。数あるシグナルの1つであって、唯一のものではありません。 |
-
-コミュニティが今も情報源を増やし続けています。Truth Social をはじめとするニッチな情報源もすでにエンジンに入っていて、さらに追加予定です。
-
-1,500アップボートの Reddit スレッドは、誰にも読まれなかったブログ記事よりも強いシグナルです。360万回再生の TikTok は、プレスリリースよりも「今、文化的に何が効いているか」を語ります。6.6万ドルの出来高に裏打ちされた Polymarket のオッズは、評論家の当て推量よりも反論しにくいものです。
-
-この統合処理は、実在の人々が実際に反応したかどうかで順位を付けます。SEO上の関連性ではなく、社会的な関連性です。
-
-## みんなが実際に使っている場面
-
-**打ち合わせの前に。** `/last30days Peter Steinberger` — OpenAI の Codex チームに参加、サードパーティ製エージェントを禁じた Anthropic の方針と対立、GitHub で23本のPRをマージ率85%でマージ、デバイスをまたいでエージェントを操作する LobsterOS を開発中。r/ClaudeCode では「OpenClaw が出てからずっと、API 以外の経路で動かせばいずれBANされると広く知られていた」(227アップボート)。これは LinkedIn には載っていません。
-
-**採用シグナルを読むために。** `/last30days Listen Labs --hiring-signals` — 現在の求人ページやキャリアページが、注力領域の変化を示す引用可能な根拠になります。エンタープライズ向けセキュリティ、カスタマーサクセス、インフラ、プロダクト拡張といった採用の動きです。レポートが述べるのは「採用が何を示唆しているように見えるか」であって、「ロードマップが何を出すか」ではありません。
-
-**ピークを迎える前の話題を見つけるために。** `/last30days what's exploding in AI agents?` と尋ねると、スキルはディスカバリーモードに切り替わります。エンジンが Reddit のカテゴリー一覧、Hacker News のフロントページとベストストーリー、Digg の AI 1000 フィード、そして認証済みであれば X を横断してさらいます。次にエージェントが候補を審査し(名前の妥当性、ノイズの除去、記事になるか)、ポッドキャストや X 記事の切り口を書きます。最後に、勢いの強さで並べた5〜10件のトピックが返ってきます。各結果には情報源をまたいだ数値、モメンタムのラベル、そしてそのまま実行できる `/last30days "<topic>"` が付いてきます。
-
-**何かが出たとき。** `/last30days Kanye West` — イギリスがビザを却下、Wireless Festival は中止、スポンサーは離脱。それでも BULLY は Billboard 初登場2位。Fantano は「Yay sabbatical」から復帰してレビューを公開(65.3万回再生)。SoFi Homecoming では Lauryn Hill と Travis Scott を迎えて44曲を披露。Polymarket では「Kanye はまたツイートするか?」が「はい」86%。Reddit のスレッド23件、YouTube の動画17本、アップボート8.6万件。
-
-**ツールを比べるために。** `/last30days OpenClaw vs Hermes vs Paperclip` — 「これらは競合ではなくレイヤーだ」。OpenClaw は実行を担うレイヤー(GitHub スター35.1万、稼働中)、Hermes は自己改善する頭脳(スター3.1万)、Paperclip は組織図(スター4.9万)。スター数は古いブログ記事からではなく GitHub API からその場で取得しています。アーキテクチャ、メモリ、セキュリティ、向いている用途を並べた比較表付き。@IMJustinBrooke いわく「OpenClaw = ヒトカゲ、Hermes = リザードン」。
-
-**世界の動きを理解するために。** `/last30days Iran vs USA` — 開戦から38日目。トランプ大統領はイランに対し、ホルムズ海峡の再開について火曜日を期限とする最後通告。米軍機2機が撃墜。原油は1バレル126ドル。IEA はこれを「世界の石油市場の歴史上最大の供給途絶」と呼びました。Polymarket では12月31日までの停戦が74%。X の投稿27件、YouTube の動画10本、予測市場20件。
-
-**旅行の前に。** `/last30days Universal Epic Universe` — 拡張エリアはすでに着工済み。「Project 680」の建設許可が申請されています。花火ショーはインフラの痕跡から確認できるものの、まだ発表はありません。待ち時間は Mine-Cart Madness が平均148分。年間パスはまだ出ておらず、地元の人たちは不満を漏らしています。Stardust Racers は4月5日まで改修で運休。
-
-**手早く学ぶために。** `/last30days Nano Banana Pro prompting` — JSON で構造化したプロンプトが、タグの寄せ集めに取って代わりつつあります。@pictsbyai の入れ子形式は「コンセプトの混線」を防ぎます。作り直すより、編集を前提にしたワークフローのほうが結果が出ます。そのうえで、コミュニティが「これは効く」と言った内容をそのまま使って、実運用向けのプロンプトを書いてくれます。
-
-## 最近の変更
-
-5月の v3.3 発表以降、v3.11.1(2026年7月)時点までで、15回のリリースにわたり175本のPRがマージされました。うち122本はコミュニティの52人によるものです。以下がその内容です。
-
-### OpenAI Codex での一級対応
-
-/last30days は、ガイド付きセットアップを備えた Codex のネイティブプラグインになりました。移植版ではなく、一級の対応です。レンダラーを踏まえた引用処理によって、Codex での出力はURLの羅列ではなくブリーフとして読めるようになり(#694)、同じエンジンが Claude Code、Cursor、Copilot、Gemini CLI、Claude Desktop、OpenClaw、そして50以上の Agent Skills ホストで動きます。Codex のプラグインマニフェストは [@rfoust](https://github.com/rfoust)(#686)、Codex の認証まわりの修正は [@tmchow](https://github.com/tmchow)(#698)によるものです。
-
-### arXiv、Techmeme、Digg — 無料、APIキー不要
-
-arXiv は話題の裏側にある論文を、Techmeme はテックニュースの編集レイヤーを持ち込みます。いずれも無料でキーは一切不要、しかも初回セットアップが各CLIをインストールするので自動的に有効になります(#709)。Digg の AI 1000 ストーリークラスターも同じように、X の認証なしで届きます。セットアップが無料の Digg CLI を入れてくれます(#590)。Trustpilot は消費者向けブランドの調査用に、任意で有効にできます。
-
-### 無料の Reddit が、実数のスコアとトップコメント付きで復活
-
-Reddit の公開 .json API は終了しましたが、無料の経路はより強くなって戻ってきました。キー不要の RSS と shreddit のスクレイピング(#457)、arctic-shift 経由で実際のアップボート数まで取れるサブレディット特定(#696)、そして話題から外れたバズ投稿にブリーフを乗っ取られないようにする関連性の下限(#488、[@rzachsmith](https://github.com/rzachsmith) に感謝)。APIキーは不要。スコアは実数。トップコメントも込みです。
-
-### どのブリーフにも最高のコメントを
-
-コメントは今や、どの情報源でも既定で有効なレイヤーです。Instagram のコメントは順位に基づいて分散させ、尖った意見5件が同じ投稿ばかりから出ないようにしています(#751)。YouTube のコメントに加えて、yt-dlp が失敗したときのために ScrapeCreators による文字起こしのバックアップも用意しました(#637)。さらに、コミュニティの投票で支持されたコメントを Best Takes のスコアに反映し、いちばん面白い一言が選別を生き延びるようにしています(#592、#608)。
-
-### doctor コマンド1つで
-
-ヘルスチェックを頼めば、doctor がすべての情報源を試したうえで、必要な対処をそのまま提示します。どのキーが足りないのか、どのCLIが PATH に入っていないのか、どのクッキーが期限切れなのか(#753)。X の結果が薄かった理由を当てずっぽうで探す必要はもうありません。
-
-### X 検索の作り直し
-
-X のパイプラインを一から作り直しました。FROM レーンと ABOUT レーンを設けて、本人の投稿と本人についての会話の両方が順位付けされるようにし(#610)、対象人物に応じてサブクエリの曖昧さを解消し(#611)、本人による投稿かどうかを裏付けたうえでインタラクションのシグナルで順位を付け(#613)、バックエンドを自動で切り替える単一の X ソースにまとめました(#622)。さらに、認証を実際に確かめる正直な `--diagnose` も入っています(#609)。
-
-### 情報源が増えました
-
-ScrapeCreators 経由の LinkedIn。記事は強いシグナルとして扱います([@ravstr](https://github.com/ravstr)、#702)。StockTwits は銘柄コードや暗号資産の話題で自動的に有効になります([@wtiwana](https://github.com/wtiwana)、#658)。Perplexity は直接APIモードと非同期の Deep Research に対応しました([@sk-holmes](https://github.com/sk-holmes)、#629)。
-
-### コミュニティによる堅牢化
-
-セキュリティ面の改善は、ほぼすべてコミュニティの手によるものです。HTML レンダラーの格納型XSSの修正([@iliaal](https://github.com/iliaal)、[@aaronjmars](https://github.com/aaronjmars))、クッキーの一時ファイルの権限強化、OpenSSF Scorecard とビルド来歴の証明を組み込んだサプライチェーン耐性のあるCI([@shaanmajid](https://github.com/shaanmajid)、[@hammadxcm](https://github.com/hammadxcm)、[@aniruddh909](https://github.com/aniruddh909))、Semgrep と OSV-Scanner によるスキャンおよびPRごとの依存関係レビューゲート([@23241a6749](https://github.com/23241a6749))、60%で導入し現在は84%まで引き上げたテストカバレッジの下限([@gourab5139014](https://github.com/gourab5139014))、そして CRITICAL の指摘がゼロになった Hermes のセキュリティスキャン(#768)。
-
-### 届く範囲が広がりました
-
-ヘブライ語をはじめとする非ラテン文字の言語に対応([@dudyme](https://github.com/dudyme))。中国語の情報源向けに CJK を考慮したトークナイズ([@An-idd](https://github.com/An-idd))。Windows 対応の改善もまとめて入りました。Chromium 系ブラウザ全体(Brave、Edge、Vivaldi、Opera、Arc)からのクッキー抽出([@andrey-esipov](https://github.com/andrey-esipov))に加え、macOS のキーチェーンと Linux の pass(1) も認証情報の取得元として使えます。`--as-of` による過去時点の振り返り([@chiyi-creator](https://github.com/chiyi-creator))。uv 経由での Python 3.12 の自動セットアップ([@buntysomroy](https://github.com/buntysomroy))。企業の求人ページを読む `--hiring-signals`。実行と実行のあいだのウォッチリスト差分。
-
-### v3 から引き続き入っているもの
-
-v3 の土台はすべて健在です。APIコールを1件も投げる前に、適切なアカウント・サブレディット・ハッシュタグを特定する事前リサーチの頭脳([@j-sperling](https://github.com/j-sperling) が構築)。関連性だけでなくユーモアやバイラル性も見る Best Takes のスコアリング。情報源をまたいだクラスターの統合。1回のパスで済む比較(「CLI vs MCP」が12分ではなく3分)。自動で候補を見つける `--competitors` 比較。GitHub の人物モード(`--github-user=steipete`)。ELI5 モード(実行後に「eli5 on」)。そして共有できる自己完結型の HTML ブリーフ(`--emit=html`)。設定項目は [CONFIGURATION.md](CONFIGURATION.md) にまとまっています。
-
-## インストール
-
-| 環境 | インストール | 更新 |
-|---------|---------|---------|
-| **Claude Code**(推奨) | `/plugin marketplace add mvanhorn/last30days-skill` | マーケットプレイス経由で自動、または `claude plugin update last30days@last30days-skill` |
-| **Grok**(xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` のあとに `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex、Cursor、Copilot、Gemini CLI、その他50以上の [Agent Skills](https://agentskills.io) ホスト** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**(ウェブ) | [`last30days.skill` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)し、claude.ai > Customize > Skills > + > Create skill > Upload a skill からアップロード | ダウンロードし直してアップロードし直す |
-| **Claude Desktop** | [お使いのプラットフォーム向けの `.mcpb` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest)し、Settings > Extensions にドラッグ | ダウンロードし直して新しいバンドルをドラッグ |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code(推奨)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Claude Code のマーケットプレイスが更新を代わりにやってくれるため、これが推奨です。プラグインのキャッシュはバージョン管理されていて、新しいリリースが公開されると自動で更新されます。`claude plugin update last30days@last30days-skill` を実行すれば、その場で確認を強制できます。
-
-Claude Code で Agent Skills 経由のインストールを使いたい場合も、それはそれで対応しています。
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-ネイティブプラグインと `npx skills` でのインストールは共存できます。ただし Claude Code はインストール方法をまたいだ重複排除を行いません。マーケットプレイス版のプラグインと `npx skills` のコピーを両方とも有効にしていると、`/last30days` が2件表示されます。1台につきインストール方法は1つにしてください。
-
-### Grok(xAI Build CLI)
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces)(`grok`)は last30days をネイティブプラグインとしてインストールします。直接インストールする場合はリポジトリを追跡します。
+**直近の任意の期間をリサーチし、有用な部分を Obsidian に残す。**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
+
+`obsidian2date` は、Reddit、X、YouTube、HN、GitHub、Polymarket、ウェブ全体に
+わたって、あるトピックについて人々が実際に何を言っているかをリサーチします —
+任意の期間を対象に（先週、直近 7 日間、直近 90 日間。30 日はあくまで
+デフォルト）— 各ランを、リンクされた永続的な Obsidian ノートに変換します。
+
+各ランが生成するもの:
+
+- ソースに基づいた **ランノート**
+- コンパクトな **ブリーフィング**
+- 関連ランへの `[[ウィキリンク]]`
+- 更新された **インデックス** と **ダッシュボード**
+
+トラッキングなし。MIT。
+[last30days-skill](https://github.com/mvanhorn/last30days-skill) の公開
+フォーク。上流のリサーチエンジンはマージ可能な状態を保ちます。Python 3.12+
+と Obsidian ボールトが必要です。ソースと API キーは任意です — 詳細は
+[CONFIGURATION.md](CONFIGURATION.md) を参照。
+
+## スラッシュコマンドとして使う（メインの経路）
+
+`obsidian2date` は Agent Skill です。リポジトリを一度インストールすれば、
+あとはエージェントで `/obsidian2date <トピック>` と打つだけです。スキルが
+リサーチエンジンを実行し、ボールトを解決し、ノートを書き込み、パスを報告します。
+覚えるべきフラグはありません — 「先週」「直近 90 日間」とリクエストに
+書けば、スキルが適切なエンジンフラグに翻訳します。
+
+| ホスト | インストール | その後 |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y`（またはこのリポジトリを `.claude-plugin` として追加） | `/obsidian2date <トピック>` |
+| Codex | リポジトリに `.codex-plugin/plugin.json` 同梱 | `/obsidian2date <トピック>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <トピック>` |
+| Gemini CLI | リポジトリに `gemini-extension.json` 同梱 | `/obsidian2date <トピック>` |
+| OpenClaw / agents.md ホスト | リポジトリに `.agents/` マニフェスト同梱 | `/obsidian2date <トピック>` |
+| pi / スキル対応エージェント全般 | `skills/obsidian2date/` をエージェントのスキルディレクトリにシムリンクまたはコピー | `/obsidian2date <トピック>` |
+
+スキルが各ランで行うこと（
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — モデルが
+読む正規のランタイム仕様 を参照）:
+
+1. ボールトを解決する（一度尋ね、セッション中は記憶する）
+2. リクエストから期間を導く（デフォルトは 30 日）
+3. `--emit=obsidian` でリサーチエンジンを実行する
+4. ブリーフィングのパス、ランノートのパス、および部分的または利用不可のソースを正直に報告する
+
+## クイックスタート（CLI フォールバック）
+
+スクリプト、cron、開発時のエンジンテストには、CLI を直接呼び出します。
+これはフォールバックの経路であり、メインではありません — 上のスラッシュ
+コマンドが本体です。
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /path/to/your/vault
 ```
 
-あるいは、このリポジトリをマーケットプレイスのソースとして追加してから、プラグイン名でインストールすることもできます。
+ボールトを一度設定しておくなら:
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/path/to/your/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-インストール時の確認を省きたい場合は `--trust` を付けてください。更新は `grok plugin update last30days` です。Grok は互換性のために Claude Code のマニフェストも読みますが、第一の経路はネイティブの `.grok-plugin/` のペアで、[xAI のマーケットプレイス](https://github.com/xai-org/plugin-marketplace)への公式掲載もこちらを指しています。`npx skills add` は、どのホストでも使える代替手段として引き続き有効です。
+### 期間
 
-### Codex、Cursor、Copilot、Gemini CLI、その他の Agent Skills ホスト
-
-オープンな [Agent Skills](https://agentskills.io) の CLI からインストールします。`codex`、`cursor`、`github-copilot`、`gemini-cli`、`claude-code`、`windsurf`、`cline`、`continue`、`roo`、`aider-desk`、`opencode`、`goose` など50以上のホストに対応しています(全一覧は [vercel-labs/skills リポジトリ](https://github.com/vercel-labs/skills)にあります)。
+`30` 日はあくまでデフォルトです。自由に指定できます:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # 先週
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # 四半期スイープ
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-`-g`(グローバル)フラグを付けるとユーザーディレクトリにインストールされ、スキルをすべてのプロジェクトで使えます。`-g` を付けない場合、`npx skills` はプロジェクト内の `./.skills/` にインストールし、リポジトリと一緒にコミットされます。世界中を調べるためのツールなので、通常はグローバルが向いています。
+スラッシュコマンドでは、ただ言うだけです: 「AI video tools の直近 7 日間を
+リサーチして」。
 
-Codex のデスクトップ版など、フォルダ単位で動くホストは、Git リポジトリでも普通のフォルダでも動作します。最初の調査を始める前に、読み込み済みのスキルディレクトリから同梱の `scripts/last30days.py --preflight` を実行するようホストのエージェントに頼んでください。ソースをチェックアウトしている場合、同等のコマンドは `python3 skills/last30days/scripts/last30days.py --preflight` です。設定の取得元、ブラウザのクッキーをどう扱う予定か、どのファイルを書き込む予定か、任意で使えるコマンド、無視されるプロジェクト設定を表示します。クッキーの読み取りもファイルの書き込みも調査の実行もしません。
+### ボールトの解決
 
-既定では、`npx skills` が検出したホスト向けにインストールされます。特定のホスト(または複数)を指定するには次のようにします。
+エクスポート先はこの順で解決されます:
+
+1. `--obsidian-vault PATH`（明示的に指定された存在しないパスはエクスポート用に作成される）
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. 既存の `~/Desktop/brain-paul`
+
+環境変数とデスクトップの候補は、すでにディレクトリとして存在している必要が
+あります。空または空白のみのボールト環境変数が設定されている場合、暗黙の
+フォールバックは意図的に無効化されます。どれも解決しない場合、コマンドは
+次のメッセージとともに停止します:
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+`.env` ファイルでは `~/...` または絶対パスを使ってください。`$HOME` はそこでは
+展開されません。既存のノートは決して上書きされません。ファイル名の衝突には
+数値の接尾辞が付きます。
+
+## 書き出されるもの
+
+ボールトルート直下のデフォルト構成:
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+ノートは上書きされません。同日の衝突には数値の接尾辞が付きます。トークンの
+重なりが検出された場合、関連する過去のランは Obsidian の `[[ウィキリンク]]`
+で結ばれます。
+
+## ソースとキー
+
+上流と同じ土台:
+
+- **デフォルトでキー不要:** Reddit、Hacker News、Polymarket、GitHub、Web
+- **オプション:** X（ブラウザ Cookie / バックエンド）、YouTube（`yt-dlp`）,
+  TikTok/IG（ScrapeCreators）、その他の有料/オプトイン バックエンド
+
+完全なマトリクスとキーの設定は
+[`CONFIGURATION.md`](CONFIGURATION.md) を参照してください。
+
+## 安全な診断
+
+リサーチの前に、権限のみのチェックを実行できます:
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` は安全です: **Cookie の読み取り、ファイルの書き込み、
+リサーチの実行を一切行わずに**動きます。ソースやインストール済みバックエンドの
+トラブルシューティングには、代わりにヘルスチェックを使ってください:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-あとから更新するには次のようにします。
+## 上流のモードもそのまま動く
 
 ```bash
-npx skills update last30days -g
+# オリジナルのコンパクトな合成エンベロープ
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# エージェント用 JSON
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# 本番向けブリーフ
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-`npx skills` でグローバルに入れたものをまとめて更新することもできます。
+## 上流との関係
+
+| 項目 | ポリシー |
+| --- | --- |
+| リサーチエンジン | `upstream/main` とマージ可能な状態を保つ |
+| Obsidian エクスポート | 追加モジュール: `lib/obsidian_export.py` |
+| ブランディング / スキル | `obsidian2date` |
+| ライセンス | MIT。上流の著作権表示を保持 |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-一覧表示と削除は `npx skills list -g` と `npx skills remove last30days -g` で行えます。
+## クレジット
 
-### claude.ai(ウェブ)
+- 上流リサーチエンジン: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Obsidian エクスポート経路 + 公開フォークのパッケージング: [pauleschwarz](https://github.com/pauleschwarz)
 
-1. 最新リリースから [`last30days.skill` をダウンロード](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)します
-2. [claude.ai > Customize > Skills](https://claude.ai/customize/skills) を開きます
-3. Skills パネルの `+` ボタンをクリックし、`Create skill` > `Upload a skill` と進んで、ファイルを選択するかドロップします
+## ライセンス
 
-先に Capabilities で「Code execution and file creation」を有効にしてください。これがないとスキルは動きません。
-
-### Claude Desktop
-
-Claude Desktop では、`.mcpb` バンドル(ワンクリック版の Model Context Protocol パッケージ)を使って `/last30days` を MCP サーバーとしてインストールします。
-
-1. [最新リリース](https://github.com/mvanhorn/last30days-skill/releases/latest)を開き、お使いのプラットフォーム向けの `.mcpb` をダウンロードします:
-   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Claude Desktop を開き、Settings > Extensions に移動して、ファイルをドラッグします。
-3. 求められたら、有効にしたい情報源のAPIキーを貼り付けます。どの項目も任意です。すべて省略した場合、エンジンはウェブのみのモードに切り替わります。キーはOSのキーチェーンに保存されます。
-4. Claude Desktop を再起動します。Claude に「Peter Steinberger について調べて」などと頼めば、`research` ツールが呼び出されます。
-
-**ホスト側の要件:** PATH の通った Python 3.12以上。バンドルにはエンジンのソースが含まれますが、実行にはローカルの Python インタプリタを使います。Windows では [python.org](https://www.python.org/downloads/) からインストールしてください。macOS とたいていの Linux ディストリビューションには、対応するバージョンが最初から入っています。
-
-**キーは Claude Code のスキルとは共有されません。** Claude Desktop と Claude Code は、設計上それぞれ別に認証情報を保管しています。Claude Code のスキル用にすでに `~/.config/last30days/.env` を設定していても、ここで同じキーをもう一度だけ入力する必要があります。
-
-Windows のサポートは、マニフェストのプラットフォーム別エントリーポイントが整理されるまで見送りとなっており、専用のIssueで追跡しています。
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-`/last30days` の調査以外で X/Twitter を操作したい場合 — ツイートや返信の投稿、
-フォロワーのエクスポート、メディアの扱い、モニタリング、プレゼント企画の抽選など —
-には、OpenClaw の補助プラグインとして [TweetClaw](https://github.com/Xquik-dev/tweetclaw)
-を使ってください。TweetClaw は Xquik-dev が管理しており、ここでは任意の補助的な
-選択肢として挙げているだけです。last30days の依存でも推奨でもありません。
-
-### 手動インストール(開発者向け)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-シンボリックリンクにしておけば、編集するたびに作業ツリーとインストール先が同期するので、コピーし直す必要はありません。`claude.ai` 用には、ソースから `.skill` ファイルをビルドしてください。`bash skills/last30days/scripts/build-skill.sh` で `dist/last30days.skill` が生成されます。
-
-Reddit(コメント込み)、Hacker News、Polymarket、GitHub はすぐに使えます。設定は不要です。`/last30days` を一度実行すれば、セットアップウィザードが30秒でさらに多くの情報源を有効にします。無料の arXiv と Techmeme の CLI も含まれます。
-
-## 自分のキーを持ち込む
-
-これらのプラットフォーム同士には何のつながりもありません。X は Reddit が何を考えているかを知りませんし、YouTube に TikTok は見えていません。しかし自分のAPIキーとブラウザのトークンを持ち込めば、それらすべてに一度にアクセスできるようになります。
-
-| 情報源 | 必要なもの | 費用 |
-|---------|---------------|------|
-| Reddit(コメント込み)+ HN + Polymarket + GitHub + StockTwits | 不要 | 無料 |
-| arXiv + Techmeme | 無料のCLI。初回セットアップが自動でインストールします | 無料 |
-| X / Twitter | 任意のブラウザで x.com にログインするか、`XQUIK_API_KEY` / `XAI_API_KEY` を設定 | ブラウザのクッキーは無料。キーの料金は提供元によります |
-| YouTube | `brew install yt-dlp` | 無料 |
-| Bluesky | bsky.app のアプリパスワード | 無料 |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube のコメント | ScrapeCreators のキー | 1万リクエストまで無料、以降は従量課金 |
-| Xiaohongshu(RED) | ログイン済みの x-mcp ブラウザプラグインか `xiaohongshu-mcp` サービスを動かしたうえで、実行ごとに `--search xhs` を付けるか `.env` に `INCLUDE_SOURCES=xiaohongshu` を設定して有効化します。last30days は `http://localhost:18060`、次に `http://host.docker.internal:18060` の順に自動で接続を試し、独自のURLを使う場合は `XIAOHONGSHU_API_BASE` を指定します | last30days 側のAPIキーは不要。ローカルのブラウザセッションのサービス次第です |
-| DripStack(有料の金融ニュースレター) | 任意で有効化: 実行ごとに `--search dripstack`、または `.env` に `INCLUDE_SOURCES=dripstack` | キー不要。無料の公開検索APIを使います |
-| Perplexity Agent API / Search API / Deep Research | Perplexity のキー、または Sonar の代替として OpenRouter のキー | 従量課金。直接キーで Agent API とバックグラウンド Deep Research が有効になります |
-| ウェブ検索 | Brave Search のキー | 月2,000クエリまで無料 |
-
-### macOS のキーチェーン(任意)
-
-macOS では、キーを `.env` ファイルではなくシステムのキーチェーンに保存できます。スキルは最も優先度の低い取得元として自動的に読み込むため、衝突した場合は `.env` ファイルとプロセスの環境変数が優先されます。
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-項目は現在のユーザー向けに、サービス名 `last30days-<KEY>` で保存されます。Darwin 以外のプラットフォームではローダーは何もしないため、Linux や Windows のユーザーにとって挙動は変わりません。
-
-すでに別のサービス名でキーチェーンにキーを保存している場合は、秘密情報をコピーする代わりに、[CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) で説明している秘密情報ではないマッピング `LAST30DAYS_KEYCHAIN_ALIASES` を設定してください。
-
-情報源ごとのキーの一覧、推論プロバイダーの優先順位、ウェブ検索バックエンドの優先順位については [CONFIGURATION.md](CONFIGURATION.md) を参照してください。
-
-## 設定
-
-初日に知っておくとよいことが2つあります。
-
-**調査ファイルの保存先。** `LAST30DAYS_MEMORY_DIR` の既定値は `~/Documents/Last30Days/` です(Windows では `C:\Users\<you>\Documents\Last30Days\`)。変更したい場合は、シェルでこの環境変数に任意のパスを設定するか、実行ごとに `--save-dir <path>` を指定します。レンダリング結果を特定のパスに出力したいときは `--output <file>` を使い、形式は `--emit` で選びます。同じトピックの複数のバリエーションを分けて残したいときは `--save-suffix=<name>` を使ってください(クライアントごとに分ける場合など)。`--save-dir` を付けた実行では `<slug>-raw[-suffix].md` が生成されます。調査を走らせる前に書き込み予定を確認するには `python3 skills/last30days/scripts/last30days.py --preflight` を実行してください。
-
-**エージェントやワークフロー向けの構造化出力。** `/last30days` に機械可読なJSONを求めると、安定したバージョン付きのエージェント向けプロファイルが返ります。スクリプトや開発でエンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json` を実行してください。バージョン管理されていない内部の `Report` のダンプが必要なときだけ `--json-profile=raw` を追加します。[JSONエクスポートのフィールド一覧とバージョニング方針](docs/reference/json-export.md)も参照してください。
-
-**トピックを決めないディスカバリー。** すでに知っているトピックを調べる代わりに、順位付きのディスカバリーブリーフがほしいときは `/last30days what's trending in AI agents?` と尋ねてください。エージェントを備えたホストでは、ホストが判定する3コマンドのプロトコルが走ります(モデルがトピックを挙げ、ノイズを除き、取り上げる価値を採点し、コンテンツの切り口を書きます)。スクリプトや cron でエンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` を実行します(単発実行。トピック名は決定論的で、切り口は付きません)。バージョン付きのディスカバリー契約がほしい場合は `--emit=json` を追加してください。ディスカバリーは、位置引数のトピックや `--drill` とは併用できません。
-
-**実行をまたいだトレンド監視。** 既定のモードでは、実行のたびに新しい Markdown のスナップショットが作られます。時間をかけて結果を蓄積したい場合は `--store` を付けて SQLite データベースに保存し、定期実行には [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py)(新しい結果が出たときの Slack や Webhook への通知も任意で設定できます)、日次・週次のまとめには [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) を使ってください。運用サイクルの全体像は [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings) にあります。
-
-**購読できる調査ライブラリ。** `/last30days` にライブラリのフィードを作らせるか、スクリプトや開発用には `python3 skills/last30days/scripts/last30days.py library feed` を直接使ってください。保存済みのブリーフが `index.html`、ローカルの Atom 形式の `feed.xml`、読みやすいブリーフのページに変換されます。HTML のインデックスとブリーフのページをホスティングしたいときだけ `--publish` を付けてください。公開は明示的に選ぶ形で、既定では誰でも見られる状態になります。Atom フィードを実際に購読できるようにするには、生成された出力ディレクトリを GitHub Pages のような静的ホスティングに置いてください。
-
-**これまで調べたものをすべて検索する。** `/last30days search my library for MCP servers` や `/last30days have I researched MCP servers before?` と尋ねてください。エンジンを直接使う場合は `python3 skills/last30days/scripts/last30days.py library search "MCP servers"` を実行します。この検索はオフラインかつ決定論的です。ライブラリのフィードが使うのと同じ保存済みブリーフを少しずつインデックス化し、実行ごとにストアへ記録された該当分をまとめ、トピックと日付で結果をグループ化します。新しく実行したときも、過去の調査が今回のトピックと重なっていれば、**From your library**(あなたのライブラリから)というコンパクトなセクションが表示されます。この受動的な文脈表示をやめたい場合は `LAST30DAYS_LIBRARY_CONTEXT=off` を設定してください。
-
-クライアントごとのラッパースクリプト、カテゴリー用のサブレディットのカスタマイズ、作業中のカスタマイズを試す実験的なベータチャンネルについても [CONFIGURATION.md](CONFIGURATION.md) に記載しています。
-
-## ショーケース: コミュニティの調査フィード
-
-last30days で、定期的なAIのまとめ、市場ウォッチ、あるいは見事にニッチな偏愛を公開しましたか。公開ライブラリのURL(または `feed.xml` を静的ホスティングに置いたあとの Atom のURL)を[コミュニティのショーケーススレッド](https://github.com/mvanhorn/last30days-skill/issues/532)で共有してください。コミュニティのフィードは、作者から届き次第ここにリンクしていきます。それまでのあいだは、このスレッドが集約先です。
-
-## 仕組み
-
-1. **トピックを入力します。** 人物、企業、プロダクト、技術、「X vs Y」。何でもかまいません。
-2. **エージェントが「誰が重要か」を特定します。** X のアカウント(創業者を含む)、GitHub のリポジトリ、サブレディット、TikTok のハッシュタグ、YouTube のチャンネルを見つけます。「Kanye West」なら r/hiphopheads、@kanyewest、YouTube の「bully review」だと分かります。「OpenClaw」なら GitHub 上の openclaw/openclaw を特定し、スター数をその場で取得します。
-3. **すべての情報源を並行して検索します。** 複数クエリへの展開。結果はエンゲージメント、関連性、新しさでスコア付けされます。
-4. **他にはない深さ。** リアクション動画の YouTube 全文文字起こし。アップボート数付きの Reddit のトップコメント。TikTok のキャプション。Polymarket のオッズ。タイトルとリンクだけではありません。
-5. **同じ話題はまとめます。** Reddit で告知され、X で語られ、TikTok にチケット価格が出た Wireless Festival は、3件の別々の項目ではなく1つのクラスターになります。
-6. **1本のブリーフに統合します。** 具体的なデータに基づき、情報源を明示し、実際に人々が反応したかどうかで順位を付けます。「見つけたものはこれです」ではなく「重要なのはこれです」を返します。
-7. **そのあとは、あなたの専門家になります。** 一度実行すれば、あなたの Claude のセッションはコミュニティが知っていることをすべて把握しています。続けて質問してください。プロンプトを書かせる、メールを下書きさせる、旅程を立てさせる、システム構成を設計させる。どれも「今、実際に起きていること」に基づきます。
-
-## 使っている人の声
-
-> 「Reddit、X、YouTube、HN を横断して直近30日のあらゆるトピックを調べてくれる Claude Code のスキルを見つけた。しかもプロンプトまで書いてくれる。書く記事ごとに、これまでは Reddit と X を手作業で調べていた。タブごと、スレッドごとに。そこが90分かかっていた部分だ。それがなくなる。」 — @itsjasonai
-
-> 「このスキル1つで、私の調査ワークフローがまるごと置き換わった。トピックを渡すと、Reddit、X、ウェブから人々が本当に話していることを拾ってくる。古いブログ記事ではなく、直近30日の生の会話だ。」 — @itswilsoncharles
-
-> 「今日 GitHub でトレンド入りしているリポジトリ10件のうち5件が Claude 関連のツール。1位は mvanhorn/last30days-skill」 — @yieldhunter95
-
-## オープンソース
-
-MIT ライセンス。トラッキングなし。アナリティクスなし。調査結果はあなたのマシンに残ります。テストは2,700件以上。
-
-Python 3.12以上、yt-dlp、Node.js(X 検索用に同梱した Bird クライアント)、ScrapeCreators API で構築しています。v3 のエンジンアーキテクチャは [@j-sperling](https://github.com/j-sperling) によるものです。
-
-PRの出し方は [CONTRIBUTING.md](CONTRIBUTING.md)、コミュニティの貢献者の一覧は [CONTRIBUTORS.md](CONTRIBUTORS.md)、バージョン履歴は [CHANGELOG.md](CHANGELOG.md) を参照してください。
-
-## スター数の推移
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT。[LICENSE](LICENSE) を参照。

--- a/README.md
+++ b/README.md
@@ -5,31 +5,48 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
 [![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
 
-`obsidian2date` researches what people actually say about a topic across
-Reddit, X, YouTube, HN, GitHub, Polymarket, and the web — over whatever window
-you ask for (last week, last 7 days, last 90 days; 30 days is just the
-default) — and turns each run into durable, linked Obsidian notes.
+`obsidian2date` turns a topic + time window into **durable, linked Obsidian
+notes** — sourced from what people actually say across Reddit, X, YouTube, HN,
+GitHub, Polymarket, and the open web.
 
-Each run produces:
+- **Window is yours:** last week, 7 days, 90 days, or a dated slice. **30 days
+  is only the default**, not the product name.
+- **Primary UX:** a multi-harness **Agent Skill** — type
+  `/obsidian2date <topic>` and get paths back. CLI is the fallback for cron and
+  debugging.
+- **Fork with a mergeable engine:** public fork of
+  [last30days-skill](https://github.com/mvanhorn/last30days-skill); upstream
+  research engine stays mergeable. Obsidian export and vault UX are the
+  opinionated layer on top.
 
-- a source-backed **run note**
-- a compact **briefing**
-- `[[wikilinks]]` to related runs
-- an updated **Index** and **Dashboard**
+Requires **Python 3.12+** and an **Obsidian vault**. API keys are optional —
+runs degrade cleanly when a source is unavailable. Full knobs:
+[CONFIGURATION.md](CONFIGURATION.md). Vocabulary: [CONCEPTS.md](CONCEPTS.md).
 
-No tracking. MIT. Public fork of
-[last30days-skill](https://github.com/mvanhorn/last30days-skill); the upstream
-research engine stays mergeable. Requires Python 3.12+ and an Obsidian vault;
-sources and API keys are optional — see
-[CONFIGURATION.md](CONFIGURATION.md).
+## What you get each run
+
+| Artifact | What it is |
+| --- | --- |
+| **Run note** | Source-backed note for this topic + window |
+| **Briefing** | Compact synthesis you can read in one sitting |
+| **Wikilinks** | `[[links]]` to related prior runs |
+| **Index + Dashboard** | Updated navigation over the research corpus |
+
+No tracking. MIT.
+
+## When to use / not use
+
+| Use when | Skip when |
+| --- | --- |
+| You want a **citable** sweep into a vault you own | You need a live chat answer with no files |
+| You re-research topics and want **compounding** notes | You only want a one-off web search |
+| An agent should run research **without you babysitting flags** | You need guaranteed coverage of paywalled sources |
 
 ## Use it as a slash command (primary path)
 
-`obsidian2date` is an Agent Skill: install the repo once, then just type
-`/obsidian2date <topic>` in your agent. The skill runs the research engine,
-resolves your vault, writes the notes, and reports the paths. No flags to
-memorize — say "last week" or "over the last 90 days" in the request and the
-skill translates it into the right engine flags.
+Install the skill once, then type `/obsidian2date <topic>`. Say the window in
+natural language ("last week", "over the last 90 days"); the skill maps that to
+engine flags.
 
 | Host | Install | Then |
 | --- | --- | --- |
@@ -38,22 +55,20 @@ skill translates it into the right engine flags.
 | Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <topic>` |
 | Gemini CLI | repo ships `gemini-extension.json` | `/obsidian2date <topic>` |
 | OpenClaw / agents.md hosts | repo ships `.agents/` manifest | `/obsidian2date <topic>` |
-| pi / any skills-capable agent | symlink or copy `skills/obsidian2date/` into the agent's skills dir | `/obsidian2date <topic>` |
+| pi / skills-capable agents | symlink or copy `skills/obsidian2date/` into the agent's skills dir | `/obsidian2date <topic>` |
 
-What the skill does on each run (see
-[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — the
-canonical runtime spec the model reads):
+Each run the skill (canonical contract:
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md)):
 
-1. resolve your vault (ask once, then remember for the session)
-2. derive the window from your request (default 30 days)
-3. run the research engine with `--emit=obsidian`
-4. report briefing path, run-note path, and any partial or unavailable sources honestly
+1. resolves your vault (ask once, remember for the session)
+2. derives the window (default **30** days)
+3. runs the research engine with `--emit=obsidian`
+4. reports briefing path, run-note path, and any partial / unavailable sources
+   honestly
 
 ## Quick start (CLI fallback)
 
-For scripting, cron, or dev-time engine testing, call the CLI directly. This
-is the fallback path, not the primary one — the slash command above is the
-product.
+For scripting, cron, or engine debugging — not the main product path:
 
 ```bash
 git clone https://github.com/pauleschwarz/obsidian2date.git
@@ -74,116 +89,78 @@ python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 
 ### Time window
 
-`30` days is only the default. Ask for anything:
-
 ```bash
-python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # last week
-python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # quarter sweep
+# last week
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7
+# quarter sweep
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90
+# fixed end date
 python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-In the slash command, just say it: "research the last 7 days of AI video
-tools".
+In the slash command, just say it: `research the last 7 days of AI video tools`.
 
-### Vault resolution
+### Vault resolution (order)
 
-The export target is resolved in this order:
-
-1. `--obsidian-vault PATH` (an explicit missing path is created for the export)
+1. `--obsidian-vault PATH` (explicit missing path may be created for export)
 2. `OBSIDIAN2DATE_VAULT`
 3. `LAST30DAYS_OBSIDIAN_VAULT`
-4. an existing `~/Desktop/brain-paul`
+4. existing `~/Desktop/brain-paul` (legacy convenience)
 
-Environment and desktop candidates must already be directories. A present empty
-or whitespace-only vault environment value intentionally disables implicit
-fallbacks. If nothing resolves, the command stops with:
+Environment and desktop candidates must already exist unless you pass an
+explicit `--obsidian-vault` you intend to create. Details:
+[CONFIGURATION.md](CONFIGURATION.md).
 
-```text
-No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
-```
+## Sources at a glance
 
-Use `~/...` or an absolute path in `.env` files; `$HOME` is not expanded there.
-Existing notes are never overwritten; filename collisions get a numeric suffix.
+The engine fans out across public and optional authenticated sources. **No key
+is required to install or to get a partial run.**
 
-## What gets written
+| Source family | Typical need | If missing |
+| --- | --- | --- |
+| HN, web fallbacks, public feeds | often none | reduced coverage |
+| Reddit / X / YouTube / GitHub / Polymarket / search APIs | optional tokens per [CONFIGURATION.md](CONFIGURATION.md) | source marked unavailable; other sources still write |
 
-Default layout under the vault root:
+Exact env vars, rate limits, and degrade behavior live in
+[CONFIGURATION.md](CONFIGURATION.md) — keep secrets out of the vault and out
+of git.
 
-```text
-90_Quellen/obsidian2date/
-  runs/YYYY-MM-DD-<slug>.md
-  briefings/YYYY-MM-DD-<slug>-briefing.md
-  Index.md
-  Dashboard.md
-```
+## Troubleshooting
 
-Notes never overwrite. Same-day collisions get numeric suffixes.
-Related prior runs are linked via Obsidian `[[wikilinks]]` when token overlap
-is detected.
-
-## Sources & keys
-
-Same floor as upstream:
-
-- **Keyless by default:** Reddit, Hacker News, Polymarket, GitHub, Web
-- **Optional:** X (browser cookies / backends), YouTube (`yt-dlp`), TikTok/IG
-  (ScrapeCreators), plus other paid/opt-in backends
-
-See [`CONFIGURATION.md`](CONFIGURATION.md) for the full matrix and key setup.
-
-## Safe diagnostics
-
-Run a permission-only check before research:
-
-```text
-$ python3 skills/last30days/scripts/last30days.py --preflight
-last30days preflight
-Status: Ready to research with safe defaults.
-...
-Local writes:
-- none planned
-```
-
-`--preflight` is safe: it runs **without reading cookies, writing files, or running research**.
-For troubleshooting sources or installed backends, use the health check instead:
-
-```bash
-python3 skills/last30days/scripts/last30days.py doctor
-```
-
-## Upstream modes still work
-
-```bash
-# original compact synthesis envelope
-python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
-
-# agent JSON
-python3 skills/last30days/scripts/last30days.py "topic" --emit=json
-
-# production brief
-python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
-```
-
-## Relationship to upstream
-
-| Concern | Policy |
+| Symptom | What to try |
 | --- | --- |
-| Research engine | Stay mergeable with `upstream/main` |
-| Obsidian export | Additive module: `lib/obsidian_export.py` |
-| Branding / skill | `obsidian2date` |
-| License | MIT; keep upstream copyright notices |
+| Skill can't find a vault | Set `OBSIDIAN2DATE_VAULT` or pass `--obsidian-vault`; confirm the folder exists |
+| Empty / thin briefing | Widen `--days`, check which sources reported unavailable, add optional keys only if you need that source |
+| Rate limits / blocks | Re-run later; reduce concurrency in config; don't hammer a single backend |
+| Notes landed in the wrong vault | Unset stale `LAST30DAYS_OBSIDIAN_VAULT` / desktop default; pass an explicit path once |
+| Python errors on 3.11 | Use **3.12+** |
 
-```bash
-git remote add upstream https://github.com/mvanhorn/last30days-skill.git
-git fetch upstream
-git merge upstream/main
-```
+## Docs map
 
-## Credits
+| Doc | Contents |
+| --- | --- |
+| [CONCEPTS.md](CONCEPTS.md) | Skill vs engine vs harness vocabulary |
+| [CONFIGURATION.md](CONFIGURATION.md) | Env, keys, flags, vault behavior |
+| [docs/](docs/README.md) | Search quality, reference, plans, releases |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup and PR expectations |
+| [CHANGELOG.md](CHANGELOG.md) | Release history |
+| [HERMES_SETUP.md](HERMES_SETUP.md) | Hermes-oriented setup notes |
+| [Plan: docs usability](docs/plans/2026-09-02-docs-usability.md) | Why this README looks like this |
 
-- Upstream research engine: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
-- Obsidian export path + public fork packaging: [pauleschwarz](https://github.com/pauleschwarz)
+## Locales
+
+**English `README.md` is canonical.** Localized files (`README.de.md`,
+`README.ja.md`, …) may lag; prefer EN when they conflict, then open a PR to
+sync.
+
+## Related tools
+
+| Tool | Layer |
+| --- | --- |
+| **obsidian2date** (this) | Research window → vault notes |
+| [pi-verity](https://github.com/pauleschwarz/pi-verity) | Deterministic proof that agent code changes match evidence |
+| [visual-qa](https://github.com/pauleschwarz/visual-qa) | Autonomous explore/fix/prove on a running web app |
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+MIT — [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,48 +1,47 @@
 # obsidian2date
 
-**Research the last 30 days. Land it cleanly in Obsidian.**
+**Research the last 30 days. Keep the useful parts in Obsidian.**
 
-`obsidian2date` is a public fork of
-[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill).
-The upstream multi-source research engine is kept intact. This fork adds a
-vault-native export path so every run becomes:
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
 
-- a durable **run note** with YAML frontmatter and an evidence index
-- a short **briefing** for daily skimming
-- **wikilinks** to related prior runs
-- an auto-updated **Index** + **Dashboard**
+`obsidian2date` researches Reddit, X, YouTube, HN, GitHub, Polymarket, and the
+web, then turns each run into durable, linked Obsidian notes. It is a public,
+MIT-licensed fork of [last30days-skill](https://github.com/mvanhorn/last30days-skill);
+the upstream research engine stays intact.
 
-MIT licensed. Upstream copyright retained. No tracking.
+Each Obsidian run produces:
 
-## Why this fork
+- a source-backed **run note**
+- a compact **briefing**
+- `[[wikilinks]]` to related runs
+- an updated **Index** and **Dashboard**
 
-last30days is excellent at *finding* what people are saying across Reddit, X,
-YouTube, HN, GitHub, Polymarket, and more. `obsidian2date` is opinionated about
-what happens next: the research should become **linked knowledge in your vault**,
-not a one-off chat dump.
+No tracking.
 
 ## Quick start
+
+Requires Python 3.12+.
 
 ```bash
 git clone https://github.com/pauleschwarz/obsidian2date.git
 cd obsidian2date
 
-# optional: point at your vault
-export OBSIDIAN2DATE_VAULT="$HOME/Desktop/brain-paul"
-
 python3 skills/last30days/scripts/last30days.py \
   "local LLM agent frameworks" \
-  --emit=obsidian
+  --emit=obsidian \
+  --obsidian-vault /path/to/your/vault
 ```
 
-If `OBSIDIAN2DATE_VAULT` / `LAST30DAYS_OBSIDIAN_VAULT` is unset, the exporter
-tries `~/Desktop/brain-paul` when that directory exists. Override anytime:
+Or configure the vault once:
 
 ```bash
-python3 skills/last30days/scripts/last30days.py "topic" \
-  --emit=obsidian \
-  --obsidian-vault /path/to/vault
+export OBSIDIAN2DATE_VAULT=/path/to/your/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
+
+The exporter also accepts `LAST30DAYS_OBSIDIAN_VAULT`. Existing notes are never
+overwritten; filename collisions get a numeric suffix.
 
 ## What gets written
 
@@ -60,15 +59,15 @@ Notes never overwrite. Same-day collisions get numeric suffixes.
 Related prior runs are linked via Obsidian `[[wikilinks]]` when token overlap
 is detected.
 
-## Agent skill entrypoints
+## Use it in an agent
 
-| Path | Role |
-| --- | --- |
-| [`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) | Vault-first skill (this fork's default) |
-| [`skills/last30days/SKILL.md`](skills/last30days/SKILL.md) | Full upstream research skill / doctor / setup |
+Load [`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) in your
+Agent Skills-compatible host. The upstream skill remains available at
+[`skills/last30days/SKILL.md`](skills/last30days/SKILL.md) for the original
+workflow and setup.
 
-Install whichever skill your harness loads (Claude Code marketplace, Codex,
-OpenClaw, plain checkout, etc.). For vault work, load `obsidian2date`.
+For a direct scripted run, use the CLI below. For key setup and all available
+backends, see [`CONFIGURATION.md`](CONFIGURATION.md).
 
 ## Upstream modes still work
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,45 @@ export OBSIDIAN2DATE_VAULT=/path/to/your/vault
 python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-The exporter also accepts `LAST30DAYS_OBSIDIAN_VAULT`. Existing notes are never
-overwritten; filename collisions get a numeric suffix.
+### Vault resolution
+
+The export target is resolved in this order:
+
+1. `--obsidian-vault PATH` (an explicit missing path is created for the export)
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. an existing `~/Desktop/brain-paul`
+
+Environment and desktop candidates must already be directories. A present empty
+or whitespace-only vault environment value intentionally disables implicit
+fallbacks. If nothing resolves, the command stops with:
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+Use `~/...` or an absolute path in `.env` files; `$HOME` is not expanded there.
+Existing notes are never overwritten; filename collisions get a numeric suffix.
+
+## Safe diagnostics
+
+Run a permission-only check before research:
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` is safe: it runs **without reading cookies, writing files, or running research**.
+For troubleshooting sources or installed backends, use the health check instead:
+
+```bash
+python3 skills/last30days/scripts/last30days.py doctor
+```
 
 ## What gets written
 

--- a/README.md
+++ b/README.md
@@ -1,382 +1,126 @@
-# /last30days
+# obsidian2date
 
-English | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
+**Research the last 30 days. Land it cleanly in Obsidian.**
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
-</p>
+`obsidian2date` is a public fork of
+[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill).
+The upstream multi-source research engine is kept intact. This fork adds a
+vault-native export path so every run becomes:
 
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
+- a durable **run note** with YAML frontmatter and an evidence index
+- a short **briefing** for daily skimming
+- **wikilinks** to related prior runs
+- an auto-updated **Index** + **Dashboard**
 
-**An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**
+MIT licensed. Upstream copyright retained. No tracking.
 
-This README tracks the current v3 pipeline. The runtime skill spec lives in [skills/last30days/SKILL.md](skills/last30days/SKILL.md), which is the source of truth for the latest command and setup behavior.
+## Why this fork
 
-**Claude Code (recommended — auto-updates via marketplace):**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
+last30days is excellent at *finding* what people are saying across Reddit, X,
+YouTube, HN, GitHub, Polymarket, and more. `obsidian2date` is opinionated about
+what happens next: the research should become **linked knowledge in your vault**,
+not a one-off chat dump.
 
-**Codex, Cursor, Copilot, Gemini CLI, or any of 50+ [Agent Skills](https://agentskills.io) hosts:**
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-(`-g` installs globally for your user, available across all projects. Drop it to scope per-project.)
-
-More install options (claude.ai web, OpenClaw, manual) in the [Install](#install) section below.
-
-Zero config. Reddit, HN, Polymarket, and GitHub work immediately. Run it once and the setup wizard unlocks X, YouTube, TikTok, arXiv, Techmeme, and more in 30 seconds.
-
----
-
-Reddit upvotes. X likes. YouTube transcripts. TikTok engagement. Polymarket odds backed by real money and insider information. That's millions of people voting with their attention and their wallets every day. /last30days searches all of it in parallel, scores it by what real people actually engage with, and an AI agent judge synthesizes it into one brief.
-
-Google aggregates editors. /last30days searches people.
-
-You can't get this search anywhere else because no single AI has access to all of it. Google search doesn't touch Reddit comments or X posts. ChatGPT has a deal with Reddit but can't search X or TikTok. Gemini has YouTube but not Reddit. Claude has none of them natively. Each platform is a walled garden with its own API, its own tokens, its own auth. But you can bring your own keys and browser sessions, and suddenly an AI agent can search all of them at once, score them against each other, and tell you what actually matters.
-
-That's the unlock. Not one better search engine. A dozen disconnected platforms, bridged by an agent.
-
-```
-/last30days Peter Steinberger
-```
-
-You have a meeting tomorrow. You Google them. You get their LinkedIn from 2023. /last30days gives you what they're actually doing this month: joined OpenAI to work on Codex, fighting Anthropic's ban on third-party agents, shipping 23 PRs at 85% merge rate, building "LobsterOS" for cross-device agent control, and r/ClaudeCode hit 569 upvotes debating whether he's a hero or "insufferable." Scattered across X posts, Reddit threads, YouTube transcripts, and GitHub commits. None of it was on Google.
-
-## Why this exists
-
-I built it to keep up in AI. Everything changes every day and the Reddit and X nerds are always on top of it first. I needed better prompts, and the training data was always months behind what the community had already figured out.
-
-But it turned into something bigger. Now I run it before a sales call to know the last 30 days truth about a business. Before a meeting to read someone's recent tweets and podcast transcripts. Before a Disney World trip to know which rides are closed and what the community says about Genie+. Before I build anything to know what problems people are actually hitting.
-
-If you're meeting with a CEO, have you read all their tweets and YouTube transcripts from the last 30 days? I have.
-
-## Sources, scored by the people
-
-| Source | What the people tell you |
-|--------|--------------------------|
-| **Reddit** | The unfiltered take. Top comments with real upvote counts, free, no API key. The real opinions that Google buries. |
-| **X / Twitter** | The hot take, the expert thread, the breaking reaction. First to know, first to argue. |
-| **YouTube** | The 45-minute deep dive. Full transcripts searched for the 5 quotable sentences that matter. |
-| **TikTok** | The creator reaching 3.6M people with a take you'll never find on Google. |
-| **Instagram Reels** | The influencer perspective with spoken-word transcripts. The visual culture signal. |
-| **Hacker News** | The developer consensus. 825 points, 899 comments. Where technical people actually argue. |
-| **Polymarket** | Not opinions. Odds. Backed by real money. 96% confidence on album sales. 4% on an acquisition. |
-| **GitHub** | For people: PR velocity, top repos by stars, release notes. For topics: issues and discussions. |
-| **Digg** | Curated story clusters from Digg's AI 1000 leaderboard (~1000 high-signal AI accounts on X), with attributable inline quotes (no X auth required). Auto-enabled when `digg-pp-cli` is on PATH. |
-| **arXiv** | The papers behind the hype. New research in the window, free, no API key. Auto-enabled when `arxiv-pp-cli` is on PATH (first-run setup installs it). |
-| **Techmeme** | The tech-news editorial layer, date-windowed to your 30 days. Free, no API key. Auto-enabled when `techmeme-pp-cli` is on PATH (first-run setup installs it). |
-| **LinkedIn** | The professional signal. Posts and articles, with articles weighted as high signal. |
-| **StockTwits** | Trader sentiment. Auto-activates when your topic is a ticker or crypto. |
-| **Threads** | The post-Twitter text layer. Conversations from creators and brands. |
-| **Pinterest** | Visual discovery. Pins, saves, and comments on products and ideas. |
-| **Xiaohongshu (RED)** | Chinese lifestyle, product, and creator signals. Requested explicitly with `--search xhs` when a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service is running locally. |
-| **Bluesky** | The decentralized social layer. AT Protocol posts from the post-Twitter migration. |
-| **Perplexity** | Controlled Agent API synthesis, OpenRouter Sonar fallback, raw Search API rows, and explicit Deep Research. |
-| **Web** | The editorial coverage, the blog comparisons. One signal of many, not the only one. |
-
-Community contributors keep adding more. Truth Social and other niche sources are in the engine with more on the way.
-
-A Reddit thread with 1,500 upvotes is a stronger signal than a blog post nobody read. A TikTok with 3.6M views tells you more about what's culturally relevant than a press release. Polymarket odds backed by $66K in volume are harder to argue with than a pundit's guess.
-
-The synthesis ranks by what real people actually engaged with. Social relevancy, not SEO relevancy.
-
-## What people actually use it for
-
-**Before a meeting.** `/last30days Peter Steinberger` - joined OpenAI's Codex team, fighting Anthropic's ban on third-party agents, 23 PRs merged at 85% merge rate on GitHub, building LobsterOS for cross-device agent control. r/ClaudeCode: "Ever since OpenClaw released, it was widely known that if you run it through anything other than the API, you were gonna get banned eventually" (227 upvotes). That's not on LinkedIn.
-
-**To read hiring signals.** `/last30days Listen Labs --hiring-signals` - current jobs and careers pages become cited evidence for focus shifts: hiring into enterprise security, customer success, infrastructure, or product expansion. The report says what the hiring appears to signal, not what the roadmap will ship.
-
-**To find the topic before it peaks.** Ask `/last30days what's exploding in AI agents?` and the skill switches to discovery mode: the engine sweeps Reddit category listings, Hacker News front/best stories, Digg's AI 1000 feed, and X when authenticated; your agent judges the nominations (names, junk filtering, content-worthiness) and writes podcast / X-article angles; then you get 5-10 velocity-ranked topics. Every result includes cross-source numbers, a momentum label, and a ready-to-run `/last30days "<topic>"` follow-up.
-
-**When something drops.** `/last30days Kanye West` - UK blocked his visa, Wireless Festival canceled, sponsors fled. But BULLY debuted #2 on Billboard. Fantano came back from his "Yay sabbatical" to review it (653K views). SoFi Homecoming brought out Lauryn Hill and Travis Scott for 44 songs. Polymarket: "Will Kanye tweet again?" 86% Yes. 23 Reddit threads, 17 YouTube videos, 86K upvotes.
-
-**To compare tools.** `/last30days OpenClaw vs Hermes vs Paperclip` - "These aren't competitors, they're layers." OpenClaw is the executor (351K GitHub stars, live), Hermes is the self-improving brain (31K stars), Paperclip is the org chart (49K stars). Star counts pulled live from the GitHub API, not stale blog posts. Side-by-side table with architecture, memory, security, best-for. Per @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
-
-**To understand the world.** `/last30days Iran vs USA` - Day 38 of the war. Trump's Tuesday deadline for Iran to reopen the Strait of Hormuz. Two US warplanes downed. Oil at $126/barrel. The IEA called it "the largest supply disruption in the history of the global oil market." Polymarket: ceasefire by Dec 31 at 74%. 27 X posts, 10 YouTube videos, 20 prediction markets.
-
-**Before a trip.** `/last30days Universal Epic Universe` - Expansion already under construction. "Project 680" permit filed. Fireworks show confirmed by infrastructure but unannounced. Wait times: Mine-Cart Madness averaging 148 minutes. No annual pass yet, and locals are frustrated. Stardust Racers down for refurbishment through April 5.
-
-**To learn something fast.** `/last30days Nano Banana Pro prompting` - JSON-structured prompts are replacing tag soup. @pictsbyai's nested format prevents "concept bleeding." Edit-first workflow beats regeneration. Then it writes you a production prompt using exactly what the community said works.
-
-## What's new
-
-Since the v3.3 announcement in May, as of v3.11.1 (July 2026): 175 merged PRs - 122 of them from 52 community contributors - across 15 releases. This is what landed.
-
-### First-class on OpenAI Codex
-
-/last30days is now a native Codex plugin with guided setup - not a port, a first-class citizen. Renderer-aware citations mean Codex output reads like a brief instead of URL soup (#694), and the same engine runs on Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw, and 50+ Agent Skills hosts. Codex plugin manifest by [@rfoust](https://github.com/rfoust) (#686), Codex auth fix by [@tmchow](https://github.com/tmchow) (#698).
-
-### arXiv, Techmeme, and Digg - free, no API keys
-
-arXiv brings the papers behind the hype and Techmeme brings the editorial tech-news layer - free, zero keys, and first-run setup installs their CLIs so they activate automatically (#709). Digg's AI 1000 story clusters arrive without X auth the same way - setup installs the free Digg CLI for you (#590). Trustpilot ships opt-in for consumer-brand research.
-
-### Free Reddit grew real scores and top comments
-
-Reddit's public .json API died; the free path came back stronger. Keyless RSS + shreddit scraping (#457), dedicated-subreddit discovery with real upvote counts via arctic-shift (#696), and a relevance floor so a viral off-topic post can't hijack your brief (#488, thanks [@rzachsmith](https://github.com/rzachsmith)). No API key. Real scores. Top comments included.
-
-### The best comments in every brief
-
-Comments are now a default-on layer across sources: Instagram comments with rank-based diversity so five hot takes don't all come from one post (#751), YouTube comments plus a ScrapeCreators transcript backup for when yt-dlp strikes out (#637), and crowd-voted comments weighted into Best Takes so the community's funniest lines survive scoring (#592, #608).
-
-### One doctor command
-
-Ask for a health check and the doctor runs every source, then prescribes exact fixes - which key is missing, which CLI is off PATH, which cookie expired (#753). No more guessing why X came back thin.
-
-### X search, rebuilt
-
-The X pipeline got a ground-up overhaul: FROM and ABOUT lanes so a person's own posts and the conversation about them both rank (#610), person-aware subquery disambiguation (#611), first-party authorship grounding with interaction-signal ranking (#613), and a single X source with automatic backend failover (#622). Plus an honest `--diagnose` that actually probes auth (#609).
-
-### More sources joined
-
-LinkedIn via ScrapeCreators, with articles as high signal ([@ravstr](https://github.com/ravstr), #702). StockTwits auto-activates for ticker and crypto topics ([@wtiwana](https://github.com/wtiwana), #658). Perplexity grew direct API modes and async Deep Research ([@sk-holmes](https://github.com/sk-holmes), #629).
-
-### Hardened by the community
-
-The security wave was almost entirely community work: stored-XSS fixes in the HTML renderer ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), locked-down cookie temp files, supply-chain-hardened CI with OpenSSF Scorecard and build provenance attestation ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), Semgrep and OSV-Scanner scans plus a PR dependency-review gate ([@23241a6749](https://github.com/23241a6749)), a test-coverage floor introduced at 60% and since raised to 84% ([@gourab5139014](https://github.com/gourab5139014)), and a Hermes security scan cleared of every CRITICAL finding (#768).
-
-### Reaches further
-
-Hebrew and non-Latin languages ([@dudyme](https://github.com/dudyme)). CJK-aware tokenization for Chinese sources ([@An-idd](https://github.com/An-idd)). A Windows compatibility wave. Cookie extraction across the full Chromium family - Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) - plus macOS Keychain and Linux pass(1) credential sources. `--as-of` historical lookback ([@chiyi-creator](https://github.com/chiyi-creator)). Auto-provisioned Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` for reading a company's job pages. Watchlist deltas between runs.
-
-### Still in the box from v3
-
-The v3 foundations are all still here: the pre-research brain that resolves the right handles, subreddits, and hashtags before a single API call fires (built by [@j-sperling](https://github.com/j-sperling)); Best Takes scoring for humor and virality alongside relevance; cross-source cluster merging; single-pass comparisons ("CLI vs MCP" in 3 minutes, not 12); auto-discovered `--competitors` comparisons; GitHub person-mode (`--github-user=steipete`); ELI5 mode ("eli5 on" after any run); and shareable, self-contained HTML briefs (`--emit=html`). Configuration knobs live in [CONFIGURATION.md](CONFIGURATION.md).
-
-## Install
-
-| Surface | Install | Updates |
-|---------|---------|---------|
-| **Claude Code** (recommended) | `/plugin marketplace add mvanhorn/last30days-skill` | Auto via marketplace, or `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` then `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI, or any of 50+ [Agent Skills](https://agentskills.io) hosts** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) and upload via claude.ai > Customize > Skills > + > Create skill > Upload a skill | Re-download and re-upload |
-| **Claude Desktop** | [Download the `.mcpb` for your platform](https://github.com/mvanhorn/last30days-skill/releases/latest) and drag into Settings > Extensions | Re-download and drag the new bundle in |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code (recommended)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Recommended because the Claude Code marketplace handles updates for you — the plugin cache is versioned and auto-refreshes when a new release publishes. Run `claude plugin update last30days@last30days-skill` to force a check.
-
-If you'd rather use the agent-skills install path on Claude Code, that's also supported:
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-The native plugin and the `npx skills` install can coexist. Note that Claude Code does not dedupe across install methods: if you have both the marketplace plugin and the `npx skills` copy active, `/last30days` will show two entries. Use one install method per machine.
-
-### Grok (xAI Build CLI)
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) installs last30days as a native plugin. Direct install tracks the repository:
+## Quick start
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+# optional: point at your vault
+export OBSIDIAN2DATE_VAULT="$HOME/Desktop/brain-paul"
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian
 ```
 
-Or add this repo as a marketplace source, then install by plugin name:
+If `OBSIDIAN2DATE_VAULT` / `LAST30DAYS_OBSIDIAN_VAULT` is unset, the exporter
+tries `~/Desktop/brain-paul` when that directory exists. Override anytime:
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+python3 skills/last30days/scripts/last30days.py "topic" \
+  --emit=obsidian \
+  --obsidian-vault /path/to/vault
 ```
 
-Add `--trust` to skip the install confirmation. Update with `grok plugin update last30days`. Grok also reads the Claude Code manifests for compatibility; the native `.grok-plugin/` pair is the first-class lane (and what an official [xAI marketplace](https://github.com/xai-org/plugin-marketplace) listing points at). `npx skills add` remains a valid cross-host fallback.
+## What gets written
 
-### Codex, Cursor, Copilot, Gemini CLI, and other Agent Skills hosts
+Default layout under the vault root:
 
-Install via the open [Agent Skills](https://agentskills.io) CLI — supports 50+ harnesses including `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose`, and more (full list on the [vercel-labs/skills repo](https://github.com/vercel-labs/skills)).
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Notes never overwrite. Same-day collisions get numeric suffixes.
+Related prior runs are linked via Obsidian `[[wikilinks]]` when token overlap
+is detected.
+
+## Agent skill entrypoints
+
+| Path | Role |
+| --- | --- |
+| [`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) | Vault-first skill (this fork's default) |
+| [`skills/last30days/SKILL.md`](skills/last30days/SKILL.md) | Full upstream research skill / doctor / setup |
+
+Install whichever skill your harness loads (Claude Code marketplace, Codex,
+OpenClaw, plain checkout, etc.). For vault work, load `obsidian2date`.
+
+## Upstream modes still work
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+# original compact synthesis envelope
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# agent JSON
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# production brief
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-The `-g` (global) flag installs to your user directory so the skill is available across all projects. Without `-g`, `npx skills` installs project-locally into `./.skills/` (committed with the repo). For a research-the-world tool, global is what you want.
+## Sources & keys
 
-Codex desktop and other folder-mode hosts can work in ordinary folders as well as Git repos. Before first research, ask the host agent to run the bundled `scripts/last30days.py --preflight` from the loaded skill directory; in a source checkout, the equivalent command is `python3 skills/last30days/scripts/last30days.py --preflight`. It shows the config source, browser-cookie plan, planned writes, optional commands, and ignored project config without reading cookies, writing files, or running research.
+Same floor as upstream:
 
-By default this installs for whichever harness `npx skills` detects. To target a specific one (or multiple):
+- **Keyless by default:** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Optional:** X (browser cookies / backends), YouTube (`yt-dlp`), TikTok/IG
+  (ScrapeCreators), plus other paid/opt-in backends
+
+See upstream [`CONFIGURATION.md`](CONFIGURATION.md) for the full matrix.
+
+## Python
+
+Requires Python ≥ 3.12 (3.13 verified for the Obsidian export tests).
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+PYTHONPATH=skills/last30days/scripts python3 -m unittest tests.test_obsidian_export -v
 ```
 
-Update later with:
+## Relationship to upstream
+
+| Concern | Policy |
+| --- | --- |
+| Research engine | Stay mergeable with `upstream/main` |
+| Obsidian export | Additive module: `lib/obsidian_export.py` |
+| Branding / skill | `obsidian2date` |
+| License | MIT; keep upstream copyright notices |
 
 ```bash
-npx skills update last30days -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-Or update everything you've installed globally via `npx skills`:
+## Credits
 
-```bash
-npx skills update -g
-```
+- Upstream research engine: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Obsidian export path + public fork packaging: [pauleschwarz](https://github.com/pauleschwarz)
 
-List and remove with `npx skills list -g` and `npx skills remove last30days -g`.
+## License
 
-### claude.ai (web)
-
-1. [Download `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) from the latest release
-2. Go to [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Click the `+` button in the Skills panel > click on `Create skill` > `Upload a skill` and browse/drop the file in
-
-Enable "Code execution and file creation" under Capabilities first — skills won't run without it.
-
-### Claude Desktop
-
-Claude Desktop installs `/last30days` as an MCP server via a `.mcpb` bundle (a one-click Model Context Protocol package).
-
-1. Go to the [latest release](https://github.com/mvanhorn/last30days-skill/releases/latest) and download the `.mcpb` for your platform:
-   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Open Claude Desktop, go to Settings > Extensions, and drag the file in.
-3. When prompted, paste API keys for the sources you want to enable. Every field is optional — the engine degrades to web-only mode if you skip them all. Keys are stored in your OS keychain.
-4. Restart Claude Desktop. Ask Claude to "research Peter Steinberger" or any topic and it will call the `research` tool.
-
-**Host requirement:** Python 3.12+ on PATH. The bundle ships the engine source but uses your local Python interpreter. Install from [python.org](https://www.python.org/downloads/) on Windows; macOS and most Linux distros ship a compatible version.
-
-**Keys don't sync with the Code skill.** Claude Desktop and Claude Code maintain separate credential stores by design. If you already configured `~/.config/last30days/.env` for the Code skill, you'll re-enter the same keys here once.
-
-Windows support is deferred until per-platform manifest entry points are sorted out; track in a follow-up issue.
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-For X/Twitter action workflows outside `/last30days` research, such as posting
-tweets or replies, follower export, media handling, monitors, and giveaway
-draws, use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) as the companion
-OpenClaw plugin. TweetClaw is maintained by Xquik-dev and is listed only as an
-optional companion path, not a last30days dependency or endorsement.
-
-### Manual (developer)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-The symlink keeps the install in sync with your working tree as you edit — no re-copy needed. For `claude.ai`, build the `.skill` file from source: `bash skills/last30days/scripts/build-skill.sh` produces `dist/last30days.skill`.
-
-Reddit (with comments), Hacker News, Polymarket, and GitHub work immediately. Zero configuration. Run `/last30days` once and the setup wizard unlocks more sources in 30 seconds, including the free arXiv and Techmeme CLIs.
-
-## Bring your own keys
-
-These platforms don't have relationships with each other. X doesn't know what Reddit thinks. YouTube doesn't see TikTok. But you can bring your own API keys and browser tokens, and suddenly you have access to all of them at once.
-
-| Sources | What you need | Cost |
-|---------|---------------|------|
-| Reddit (with comments) + HN + Polymarket + GitHub + StockTwits | Nothing | Free |
-| arXiv + Techmeme | Free CLIs, auto-installed by first-run setup | Free |
-| X / Twitter | Log into x.com in any browser, or set `XQUIK_API_KEY` / `XAI_API_KEY` | Browser cookies are free; keys are provider-specific |
-| YouTube | `brew install yt-dlp` | Free |
-| Bluesky | App password from bsky.app | Free |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube comments | ScrapeCreators key | 10,000 free calls, then PAYG |
-| Xiaohongshu (RED) | Run a logged-in x-mcp browser plugin or `xiaohongshu-mcp` service and opt in with `--search xhs` per run or `INCLUDE_SOURCES=xiaohongshu` in `.env`; last30days auto-probes `http://localhost:18060` then `http://host.docker.internal:18060`, or use `XIAOHONGSHU_API_BASE` for a custom URL | No last30days API key; depends on your local browser-session service |
-| DripStack (premium financial newsletters) | Opt-in: `--search dripstack` per run, or `INCLUDE_SOURCES=dripstack` in `.env` | No key; free public search API |
-| Perplexity Agent API / Search API / Deep Research | Perplexity key, or OpenRouter key as Sonar fallback | Pay as you go; a direct key enables Agent API and background Deep Research |
-| Web search | Brave Search key | 2,000 free queries/month |
-
-### macOS Keychain (optional)
-
-On macOS you can store keys in the system Keychain instead of a `.env` file. The skill picks them up automatically as the lowest-priority source — `.env` files and process environment still win on collision.
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-Items are stored under service name `last30days-<KEY>` for the current user. On non-Darwin platforms the loader is a no-op, so there is no behaviour change for Linux/Windows users.
-
-Already have keys under different Keychain service names? Set the non-secret `LAST30DAYS_KEYCHAIN_ALIASES` mapping described in [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) instead of copying secrets.
-
-See [CONFIGURATION.md](CONFIGURATION.md) for the full per-source key matrix, reasoning provider priority, and web-search backend priority.
-
-## Configuration
-
-Two things you'll likely want to know on day one:
-
-**Where research files are saved.** `LAST30DAYS_MEMORY_DIR` defaults to `~/Documents/Last30Days/` (Windows: `C:\Users\<you>\Documents\Last30Days\`). Override by setting that env var to any path in your shell, or `--save-dir <path>` per run. Use `--output <file>` when you need the rendered result at an exact path, using the format selected by `--emit`. Use `--save-suffix=<name>` to keep multiple variations of the same topic separate (e.g. per client). Each `--save-dir` run produces `<slug>-raw[-suffix].md`. Run `python3 skills/last30days/scripts/last30days.py --preflight` to review planned writes before a research run.
-
-**Structured output for agents and workflows.** Ask `/last30days` for machine-readable JSON to receive the stable, versioned agent profile. For direct engine use in scripts or development, run `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; add `--json-profile=raw` only when you need the unversioned internal `Report` dump. See the [JSON export field reference and versioning policy](docs/reference/json-export.md).
-
-**Topic-less discovery.** Ask `/last30days what's trending in AI agents?` to get a ranked discovery brief instead of researching a topic you already know - on an agent host this runs the three-command host-judged protocol (the model names topics, filters junk, scores worthiness, and writes the content angles). For direct engine use in scripts or cron, run `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (one-shot: deterministic topic names, no angles); add `--emit=json` for the versioned discovery contract. Discovery is mutually exclusive with a positional topic and `--drill`.
-
-**Trend monitoring across runs.** The default mode produces a fresh markdown snapshot per run. To accumulate findings over time, add `--store` to persist into a SQLite database, then use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) for scheduled runs (with optional Slack / webhook delivery on new findings) and [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) for daily / weekly digests. The full cadence pattern is in [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
-
-**A subscribable research library.** Ask `/last30days` to build your library feed, or use `python3 skills/last30days/scripts/last30days.py library feed` directly for scripting and development. It turns saved briefs into `index.html`, a local Atom `feed.xml`, and readable brief pages. Add `--publish` only when you want the HTML index and brief pages hosted; publishing is explicit opt-in and public by default. To make the Atom feed subscribable, host the generated output directory on a static host such as GitHub Pages.
-
-**Search everything you've researched.** Ask `/last30days search my library for MCP servers` or `/last30days have I researched MCP servers before?`. For direct engine use, run `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. Search is offline and deterministic: it incrementally indexes the same saved briefs used by the library feed, merges matching per-run store sightings, and groups results by topic and date. Fresh runs also surface a compact **From your library** section when prior research overlaps the current topic; set `LAST30DAYS_LIBRARY_CONTEXT=off` to disable that passive context.
-
-Per-client wrapper scripts, custom category-peer subreddits, and the experimental beta channel for in-progress customizations are also documented in [CONFIGURATION.md](CONFIGURATION.md).
-
-## Showcase: community research feeds
-
-Published a recurring AI update, market watch, or wonderfully narrow obsession with last30days? Share the public library URL—or the Atom URL after hosting `feed.xml` on a static host—in [the community showcase thread](https://github.com/mvanhorn/last30days-skill/issues/532). Community feeds will be linked here as their owners submit them; the thread is the collection point in the meantime.
-
-## How it works
-
-1. **You type a topic.** Person, company, product, technology, "X vs Y." Anything.
-2. **The agent resolves who matters.** Finds X handles (including founders), GitHub repos, subreddits, TikTok hashtags, YouTube channels. For "Kanye West" it knows r/hiphopheads, @kanyewest, and "bully review" on YouTube. For "OpenClaw" it resolves openclaw/openclaw on GitHub and fetches live star counts.
-3. **All sources searched in parallel.** Multi-query expansion. Results scored by engagement, relevance, freshness.
-4. **The depth nobody else has.** Full YouTube transcripts from reaction videos. Top Reddit comments with upvote counts. TikTok captions. Polymarket odds. Not just titles and links.
-5. **Same story, merged.** Wireless Festival announced on Reddit, discussed on X, ticket prices on TikTok = one cluster, not three separate items.
-6. **Synthesized into one brief.** Grounded in specific data. Cited by source. Ranked by what people actually engage with. Not "here's what I found." It's "here's what matters."
-7. **Then it becomes your expert.** After one run, your Claude session knows everything the community knows. Ask follow-up questions. Have it write prompts, draft emails, plan trips, architect systems - all grounded in what's real right now.
-
-## What people are saying
-
-> "I found a Claude Code skill that researches any topic across Reddit, X, YouTube, and HN from the last 30 days. Then writes the prompts for you. I've been manually searching Reddit and X for research before every piece of content I write. Tab by tab. Thread by thread. That's the part that takes 90 minutes. This eliminates it." -@itsjasonai
-
-> "This one skill replaced my entire research workflow. You give it a topic, it scrapes Reddit, X, and the web for what people are actually talking about. Not old blog posts. Real conversations from the last 30 days." -@itswilsoncharles
-
-> "5 of the 10 trending repos on GitHub today are Claude tools. #1: mvanhorn/last30days-skill" -@yieldhunter95
-
-## Open source
-
-MIT license. No tracking. No analytics. Your research stays on your machine. 2,700+ tests.
-
-Built with Python 3.12+, yt-dlp, Node.js (vendored Bird client for X search), and ScrapeCreators API. v3 engine architecture by [@j-sperling](https://github.com/j-sperling).
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) to open a PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list of community contributors, and [CHANGELOG.md](CHANGELOG.md) for version history.
-
-## Star History
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,27 +1,59 @@
 # obsidian2date
 
-**Research the last 30 days. Keep the useful parts in Obsidian.**
+**Research any recent window. Keep the useful parts in Obsidian.**
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
 [![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
 
-`obsidian2date` researches Reddit, X, YouTube, HN, GitHub, Polymarket, and the
-web, then turns each run into durable, linked Obsidian notes. It is a public,
-MIT-licensed fork of [last30days-skill](https://github.com/mvanhorn/last30days-skill);
-the upstream research engine stays intact.
+`obsidian2date` researches what people actually say about a topic across
+Reddit, X, YouTube, HN, GitHub, Polymarket, and the web — over whatever window
+you ask for (last week, last 7 days, last 90 days; 30 days is just the
+default) — and turns each run into durable, linked Obsidian notes.
 
-Each Obsidian run produces:
+Each run produces:
 
 - a source-backed **run note**
 - a compact **briefing**
 - `[[wikilinks]]` to related runs
 - an updated **Index** and **Dashboard**
 
-No tracking.
+No tracking. MIT. Public fork of
+[last30days-skill](https://github.com/mvanhorn/last30days-skill); the upstream
+research engine stays mergeable. Requires Python 3.12+ and an Obsidian vault;
+sources and API keys are optional — see
+[CONFIGURATION.md](CONFIGURATION.md).
 
-## Quick start
+## Use it as a slash command (primary path)
 
-Requires Python 3.12+.
+`obsidian2date` is an Agent Skill: install the repo once, then just type
+`/obsidian2date <topic>` in your agent. The skill runs the research engine,
+resolves your vault, writes the notes, and reports the paths. No flags to
+memorize — say "last week" or "over the last 90 days" in the request and the
+skill translates it into the right engine flags.
+
+| Host | Install | Then |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y` (or add this repo as a `.claude-plugin`) | `/obsidian2date <topic>` |
+| Codex | repo ships `.codex-plugin/plugin.json` | `/obsidian2date <topic>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <topic>` |
+| Gemini CLI | repo ships `gemini-extension.json` | `/obsidian2date <topic>` |
+| OpenClaw / agents.md hosts | repo ships `.agents/` manifest | `/obsidian2date <topic>` |
+| pi / any skills-capable agent | symlink or copy `skills/obsidian2date/` into the agent's skills dir | `/obsidian2date <topic>` |
+
+What the skill does on each run (see
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — the
+canonical runtime spec the model reads):
+
+1. resolve your vault (ask once, then remember for the session)
+2. derive the window from your request (default 30 days)
+3. run the research engine with `--emit=obsidian`
+4. report briefing path, run-note path, and any partial or unavailable sources honestly
+
+## Quick start (CLI fallback)
+
+For scripting, cron, or dev-time engine testing, call the CLI directly. This
+is the fallback path, not the primary one — the slash command above is the
+product.
 
 ```bash
 git clone https://github.com/pauleschwarz/obsidian2date.git
@@ -39,6 +71,19 @@ Or configure the vault once:
 export OBSIDIAN2DATE_VAULT=/path/to/your/vault
 python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
+
+### Time window
+
+`30` days is only the default. Ask for anything:
+
+```bash
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # last week
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # quarter sweep
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
+```
+
+In the slash command, just say it: "research the last 7 days of AI video
+tools".
 
 ### Vault resolution
 
@@ -60,6 +105,32 @@ No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
 Use `~/...` or an absolute path in `.env` files; `$HOME` is not expanded there.
 Existing notes are never overwritten; filename collisions get a numeric suffix.
 
+## What gets written
+
+Default layout under the vault root:
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Notes never overwrite. Same-day collisions get numeric suffixes.
+Related prior runs are linked via Obsidian `[[wikilinks]]` when token overlap
+is detected.
+
+## Sources & keys
+
+Same floor as upstream:
+
+- **Keyless by default:** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Optional:** X (browser cookies / backends), YouTube (`yt-dlp`), TikTok/IG
+  (ScrapeCreators), plus other paid/opt-in backends
+
+See [`CONFIGURATION.md`](CONFIGURATION.md) for the full matrix and key setup.
+
 ## Safe diagnostics
 
 Run a permission-only check before research:
@@ -80,32 +151,6 @@ For troubleshooting sources or installed backends, use the health check instead:
 python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-## What gets written
-
-Default layout under the vault root:
-
-```text
-90_Quellen/obsidian2date/
-  runs/YYYY-MM-DD-<slug>.md
-  briefings/YYYY-MM-DD-<slug>-briefing.md
-  Index.md
-  Dashboard.md
-```
-
-Notes never overwrite. Same-day collisions get numeric suffixes.
-Related prior runs are linked via Obsidian `[[wikilinks]]` when token overlap
-is detected.
-
-## Use it in an agent
-
-Load [`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) in your
-Agent Skills-compatible host. The upstream skill remains available at
-[`skills/last30days/SKILL.md`](skills/last30days/SKILL.md) for the original
-workflow and setup.
-
-For a direct scripted run, use the CLI below. For key setup and all available
-backends, see [`CONFIGURATION.md`](CONFIGURATION.md).
-
 ## Upstream modes still work
 
 ```bash
@@ -117,24 +162,6 @@ python3 skills/last30days/scripts/last30days.py "topic" --emit=json
 
 # production brief
 python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
-```
-
-## Sources & keys
-
-Same floor as upstream:
-
-- **Keyless by default:** Reddit, Hacker News, Polymarket, GitHub, Web
-- **Optional:** X (browser cookies / backends), YouTube (`yt-dlp`), TikTok/IG
-  (ScrapeCreators), plus other paid/opt-in backends
-
-See upstream [`CONFIGURATION.md`](CONFIGURATION.md) for the full matrix.
-
-## Python
-
-Requires Python ≥ 3.12 (3.13 verified for the Obsidian export tests).
-
-```bash
-PYTHONPATH=skills/last30days/scripts python3 -m unittest tests.test_obsidian_export -v
 ```
 
 ## Relationship to upstream

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,383 +1,196 @@
-# /last30days
+# obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | Português (Brasil) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days - an AI agent-led search engine that searches people, not editors" />
-</p>
-
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending #1 Repository Of The Day" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
-
-**Um buscador conduzido por um agente de IA, que pontua por votos positivos, curtidas e dinheiro de verdade — não por redações.**
-
-Este README descreve o pipeline v3 atual. A especificação de execução da skill fica em [skills/last30days/SKILL.md](skills/last30days/SKILL.md), que é a referência definitiva sobre o comportamento dos comandos e da configuração.
-
-**Claude Code (recomendado — atualizações automáticas via marketplace):**
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
-
-**Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ hosts do [Agent Skills](https://agentskills.io):**
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-(`-g` instala globalmente para o seu usuário, então fica disponível em todos os projetos. Omita essa flag se quiser limitar a instalação a um projeto.)
-
-Outras formas de instalar (claude.ai web, OpenClaw, manual) estão na seção [Instalação](#instalação), mais abaixo.
-
-Configuração zero. Reddit, HN, Polymarket e GitHub funcionam de imediato. Rode uma vez e o assistente de configuração libera X, YouTube, TikTok, arXiv, Techmeme e mais em 30 segundos.
-
----
-
-Os votos positivos do Reddit. As curtidas do X. As transcrições do YouTube. O engajamento no TikTok. As probabilidades do Polymarket, lastreadas em dinheiro de verdade e em informação privilegiada. São milhões de pessoas votando todo dia com a atenção e com o bolso. O /last30days busca tudo isso em paralelo, pontua pelo que as pessoas realmente engajam e um agente de IA atua como juiz para sintetizar tudo em um único briefing.
-
-O Google agrega redações. O /last30days busca pessoas.
-
-Essa busca você não encontra em nenhum outro lugar, porque nenhuma IA sozinha tem acesso a tudo. O Google não alcança nem os comentários do Reddit nem as publicações do X. O ChatGPT tem acordo com o Reddit, mas não consegue buscar no X nem no TikTok. O Gemini tem o YouTube, mas não o Reddit. O Claude não tem nenhum deles de forma nativa. Cada plataforma é um jardim murado, com API, tokens e autenticação próprios. Mas você pode trazer suas próprias chaves e sessões de navegador e, de repente, um agente de IA busca em todas ao mesmo tempo, compara umas com as outras e diz o que realmente importa.
-
-É esse o destravamento. Não é um buscador melhor: é uma dúzia de plataformas isoladas, conectadas por um agente.
-
-```
-/last30days Peter Steinberger
-```
-
-Você tem uma reunião amanhã. Procura a pessoa no Google. Aparece o LinkedIn dela de 2023. O /last30days entrega o que ela está fazendo de fato neste mês: entrou na OpenAI para trabalhar no Codex, enfrenta o veto da Anthropic a agentes de terceiros, entregou 23 PRs com 85 % de taxa de merge, constrói o "LobsterOS" para controlar agentes entre dispositivos, e uma thread no r/ClaudeCode chegou a 569 votos positivos discutindo se ele é um herói ou "insuportável". Tudo espalhado entre publicações no X, threads no Reddit, transcrições do YouTube e commits no GitHub. Nada disso estava no Google.
-
-## Por que isso existe
-
-Construí para acompanhar o ritmo da IA. Tudo muda todo dia, e o pessoal do Reddit e do X sempre sabe primeiro. Eu precisava de prompts melhores, e os dados de treinamento estavam sempre meses atrás do que a comunidade já tinha descoberto.
-
-Mas virou algo maior. Hoje eu rodo antes de uma call de vendas, para saber a verdade dos últimos 30 dias sobre uma empresa. Antes de uma reunião, para ler os tweets recentes e as transcrições de podcast de quem vou encontrar. Antes de uma viagem à Disney World, para saber quais brinquedos estão fechados e o que a comunidade acha do Genie+. Antes de construir qualquer coisa, para saber em quais problemas as pessoas realmente estão esbarrando.
-
-Se você vai se reunir com um CEO, já leu todos os tweets e todas as transcrições do YouTube dos últimos 30 dias? Eu li.
-
-## Fontes, pontuadas pelas pessoas
-
-| Fonte | O que as pessoas te contam |
-|--------|--------------------------|
-| **Reddit** | A opinião sem filtro. Os melhores comentários com a contagem real de votos positivos, de graça e sem chave de API. As opiniões de verdade que o Google enterra. |
-| **X / Twitter** | A opinião quente, a thread do especialista, a primeira reação ao factual. Os primeiros a saber, os primeiros a discutir. |
-| **YouTube** | A análise de 45 minutos. Transcrições completas, garimpadas atrás das 5 frases citáveis que importam. |
-| **TikTok** | O criador que alcança 3,6 milhões de pessoas com uma leitura que você nunca vai achar no Google. |
-| **Instagram Reels** | O olhar dos influenciadores, com a transcrição do que é falado. O sinal da cultura visual. |
-| **Hacker News** | O consenso da turma de desenvolvimento. 825 pontos, 899 comentários. Onde o pessoal técnico discute de verdade. |
-| **Polymarket** | Não são opiniões. São probabilidades. Lastreadas em dinheiro de verdade. 96 % de confiança em vendas de um álbum. 4 % em uma aquisição. |
-| **GitHub** | Para pessoas: ritmo de PRs, principais repositórios por estrelas, notas de versão. Para assuntos: issues e discussions. |
-| **Digg** | Agrupamentos de histórias curados a partir do ranking AI 1000 do Digg (cerca de 1000 contas de IA com alto sinal no X), com citações atribuíveis embutidas e sem exigir autenticação no X. Ativa sozinho quando `digg-pp-cli` está no PATH. |
-| **arXiv** | Os artigos científicos por trás do hype. Pesquisa nova dentro da janela, de graça e sem chave de API. Ativa sozinho quando `arxiv-pp-cli` está no PATH (a configuração inicial instala). |
-| **Techmeme** | A camada editorial do noticiário de tecnologia, limitada à sua janela de 30 dias. De graça e sem chave de API. Ativa sozinho quando `techmeme-pp-cli` está no PATH (a configuração inicial instala). |
-| **LinkedIn** | O sinal profissional. Publicações e artigos, com os artigos ponderados como sinal forte. |
-| **StockTwits** | O humor dos traders. Ativa automaticamente quando seu assunto é um ticker ou uma cripto. |
-| **Threads** | A camada de texto do pós-Twitter. Conversas de criadores e marcas. |
-| **Pinterest** | Descoberta visual. Pins, itens salvos e comentários sobre produtos e ideias. |
-| **Xiaohongshu (RED)** | Sinais chineses sobre estilo de vida, produtos e criadores. É pedido explicitamente com `--search xhs` quando há um plugin de navegador x-mcp logado ou um serviço `xiaohongshu-mcp` rodando localmente. |
-| **Bluesky** | A camada social descentralizada. Publicações do AT Protocol vindas da migração pós-Twitter. |
-| **Perplexity** | Síntese controlada da Agent API, alternativa Sonar via OpenRouter, resultados brutos da Search API e Deep Research explícito. |
-| **Web** | A cobertura editorial, as comparações de blog. Um sinal entre muitos, não o único. |
-
-A comunidade não para de acrescentar fontes. Truth Social e outras fontes de nicho já estão no motor, e vêm mais por aí.
-
-Uma thread do Reddit com 1.500 votos positivos é um sinal mais forte do que um post de blog que ninguém leu. Um TikTok com 3,6 milhões de visualizações diz mais sobre o que é culturalmente relevante do que qualquer release de imprensa. Probabilidades do Polymarket lastreadas em US$ 66 mil de volume são bem mais difíceis de contestar do que o palpite de um comentarista.
-
-A síntese ordena pelo que as pessoas de verdade realmente engajaram. Relevância social, não relevância de SEO.
-
-## Para que as pessoas realmente usam
-
-**Antes de uma reunião.** `/last30days Peter Steinberger` — entrou no time do Codex na OpenAI, enfrenta o veto da Anthropic a agentes de terceiros, 23 PRs mergeados com 85 % de taxa de merge no GitHub, constrói o LobsterOS para controlar agentes entre dispositivos. r/ClaudeCode: "Desde que o OpenClaw saiu, todo mundo já sabia que, se você rodasse por qualquer coisa que não fosse a API, uma hora ia ser banido" (227 votos positivos). Isso não está no LinkedIn.
-
-**Para ler sinais de contratação.** `/last30days Listen Labs --hiring-signals` — as vagas e páginas de carreira atuais viram evidência citada de mudança de prioridade: contratação em segurança para empresas, customer success, infraestrutura ou expansão de produto. O relatório diz o que a contratação parece sinalizar, não o que o roadmap vai entregar.
-
-**Para achar o assunto antes do pico.** Pergunte `/last30days what's exploding in AI agents?` e a skill muda para o modo descoberta: o motor varre as listagens por categoria do Reddit, a capa e as melhores histórias do Hacker News, o feed AI 1000 do Digg e o X quando você está autenticado; seu agente avalia as indicações (nomes, filtragem de ruído, se rende conteúdo) e escreve ângulos para podcast ou para um artigo no X; depois você recebe de 5 a 10 assuntos ordenados por velocidade. Cada resultado traz números de várias fontes, um rótulo de momentum e um comando `/last30days "<topic>"` pronto para rodar.
-
-**Quando alguma coisa é lançada.** `/last30days Kanye West` — o Reino Unido bloqueou o visto dele, o Wireless Festival foi cancelado, os patrocinadores fugiram. Mas BULLY estreou em 2º na Billboard. Fantano voltou do "Yay sabbatical" para resenhar o disco (653 mil visualizações). No SoFi Homecoming, ele levou Lauryn Hill e Travis Scott ao palco para 44 músicas. Polymarket: "Kanye vai tuitar de novo?" 86 % sim. 23 threads no Reddit, 17 vídeos no YouTube, 86 mil votos positivos.
-
-**Para comparar ferramentas.** `/last30days OpenClaw vs Hermes vs Paperclip` — "Não são concorrentes, são camadas." O OpenClaw é a camada de execução (351 mil estrelas no GitHub, em produção), o Hermes é o cérebro que se aprimora sozinho (31 mil estrelas), o Paperclip é o organograma (49 mil estrelas). As contagens de estrelas vêm ao vivo da API do GitHub, não de posts de blog desatualizados. Tabela lado a lado com arquitetura, memória, segurança e melhor caso de uso. Segundo @IMJustinBrooke: "OpenClaw = Charmander, Hermes = Charizard."
-
-**Para entender o mundo.** `/last30days Iran vs USA` — dia 38 da guerra. O ultimato de Trump, com prazo até terça, para o Irã reabrir o Estreito de Ormuz. Dois caças americanos abatidos. Petróleo a US$ 126 o barril. A AIE chamou o episódio de "a maior interrupção de fornecimento da história do mercado global de petróleo". Polymarket: cessar-fogo até 31 de dezembro a 74 %. 27 publicações no X, 10 vídeos no YouTube, 20 mercados de previsão.
-
-**Antes de uma viagem.** `/last30days Universal Epic Universe` — a expansão já está em obras. Alvará do "Project 680" protocolado. Show de fogos confirmado pela infraestrutura, mas ainda não anunciado. Tempo de espera: Mine-Cart Madness com média de 148 minutos. Ainda sem passe anual, e os moradores estão irritados. Stardust Racers fechada para reforma até 5 de abril.
-
-**Para aprender algo rápido.** `/last30days Nano Banana Pro prompting` — prompts estruturados em JSON estão substituindo a sopa de tags. O formato aninhado do @pictsbyai evita o "concept bleeding". Editar ganha de regerar. E depois a skill escreve um prompt de produção usando exatamente o que a comunidade disse que funciona.
-
-## Novidades
-
-Desde o anúncio da v3.3 em maio e até a v3.11.1 (julho de 2026): 175 PRs mergeados — 122 deles de 52 pessoas da comunidade — distribuídos em 15 versões. Foi isso que entrou.
-
-### Cidadão de primeira classe no OpenAI Codex
-
-O /last30days agora é um plugin nativo do Codex com configuração guiada: não é um port, é cidadão de primeira classe. As citações levam o renderizador em conta, então a saída no Codex se lê como um briefing e não como uma sopa de URLs (#694), e o mesmo motor roda no Claude Code, Cursor, Copilot, Gemini CLI, Claude Desktop, OpenClaw e em 50+ hosts do Agent Skills. Manifesto do plugin do Codex por [@rfoust](https://github.com/rfoust) (#686), correção de autenticação no Codex por [@tmchow](https://github.com/tmchow) (#698).
-
-### arXiv, Techmeme e Digg — de graça, sem chaves de API
-
-O arXiv traz os artigos científicos por trás do hype e o Techmeme traz a camada editorial do noticiário de tecnologia — de graça, sem nenhuma chave, e a configuração inicial instala as CLIs deles para que ativem sozinhos (#709). Os agrupamentos de histórias AI 1000 do Digg chegam do mesmo jeito, sem autenticação no X: a configuração instala a CLI gratuita do Digg para você (#590). O Trustpilot está disponível como opção para pesquisa de marcas de consumo.
-
-### Reddit gratuito, com pontuações reais e melhores comentários
-
-A API pública .json do Reddit morreu; o caminho gratuito voltou mais forte. RSS sem chave e scraping do shreddit (#457), descoberta de subreddits específicos com contagem real de votos positivos via arctic-shift (#696) e um piso de relevância para que um post viral fora do tema não sequestre seu briefing (#488, valeu [@rzachsmith](https://github.com/rzachsmith)). Sem chave de API. Pontuações reais. Melhores comentários incluídos.
-
-### Os melhores comentários em cada briefing
-
-Os comentários agora são uma camada ligada por padrão em todas as fontes: comentários do Instagram com diversidade baseada em ranking, para que cinco opiniões fortes não venham todas do mesmo post (#751), comentários do YouTube mais um backup de transcrição via ScrapeCreators para quando o yt-dlp falha (#637), e comentários votados pela comunidade entrando com peso no Best Takes, para que as melhores tiradas sobrevivam à pontuação (#592, #608).
-
-### Um único comando doctor
-
-Peça um diagnóstico: o doctor testa cada fonte e receita as correções exatas — qual chave está faltando, qual CLI não está no PATH, qual cookie expirou (#753). Chega de adivinhar por que o X voltou fraco.
-
-### A busca no X, reconstruída
-
-O pipeline do X foi refeito do zero: faixas FROM e ABOUT para que tanto as publicações da própria pessoa quanto a conversa sobre ela sejam ranqueadas (#610), desambiguação de subconsultas conforme a pessoa buscada (#611), verificação de autoria de primeira mão com ranqueamento por sinais de interação (#613) e uma única fonte X com failover automático entre backends (#622). Além de um `--diagnose` honesto, que testa a autenticação de verdade (#609).
-
-### Mais fontes entraram
-
-LinkedIn via ScrapeCreators, com artigos como sinal forte ([@ravstr](https://github.com/ravstr), #702). O StockTwits ativa sozinho em assuntos de ticker e cripto ([@wtiwana](https://github.com/wtiwana), #658). O Perplexity ganhou modos de API diretos e Deep Research assíncrono ([@sk-holmes](https://github.com/sk-holmes), #629).
-
-### Endurecido pela comunidade
-
-A onda de segurança foi quase toda trabalho da comunidade: correções de XSS armazenado no renderizador HTML ([@iliaal](https://github.com/iliaal), [@aaronjmars](https://github.com/aaronjmars)), arquivos temporários de cookie protegidos, CI endurecida contra ataques à cadeia de suprimentos com OpenSSF Scorecard e atestação de proveniência de build ([@shaanmajid](https://github.com/shaanmajid), [@hammadxcm](https://github.com/hammadxcm), [@aniruddh909](https://github.com/aniruddh909)), varreduras com Semgrep e OSV-Scanner mais um portão de revisão de dependências em cada PR ([@23241a6749](https://github.com/23241a6749)), um piso de cobertura de testes criado em 60 % e desde então elevado para 84 % ([@gourab5139014](https://github.com/gourab5139014)), e uma varredura de segurança do Hermes que hoje não tem nenhum achado CRITICAL (#768).
-
-### Alcança mais longe
-
-Hebraico e outras línguas não latinas ([@dudyme](https://github.com/dudyme)). Tokenização adaptada a CJK para fontes chinesas ([@An-idd](https://github.com/An-idd)). Uma onda de compatibilidade com Windows. Extração de cookies em toda a família Chromium — Brave, Edge, Vivaldi, Opera, Arc ([@andrey-esipov](https://github.com/andrey-esipov)) — além do Keychain do macOS e do pass(1) no Linux como origens de credenciais. Consulta retroativa com `--as-of` ([@chiyi-creator](https://github.com/chiyi-creator)). Provisionamento automático do Python 3.12 via uv ([@buntysomroy](https://github.com/buntysomroy)). `--hiring-signals` para ler as páginas de vagas de uma empresa. Deltas de watchlist entre execuções.
-
-### O que já vinha de fábrica desde a v3
-
-As bases da v3 continuam todas aqui: o cérebro de pré-pesquisa, que identifica os handles, subreddits e hashtags certos antes de disparar uma única chamada de API (construído por [@j-sperling](https://github.com/j-sperling)); a pontuação Best Takes, que considera humor e viralidade além de relevância; a fusão de clusters entre fontes; as comparações em uma única passada ("CLI vs MCP" em 3 minutos, não em 12); as comparações `--competitors` descobertas automaticamente; o modo pessoa do GitHub (`--github-user=steipete`); o modo ELI5 ("eli5 on" depois de qualquer execução); e os briefings HTML autocontidos e compartilháveis (`--emit=html`). Os ajustes de configuração estão em [CONFIGURATION.md](CONFIGURATION.md).
-
-## Instalação
-
-| Ambiente | Instalação | Atualizações |
-|---------|---------|---------|
-| **Claude Code** (recomendado) | `/plugin marketplace add mvanhorn/last30days-skill` | Automáticas via marketplace, ou `claude plugin update last30days@last30days-skill` |
-| **Grok** (xAI Build CLI) | `grok plugin marketplace add mvanhorn/last30days-skill` e depois `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex, Cursor, Copilot, Gemini CLI, ou qualquer um dos 50+ hosts do [Agent Skills](https://agentskills.io)** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai** (web) | [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) e envie por claude.ai > Customize > Skills > + > Create skill > Upload a skill | Baixar de novo e enviar de novo |
-| **Claude Desktop** | [Baixe o `.mcpb` da sua plataforma](https://github.com/mvanhorn/last30days-skill/releases/latest) e arraste para Settings > Extensions | Baixar de novo e arrastar o novo pacote |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code (recomendado)
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-Recomendado porque o marketplace do Claude Code cuida das atualizações por você: o cache do plugin é versionado e se atualiza sozinho quando sai uma versão nova. Rode `claude plugin update last30days@last30days-skill` para forçar uma verificação.
-
-Se preferir usar o caminho de instalação do Agent Skills no Claude Code, ele também é suportado:
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-O plugin nativo e a instalação com `npx skills` podem conviver. Só atenção: o Claude Code não deduplica entre métodos de instalação. Se você tiver ativos ao mesmo tempo o plugin do marketplace e a cópia do `npx skills`, o `/last30days` vai aparecer duas vezes. Use um método de instalação por máquina.
-
-### Grok (xAI Build CLI)
-
-O [Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces) (`grok`) instala o last30days como plugin nativo. A instalação direta acompanha o repositório:
+**Pesquise qualquer janela recente. Mantenha o útil no Obsidian.**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
+
+O `obsidian2date` pesquisa o que as pessoas realmente dizem sobre um tema no
+Reddit, X, YouTube, HN, GitHub, Polymarket e na web — sobre a janela que você
+pedir (semana passada, últimos 7 dias, últimos 90 dias; 30 dias é só o
+padrão) — e transforma cada execução em notas de Obsidian duráveis e
+interligadas.
+
+Cada execução produz:
+
+- uma **nota de execução** respaldada por fontes
+- um **briefing** compacto
+- `[[wikilinks]]` para execuções relacionadas
+- um **Índice** e um **Dashboard** atualizados
+
+Sem rastreamento. MIT. Fork público de
+[last30days-skill](https://github.com/mvanhorn/last30days-skill); o motor de
+pesquisa upstream permanece mesclável. Requer Python 3.12+ e um vault do
+Obsidian; fontes e chaves de API são opcionais — veja
+[CONFIGURATION.md](CONFIGURATION.md).
+
+## Use como comando de barra (caminho principal)
+
+O `obsidian2date` é um Agent Skill: instale o repositório uma vez e depois
+digite `/obsidian2date <tema>` no seu agente. O skill roda o motor de
+pesquisa, resolve o seu vault, escreve as notas e informa os caminhos. Sem
+flags para memorizar — diga "semana passada" ou "nos últimos 90 dias" no
+pedido e o skill traduz para as flags corretas do motor.
+
+| Host | Instalação | Depois |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y` (ou adicione este repo como `.claude-plugin`) | `/obsidian2date <tema>` |
+| Codex | o repositório inclui `.codex-plugin/plugin.json` | `/obsidian2date <tema>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <tema>` |
+| Gemini CLI | o repositório inclui `gemini-extension.json` | `/obsidian2date <tema>` |
+| OpenClaw / hosts agents.md | o repositório inclui o manifesto `.agents/` | `/obsidian2date <tema>` |
+| pi / qualquer agente com skills | crie um symlink ou copie `skills/obsidian2date/` para o diretório de skills do agente | `/obsidian2date <tema>` |
+
+O que o skill faz em cada execução (veja
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) — a
+especificação de runtime canônica que o modelo lê):
+
+1. resolver o seu vault (perguntar uma vez, lembrar pela sessão)
+2. derivar a janela do seu pedido (padrão: 30 dias)
+3. rodar o motor de pesquisa com `--emit=obsidian`
+4. informar com honestidade o caminho do briefing, da nota de execução e quaisquer fontes parciais ou indisponíveis
+
+## Início rápido (fallback CLI)
+
+Para scripts, cron ou testes do motor em desenvolvimento, chame a CLI
+diretamente. Este é o caminho de reserva, não o principal — o comando de
+barra acima é o produto.
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /caminho/para/seu/vault
 ```
 
-Ou adicione este repositório como fonte de marketplace e depois instale pelo nome do plugin:
+Ou configure o vault uma vez:
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/caminho/para/seu/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-Acrescente `--trust` para pular a confirmação de instalação. Atualize com `grok plugin update last30days`. O Grok também lê os manifestos do Claude Code por compatibilidade; o par nativo `.grok-plugin/` é o caminho principal — e é para ele que aponta um registro oficial no [marketplace da xAI](https://github.com/xai-org/plugin-marketplace). O `npx skills add` continua sendo uma alternativa válida em qualquer host.
+### Janela de tempo
 
-### Codex, Cursor, Copilot, Gemini CLI e outros hosts do Agent Skills
-
-Instale pela CLI aberta do [Agent Skills](https://agentskills.io) — ela suporta 50+ hosts, entre eles `codex`, `cursor`, `github-copilot`, `gemini-cli`, `claude-code`, `windsurf`, `cline`, `continue`, `roo`, `aider-desk`, `opencode`, `goose` e outros (lista completa no [repositório vercel-labs/skills](https://github.com/vercel-labs/skills)).
+`30` dias é só o padrão. Peça o que quiser:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # semana passada
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # varredura de um trimestre
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-A flag `-g` (global) instala no seu diretório de usuário, então a skill fica disponível em todos os projetos. Sem `-g`, o `npx skills` instala só no projeto, dentro de `./.skills/` (e vai versionado junto com o repositório). Para uma ferramenta feita para pesquisar o mundo inteiro, o que você quer é a instalação global.
+No comando de barra, é só dizer: "pesquise os últimos 7 dias de AI video
+tools".
 
-O Codex desktop e outros hosts que trabalham no nível de pasta funcionam tanto em pastas comuns quanto em repositórios Git. Antes da primeira pesquisa, peça ao agente host que rode o `scripts/last30days.py --preflight` que acompanha a skill, a partir do diretório da skill carregada; em um clone do código-fonte, o comando equivalente é `python3 skills/last30days/scripts/last30days.py --preflight`. Ele mostra de onde vem a configuração, quais cookies do navegador seriam lidos, quais arquivos seriam escritos, quais comandos opcionais existem e qual configuração de projeto está sendo ignorada — sem ler cookies, sem escrever arquivos e sem rodar pesquisa nenhuma.
+### Resolução do vault
 
-Por padrão, a instalação vale para o host que o `npx skills` detectar. Para mirar em um específico (ou em vários):
+O destino de exportação é resolvido nesta ordem:
+
+1. `--obsidian-vault PATH` (um caminho explícito inexistente é criado para a exportação)
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. um `~/Desktop/brain-paul` existente
+
+Os candidatos de ambiente e desktop já devem ser diretórios. Um valor de
+ambiente de vault presente porém vazio ou só com espaços desativa
+deliberadamente os fallbacks implícitos. Se nada resolver, o comando para
+com:
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+Use `~/...` ou caminho absoluto em arquivos `.env`; `$HOME` não é expandido
+lá. Notas existentes nunca são sobrescritas; colisões de nome de arquivo
+ganham um sufixo numérico.
+
+## O que é escrito
+
+Layout padrão sob a raiz do vault:
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+Notas nunca são sobrescritas. Colisões no mesmo dia ganham sufixos
+numéricos. Execuções anteriores relacionadas são ligadas via `[[wikilinks]]`
+do Obsidian quando sobreposição de tokens é detectada.
+
+## Fontes e chaves
+
+Mesmo piso do upstream:
+
+- **Sem chave por padrão:** Reddit, Hacker News, Polymarket, GitHub, Web
+- **Opcionais:** X (cookies do navegador / backends), YouTube (`yt-dlp`),
+  TikTok/IG (ScrapeCreators), além de outros backends pagos/opt-in
+
+Veja [`CONFIGURATION.md`](CONFIGURATION.md) para a matriz completa e a
+configuração de chaves.
+
+## Diagnóstico seguro
+
+Rode uma verificação só de permissões antes de pesquisar:
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+O `--preflight` é seguro: roda **sem ler cookies, escrever arquivos ou
+iniciar a pesquisa**. Para diagnosticar fontes ou backends instalados, use
+em vez disso a checagem de saúde:
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-Para atualizar depois:
+## Os modos do upstream continuam funcionando
 
 ```bash
-npx skills update last30days -g
+# envelope compacto de síntese original
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# JSON para agentes
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# brief de produção
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-Ou atualize tudo que você instalou globalmente pelo `npx skills`:
+## Relação com o upstream
+
+| Aspecto | Política |
+| --- | --- |
+| Motor de pesquisa | Permanecer mesclável com `upstream/main` |
+| Exportação para Obsidian | Módulo aditivo: `lib/obsidian_export.py` |
+| Marca / skill | `obsidian2date` |
+| Licença | MIT; manter os avisos de copyright do upstream |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-Dá para listar e remover com `npx skills list -g` e `npx skills remove last30days -g`.
+## Créditos
 
-### claude.ai (web)
+- Motor de pesquisa upstream: [Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Caminho de exportação para Obsidian + empacotamento do fork público: [pauleschwarz](https://github.com/pauleschwarz)
 
-1. [Baixe `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill) da versão mais recente
-2. Vá em [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. Clique no botão `+` no painel de Skills, depois em `Create skill` > `Upload a skill`, e escolha ou arraste o arquivo
+## Licença
 
-Ative antes "Code execution and file creation" em Capabilities — sem isso, as skills não rodam.
-
-### Claude Desktop
-
-O Claude Desktop instala o `/last30days` como servidor MCP por meio de um pacote `.mcpb` (um pacote Model Context Protocol de um clique).
-
-1. Vá até a [versão mais recente](https://github.com/mvanhorn/last30days-skill/releases/latest) e baixe o `.mcpb` da sua plataforma:
-   - macOS Apple Silicon: `last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel: `last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64: `last30days-pp-mcp-linux-amd64.mcpb`
-2. Abra o Claude Desktop, vá em Settings > Extensions e arraste o arquivo para lá.
-3. Quando for solicitado, cole as chaves de API das fontes que quiser ativar. Todo campo é opcional — se pular todos, o motor cai para o modo só web. As chaves ficam guardadas no chaveiro do seu sistema operacional.
-4. Reinicie o Claude Desktop. Peça ao Claude para "pesquisar sobre Peter Steinberger", ou sobre qualquer outro assunto, e ele vai chamar a ferramenta `research`.
-
-**Requisito do host:** Python 3.12+ no PATH. O pacote traz o código do motor, mas usa o seu interpretador Python local. No Windows, instale a partir do [python.org](https://www.python.org/downloads/); o macOS e a maioria das distribuições Linux já vêm com uma versão compatível.
-
-**As chaves não são compartilhadas com a skill do Claude Code.** O Claude Desktop e o Claude Code mantêm armazenamentos de credenciais separados de propósito. Se você já configurou o `~/.config/last30days/.env` para a skill do Claude Code, vai precisar digitar essas mesmas chaves aqui uma vez.
-
-O suporte a Windows está adiado até que os pontos de entrada por plataforma no manifesto sejam resolvidos; o acompanhamento fica em uma issue à parte.
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-Para fluxos de ação no X/Twitter fora da pesquisa do `/last30days` — publicar
-tweets ou respostas, exportar seguidores, cuidar de mídia, monitorar contas e
-apurar sorteios — use o [TweetClaw](https://github.com/Xquik-dev/tweetclaw) como
-plugin complementar do OpenClaw. O TweetClaw é mantido pelo Xquik-dev e aparece
-aqui apenas como opção complementar: não é dependência nem recomendação do
-last30days.
-
-### Manual (para quem desenvolve)
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-O symlink mantém a instalação em sincronia com sua árvore de trabalho conforme você edita — não precisa copiar de novo. Para o `claude.ai`, compile o arquivo `.skill` a partir do código-fonte: `bash skills/last30days/scripts/build-skill.sh` gera `dist/last30days.skill`.
-
-Reddit (com comentários), Hacker News, Polymarket e GitHub funcionam de imediato. Configuração zero. Rode `/last30days` uma vez e o assistente de configuração libera mais fontes em 30 segundos, incluindo as CLIs gratuitas do arXiv e do Techmeme.
-
-## Traga suas próprias chaves
-
-Essas plataformas não têm relação nenhuma entre si. O X não sabe o que o Reddit pensa. O YouTube não enxerga o TikTok. Mas você pode trazer suas próprias chaves de API e tokens de navegador e, de repente, tem acesso a todas ao mesmo tempo.
-
-| Fontes | O que você precisa | Custo |
-|---------|---------------|------|
-| Reddit (com comentários) + HN + Polymarket + GitHub + StockTwits | Nada | De graça |
-| arXiv + Techmeme | CLIs gratuitas, instaladas automaticamente pela configuração inicial | De graça |
-| X / Twitter | Faça login em x.com em qualquer navegador, ou defina `XQUIK_API_KEY` / `XAI_API_KEY` | Os cookies do navegador são gratuitos; as chaves dependem do provedor |
-| YouTube | `brew install yt-dlp` | De graça |
-| Bluesky | Uma senha de aplicativo do bsky.app | De graça |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + comentários do YouTube | Uma chave do ScrapeCreators | 10.000 chamadas gratuitas e depois pagamento por uso |
-| Xiaohongshu (RED) | Deixe rodando um plugin de navegador x-mcp logado ou um serviço `xiaohongshu-mcp` e habilite a fonte com `--search xhs` por execução ou com `INCLUDE_SOURCES=xiaohongshu` no `.env`; o last30days testa automaticamente `http://localhost:18060` e depois `http://host.docker.internal:18060`, ou use `XIAOHONGSHU_API_BASE` para uma URL própria | Não precisa de chave de API do last30days; depende do seu serviço local de sessão de navegador |
-| DripStack (newsletters financeiras premium) | Opcional: `--search dripstack` por execução, ou `INCLUDE_SOURCES=dripstack` no `.env` | Sem chave; API de busca pública e gratuita |
-| Perplexity Agent API / Search API / Deep Research | Uma chave do Perplexity, ou uma chave do OpenRouter como alternativa para o Sonar | Pagamento por uso; uma chave direta ativa a Agent API e o Deep Research em segundo plano |
-| Busca na web | Uma chave do Brave Search | 2.000 consultas gratuitas por mês |
-
-### Keychain do macOS (opcional)
-
-No macOS você pode guardar as chaves no Keychain do sistema em vez de em um arquivo `.env`. A skill as encontra automaticamente como a origem de menor prioridade — em caso de conflito, os arquivos `.env` e o ambiente do processo continuam ganhando.
-
-```bash
-# Interactive setup — prompts for each known key, skip with empty input
-skills/last30days/scripts/setup-keychain.sh
-
-# Or store a single key by hand
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# Inspect / clean up
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-Os itens ficam guardados sob o nome de serviço `last30days-<KEY>` para o usuário atual. Em plataformas que não são Darwin o carregador não faz nada, então não há mudança de comportamento para quem usa Linux ou Windows.
-
-Já tem chaves guardadas com outros nomes de serviço no Keychain? Defina o mapeamento não secreto `LAST30DAYS_KEYCHAIN_ALIASES` descrito em [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items), em vez de copiar segredos.
-
-Veja [CONFIGURATION.md](CONFIGURATION.md) para a matriz completa de chaves por fonte, a ordem de prioridade dos provedores de raciocínio e a dos backends de busca web.
-
-## Configuração
-
-Duas coisas que você provavelmente vai querer saber no primeiro dia:
-
-**Onde os arquivos de pesquisa são salvos.** O `LAST30DAYS_MEMORY_DIR` aponta por padrão para `~/Documents/Last30Days/` (no Windows: `C:\Users\<you>\Documents\Last30Days\`). Para mudar, defina essa variável de ambiente no seu shell com o caminho que quiser, ou use `--save-dir <path>` em uma execução específica. Use `--output <file>` quando precisar do resultado renderizado em um caminho exato, no formato escolhido por `--emit`. Use `--save-suffix=<name>` para manter separadas várias variações do mesmo assunto (por cliente, por exemplo). Cada execução com `--save-dir` gera `<slug>-raw[-suffix].md`. Rode `python3 skills/last30days/scripts/last30days.py --preflight` para conferir o que será escrito antes de disparar uma pesquisa.
-
-**Saída estruturada para agentes e fluxos de trabalho.** Peça ao `/last30days` um JSON legível por máquina e você recebe o perfil de agente estável e versionado. Para usar o motor direto em scripts ou no desenvolvimento, rode `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`; use `--json-profile=raw` só quando precisar do dump interno não versionado do `Report`. Veja a [referência de campos da exportação JSON e a política de versionamento](docs/reference/json-export.md).
-
-**Descoberta sem assunto definido.** Pergunte `/last30days what's trending in AI agents?` para receber um briefing de descoberta ordenado, em vez de pesquisar um assunto que você já conhece. Em um host com agente, isso executa o protocolo de três comandos arbitrado pelo host (o modelo nomeia os assuntos, filtra ruído, avalia o que vale a pena e escreve os ângulos de conteúdo). Para usar o motor direto em scripts ou no cron, rode `python3 skills/last30days/scripts/last30days.py --discover "AI agents"` (passada única: nomes de assunto determinísticos, sem ângulos); acrescente `--emit=json` para o contrato de descoberta versionado. A descoberta é mutuamente exclusiva com um assunto posicional e com `--drill`.
-
-**Monitoramento de tendências entre execuções.** O modo padrão gera um snapshot Markdown novo a cada execução. Para acumular achados ao longo do tempo, acrescente `--store` e eles ficam guardados em um banco SQLite; depois use [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) para execuções agendadas (com envio opcional por Slack ou webhook quando surgirem achados novos) e [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) para resumos diários ou semanais. O padrão de cadência completo está em [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings).
-
-**Uma biblioteca de pesquisa que dá para assinar.** Peça ao `/last30days` que monte o feed da sua biblioteca, ou use direto `python3 skills/last30days/scripts/last30days.py library feed` para scripts e desenvolvimento. Ele transforma os briefings salvos em um `index.html`, um `feed.xml` Atom local e páginas de briefing legíveis. Acrescente `--publish` só quando quiser hospedar o índice HTML e as páginas de briefing; publicar é uma decisão explícita e, por padrão, é público. Para o feed Atom ficar realmente assinável, hospede o diretório de saída gerado em um serviço estático como o GitHub Pages.
-
-**Busque em tudo que você já pesquisou.** Pergunte `/last30days search my library for MCP servers` ou `/last30days have I researched MCP servers before?`. Para usar o motor direto, rode `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`. A busca é offline e determinística: ela indexa aos poucos os mesmos briefings salvos que o feed da biblioteca usa, junta as ocorrências correspondentes registradas no store a cada execução e agrupa os resultados por assunto e data. Execuções novas também exibem uma seção compacta **From your library** ("da sua biblioteca") quando pesquisas anteriores se sobrepõem ao assunto atual; defina `LAST30DAYS_LIBRARY_CONTEXT=off` para desativar esse contexto passivo.
-
-Scripts wrapper por cliente, subreddits de categoria personalizados e o canal beta experimental para personalizações em andamento também estão documentados em [CONFIGURATION.md](CONFIGURATION.md).
-
-## Vitrine: feeds de pesquisa da comunidade
-
-Publicou com o last30days um panorama recorrente de IA, um acompanhamento de mercado ou uma obsessão maravilhosamente específica? Compartilhe a URL da sua biblioteca pública — ou a URL do Atom, depois de hospedar o `feed.xml` em um serviço estático — na [thread de vitrine da comunidade](https://github.com/mvanhorn/last30days-skill/issues/532). Os feeds da comunidade serão linkados aqui conforme as pessoas os enviarem; enquanto isso, a thread é o ponto de coleta.
-
-## Como funciona
-
-1. **Você digita um assunto.** Pessoa, empresa, produto, tecnologia, "X vs Y". Qualquer coisa.
-2. **O agente descobre quem importa.** Ele encontra os perfis do X (inclusive de fundadores), os repositórios do GitHub, os subreddits, as hashtags do TikTok e os canais do YouTube. Para "Kanye West" ele sabe que o caminho é r/hiphopheads, @kanyewest e "bully review" no YouTube. Para "OpenClaw" ele resolve openclaw/openclaw no GitHub e busca a contagem de estrelas ao vivo.
-3. **Todas as fontes buscadas em paralelo.** Expansão com várias consultas. Resultados pontuados por engajamento, relevância e frescor.
-4. **A profundidade que ninguém mais tem.** Transcrições completas do YouTube de vídeos de reação. Os melhores comentários do Reddit com a contagem de votos positivos. As legendas dos TikToks. As probabilidades do Polymarket. Não só títulos e links.
-5. **Mesma história, unificada.** O Wireless Festival anunciado no Reddit, discutido no X e com preço de ingresso no TikTok vira um cluster só, não três itens separados.
-6. **Sintetizado em um único briefing.** Ancorado em dados específicos. Citado por fonte. Ordenado pelo que as pessoas realmente engajam. Não é "olha o que eu encontrei", é "olha o que importa".
-7. **E então ele vira o seu especialista.** Depois de uma única execução, sua sessão do Claude sabe tudo o que a comunidade sabe. Faça perguntas de acompanhamento. Peça para escrever prompts, redigir e-mails, planejar viagens, desenhar arquiteturas — tudo ancorado no que é real agora.
-
-## O que as pessoas estão dizendo
-
-> "Achei uma skill do Claude Code que pesquisa qualquer assunto no Reddit, X, YouTube e HN dos últimos 30 dias. E ainda escreve os prompts pra você. Antes de cada conteúdo que eu escrevo, eu fazia essa busca na mão no Reddit e no X. Aba por aba. Thread por thread. É justamente essa a parte que leva 90 minutos. Isso elimina ela." — @itsjasonai
-
-> "Essa skill sozinha substituiu todo o meu fluxo de pesquisa. Você dá um assunto e ela raspa Reddit, X e a web atrás do que as pessoas estão falando de verdade. Nada de post de blog velho. Conversas reais dos últimos 30 dias." — @itswilsoncharles
-
-> "5 dos 10 repositórios em alta no GitHub hoje são ferramentas do Claude. O nº 1: mvanhorn/last30days-skill" — @yieldhunter95
-
-## Código aberto
-
-Licença MIT. Sem rastreamento. Sem analytics. Sua pesquisa fica na sua máquina. Mais de 2.700 testes.
-
-Construído com Python 3.12+, yt-dlp, Node.js (cliente Bird embarcado para a busca no X) e a API do ScrapeCreators. Arquitetura do motor v3 por [@j-sperling](https://github.com/j-sperling).
-
-Veja [CONTRIBUTING.md](CONTRIBUTING.md) para abrir um PR, [CONTRIBUTORS.md](CONTRIBUTORS.md) para a lista completa de quem contribuiu e [CHANGELOG.md](CHANGELOG.md) para o histórico de versões.
-
-## Histórico de estrelas
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT. Veja [LICENSE](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,381 +1,187 @@
-# /last30days
+# obsidian2date
 
 [English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](README.es.md) | [Português (Brasil)](README.pt-BR.md) | [日本語](README.ja.md) | 简体中文
 
-<p align="center">
-  <img src="media/pr-assets/last30days-ad.gif" width="720" alt="last30days——由 AI 智能体驱动、搜索真实用户而非编辑内容的搜索引擎" />
-</p>
-
-<p align="center">
-  <a href="https://github.com/mvanhorn/last30days-skill">
-    <img src="https://img.shields.io/badge/%231-Repository%20Of%20The%20Day-6f42c1?style=for-the-badge&logo=github&label=GITHUB%20TRENDING" alt="GitHub Trending 单日排名第一的仓库" />
-  </a>
-  <br/>
-  <a href="https://trendshift.io/repositories/21997" target="_blank">
-    <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-</p>
-
-**一个由 AI 智能体驱动的搜索引擎：按赞同票、点赞和真金白银评分，而不是由编辑决定。**
-
-本文档对应当前的 v3 流水线。运行时 Skill 规范位于 [skills/last30days/SKILL.md](skills/last30days/SKILL.md)，最新命令与配置行为以该文件为准。
-
-**Claude Code（推荐——通过 marketplace 自动更新）：**
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-/plugin install last30days
-```
-
-**Codex、Cursor、Copilot、Gemini CLI，或其他 50 多个支持 [Agent Skills](https://agentskills.io) 的宿主：**
-
-```
-npx skills add mvanhorn/last30days-skill -g
-```
-
-（`-g` 会安装到当前用户的全局环境，所有项目均可使用；去掉该参数则仅安装到当前项目。）
-
-更多安装方式（claude.ai 网页版、OpenClaw、手动安装）见下方[安装](#安装)章节。
-
-开箱即用。Reddit、Hacker News、Polymarket 和 GitHub 无需配置即可搜索。首次运行时，配置向导会在 30 秒内帮你解锁 X、YouTube、TikTok、arXiv、Techmeme 等更多来源。
-
----
-
-Reddit 的赞同票、X 的点赞、YouTube 的完整字幕、TikTok 的互动数据，以及由真金白银和内幕信息支撑的 Polymarket 概率——每天都有数百万人用注意力和钱包投票。`/last30days` 会并行搜索这些平台，按照真实用户的参与度评分，再由 AI 智能体裁判综合成一份简报。
-
-Google 聚合编辑选出的内容，`/last30days` 搜索真实的人。
-
-你无法从别的单一搜索产品获得这些结果，因为没有哪个 AI 天生能访问所有平台。Google 搜不到 Reddit 评论和 X 帖子；ChatGPT 虽然与 Reddit 合作，却无法搜索 X 或 TikTok；Gemini 能访问 YouTube，却没有 Reddit；Claude 原生不具备这些能力。每个平台都是一座围墙花园，有自己的 API、令牌和认证机制。但只要接入你自己的密钥和浏览器会话，AI 智能体就能同时搜索所有平台、横向比较信号，并告诉你真正值得关注的内容。
-
-这才是关键：不是再造一个更好的搜索引擎，而是让一个智能体把十几个彼此割裂的平台连接起来。
-
-```
-/last30days Peter Steinberger
-```
-
-假设你明天要和一个人开会。用 Google 搜他，你看到的可能还是 2023 年的 LinkedIn 页面；`/last30days` 告诉你的则是他这个月真正做了什么：加入 OpenAI 参与 Codex、反对 Anthropic 禁止第三方智能体、提交 23 个 PR 且合并率达到 85%、打造用于跨设备智能体控制的 “LobsterOS”，以及 r/ClaudeCode 上一场获得 569 个赞同票的争论——他究竟是英雄，还是“令人难以忍受”。这些信息散落在 X 帖子、Reddit 讨论、YouTube 字幕和 GitHub 提交中，Google 上根本没有。
-
-## 为什么要做这个项目
-
-最初，我做它是为了跟上 AI 的变化。这个领域每天都在变，而 Reddit 和 X 上的极客通常最先发现新东西。我需要更好的提示词，但模型训练数据总比社区已经摸索出的经验慢几个月。
-
-后来，它变成了更大的东西。现在，销售通话前，我用它了解一家公司过去 30 天的真实动态；开会前，我用它读完对方最近的推文和播客字幕；去迪士尼世界前，我用它确认哪些项目停运、社区怎么看 Genie+；开始做任何产品前，我用它找出人们真正遇到的问题。
-
-如果你要见一位 CEO，你读过他过去 30 天的所有推文和 YouTube 字幕吗？我读过。
-
-## 由真实用户评分的信息源
-
-| 来源 | 人们会告诉你什么 |
-|------|------------------|
-| **Reddit** | 未经过滤的真实看法。免费获取带实际赞同数的热门评论，无需 API 密钥；那些常被 Google 埋没的真实意见。 |
-| **X / Twitter** | 犀利观点、专家长帖和突发事件的第一反应。最早知道，也最早争论。 |
-| **YouTube** | 45 分钟的深度内容。搜索完整字幕，只提取真正值得引用的 5 句话。 |
-| **TikTok** | 一个触达 360 万人的创作者观点——你永远不会在 Google 上搜到。 |
-| **Instagram Reels** | 带口播字幕的影响者视角，反映视觉文化的信号。 |
-| **Hacker News** | 开发者共识：825 分、899 条评论，技术从业者真正交锋的地方。 |
-| **Polymarket** | 不是观点，而是由真金白银支撑的概率：专辑销量 96%，收购概率 4%。 |
-| **GitHub** | 搜人时查看 PR 速度、按 Star 排名的热门仓库和发行说明；搜主题时查看 Issue 与 Discussion。 |
-| **Digg** | 来自 Digg AI 1000 排行榜（约 1,000 个高信号 X 账号）的精选话题聚类，包含可追溯的行内引用，无需 X 认证。当 PATH 中存在 `digg-pp-cli` 时自动启用。 |
-| **arXiv** | 热点背后的论文。免费查找时间窗口内的新研究，无需 API 密钥。当 PATH 中存在 `arxiv-pp-cli` 时自动启用（首次配置会安装）。 |
-| **Techmeme** | 科技新闻的编辑视角，并按你设定的 30 天窗口筛选。免费且无需 API 密钥。当 PATH 中存在 `techmeme-pp-cli` 时自动启用（首次配置会安装）。 |
-| **LinkedIn** | 职业领域的信号。搜索帖子和文章，其中文章被视为高价值信号。 |
-| **StockTwits** | 交易者情绪。当主题是股票代码或加密货币时自动启用。 |
-| **Threads** | 后 Twitter 时代的文字内容层，汇集创作者和品牌的讨论。 |
-| **Pinterest** | 视觉发现：围绕产品和创意的 Pin、收藏与评论。 |
-| **小红书（RED）** | 来自中国生活方式、产品和创作者的信号。当本机运行已登录的 x-mcp 浏览器插件或 `xiaohongshu-mcp` 服务时，通过 `--search xhs` 显式启用。 |
-| **Bluesky** | 去中心化的社交内容层，搜索 Twitter 用户迁移后产生的 AT Protocol 帖子。 |
-| **Perplexity** | 受控 Agent API 综合结果、OpenRouter Sonar 回退、原始 Search API 数据和显式 Deep Research。 |
-| **Web** | 编辑报道和博客对比。它只是众多信号之一，而不是唯一来源。 |
-
-社区贡献者仍在不断加入更多平台。Truth Social 等垂直来源已经进入引擎，更多来源也在路上。
-
-一条获得 1,500 个赞同票的 Reddit 帖子，信号强度高于一篇无人阅读的博客；一个拥有 360 万次观看的 TikTok，比新闻稿更能说明当下的文化热点；一个有 6.6 万美元成交量支撑的 Polymarket 概率，也比评论员的猜测更难反驳。
-
-综合排序依据的是人们真正参与过的内容——看社会相关性，而不是 SEO 相关性。
-
-## 大家实际上怎么用它
-
-**开会之前。** `/last30days Peter Steinberger`——加入 OpenAI Codex 团队、反对 Anthropic 禁止第三方智能体、GitHub 上合并了 23 个 PR 且合并率达 85%、正在开发跨设备智能体控制系统 LobsterOS。r/ClaudeCode 上的一条评论说：“自从 OpenClaw 发布之后，大家就知道，只要你不是通过 API 运行它，迟早会被封。”（227 个赞同票）。这些不会出现在 LinkedIn 上。
-
-**判断招聘信号。** `/last30days Listen Labs --hiring-signals`——把最新职位和招聘页面变成有引用依据的证据，从中判断公司是否正转向企业安全、客户成功、基础设施或产品扩张。报告只解释招聘看起来释放了什么信号，不会武断预测路线图一定会交付什么。
-
-**在话题爆发前发现它。** 输入 `/last30days what's exploding in AI agents?`，Skill 会切换到发现模式：引擎扫描 Reddit 分类列表、Hacker News 的 front/best 故事、Digg AI 1000 信息流，以及认证后的 X；随后由你的智能体评审候选主题（命名、过滤垃圾、判断内容价值），并写出播客或 X 长文的切入角度；最终给出 5–10 个按增长速度排序的话题。每条结果都包含跨平台数据、势头标签，以及可直接运行的 `/last30days "<topic>"` 后续命令。
-
-**突发事件发生时。** `/last30days Kanye West`——英国拒绝其签证，Wireless Festival 取消演出，赞助商纷纷离场；但《BULLY》首周登上 Billboard 第二名。Fantano 结束自己的 “Yay sabbatical” 回归评测（65.3 万次观看）；SoFi Homecoming 请来 Lauryn Hill 和 Travis Scott，共演出 44 首歌。Polymarket：“Kanye 还会再发推吗？”86% 认为会。共找到 23 个 Reddit 主题、17 个 YouTube 视频和 8.6 万次赞同。
-
-**比较工具。** `/last30days OpenClaw vs Hermes vs Paperclip`——“它们并非竞品，而是处于不同层次。”OpenClaw 是执行层（GitHub 35.1 万 Star，已上线），Hermes 是会自我改进的大脑（3.1 万 Star），Paperclip 是组织结构图（4.9 万 Star）。Star 数来自 GitHub API 的实时数据，不是过期博客。报告会提供架构、记忆、安全性和适用场景的横向表格。正如 @IMJustinBrooke 所说：“OpenClaw = 小火龙，Hermes = 喷火龙。”
-
-**理解世界。** `/last30days Iran vs USA`——战争进入第 38 天。特朗普要求伊朗在周二的最后期限前重新开放霍尔木兹海峡；两架美国战机被击落；油价涨至每桶 126 美元。IEA 称之为“全球石油市场史上最大规模的供应中断”。Polymarket 认为 12 月 31 日前停火的概率为 74%。共找到 27 条 X 帖子、10 个 YouTube 视频和 20 个预测市场。
-
-**旅行之前。** `/last30days Universal Epic Universe`——扩建工程已经开工，“Project 680” 许可已提交；基础设施证实将有烟花表演，但官方尚未公布。Mine-Cart Madness 平均排队 148 分钟；年票仍未推出，当地居民对此不满；Stardust Racers 将停运翻修至 4 月 5 日。
-
-**快速学习。** `/last30days Nano Banana Pro prompting`——JSON 结构化提示词正在取代标签堆砌；@pictsbyai 的嵌套格式能避免“概念串色”；以编辑为先的工作流优于反复重新生成。随后，它会严格依据社区验证有效的方法，为你写出一条可用于生产的提示词。
-
-## 最近更新
-
-自 5 月发布 v3.3 公告以来，截至 v3.11.1（2026 年 7 月），项目已在 15 个版本中合并 175 个 PR，其中 122 个来自 52 位社区贡献者。下面是主要变化。
-
-### 正式支持 OpenAI Codex
-
-`/last30days` 现在是带引导式配置的原生 Codex 插件——不是简单移植，而是一等公民。针对不同渲染器优化的引用格式，让 Codex 输出读起来像简报，而不是一团 URL（#694）。同一套引擎也运行在 Claude Code、Cursor、Copilot、Gemini CLI、Claude Desktop、OpenClaw 以及 50 多个 Agent Skills 宿主上。Codex 插件清单由 [@rfoust](https://github.com/rfoust) 贡献（#686），Codex 认证修复由 [@tmchow](https://github.com/tmchow) 贡献（#698）。
-
-### arXiv、Techmeme 与 Digg——免费，无需 API 密钥
-
-arXiv 提供热点背后的论文，Techmeme 提供科技新闻的编辑视角；二者均免费、无需密钥，首次配置会安装相应 CLI 并自动启用（#709）。Digg 的 AI 1000 话题聚类同样无需 X 认证——配置过程会自动安装免费的 Digg CLI（#590）。此外还加入了可选的 Trustpilot 来源，适合消费品牌研究。
-
-### 免费 Reddit 搜索也有真实评分和热门评论
-
-Reddit 的公开 `.json` API 停止工作后，免费的数据通路以更强的方式回归：无密钥 RSS + shreddit 抓取（#457）、通过 arctic-shift 发现垂直 subreddit 并获取真实赞同数（#696），以及相关性下限，防止病毒式传播但偏题的帖子劫持整份简报（#488，感谢 [@rzachsmith](https://github.com/rzachsmith)）。无需 API 密钥，提供真实评分和热门评论。
-
-### 每份简报都收录最好的评论
-
-评论现在是各来源默认启用的一层：Instagram 评论采用基于排名的多样性机制，避免五条热门观点全来自同一篇帖子（#751）；YouTube 评论配合 ScrapeCreators 字幕回退，以应对 yt-dlp 失效（#637）；经过社区投票的评论还会计入 Best Takes 的权重，让最有趣的金句不会在评分中消失（#592、#608）。
-
-### 一个 doctor 命令解决健康检查
-
-要求执行健康检查时，doctor 会逐一测试所有来源，并给出精确修复建议：缺少哪个密钥、哪个 CLI 不在 PATH、哪个 Cookie 已过期（#753）。不必再猜为什么 X 的结果这么少。
-
-### 重构 X 搜索
-
-X 流水线经过彻底重构：新增 FROM 和 ABOUT 两条通路，让某人的原创帖子和外界对他的讨论都能进入排名（#610）；按人物感知的子查询消歧（#611）；基于第一方作者身份的信息归属，并结合互动信号排序（#613）；统一的 X 来源与自动后端故障转移（#622）。另外，`--diagnose` 现在会真正探测认证状态，如实报告问题（#609）。
-
-### 更多信息源加入
-
-通过 ScrapeCreators 接入 LinkedIn，并将文章视为高价值信号（[@ravstr](https://github.com/ravstr)，#702）。StockTwits 会在股票代码和加密货币主题下自动启用（[@wtiwana](https://github.com/wtiwana)，#658）。Perplexity 新增直接 API 模式和异步 Deep Research（[@sk-holmes](https://github.com/sk-holmes)，#629）。
-
-### 在社区协作下进一步加固
-
-这一轮安全改进几乎全部来自社区：修复 HTML 渲染器中的存储型 XSS（[@iliaal](https://github.com/iliaal)、[@aaronjmars](https://github.com/aaronjmars)）；收紧 Cookie 临时文件权限；通过 OpenSSF Scorecard 和构建来源证明加固 CI 供应链（[@shaanmajid](https://github.com/shaanmajid)、[@hammadxcm](https://github.com/hammadxcm)、[@aniruddh909](https://github.com/aniruddh909)）；增加 Semgrep、OSV-Scanner 扫描以及 PR 依赖审查门禁（[@23241a6749](https://github.com/23241a6749)）；测试覆盖率门槛从 60% 起步，现已提高到 84%（[@gourab5139014](https://github.com/gourab5139014)）；Hermes 安全扫描中的所有 CRITICAL 问题也已清零（#768）。
-
-### 覆盖范围更广
-
-支持希伯来语和其他非拉丁文字语言（[@dudyme](https://github.com/dudyme)）；为中文来源加入 CJK 感知的分词（[@An-idd](https://github.com/An-idd)）；推进一系列 Windows 兼容性改进；支持从完整 Chromium 浏览器家族提取 Cookie——Brave、Edge、Vivaldi、Opera、Arc（[@andrey-esipov](https://github.com/andrey-esipov)）——并接入 macOS Keychain 和 Linux `pass(1)` 凭据来源。此外还有 `--as-of` 历史回溯（[@chiyi-creator](https://github.com/chiyi-creator)）、通过 uv 自动配置 Python 3.12（[@buntysomroy](https://github.com/buntysomroy)）、用于解读公司招聘页面的 `--hiring-signals`，以及多次运行之间的观察列表差异。
-
-### v3 的核心能力仍然完整保留
-
-v3 打下的基础都还在：真正调用 API 前先运行预研究模块，解析正确的账号、subreddit 和话题标签（由 [@j-sperling](https://github.com/j-sperling) 开发）；Best Takes 评分在相关性之外也衡量幽默感和传播力；跨来源故事聚类；单次完成对比研究（例如 “CLI vs MCP” 只需 3 分钟，而不是 12 分钟）；自动发现竞品的 `--competitors` 对比；GitHub 人物模式（`--github-user=steipete`）；任何研究结束后可开启的 ELI5 模式（输入 “eli5 on”）；以及可分享、自包含的 HTML 简报（`--emit=html`）。配置项详见 [CONFIGURATION.md](CONFIGURATION.md)。
-
-## 安装
-
-| 使用环境 | 安装方式 | 更新方式 |
-|---------|---------|---------|
-| **Claude Code**（推荐） | `/plugin marketplace add mvanhorn/last30days-skill` | 通过 marketplace 自动更新，或运行 `claude plugin update last30days@last30days-skill` |
-| **Grok**（xAI Build CLI） | 先运行 `grok plugin marketplace add mvanhorn/last30days-skill`，再运行 `grok plugin install last30days` | `grok plugin update last30days` |
-| **Codex、Cursor、Copilot、Gemini CLI，或其他 50 多个支持 [Agent Skills](https://agentskills.io) 的宿主** | `npx skills add mvanhorn/last30days-skill -g` | `npx skills update last30days -g` |
-| **claude.ai**（网页） | [下载 `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)，然后在 claude.ai 中依次进入 Customize > Skills > + > Create skill > Upload a skill 上传 | 重新下载并上传 |
-| **Claude Desktop** | 从[最新版本](https://github.com/mvanhorn/last30days-skill/releases/latest)下载适用于你的平台的 `.mcpb`，拖入 Settings > Extensions | 重新下载新包并拖入 |
-| **OpenClaw** | `clawhub install last30days-official` | `clawhub update last30days-official` |
-
-### Claude Code（推荐）
-
-```
-/plugin marketplace add mvanhorn/last30days-skill
-```
-
-推荐这种方式，是因为 Claude Code marketplace 会替你处理更新：插件缓存按版本管理，每次发布新版本都会自动刷新。要强制检查更新，请运行 `claude plugin update last30days@last30days-skill`。
-
-如果你更愿意在 Claude Code 中使用 Agent Skills 的安装方式，同样支持：
-
-```
-npx skills add mvanhorn/last30days-skill -g -a claude-code
-```
-
-原生插件和 `npx skills` 安装可以共存。但 Claude Code 不会对不同安装方式进行去重：若两者同时启用，`/last30days` 会出现两个条目。建议每台机器只选一种安装方式。
-
-### Grok（xAI Build CLI）
-
-[Grok Build](https://docs.x.ai/build/features/skills-plugins-marketplaces)（`grok`）可以将 last30days 安装为原生插件。直接安装会跟踪仓库更新：
+**研究任意近期时间窗口，把有用的部分留在 Obsidian。**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-0f766e.svg)](LICENSE)
+[![Tests](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml/badge.svg)](https://github.com/pauleschwarz/obsidian2date/actions/workflows/validate.yml)
+
+`obsidian2date` 研究人们在 Reddit、X、YouTube、HN、GitHub、Polymarket 和
+全网范围内关于某个话题的真实言论 —— 覆盖你指定的任意时间窗口（上周、最近
+7 天、最近 90 天；30 天只是默认值）—— 并把每次运行转化为持久、互相关联的
+Obsidian 笔记。
+
+每次运行产出：
+
+- 有来源支撑的 **运行笔记**
+- 精炼的 **简报**
+- 指向相关运行的 `[[双链]]`
+- 更新后的 **索引** 和 **仪表盘**
+
+无追踪。MIT。
+[last30days-skill](https://github.com/mvanhorn/last30days-skill) 的公开
+fork；上游研究引擎保持可合并。需要 Python 3.12+ 和一个 Obsidian
+仓库（vault）；数据源和 API 密钥可选 —— 详见
+[CONFIGURATION.md](CONFIGURATION.md)。
+
+## 以斜杠命令使用（主路径）
+
+`obsidian2date` 是一个 Agent Skill：安装本仓库一次，之后在智能体中直接输入
+`/obsidian2date <主题>` 即可。技能会运行研究引擎、解析你的仓库、写入笔记并
+汇报路径。无需记忆任何旗标 —— 在请求中说"上周"或"最近 90 天"，技能会把它
+翻译成正确的引擎参数。
+
+| 宿主 | 安装 | 之后 |
+| --- | --- | --- |
+| Claude Code | `npx skills add pauleschwarz/obsidian2date -g -y`（或将本仓库作为 `.claude-plugin` 添加） | `/obsidian2date <主题>` |
+| Codex | 仓库自带 `.codex-plugin/plugin.json` | `/obsidian2date <主题>` |
+| Grok | `grok plugin marketplace add pauleschwarz/obsidian2date` | `/obsidian2date <主题>` |
+| Gemini CLI | 仓库自带 `gemini-extension.json` | `/obsidian2date <主题>` |
+| OpenClaw / agents.md 宿主 | 仓库自带 `.agents/` 清单 | `/obsidian2date <主题>` |
+| pi / 任何支持技能的智能体 | 将 `skills/obsidian2date/` 软链接或复制到智能体的技能目录 | `/obsidian2date <主题>` |
+
+技能在每次运行时做什么（见
+[`skills/obsidian2date/SKILL.md`](skills/obsidian2date/SKILL.md) —— 模型
+读取的规范运行时说明）：
+
+1. 解析你的仓库（询问一次，会话内记住）
+2. 从请求中推导时间窗口（默认 30 天）
+3. 以 `--emit=obsidian` 运行研究引擎
+4. 诚实汇报简报路径、运行笔记路径，以及部分或不可用的数据源
+
+## 快速开始（CLI 兜底）
+
+用于脚本、cron 或开发期引擎测试时，直接调用 CLI。这是兜底路径，不是主路径
+—— 上面的斜杠命令才是产品。
 
 ```bash
-grok plugin install mvanhorn/last30days-skill
+git clone https://github.com/pauleschwarz/obsidian2date.git
+cd obsidian2date
+
+python3 skills/last30days/scripts/last30days.py \
+  "local LLM agent frameworks" \
+  --emit=obsidian \
+  --obsidian-vault /path/to/your/vault
 ```
 
-也可以先把本仓库添加为 marketplace 来源，再按插件名安装：
+或者一次性配置仓库：
 
 ```bash
-grok plugin marketplace add mvanhorn/last30days-skill
-grok plugin install last30days
+export OBSIDIAN2DATE_VAULT=/path/to/your/vault
+python3 skills/last30days/scripts/last30days.py "topic" --emit=obsidian
 ```
 
-加入 `--trust` 可跳过安装确认；使用 `grok plugin update last30days` 更新。为兼容旧机制，Grok 也会读取 Claude Code 的清单文件；原生 `.grok-plugin/` 文件是首选通路，也是 [xAI marketplace](https://github.com/xai-org/plugin-marketplace) 官方目录条目指向的对象。`npx skills add` 仍是有效的跨宿主备用方案。
+### 时间窗口
 
-### Codex、Cursor、Copilot、Gemini CLI 与其他 Agent Skills 宿主
-
-通过开放的 [Agent Skills](https://agentskills.io) CLI 安装。它支持 50 多种运行环境，包括 `codex`、`cursor`、`github-copilot`、`gemini-cli`、`claude-code`、`windsurf`、`cline`、`continue`、`roo`、`aider-desk`、`opencode`、`goose` 等（完整列表见 [vercel-labs/skills 仓库](https://github.com/vercel-labs/skills)）。
+`30` 天只是默认值。想查多久的都行：
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g
+python3 skills/last30days/scripts/last30days.py "AI video tools" --emit=obsidian --days 7    # 上周
+python3 skills/last30days/scripts/last30days.py "rust async runtimes" --emit=obsidian --days 90  # 季度扫描
+python3 skills/last30days/scripts/last30days.py "election odds" --emit=obsidian --days 14 --as-of 2026-08-15
 ```
 
-`-g`（全局）参数会把 Skill 安装到用户目录，因此所有项目均可使用。不加 `-g` 时，`npx skills` 会安装到当前项目的 `./.skills/` 中，并随仓库提交。对于一个用于研究整个世界的工具，全局安装通常更合适。
+在斜杠命令里直接说："研究 AI video tools 最近 7 天的动态"。
 
-Codex 桌面版和其他以文件夹为工作区的宿主，不仅能在 Git 仓库中运行，也能在普通文件夹中工作。第一次研究前，请让宿主智能体从已加载的 Skill 目录运行随附的 `scripts/last30days.py --preflight`；若在源码仓库中，则运行等价命令 `python3 skills/last30days/scripts/last30days.py --preflight`。该命令会展示配置来源、浏览器 Cookie 方案、计划写入的文件、可选命令和被忽略的项目配置，但不会读取 Cookie、写入文件或执行研究。
+### 仓库解析
 
-默认情况下，`npx skills` 会安装到它自动检测到的宿主。若要指定一个或多个宿主：
+导出目标按以下顺序解析：
+
+1. `--obsidian-vault PATH`（显式指定且不存在的路径会为导出而创建）
+2. `OBSIDIAN2DATE_VAULT`
+3. `LAST30DAYS_OBSIDIAN_VAULT`
+4. 已存在的 `~/Desktop/brain-paul`
+
+环境变量和桌面候选必须已经是目录。环境变量存在但为空或只含空白时，会刻意
+禁用所有隐式兜底。如果都无法解析，命令会停止并输出：
+
+```text
+No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.
+```
+
+在 `.env` 文件中使用 `~/...` 或绝对路径；`$HOME` 在其中不会被展开。已有笔记
+永远不会被覆盖；文件名冲突会追加数字后缀。
+
+## 写入什么
+
+仓库根目录下的默认布局：
+
+```text
+90_Quellen/obsidian2date/
+  runs/YYYY-MM-DD-<slug>.md
+  briefings/YYYY-MM-DD-<slug>-briefing.md
+  Index.md
+  Dashboard.md
+```
+
+笔记绝不覆盖。同日冲突追加数字后缀。检测到词元重叠时，相关历史运行会通过
+Obsidian 的 `[[双链]]` 关联起来。
+
+## 数据源与密钥
+
+与上游同一底线：
+
+- **默认免密钥：** Reddit、Hacker News、Polymarket、GitHub、Web
+- **可选：** X（浏览器 cookie / 后端）、YouTube（`yt-dlp`）、TikTok/IG
+  （ScrapeCreators），以及其他付费/选择性开启的后端
+
+完整矩阵与密钥配置见
+[`CONFIGURATION.md`](CONFIGURATION.md)。
+
+## 安全诊断
+
+研究开始前运行仅权限检查：
+
+```text
+$ python3 skills/last30days/scripts/last30days.py --preflight
+last30days preflight
+Status: Ready to research with safe defaults.
+...
+Local writes:
+- none planned
+```
+
+`--preflight` 是安全的：它**不读取 cookie、不写文件、不运行研究**。排查数据
+源或已安装后端时，请改用健康检查：
 
 ```bash
-npx skills add mvanhorn/last30days-skill -g -a codex
-npx skills add mvanhorn/last30days-skill -g -a cursor
-npx skills add mvanhorn/last30days-skill -g -a gemini-cli
-npx skills add mvanhorn/last30days-skill -g -a codex -a cursor
+python3 skills/last30days/scripts/last30days.py doctor
 ```
 
-日后可通过以下命令更新：
+## 上游模式依然可用
 
 ```bash
-npx skills update last30days -g
+# 原始的紧凑综合输出
+python3 skills/last30days/scripts/last30days.py "topic" --emit=compact
+
+# 智能体 JSON
+python3 skills/last30days/scripts/last30days.py "topic" --emit=json
+
+# 生产简报
+python3 skills/last30days/scripts/last30days.py "topic" --emit=brief
 ```
 
-也可以一次更新所有通过 `npx skills` 全局安装的 Skill：
+## 与上游的关系
+
+| 事项 | 策略 |
+| --- | --- |
+| 研究引擎 | 与 `upstream/main` 保持可合并 |
+| Obsidian 导出 | 附加模块：`lib/obsidian_export.py` |
+| 品牌 / 技能 | `obsidian2date` |
+| 许可证 | MIT；保留上游版权声明 |
 
 ```bash
-npx skills update -g
+git remote add upstream https://github.com/mvanhorn/last30days-skill.git
+git fetch upstream
+git merge upstream/main
 ```
 
-使用 `npx skills list -g` 查看列表，使用 `npx skills remove last30days -g` 卸载。
+## 致谢
 
-### claude.ai（网页）
+- 上游研究引擎：[Matt Van Horn / last30days](https://github.com/mvanhorn/last30days-skill)
+- Obsidian 导出路径 + 公开 fork 打包：[pauleschwarz](https://github.com/pauleschwarz)
 
-1. 从最新版本[下载 `last30days.skill`](https://github.com/mvanhorn/last30days-skill/releases/latest/download/last30days.skill)
-2. 打开 [claude.ai > Customize > Skills](https://claude.ai/customize/skills)
-3. 在 Skills 面板点击 `+`，再选择 `Create skill` > `Upload a skill`，浏览或拖入文件
+## 许可证
 
-请先在 Capabilities 中启用 “Code execution and file creation”——否则 Skill 无法运行。
-
-### Claude Desktop
-
-Claude Desktop 通过 `.mcpb` 包（一种一键式 Model Context Protocol 软件包）将 `/last30days` 安装为 MCP 服务器。
-
-1. 打开[最新版本](https://github.com/mvanhorn/last30days-skill/releases/latest)，下载适用于你的平台的 `.mcpb`：
-   - macOS Apple Silicon：`last30days-pp-mcp-darwin-arm64.mcpb`
-   - macOS Intel：`last30days-pp-mcp-darwin-amd64.mcpb`
-   - Linux x86_64：`last30days-pp-mcp-linux-amd64.mcpb`
-2. 打开 Claude Desktop，进入 Settings > Extensions，将文件拖入。
-3. 出现提示时，粘贴你想启用的数据源所需的 API 密钥。所有字段均可留空——如果全部跳过，引擎会降级为纯 Web 模式。密钥存储在操作系统的钥匙串中。
-4. 重启 Claude Desktop。让 Claude “research Peter Steinberger” 或研究任意主题，它就会调用 `research` 工具。
-
-**宿主要求：** PATH 中需要 Python 3.12+。软件包自带引擎源码，但使用本地 Python 解释器。Windows 用户可从 [python.org](https://www.python.org/downloads/) 安装；macOS 和大多数 Linux 发行版通常已提供兼容版本。
-
-**密钥不会与 Code Skill 同步。** Claude Desktop 与 Claude Code 采用彼此独立的凭据存储，这是有意的设计。即使你已为 Code Skill 配置 `~/.config/last30days/.env`，仍需在这里重新输入一次相同的密钥。
-
-Windows 支持需要等各平台的清单入口点确定后再实现，请关注后续 Issue。
-
-### OpenClaw
-
-```bash
-clawhub install last30days-official
-```
-
-如果你需要在 `/last30days` 研究之外执行 X/Twitter 操作，例如发布推文或回复、导出关注者、处理媒体、监控账号或抽奖，可使用 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 作为配套 OpenClaw 插件。TweetClaw 由 Xquik-dev 维护，这里仅将其列为可选配套方案；它不是 last30days 的依赖，也不代表本项目为其背书。
-
-### 手动安装（开发者）
-
-```bash
-git clone https://github.com/mvanhorn/last30days-skill.git
-ln -s "$(pwd)/last30days-skill/skills/last30days" ~/.claude/skills/last30days
-```
-
-这个符号链接会让安装内容随工作区代码实时同步，无需重复复制。若用于 `claude.ai`，可从源码构建 `.skill` 文件：运行 `bash skills/last30days/scripts/build-skill.sh`，产物位于 `dist/last30days.skill`。
-
-Reddit（含评论）、Hacker News、Polymarket 和 GitHub 无需任何配置即可使用。首次运行 `/last30days` 后，配置向导会在 30 秒内解锁更多来源，包括免费的 arXiv 与 Techmeme CLI。
-
-## 使用你自己的密钥
-
-这些平台之间互不相通：X 不知道 Reddit 在讨论什么，YouTube 也看不到 TikTok。但只要接入你自己的 API 密钥和浏览器令牌，就能一次访问所有平台。
-
-| 来源 | 你需要准备什么 | 成本 |
-|------|----------------|------|
-| Reddit（含评论）+ HN + Polymarket + GitHub + StockTwits | 无 | 免费 |
-| arXiv + Techmeme | 免费 CLI，由首次配置自动安装 | 免费 |
-| X / Twitter | 在任意浏览器中登录 x.com，或设置 `XQUIK_API_KEY` / `XAI_API_KEY` | 浏览器 Cookie 免费；密钥费用取决于服务商 |
-| YouTube | `brew install yt-dlp` | 免费 |
-| Bluesky | 来自 bsky.app 的应用密码 | 免费 |
-| TikTok + Instagram + Threads + Pinterest + LinkedIn + YouTube 评论 | ScrapeCreators 密钥 | 前 10,000 次调用免费，之后按量付费 |
-| 小红书（RED） | 运行已登录的 x-mcp 浏览器插件或 `xiaohongshu-mcp` 服务，并在单次运行中通过 `--search xhs` 启用，或在 `.env` 中设置 `INCLUDE_SOURCES=xiaohongshu`；last30days 会依次自动探测 `http://localhost:18060` 和 `http://host.docker.internal:18060`，也可通过 `XIAOHONGSHU_API_BASE` 指定自定义地址 | last30days 不需要 API 密钥；依赖本地浏览器会话服务 |
-| DripStack（付费金融通讯） | 每次运行通过 `--search dripstack` 启用，或在 `.env` 中设置 `INCLUDE_SOURCES=dripstack` | 无需密钥；公共搜索 API 免费 |
-| Perplexity Agent API / Search API / Deep Research | Perplexity 密钥，或作为 Sonar 回退方案的 OpenRouter 密钥 | 按量付费；直接密钥启用 Agent API 和后台 Deep Research |
-| Web 搜索 | Brave Search 密钥 | 每月 2,000 次免费查询 |
-
-### macOS Keychain（可选）
-
-在 macOS 上，你可以把密钥存入系统 Keychain，而不是 `.env` 文件。Skill 会自动将其作为最低优先级的密钥来源；发生冲突时，`.env` 文件和进程环境变量仍然优先。
-
-```bash
-# 交互式配置——逐个询问已知密钥，留空即可跳过
-skills/last30days/scripts/setup-keychain.sh
-
-# 也可以手动存入单个密钥
-security add-generic-password -a "$USER" -s last30days-XAI_API_KEY -w "xai-..."
-
-# 查看 / 清理
-skills/last30days/scripts/setup-keychain.sh --list
-skills/last30days/scripts/setup-keychain.sh --delete XAI_API_KEY
-```
-
-密钥项以 `last30days-<KEY>` 作为服务名称，归当前用户所有。在非 Darwin 平台上，加载器不会执行任何操作，因此 Linux/Windows 用户的行为不受影响。
-
-如果已有密钥使用其他 Keychain 服务名称，可按 [CONFIGURATION.md](CONFIGURATION.md#reusing-existing-macos-keychain-items) 中的说明设置不含秘密的 `LAST30DAYS_KEYCHAIN_ALIASES` 映射，无需复制密钥。
-
-各来源的完整密钥矩阵、推理服务商优先级和 Web 搜索后端优先级，请参阅 [CONFIGURATION.md](CONFIGURATION.md)。
-
-## 配置
-
-第一天使用时，你大概最想知道以下两件事：
-
-**研究文件保存在哪里。** `LAST30DAYS_MEMORY_DIR` 默认指向 `~/Documents/Last30Days/`（Windows：`C:\Users\<you>\Documents\Last30Days\`）。可以在 shell 中把该环境变量设为任意路径，也可以为单次运行传入 `--save-dir <path>`。若需要把渲染结果精确写入某个路径，请使用 `--output <file>`；文件格式由 `--emit` 决定。使用 `--save-suffix=<name>` 可分别保存同一主题的多个版本（例如按客户区分）。每次使用 `--save-dir` 都会生成 `<slug>-raw[-suffix].md`。研究前运行 `python3 skills/last30days/scripts/last30days.py --preflight`，可预览计划写入的内容。
-
-**面向智能体和工作流的结构化输出。** 让 `/last30days` 输出机器可读的 JSON，即可获得稳定且带版本号的 agent profile。若在脚本或开发中直接调用引擎，可运行 `python3 skills/last30days/scripts/last30days.py "AI coding agents" --emit=json`；只有确实需要未版本化的内部 `Report` 转储时，才添加 `--json-profile=raw`。详见 [JSON 导出字段参考与版本策略](docs/reference/json-export.md)。
-
-**无指定主题的趋势发现。** 输入 `/last30days what's trending in AI agents?`，会得到按排名整理的发现简报，而不是研究一个你已经知道的主题。在智能体宿主上，它会执行由宿主模型评审的三段式流程：模型命名主题、过滤垃圾、判断内容价值并撰写切入角度。在脚本或定时任务中直接调用引擎时，可运行 `python3 skills/last30days/scripts/last30days.py --discover "AI agents"`（单次执行：主题名称由确定性逻辑生成，不含内容角度）；加入 `--emit=json` 可获得带版本号的发现数据契约。发现模式不能与位置参数主题或 `--drill` 同时使用。
-
-**跨运行趋势监控。** 默认模式每次运行都会生成新的 Markdown 快照。若要长期积累结果，可添加 `--store` 写入 SQLite 数据库；随后使用 [`scripts/watchlist.py`](skills/last30days/scripts/watchlist.py) 定时运行（发现新内容时可发送到 Slack 或 Webhook），使用 [`scripts/briefing.py`](skills/last30days/scripts/briefing.py) 生成日报或周报。完整的周期配置见 [CONFIGURATION.md](CONFIGURATION.md#trend-monitoring-store--watchlist--briefings)。
-
-**可订阅的研究资料库。** 让 `/last30days` 构建你的资料库信息流；在脚本和开发中也可以直接运行 `python3 skills/last30days/scripts/last30days.py library feed`。该命令会把已保存的简报整理成 `index.html`、本地 Atom `feed.xml` 和便于阅读的简报页面。仅在确实想托管 HTML 索引和简报页面时添加 `--publish`；发布必须显式开启，且默认公开。若要让 Atom 信息流可订阅，请将生成目录托管到 GitHub Pages 等静态站点服务。
-
-**搜索你做过的所有研究。** 输入 `/last30days search my library for MCP servers` 或 `/last30days have I researched MCP servers before?`。直接调用引擎时，运行 `python3 skills/last30days/scripts/last30days.py library search "MCP servers"`。搜索完全离线且结果确定：它增量索引资料库信息流使用的同一批简报，合并每次运行存储的匹配记录，并按主题和日期分组。新的研究若与历史内容重叠，还会显示精简的 **From your library** 章节；设置 `LAST30DAYS_LIBRARY_CONTEXT=off` 可关闭这种被动上下文。
-
-各客户端包装脚本、自定义分类同类 subreddit，以及用于试验进行中定制功能的 beta 通道，也都记录在 [CONFIGURATION.md](CONFIGURATION.md) 中。
-
-## 展示：社区研究信息流
-
-你是否用 last30days 发布了定期 AI 动态、市场观察，或某个小众到可爱的长期专题？欢迎在[社区展示帖](https://github.com/mvanhorn/last30days-skill/issues/532)分享公开资料库 URL；若已将 `feed.xml` 托管到静态站点，也可分享 Atom URL。社区成员提交后，我们会在这里陆续添加链接；在此之前，该讨论帖就是统一的收集入口。
-
-## 工作原理
-
-1. **你输入一个主题。** 人物、公司、产品、技术、“X vs Y”——任何内容都可以。
-2. **智能体识别关键对象。** 找出 X 账号（包括创始人）、GitHub 仓库、subreddit、TikTok 话题标签和 YouTube 频道。搜索 “Kanye West” 时，它知道该查 r/hiphopheads、@kanyewest，以及 YouTube 上的 “bully review”；搜索 “OpenClaw” 时，它会定位 GitHub 上的 openclaw/openclaw 并获取实时 Star 数。
-3. **并行搜索所有来源。** 扩展多个查询，再按互动度、相关性和新鲜度评分。
-4. **提供其他工具没有的深度。** 获取反应视频的完整 YouTube 字幕、带赞同数的 Reddit 热门评论、TikTok 文案和 Polymarket 概率，而不只是标题和链接。
-5. **合并同一事件。** Wireless Festival 在 Reddit 官宣、在 X 上引发讨论、TikTok 出现票价信息——这些会合并为一个故事聚类，而不是三条重复结果。
-6. **综合成一份简报。** 用具体数据作依据，为来源添加引用，并按真实互动排序。不是“这是我找到的内容”，而是“这是最重要的内容”。
-7. **随后成为你的领域专家。** 运行一次后，当前 Claude 会话就掌握社区知道的一切。你可以继续追问，让它写提示词、起草邮件、规划旅行或设计系统架构——所有回答都基于此刻真实存在的信息。
-
-## 用户怎么评价
-
-> “我发现了一个 Claude Code Skill，可以研究任意主题过去 30 天在 Reddit、X、YouTube 和 HN 上的内容，然后替你写提示词。以前每写一篇内容，我都得手动在 Reddit 和 X 上做研究：一个标签页接一个标签页，一条讨论接一条讨论。光这一步就要 90 分钟。它彻底省掉了这些工作。” ——@itsjasonai
-
-> “仅仅这一个 Skill，就取代了我的整套研究工作流。给它一个主题，它会抓取 Reddit、X 和 Web 上人们真正在谈论的内容。不是陈旧的博客，而是过去 30 天里真实发生的讨论。” ——@itswilsoncharles
-
-> “今天 GitHub 的 10 个趋势仓库中，有 5 个是 Claude 工具。第一名：mvanhorn/last30days-skill。” ——@yieldhunter95
-
-## 开源
-
-采用 MIT 许可证。无跟踪、无分析，你的研究数据始终留在本机。拥有 2,700 多项测试。
-
-项目基于 Python 3.12+、yt-dlp、Node.js（内置用于 X 搜索的 Bird 客户端）和 ScrapeCreators API 构建。v3 引擎架构由 [@j-sperling](https://github.com/j-sperling) 设计。
-
-提交 PR 请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)，完整社区贡献者名单见 [CONTRIBUTORS.md](CONTRIBUTORS.md)，版本历史见 [CHANGELOG.md](CHANGELOG.md)。
-
-## Star 历史
-
-<a href="https://star-history.dera.page/#mvanhorn/last30days-skill&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-    <img alt="Star 历史图" src="https://star-history.dera.page/svg?repos=mvanhorn/last30days-skill&type=Date" />
-  </picture>
-</a>
-
----
-
-**@slashlast30days** · [github.com/mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)
+MIT。见 [LICENSE](LICENSE)。

--- a/changelog.d/+obsidian-wikilink-alias.fixed.md
+++ b/changelog.d/+obsidian-wikilink-alias.fixed.md
@@ -1,0 +1,1 @@
+Obsidian export links now target the note filename with the title as alias (`[[YYYY-MM-DD-slug|Title]]`). Previously wikilinks pointed at the frontmatter title, which Obsidian cannot resolve against the `YYYY-MM-DD-<slug>.md` filenames the exporter writes, so every related-note, briefing "Full run", Index, and Dashboard link was broken.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# obsidian2date docs
+
+Start at the root [README.md](../README.md) for install and the slash-command
+path. This folder holds deeper reference, eval, and planning material.
+
+## Map
+
+| Path | What |
+| --- | --- |
+| [how-search-works.md](how-search-works.md) | Retrieval / ranking behavior |
+| [search-quality-eval.md](search-quality-eval.md) | How search quality is judged |
+| [reference/](reference/) | Machine contracts (e.g. JSON export) |
+| [plans/](plans/) | Implementation and docs plans |
+| [releases/](releases/) | Release notes / launch material |
+| [solutions/](solutions/) | Worked solution write-ups |
+| [pr-credits.md](pr-credits.md) | Credit attributions |
+
+Also at repo root (not under `docs/`):
+
+| Path | What |
+| --- | --- |
+| [../CONCEPTS.md](../CONCEPTS.md) | Shared vocabulary |
+| [../CONFIGURATION.md](../CONFIGURATION.md) | Env, keys, flags, vault |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contributor setup |
+| [../CHANGELOG.md](../CHANGELOG.md) | Shipped history |
+
+## Plans
+
+- [2026-09-02 docs & usability](plans/2026-09-02-docs-usability.md)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,12 +1,18 @@
 {
-  "name": "last30days-skill",
-  "version": "3.21.1",
-  "description": "Research a topic from the last 30 days across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, and the web.",
+  "name": "obsidian2date",
+  "version": "0.1.0",
+  "description": "Research a topic from the last 30 days, then write durable Obsidian run notes and briefings.",
   "settings": [
     {
       "name": "Extension Directory",
       "description": "Extension installation directory (auto-set by Gemini CLI)",
       "envVar": "GEMINI_EXTENSION_DIR",
+      "sensitive": false
+    },
+    {
+      "name": "Obsidian Vault",
+      "description": "Existing Obsidian vault root for --emit=obsidian exports",
+      "envVar": "OBSIDIAN2DATE_VAULT",
       "sensitive": false
     },
     {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian2date",
   "version": "0.1.0",
-  "description": "Research a topic from the last 30 days, then write durable Obsidian run notes and briefings.",
+  "description": "Research a topic over any recent window, then write durable Obsidian run notes and briefings.",
   "settings": [
     {
       "name": "Extension Directory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "last30days-skill"
-version = "3.21.1"
-description = "Multi-source last-30-days research skill"
+name = "obsidian2date"
+version = "0.1.0"
+description = "last30days research engine with Obsidian-native export (fork)"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []
@@ -15,7 +15,7 @@ dev = [
 ]
 
 [tool.towncrier]
-name = "last30days-skill"
+name = "obsidian2date"
 directory = "changelog.d"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "obsidian2date"
 version = "0.1.0"
-description = "last30days research engine with Obsidian-native export (fork)"
+description = "Research engine with Obsidian-native export, based on last30days"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -765,8 +765,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--obsidian-vault",
         help=(
-            "Obsidian vault root for --emit=obsidian "
-            "(default: OBSIDIAN2DATE_VAULT / LAST30DAYS_OBSIDIAN_VAULT / ~/Desktop/brain-paul)"
+            "Obsidian vault root for --emit=obsidian (otherwise: "
+            "OBSIDIAN2DATE_VAULT, LAST30DAYS_OBSIDIAN_VAULT, or existing ~/Desktop/brain-paul)"
         ),
     )
     parser.add_argument("--synthesis-file", help="Markdown synthesis to embed in --emit=html output")
@@ -2554,16 +2554,19 @@ def _render_save_and_print(
 
 
 def _propagate_config_to_environ(config: dict[str, object]) -> None:
-    """Push relevant env keys to os.environ so provider modules can read them.
+    """Push file-configured library settings into ``os.environ``.
 
-    The env.get_config() function reads from a .env file, but providers.py
-    reads from os.environ directly. Without this, OPENAI_BASE_URL and
-    XAI_BASE_URL overrides are silently ignored. This is a no-op for
-    keys that are already set in process env.
+    Some provider modules and the Obsidian resolver intentionally read the
+    process environment directly. Process values, including deliberate empty
+    values, always win over lower-priority configuration files.
     """
     for key in ("OPENAI_BASE_URL", "XAI_BASE_URL", "OPENROUTER_BASE_URL"):
         val = config.get(key)
-        if val and not os.environ.get(key):
+        if val and key not in os.environ:
+            os.environ[key] = str(val)
+    for key in ("OBSIDIAN2DATE_VAULT", "LAST30DAYS_OBSIDIAN_VAULT"):
+        val = config.get(key)
+        if val is not None and key not in os.environ:
             os.environ[key] = str(val)
 
 

--- a/skills/last30days/scripts/last30days.py
+++ b/skills/last30days/scripts/last30days.py
@@ -489,6 +489,15 @@ def emit_output(
         return render.render_context(report)
     if emit == "brief":
         return render.render_brief(report)
+    if emit == "obsidian":
+        # Obsidian export is handled by _export_obsidian_and_print after research.
+        # Keep a compact evidence envelope available for hosts that only read stdout.
+        return render.render_compact(
+            report,
+            fun_level=fun_level,
+            save_path=save_path,
+            register=register,
+        )
     raise SystemExit(f"Unsupported emit mode: {emit}")
 
 
@@ -627,7 +636,15 @@ def build_parser() -> argparse.ArgumentParser:
         allow_abbrev=False,
     )
     parser.add_argument("topic", nargs="*", help="Research topic")
-    parser.add_argument("--emit", default="compact", choices=["compact", "json", "context", "md", "html", "brief"])
+    parser.add_argument(
+        "--emit",
+        default="compact",
+        choices=["compact", "json", "context", "md", "html", "brief", "obsidian"],
+        help=(
+            "Output mode. Use 'obsidian' to write a durable vault run note, "
+            "briefing, index, and dashboard under the Obsidian vault."
+        ),
+    )
     parser.add_argument(
         "--register",
         choices=registers.REGISTER_NAMES,
@@ -745,6 +762,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include matching corpus files older than the research window",
     )
     parser.add_argument("--output", help="Optional exact file path for saving the rendered output")
+    parser.add_argument(
+        "--obsidian-vault",
+        help=(
+            "Obsidian vault root for --emit=obsidian "
+            "(default: OBSIDIAN2DATE_VAULT / LAST30DAYS_OBSIDIAN_VAULT / ~/Desktop/brain-paul)"
+        ),
+    )
     parser.add_argument("--synthesis-file", help="Markdown synthesis to embed in --emit=html output")
     parser.add_argument("--publish-html", action="store_true",
                         help="Publish --emit=html output to ht-ml.app (explicit opt-in; public by default)")
@@ -2501,6 +2525,30 @@ def _render_save_and_print(
         except Exception as exc:
             sys.stderr.write(f"[last30days] HTML publish failed: {exc}\n")
             sys.stderr.flush()
+
+    if args.emit == "obsidian":
+        try:
+            from lib import obsidian_export
+
+            export_report = report
+            if entity_reports:
+                # Comparison runs: keep the leading/merged report as the vault anchor.
+                export_report = report
+            result = obsidian_export.export_report_to_obsidian(
+                export_report,
+                vault_root=getattr(args, "obsidian_vault", None),
+            )
+            rendered = obsidian_export.render_obsidian_stdout(result, export_report)
+            sys.stderr.write(
+                f"[obsidian2date] Wrote run note {result.run_note} and "
+                f"briefing {result.briefing_note}\n"
+            )
+            sys.stderr.flush()
+        except Exception as exc:
+            sys.stderr.write(f"[obsidian2date] Vault export failed: {exc}\n")
+            sys.stderr.flush()
+            return 1
+
     print(rendered)
     return _strict_exit_code(report, entity_reports, config)
 
@@ -2516,7 +2564,7 @@ def _propagate_config_to_environ(config: dict[str, object]) -> None:
     for key in ("OPENAI_BASE_URL", "XAI_BASE_URL", "OPENROUTER_BASE_URL"):
         val = config.get(key)
         if val and not os.environ.get(key):
-            os.environ[key] = val
+            os.environ[key] = str(val)
 
 
 def _setup_allows_browser_cookies(args: argparse.Namespace, extra_argv: list[str]) -> bool:

--- a/skills/last30days/scripts/lib/env.py
+++ b/skills/last30days/scripts/lib/env.py
@@ -490,6 +490,8 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
         # degraded (neither ok, no-results, nor skipped-unconfigured). #384.
         ('LAST30DAYS_STRICT_EXIT', None),
         ('LAST30DAYS_MEMORY_DIR', None),
+        ('OBSIDIAN2DATE_VAULT', None),
+        ('LAST30DAYS_OBSIDIAN_VAULT', None),
         # Optional local-only evidence source. Paths are separated with the
         # platform path separator (":" on macOS/Linux, ";" on Windows).
         ('LAST30DAYS_CORPUS_DIRS', None),
@@ -585,7 +587,7 @@ def get_config(policy: ConfigLoadPolicy | None = None) -> dict[str, Any]:
     ]
 
     for key, default in keys:
-        config[key] = os.environ.get(key) or merged_env.get(key, default)
+        config[key] = os.environ[key] if key in os.environ else merged_env.get(key, default)
 
     # Export debug flag to os.environ so log.py's lazy os.environ.get()
     # picks up .env values. setdefault ensures a shell-exported value is

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -150,13 +150,21 @@ def resolve_vault_root(
     2. OBSIDIAN2DATE_VAULT / LAST30DAYS_OBSIDIAN_VAULT
     3. ~/Desktop/brain-paul when present
     """
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+
     env_map: dict[str, str] = dict(env) if env is not None else dict(os.environ)
     candidates: list[Path] = []
-    if explicit:
-        candidates.append(Path(explicit).expanduser())
     for key in ("OBSIDIAN2DATE_VAULT", "LAST30DAYS_OBSIDIAN_VAULT"):
         value = env_map.get(key)
-        if value:
+        if value is not None:
+            # A present blank value deliberately disables implicit vault
+            # discovery instead of falling through to a lower-priority key or
+            # the desktop fallback.
+            if not value.strip():
+                raise FileNotFoundError(
+                    "No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT."
+                )
             candidates.append(Path(value).expanduser())
     candidates.append(Path.home() / "Desktop" / "brain-paul")
 
@@ -164,8 +172,6 @@ def resolve_vault_root(
         resolved = candidate.resolve()
         if resolved.is_dir():
             return resolved
-    if explicit:
-        return Path(explicit).expanduser().resolve()
     raise FileNotFoundError(
         "No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT."
     )

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -291,10 +291,12 @@ def _frontmatter(
     sources: list[str],
     run_note_title: str | None = None,
 ) -> str:
+    # brain-paul convention uses `typ:` + free tags; keep `type:` for exporters.
     lines = [
         "---",
         f"title: {_yaml_scalar(title)}",
         f"topic: {_yaml_scalar(topic)}",
+        f"typ: {_yaml_scalar(note_kind)}",
         f"type: {_yaml_scalar(note_kind)}",
         f"status: complete",
         f"generated_at: {_yaml_scalar(report.generated_at)}",
@@ -450,6 +452,22 @@ def render_run_note(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _builder_takeaway(report: schema.Report, clusters: list[schema.Cluster]) -> str:
+    """One short paragraph a builder can act on; honest when evidence is thin."""
+    if not clusters:
+        return (
+            "Evidence is thin this window — treat conclusions as hypotheses, "
+            "widen sources or re-run with --deep before locking product decisions."
+        )
+    top = clusters[0]
+    extras = [c.title for c in clusters[1:3]]
+    extra_bit = f" Watch also: {', '.join(extras)}." if extras else ""
+    return (
+        f"Strongest signal right now: **{top.title}** — {_cluster_summary(report, top)}."
+        f"{extra_bit} Prefer patterns that show up in ≥2 sources; discard single-thread hype."
+    )
+
+
 def render_briefing_note(
     report: schema.Report,
     *,
@@ -463,7 +481,7 @@ def render_briefing_note(
     evidence_report = schema.without_sources(report, {"corpus"})
     today = _dt.date.today().isoformat()
     title = f"Briefing: {report.topic} — {today}"
-    tags = ["obsidian2date", "briefing"]
+    tags = ["obsidian2date", "briefing", "research-run"]
     related_titles = [run_note_title, *[item.title for item in related]]
 
     lines = [
@@ -490,15 +508,45 @@ def render_briefing_note(
         lines.append("- Nothing solid in this window.")
     else:
         for cluster in clusters:
+            src = ", ".join(_source_label(s) for s in cluster.sources) or "mixed"
             lines.append(
-                f"- **{cluster.title}** — {_cluster_summary(evidence_report, cluster)}"
+                f"- **{cluster.title}** ({src}) — {_cluster_summary(evidence_report, cluster)}"
             )
     lines.append("")
+    lines.extend(
+        [
+            "## Builder takeaway",
+            "",
+            _builder_takeaway(evidence_report, clusters),
+            "",
+        ]
+    )
 
     if related:
         lines.extend(["## Related vault notes", ""])
         for item in related:
             lines.append(f"- [[{wikilink_title(item.title)}]]")
+        lines.append("")
+
+    thin = len(clusters) < 2 or len(sources) < 2
+    gaps: list[str] = []
+    if thin:
+        gaps.append("Cross-source corroboration is weak — verify before shipping." )
+    if report.warnings:
+        gaps.extend(str(w) for w in report.warnings[:4])
+    missing = [
+        name
+        for name, outcome in sorted(report.source_status.items())
+        if outcome.state not in {"ok", "no-results"} and outcome.attempted
+    ]
+    if missing:
+        gaps.append(
+            "Source issues: "
+            + ", ".join(f"{_source_label(name)}" for name in missing[:6])
+        )
+    if gaps:
+        lines.extend(["## Gaps / honesty", ""])
+        lines.extend(f"- {g}" for g in gaps)
         lines.append("")
 
     lines.extend(
@@ -507,6 +555,7 @@ def render_briefing_note(
             "",
             f"- Window `{report.range_from}` → `{report.range_to}`",
             f"- Sources: {', '.join(_source_label(s) for s in sources) or 'none'}",
+            f"- Clusters: {len(evidence_report.clusters)} · candidates: {len(evidence_report.ranked_candidates)}",
             f"- Generated `{report.generated_at}`",
             "",
             f"_obsidian2date briefing · v{_skill_version()}_",

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -138,6 +138,16 @@ def wikilink_title(title: str) -> str:
     return _WIKILINK_SAFE_RE.sub("", (title or "").strip()) or "untitled"
 
 
+def wikilink_alias(stem: str, title: str) -> str:
+    """Link the note file by stem and show the human title as alias.
+
+    Obsidian resolves wikilinks against note filenames, not frontmatter
+    titles. Linking the title directly produces a broken link because the
+    exporter names files ``YYYY-MM-DD-<slug>[.md]``.
+    """
+    return f"{wikilink_title(stem)}|{wikilink_title(title)}"
+
+
 def resolve_vault_root(
     explicit: str | Path | None = None,
     *,
@@ -479,8 +489,7 @@ def render_run_note(
     if related:
         lines.extend(["## Related in vault", ""])
         for item in related:
-            link = wikilink_title(item.title)
-            lines.append(f"- [[{link}]] — {item.reason}")
+            lines.append(f"- [[{wikilink_alias(item.path.stem, item.title)}]] — {item.reason}")
         lines.append("")
 
     lines.extend(
@@ -587,6 +596,7 @@ def render_briefing_note(
     run_note_title: str,
     related: list[RelatedNote] | None = None,
     cluster_limit: int = 5,
+    run_note_target: str | None = None,
 ) -> str:
     """Render a short briefing note meant for daily reading."""
     related = related or []
@@ -597,6 +607,11 @@ def render_briefing_note(
     tags = ["obsidian2date", "briefing", "research-run"]
     related_titles = [run_note_title, *[item.title for item in related]]
 
+    run_link = (
+        wikilink_alias(run_note_target, run_note_title)
+        if run_note_target
+        else wikilink_title(run_note_title)
+    )
     lines = [
         _frontmatter(
             title=title,
@@ -611,7 +626,7 @@ def render_briefing_note(
         "",
         f"# Briefing: {report.topic}",
         "",
-        f"Full run: [[{wikilink_title(run_note_title)}]]",
+        f"Full run: [[{run_link}]]",
         "",
         "## What matters now",
         "",
@@ -639,7 +654,7 @@ def render_briefing_note(
     if related:
         lines.extend(["## Related vault notes", ""])
         for item in related:
-            lines.append(f"- [[{wikilink_title(item.title)}]]")
+            lines.append(f"- [[{wikilink_alias(item.path.stem, item.title)}]]")
         lines.append("")
 
     thin = len(clusters) < 2 or len(sources) < 2
@@ -779,9 +794,16 @@ def _prepend_list_item(path: Path, heading: str, item_line: str, *, max_items: i
     path.write_text(head + rebuilt, encoding="utf-8")
 
 
-def update_index(index_path: Path, *, run_title: str, topic: str, date_str: str) -> None:
+def update_index(
+    index_path: Path,
+    *,
+    run_title: str,
+    topic: str,
+    date_str: str,
+    run_path: Path | None = None,
+) -> None:
     _ensure_index(index_path)
-    link = wikilink_title(run_title)
+    link = wikilink_alias(run_path.stem, run_title) if run_path else wikilink_title(run_title)
     item = f"- {date_str} · [[{link}]] — {topic}"
     _prepend_list_item(index_path, "Runs", item)
 
@@ -792,9 +814,14 @@ def update_dashboard(
     briefing_title: str,
     topic: str,
     date_str: str,
+    briefing_path: Path | None = None,
 ) -> None:
     _ensure_dashboard(dashboard_path)
-    link = wikilink_title(briefing_title)
+    link = (
+        wikilink_alias(briefing_path.stem, briefing_title)
+        if briefing_path
+        else wikilink_title(briefing_title)
+    )
     item = f"- {date_str} · [[{link}]] — {topic}"
     _prepend_list_item(dashboard_path, "Latest briefings", item)
 
@@ -862,6 +889,7 @@ def export_report_to_obsidian(
         report,
         run_note_title=run_title,
         related=related,
+        run_note_target=run_path.stem,
     )
     if briefing_title != f"Briefing: {report.topic} — {today}":
         briefing_body = briefing_body.replace(
@@ -871,12 +899,19 @@ def export_report_to_obsidian(
         )
     briefing_path.write_text(briefing_body, encoding="utf-8")
 
-    update_index(paths.index_path, run_title=run_title, topic=report.topic, date_str=today)
+    update_index(
+        paths.index_path,
+        run_title=run_title,
+        topic=report.topic,
+        date_str=today,
+        run_path=run_path,
+    )
     update_dashboard(
         paths.dashboard_path,
         briefing_title=briefing_title,
         topic=report.topic,
         date_str=today,
+        briefing_path=briefing_path,
     )
 
     return ObsidianExportResult(
@@ -900,7 +935,7 @@ def render_obsidian_stdout(result: ObsidianExportResult, report: schema.Report) 
     if result.related:
         lines.append("- related:")
         for item in result.related:
-            lines.append(f"  - [[{wikilink_title(item.title)}]] ({item.reason})")
+            lines.append(f"  - [[{wikilink_alias(item.path.stem, item.title)}]] ({item.reason})")
     else:
         lines.append("- related: none yet")
     return "\n".join(lines) + "\n"

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -257,16 +257,67 @@ def _engagement_total(candidate: schema.Candidate) -> float:
     return 0.0
 
 
+def _clean_text(text: str) -> str:
+    return " ".join((text or "").split())
+
+
+def _is_title_echo(text: str, title: str) -> bool:
+    return bool(title and text.casefold() == _clean_text(title).casefold())
+
+
+def _is_synthetic_blurb(text: str) -> bool:
+    return text.casefold().startswith("hn story about ")
+
+
+def _item_blurb(item: schema.SourceItem | None) -> str:
+    if item is None:
+        return ""
+    for raw in (item.snippet, item.body, item.why_relevant, item.title):
+        text = _clean_text(str(raw or ""))
+        if not text:
+            continue
+        # Skip pure title echoes and connector-generated HN fallbacks.
+        if _is_title_echo(text, item.title or ""):
+            continue
+        if _is_synthetic_blurb(text):
+            continue
+        return text
+    return ""
+
+
+def _candidate_blurb(candidate: schema.Candidate) -> str:
+    primary = _candidate_primary(candidate)
+    blurb = _item_blurb(primary)
+    if blurb:
+        return blurb
+    for item in candidate.source_items or []:
+        blurb = _item_blurb(item)
+        if blurb:
+            return blurb
+    return ""
+
+
 def _cluster_summary(report: schema.Report, cluster: schema.Cluster) -> str:
     by_id = {c.candidate_id: c for c in report.ranked_candidates}
+    blurbs: list[str] = []
     for candidate_id in list(cluster.representative_ids) + list(cluster.candidate_ids):
         candidate = by_id.get(candidate_id)
         if not candidate:
             continue
-        text = (candidate.snippet or candidate.title or "").strip()
-        if text:
-            return text.replace("\n", " ")
-    return cluster.title
+        blurb = _candidate_blurb(candidate)
+        if not blurb:
+            continue
+        if _is_title_echo(blurb, cluster.title):
+            continue
+        if blurb not in blurbs:
+            blurbs.append(blurb)
+        if len(blurbs) >= 2:
+            break
+    if blurbs:
+        joined = " · ".join(blurbs)
+        return joined if len(joined) <= 360 else joined[:357].rstrip() + "..."
+    sources = ", ".join(_source_label(s) for s in cluster.sources) or "mixed sources"
+    return f"Cluster across {sources}; open the evidence index for links."
 
 
 def _tokens(text: str) -> set[str]:
@@ -487,9 +538,10 @@ def render_run_note(
             f"{index}. [{candidate.title or candidate.url or candidate.candidate_id}]({candidate.url}) "
             f"— {_source_label(candidate.source)} ({host}{eng})"
         )
-        snippet = (candidate.snippet or "").strip()
-        if snippet:
-            lines.append(f"   - {snippet[:280]}")
+        blurb = _candidate_blurb(candidate)
+        title = _clean_text(candidate.title or "")
+        if blurb and not _is_title_echo(blurb, title):
+            lines.append(f"   - {blurb[:280]}")
     lines.append("")
 
     lines.extend(
@@ -564,9 +616,10 @@ def render_briefing_note(
     else:
         for cluster in clusters:
             src = ", ".join(_source_label(s) for s in cluster.sources) or "mixed"
-            lines.append(
-                f"- **{cluster.title}** ({src}) — {_cluster_summary(evidence_report, cluster)}"
-            )
+            summary = _cluster_summary(evidence_report, cluster)
+            if summary.casefold() == cluster.title.casefold():
+                summary = "Evidence is title-only; open the evidence index before drawing conclusions."
+            lines.append(f"- **{cluster.title}** ({src}) — {summary}")
     lines.append("")
     lines.extend(
         [

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -25,6 +25,57 @@ DEFAULT_RELATIVE_DASHBOARD = "90_Quellen/obsidian2date/Dashboard.md"
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _WIKILINK_SAFE_RE = re.compile(r"[\[\]|#^]")
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "as",
+        "at",
+        "for",
+        "from",
+        "in",
+        "into",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+        "who",
+        "what",
+        "when",
+        "where",
+        "why",
+        "how",
+        "over",
+        "under",
+        "users",
+        "user",
+        "ai",
+        "ux",
+        "app",
+        "web",
+        "website",
+        "building",
+        "build",
+        "framework",
+        "frameworks",
+        "approachable",
+        "product",
+        "onboarding",
+        "non",
+        "technical",
+        "last",
+        "days",
+        "run",
+        "briefing",
+        "smoke",
+        "test",
+        "obsidian2date",
+        "obsidian",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -219,7 +270,11 @@ def _cluster_summary(report: schema.Report, cluster: schema.Cluster) -> str:
 
 
 def _tokens(text: str) -> set[str]:
-    return {token for token in _SLUG_RE.split((text or "").lower()) if len(token) >= 3}
+    return {
+        token
+        for token in _SLUG_RE.split((text or "").lower())
+        if len(token) >= 4 and token not in _STOPWORDS
+    }
 
 
 def find_related_notes(

--- a/skills/last30days/scripts/lib/obsidian_export.py
+++ b/skills/last30days/scripts/lib/obsidian_export.py
@@ -1,0 +1,743 @@
+"""Obsidian-native export for durable research notes and briefings.
+
+This module is intentionally additive: it does not change upstream retrieval,
+clustering, or existing emit modes. It turns a finished ``schema.Report`` into
+a vault-safe Markdown note with YAML frontmatter, wikilinks to related prior
+runs, a source index, and a short briefing surface.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from . import render, schema, skill_meta
+
+DEFAULT_RELATIVE_RUNS_DIR = "90_Quellen/obsidian2date/runs"
+DEFAULT_RELATIVE_BRIEFINGS_DIR = "90_Quellen/obsidian2date/briefings"
+DEFAULT_RELATIVE_INDEX = "90_Quellen/obsidian2date/Index.md"
+DEFAULT_RELATIVE_DASHBOARD = "90_Quellen/obsidian2date/Dashboard.md"
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_WIKILINK_SAFE_RE = re.compile(r"[\[\]|#^]")
+
+
+@dataclass(frozen=True)
+class ObsidianPaths:
+    """Resolved vault layout for one export."""
+
+    vault_root: Path
+    runs_dir: Path
+    briefings_dir: Path
+    index_path: Path
+    dashboard_path: Path
+
+
+@dataclass(frozen=True)
+class RelatedNote:
+    """A prior vault note that looks topically related."""
+
+    title: str
+    path: Path
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ObsidianExportResult:
+    """Artifacts written for one research run."""
+
+    run_note: Path
+    briefing_note: Path
+    index_path: Path
+    dashboard_path: Path
+    related: list[RelatedNote]
+
+
+def _skill_version() -> str:
+    try:
+        version = render._skill_version()  # type: ignore[attr-defined]
+        if version:
+            return str(version)
+    except Exception:
+        pass
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        skill_md = parent / "SKILL.md"
+        if skill_md.is_file():
+            version = skill_meta.read_skill_version(skill_md)
+            if version:
+                return str(version)
+    return "?"
+
+
+def slugify_topic(topic: str) -> str:
+    """Lowercase slug safe for filenames and Obsidian note stems."""
+    cleaned = _SLUG_RE.sub("-", (topic or "").strip().lower()).strip("-")
+    return cleaned or "topic"
+
+
+def wikilink_title(title: str) -> str:
+    """Strip characters that break Obsidian wikilinks."""
+    return _WIKILINK_SAFE_RE.sub("", (title or "").strip()) or "untitled"
+
+
+def resolve_vault_root(
+    explicit: str | Path | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> Path:
+    """Resolve the Obsidian vault root.
+
+    Order:
+    1. explicit path
+    2. OBSIDIAN2DATE_VAULT / LAST30DAYS_OBSIDIAN_VAULT
+    3. ~/Desktop/brain-paul when present
+    """
+    env_map: dict[str, str] = dict(env) if env is not None else dict(os.environ)
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    for key in ("OBSIDIAN2DATE_VAULT", "LAST30DAYS_OBSIDIAN_VAULT"):
+        value = env_map.get(key)
+        if value:
+            candidates.append(Path(value).expanduser())
+    candidates.append(Path.home() / "Desktop" / "brain-paul")
+
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved.is_dir():
+            return resolved
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    raise FileNotFoundError(
+        "No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT."
+    )
+
+
+def resolve_paths(
+    vault_root: Path,
+    *,
+    runs_rel: str = DEFAULT_RELATIVE_RUNS_DIR,
+    briefings_rel: str = DEFAULT_RELATIVE_BRIEFINGS_DIR,
+    index_rel: str = DEFAULT_RELATIVE_INDEX,
+    dashboard_rel: str = DEFAULT_RELATIVE_DASHBOARD,
+) -> ObsidianPaths:
+    root = vault_root.expanduser().resolve()
+    return ObsidianPaths(
+        vault_root=root,
+        runs_dir=(root / runs_rel).resolve(),
+        briefings_dir=(root / briefings_rel).resolve(),
+        index_path=(root / index_rel).resolve(),
+        dashboard_path=(root / dashboard_rel).resolve(),
+    )
+
+
+def _yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if text == "":
+        return '""'
+    if re.search(r'[:#\[\]{},&*!|>\'"%@`]|\s', text) or text.lower() in {
+        "true",
+        "false",
+        "null",
+        "yes",
+        "no",
+    }:
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return text
+
+
+def _yaml_list(values: Iterable[Any], *, indent: int = 0) -> list[str]:
+    pad = " " * indent
+    items = list(values)
+    if not items:
+        return [f"{pad}[]"]
+    return [f"{pad}- {_yaml_scalar(item)}" for item in items]
+
+
+def _source_label(source: str) -> str:
+    labels = {
+        "reddit": "Reddit",
+        "x": "X",
+        "youtube": "YouTube",
+        "hackernews": "Hacker News",
+        "hn": "Hacker News",
+        "polymarket": "Polymarket",
+        "github": "GitHub",
+        "web": "Web",
+        "tiktok": "TikTok",
+        "instagram": "Instagram",
+        "bluesky": "Bluesky",
+        "linkedin": "LinkedIn",
+        "arxiv": "arXiv",
+    }
+    return labels.get(source, source.replace("_", " ").title())
+
+
+def _active_sources(report: schema.Report) -> list[str]:
+    return sorted(source for source, items in report.items_by_source.items() if items)
+
+
+def _candidate_primary(candidate: schema.Candidate) -> schema.SourceItem | None:
+    if candidate.source_items:
+        return candidate.source_items[0]
+    return None
+
+
+def _engagement_total(candidate: schema.Candidate) -> float:
+    primary = _candidate_primary(candidate)
+    if primary and primary.engagement:
+        return float(sum(float(v) for v in primary.engagement.values() if isinstance(v, (int, float))))
+    if isinstance(candidate.engagement, (int, float)):
+        return float(candidate.engagement)
+    return 0.0
+
+
+def _cluster_summary(report: schema.Report, cluster: schema.Cluster) -> str:
+    by_id = {c.candidate_id: c for c in report.ranked_candidates}
+    for candidate_id in list(cluster.representative_ids) + list(cluster.candidate_ids):
+        candidate = by_id.get(candidate_id)
+        if not candidate:
+            continue
+        text = (candidate.snippet or candidate.title or "").strip()
+        if text:
+            return text.replace("\n", " ")
+    return cluster.title
+
+
+def _tokens(text: str) -> set[str]:
+    return {token for token in _SLUG_RE.split((text or "").lower()) if len(token) >= 3}
+
+
+def find_related_notes(
+    topic: str,
+    runs_dir: Path,
+    *,
+    limit: int = 5,
+    exclude: Path | None = None,
+) -> list[RelatedNote]:
+    """Find prior run notes by token overlap on filename/title."""
+    if not runs_dir.is_dir():
+        return []
+    topic_tokens = _tokens(topic)
+    if not topic_tokens:
+        return []
+    scored: list[RelatedNote] = []
+    exclude_resolved = exclude.resolve() if exclude else None
+    for path in sorted(runs_dir.glob("*.md")):
+        if exclude_resolved and path.resolve() == exclude_resolved:
+            continue
+        if path.name.lower() in {"index.md", "dashboard.md", "readme.md"}:
+            continue
+        stem_tokens = _tokens(path.stem)
+        title = path.stem
+        try:
+            head = path.read_text(encoding="utf-8", errors="replace")[:1200]
+        except OSError:
+            head = ""
+        title_match = re.search(r"^title:\s*(.+)$", head, re.MULTILINE)
+        if title_match:
+            title = title_match.group(1).strip().strip('"').strip("'")
+        overlap = topic_tokens & (stem_tokens | _tokens(title) | _tokens(head))
+        if not overlap:
+            continue
+        score = len(overlap) / max(len(topic_tokens), 1)
+        scored.append(
+            RelatedNote(
+                title=title,
+                path=path,
+                score=score,
+                reason=f"shared tokens: {', '.join(sorted(overlap)[:6])}",
+            )
+        )
+    scored.sort(key=lambda item: (-item.score, item.path.name))
+    return scored[:limit]
+
+
+def unique_note_path(directory: Path, stem: str, extension: str = ".md") -> Path:
+    """Allocate a collision-safe path without overwriting existing notes."""
+    directory.mkdir(parents=True, exist_ok=True)
+    base = directory / f"{stem}{extension}"
+    if not base.exists():
+        return base
+    for index in range(1, 1000):
+        candidate = directory / f"{stem}-{index}{extension}"
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"Could not allocate unique note path under {directory}")
+
+
+def _frontmatter(
+    *,
+    title: str,
+    topic: str,
+    report: schema.Report,
+    note_kind: str,
+    tags: list[str],
+    related_titles: list[str],
+    sources: list[str],
+    run_note_title: str | None = None,
+) -> str:
+    lines = [
+        "---",
+        f"title: {_yaml_scalar(title)}",
+        f"topic: {_yaml_scalar(topic)}",
+        f"type: {_yaml_scalar(note_kind)}",
+        f"status: complete",
+        f"generated_at: {_yaml_scalar(report.generated_at)}",
+        f"range_from: {_yaml_scalar(report.range_from)}",
+        f"range_to: {_yaml_scalar(report.range_to)}",
+        f"skill: obsidian2date",
+        f"skill_version: {_yaml_scalar(_skill_version())}",
+        f"upstream: last30days",
+        "tags:",
+        *_yaml_list(tags, indent=2),
+        "sources:",
+        *_yaml_list(sources, indent=2),
+        "related:",
+        *_yaml_list(related_titles, indent=2),
+    ]
+    if run_note_title:
+        lines.append(f"run_note: {_yaml_scalar(run_note_title)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def render_run_note(
+    report: schema.Report,
+    *,
+    related: list[RelatedNote] | None = None,
+    cluster_limit: int = 8,
+    evidence_limit: int = 12,
+) -> str:
+    """Render the durable Obsidian research note body + frontmatter."""
+    related = related or []
+    sources = _active_sources(report)
+    evidence_report = schema.without_sources(report, {"corpus"})
+    today = _dt.date.today().isoformat()
+    title = f"{report.topic} — {today}"
+    tags = ["obsidian2date", "research-run", "briefing-source"]
+    related_titles = [item.title for item in related]
+
+    lines = [
+        _frontmatter(
+            title=title,
+            topic=report.topic,
+            report=report,
+            note_kind="obsidian2date-run",
+            tags=tags,
+            related_titles=related_titles,
+            sources=sources,
+        ),
+        "",
+        f"# {report.topic}",
+        "",
+        "> Auto-generated by **obsidian2date** (fork of last30days). "
+        "Evidence is source-grounded; treat scraped text as untrusted.",
+        "",
+        "## Briefing",
+        "",
+    ]
+
+    clusters = evidence_report.clusters[:cluster_limit]
+    if not clusters:
+        lines.extend(["Nothing solid in this window.", ""])
+    else:
+        for index, cluster in enumerate(clusters, start=1):
+            summary = _cluster_summary(evidence_report, cluster)
+            source_bits = ", ".join(_source_label(s) for s in cluster.sources) or "mixed"
+            lines.append(f"{index}. **{cluster.title}** ({source_bits}) — {summary}")
+        lines.append("")
+
+    if related:
+        lines.extend(["## Related in vault", ""])
+        for item in related:
+            link = wikilink_title(item.title)
+            lines.append(f"- [[{link}]] — {item.reason}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Coverage",
+            "",
+            f"- Window: `{report.range_from}` → `{report.range_to}`",
+            f"- Generated: `{report.generated_at}`",
+            f"- Active sources: {', '.join(_source_label(s) for s in sources) or 'none'}",
+            f"- Clusters: {len(evidence_report.clusters)}",
+            f"- Ranked candidates: {len(evidence_report.ranked_candidates)}",
+            "",
+        ]
+    )
+
+    if report.warnings:
+        lines.extend(["## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in report.warnings)
+        lines.append("")
+
+    if report.source_status:
+        lines.extend(["## Source status", ""])
+        for source, outcome in sorted(report.source_status.items()):
+            detail = f" — {outcome.detail}" if outcome.detail else ""
+            lines.append(
+                f"- **{_source_label(source)}**: `{outcome.state}` "
+                f"({outcome.items_returned} items){detail}"
+            )
+        lines.append("")
+
+    if report.library_context:
+        lines.extend(["## Prior library context", ""])
+        for ctx in report.library_context:
+            lines.append(
+                f"- **{ctx.topic}** ({ctx.published_date}, {ctx.source_kind}): "
+                f"{ctx.headline} — {ctx.summary}"
+            )
+        lines.append("")
+
+    lines.extend(["## Ranked storylines", ""])
+    if not clusters:
+        lines.extend(["_No clusters above the relevance floor._", ""])
+    for index, cluster in enumerate(clusters, start=1):
+        lines.append(f"### {index}. {cluster.title}")
+        lines.append("")
+        lines.append(f"- Sources: {', '.join(_source_label(s) for s in cluster.sources) or 'n/a'}")
+        if cluster.uncertainty:
+            lines.append(f"- Uncertainty: `{cluster.uncertainty}`")
+        lines.append(f"- Summary: {_cluster_summary(evidence_report, cluster)}")
+        lines.append("")
+
+    lines.extend(["## Evidence index", ""])
+    candidates = evidence_report.ranked_candidates[:evidence_limit]
+    if not candidates:
+        lines.extend(["_No ranked candidates._", ""])
+    for index, candidate in enumerate(candidates, start=1):
+        host = urlparse(candidate.url or "").netloc or candidate.source
+        engagement = _engagement_total(candidate)
+        eng = f", engagement={engagement:g}" if engagement else ""
+        lines.append(
+            f"{index}. [{candidate.title or candidate.url or candidate.candidate_id}]({candidate.url}) "
+            f"— {_source_label(candidate.source)} ({host}{eng})"
+        )
+        snippet = (candidate.snippet or "").strip()
+        if snippet:
+            lines.append(f"   - {snippet[:280]}")
+    lines.append("")
+
+    lines.extend(
+        [
+            "## How to use",
+            "",
+            "- Link this note from project pages with `[[...]]`.",
+            "- Prefer the briefing note for a daily skim; keep this run note as the durable source record.",
+            "- Re-run with the same topic to append a new dated note; prior notes stay linked under Related.",
+            "",
+            f"_obsidian2date v{_skill_version()} · upstream last30days_",
+            "",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_briefing_note(
+    report: schema.Report,
+    *,
+    run_note_title: str,
+    related: list[RelatedNote] | None = None,
+    cluster_limit: int = 5,
+) -> str:
+    """Render a short briefing note meant for daily reading."""
+    related = related or []
+    sources = _active_sources(report)
+    evidence_report = schema.without_sources(report, {"corpus"})
+    today = _dt.date.today().isoformat()
+    title = f"Briefing: {report.topic} — {today}"
+    tags = ["obsidian2date", "briefing"]
+    related_titles = [run_note_title, *[item.title for item in related]]
+
+    lines = [
+        _frontmatter(
+            title=title,
+            topic=report.topic,
+            report=report,
+            note_kind="obsidian2date-briefing",
+            tags=tags,
+            related_titles=related_titles,
+            sources=sources,
+            run_note_title=run_note_title,
+        ),
+        "",
+        f"# Briefing: {report.topic}",
+        "",
+        f"Full run: [[{wikilink_title(run_note_title)}]]",
+        "",
+        "## What matters now",
+        "",
+    ]
+    clusters = evidence_report.clusters[:cluster_limit]
+    if not clusters:
+        lines.append("- Nothing solid in this window.")
+    else:
+        for cluster in clusters:
+            lines.append(
+                f"- **{cluster.title}** — {_cluster_summary(evidence_report, cluster)}"
+            )
+    lines.append("")
+
+    if related:
+        lines.extend(["## Related vault notes", ""])
+        for item in related:
+            lines.append(f"- [[{wikilink_title(item.title)}]]")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Coverage snapshot",
+            "",
+            f"- Window `{report.range_from}` → `{report.range_to}`",
+            f"- Sources: {', '.join(_source_label(s) for s in sources) or 'none'}",
+            f"- Generated `{report.generated_at}`",
+            "",
+            f"_obsidian2date briefing · v{_skill_version()}_",
+            "",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _ensure_index(path: Path) -> None:
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                'title: "obsidian2date Index"',
+                "type: obsidian2date-index",
+                "tags:",
+                "  - obsidian2date",
+                "  - index",
+                "---",
+                "",
+                "# obsidian2date Index",
+                "",
+                "Auto-maintained list of research runs. Newest first.",
+                "",
+                "## Runs",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _ensure_dashboard(path: Path) -> None:
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                'title: "obsidian2date Dashboard"',
+                "type: obsidian2date-dashboard",
+                "tags:",
+                "  - obsidian2date",
+                "  - dashboard",
+                "---",
+                "",
+                "# obsidian2date Dashboard",
+                "",
+                "Latest research briefings for quick scanning.",
+                "",
+                "## Latest briefings",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _prepend_list_item(path: Path, heading: str, item_line: str, *, max_items: int = 100) -> None:
+    text = path.read_text(encoding="utf-8")
+    if item_line in text:
+        return
+    marker = f"## {heading}"
+    if marker not in text:
+        text = text.rstrip() + f"\n\n{marker}\n\n"
+    head, tail = text.split(marker, 1)
+    # Keep only the list under this heading (until next ## or EOF).
+    lines = tail.splitlines()
+    body_lines: list[str] = []
+    rest_lines: list[str] = []
+    seen_body = False
+    for line in lines:
+        if not seen_body:
+            body_lines.append(line)
+            if line.startswith("- "):
+                seen_body = True
+            continue
+        if line.startswith("## "):
+            rest_lines.append(line)
+            rest_lines.extend(lines[lines.index(line) + 1 :])
+            break
+        body_lines.append(line)
+    else:
+        rest_lines = []
+
+    # Rebuild list: marker line + blank + new item + existing items.
+    existing_items = [line for line in body_lines if line.startswith("- ")]
+    prefix = [line for line in body_lines if not line.startswith("- ")]
+    # prefix usually starts with '' after the heading split.
+    new_items = [item_line, *existing_items]
+    new_items = new_items[:max_items]
+    rebuilt = marker + "\n".join(prefix)
+    if not rebuilt.endswith("\n"):
+        rebuilt += "\n"
+    if prefix and prefix[-1].strip() != "":
+        rebuilt += "\n"
+    rebuilt += "\n".join(new_items) + "\n"
+    if rest_lines:
+        rebuilt += "\n" + "\n".join(rest_lines).lstrip("\n")
+    path.write_text(head + rebuilt, encoding="utf-8")
+
+
+def update_index(index_path: Path, *, run_title: str, topic: str, date_str: str) -> None:
+    _ensure_index(index_path)
+    link = wikilink_title(run_title)
+    item = f"- {date_str} · [[{link}]] — {topic}"
+    _prepend_list_item(index_path, "Runs", item)
+
+
+def update_dashboard(
+    dashboard_path: Path,
+    *,
+    briefing_title: str,
+    topic: str,
+    date_str: str,
+) -> None:
+    _ensure_dashboard(dashboard_path)
+    link = wikilink_title(briefing_title)
+    item = f"- {date_str} · [[{link}]] — {topic}"
+    _prepend_list_item(dashboard_path, "Latest briefings", item)
+
+
+def export_report_to_obsidian(
+    report: schema.Report,
+    *,
+    vault_root: str | Path | None = None,
+    paths: ObsidianPaths | None = None,
+    env: dict[str, str] | None = None,
+    related_limit: int = 5,
+) -> ObsidianExportResult:
+    """Write run note + briefing and update index/dashboard."""
+    if paths is None:
+        root = resolve_vault_root(vault_root, env=env)
+        paths = resolve_paths(root)
+
+    today = _dt.date.today().isoformat()
+    slug = slugify_topic(report.topic)
+    related = find_related_notes(report.topic, paths.runs_dir, limit=related_limit)
+
+    run_stem = f"{today}-{slug}"
+    run_path = unique_note_path(paths.runs_dir, run_stem)
+    run_title = f"{report.topic} — {today}"
+    if run_path.stem != run_stem:
+        # Collision suffix — keep title unique for wikilinks.
+        suffix = run_path.stem[len(run_stem) :]
+        run_title = f"{run_title}{suffix}"
+
+    run_body = render_run_note(report, related=related)
+    # Re-render frontmatter title if collision renamed the note.
+    if f'title: "{report.topic} — {today}"' in run_body or f"title: {report.topic} — {today}" in run_body:
+        run_body = run_body.replace(
+            f"{report.topic} — {today}",
+            run_title,
+            2,
+        )
+    run_path.write_text(run_body, encoding="utf-8")
+
+    # Related notes should not include the note we just wrote.
+    related = find_related_notes(
+        report.topic,
+        paths.runs_dir,
+        limit=related_limit,
+        exclude=run_path,
+    )
+    # Patch related section if we discovered more after write (first pass had none).
+    if related and "## Related in vault" not in run_body:
+        run_body = render_run_note(report, related=related)
+        run_body = run_body.replace(
+            f"{report.topic} — {today}",
+            run_title,
+            2,
+        )
+        run_path.write_text(run_body, encoding="utf-8")
+
+    briefing_stem = f"{today}-{slug}-briefing"
+    briefing_path = unique_note_path(paths.briefings_dir, briefing_stem)
+    briefing_title = f"Briefing: {report.topic} — {today}"
+    if briefing_path.stem != briefing_stem:
+        suffix = briefing_path.stem[len(briefing_stem) :]
+        briefing_title = f"{briefing_title}{suffix}"
+
+    briefing_body = render_briefing_note(
+        report,
+        run_note_title=run_title,
+        related=related,
+    )
+    if briefing_title != f"Briefing: {report.topic} — {today}":
+        briefing_body = briefing_body.replace(
+            f"Briefing: {report.topic} — {today}",
+            briefing_title,
+            2,
+        )
+    briefing_path.write_text(briefing_body, encoding="utf-8")
+
+    update_index(paths.index_path, run_title=run_title, topic=report.topic, date_str=today)
+    update_dashboard(
+        paths.dashboard_path,
+        briefing_title=briefing_title,
+        topic=report.topic,
+        date_str=today,
+    )
+
+    return ObsidianExportResult(
+        run_note=run_path,
+        briefing_note=briefing_path,
+        index_path=paths.index_path,
+        dashboard_path=paths.dashboard_path,
+        related=related,
+    )
+
+
+def render_obsidian_stdout(result: ObsidianExportResult, report: schema.Report) -> str:
+    """Human-readable summary printed to stdout after export."""
+    lines = [
+        f"obsidian2date export complete: {report.topic}",
+        f"- run: {result.run_note}",
+        f"- briefing: {result.briefing_note}",
+        f"- index: {result.index_path}",
+        f"- dashboard: {result.dashboard_path}",
+    ]
+    if result.related:
+        lines.append("- related:")
+        for item in result.related:
+            lines.append(f"  - [[{wikilink_title(item.title)}]] ({item.reason})")
+    else:
+        lines.append("- related: none yet")
+    return "\n".join(lines) + "\n"

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -48,29 +48,48 @@ metadata:
 
 # obsidian2date
 
-Fork of [last30days](https://github.com/mvanhorn/last30days-skill) focused on **durable Obsidian capture**.
+Research a topic from the last 30 days and keep the useful evidence in Obsidian.
+This is the vault-first entrypoint for the public
+[obsidian2date](https://github.com/pauleschwarz/obsidian2date) fork of
+[last30days](https://github.com/mvanhorn/last30days-skill).
 
-The research engine remains upstream-compatible under `skills/last30days/`.
-This skill is the vault-first entrypoint: research a topic, write notes, link related prior runs, and surface a short briefing.
+The upstream research engine remains under `skills/last30days/`.
 
-**Vault contract (read when writing to brain-paul):**
-`/Users/paulschwarz/Desktop/brain-paul/90_Quellen/obsidian2date/AGENT-DEKLARATION.md`
+## Run
 
-Default vault: `/Users/paulschwarz/Desktop/brain-paul`.
-Writes only under `90_Quellen/obsidian2date/{runs,briefings,Index,Dashboard}` — never into `00_Prime/`, `10_Projekte/`, or `70_Archiv/` without an explicit user order.
+1. Get the topic from the user's request.
+2. Resolve the vault from `OBSIDIAN2DATE_VAULT`, then
+   `LAST30DAYS_OBSIDIAN_VAULT`. If neither is set, ask the user for the vault
+   path before writing.
+3. Run the existing research engine with `--emit=obsidian` and the resolved
+   vault, preserving the engine's normal source and fallback behavior.
+4. Report the briefing path, run-note path, and any partial or unavailable
+   sources honestly.
 
-## Default command
-
-Resolve `SKILL_DIR` to the directory that contains **this** `SKILL.md`.
-The engine still lives next door:
+Example from the repository root:
 
 ```bash
-ENGINE="$SKILL_DIR/../last30days/scripts/last30days.py"
-python3 "$ENGINE" "<topic>" --emit=obsidian --obsidian-vault "$VAULT"
+python3 skills/last30days/scripts/last30days.py "topic" \
+  --emit=obsidian \
+  --obsidian-vault /path/to/your/vault
 ```
 
-If `OBSIDIAN2DATE_VAULT` (or `LAST30DAYS_OBSIDIAN_VAULT`) is set, `--obsidian-vault` can be omitted.
-If neither is set, the engine tries `~/Desktop/brain-paul` when that directory exists.
+## Vault contract
+
+Write only under `90_Quellen/obsidian2date/`:
+
+- `runs/` contains source-backed research notes.
+- `briefings/` contains compact briefings for daily review.
+- `Index.md` and `Dashboard.md` are maintained by the exporter.
+
+Never overwrite an existing note. The exporter adds a numeric suffix on
+filename collisions and links related prior runs with Obsidian `[[wikilinks]]`.
+Do not write API keys or other sensitive values into notes.
+
+## Upstream mode
+
+Use `skills/last30days/SKILL.md` for the original non-Obsidian workflow. Keep
+changes to the research engine additive and upstream-compatible.
 
 ## What gets written
 

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -124,6 +124,8 @@ Related prior runs are linked with Obsidian `[[wikilinks]]` when token overlap i
 ## Quick examples
 
 ```bash
+ENGINE="skills/last30days/scripts/last30days.py"
+
 # Vault-native research, default 30-day window
 python3 "$ENGINE" "local LLM agent frameworks" --emit=obsidian
 

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -58,9 +58,12 @@ The upstream research engine remains under `skills/last30days/`.
 ## Run
 
 1. Get the topic from the user's request.
-2. Resolve the vault from `OBSIDIAN2DATE_VAULT`, then
-   `LAST30DAYS_OBSIDIAN_VAULT`. If neither is set, ask the user for the vault
-   path before writing.
+2. Resolve the vault from an explicit `--obsidian-vault` path, then
+   `OBSIDIAN2DATE_VAULT`, then `LAST30DAYS_OBSIDIAN_VAULT`, then an existing
+   `~/Desktop/brain-paul`. Environment and desktop candidates must already be
+   directories; an explicit missing path is the requested export target. If no
+   path resolves, ask the user for one before writing (the CLI otherwise raises
+   `No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.`).
 3. Run the existing research engine with `--emit=obsidian` and the resolved
    vault, preserving the engine's normal source and fallback behavior.
 4. Report the briefing path, run-note path, and any partial or unavailable
@@ -109,7 +112,7 @@ Related prior runs are linked with Obsidian `[[wikilinks]]` when token overlap i
 
 1. **Do not improvise research.** Run the engine. Pass its stdout through.
 2. **Prefer `--emit=obsidian`** for this skill. Use upstream modes (`compact`, `json`, `brief`, …) only when the user explicitly asks.
-3. **Vault path:** ask once if no vault can be resolved; then pin `OBSIDIAN2DATE_VAULT` for the session.
+3. **Vault path:** ask once if no vault can be resolved; then pin `OBSIDIAN2DATE_VAULT` for the session. An empty or whitespace-only vault environment value deliberately disables implicit fallback.
 4. **Keys are optional.** Reddit / HN / Polymarket / GitHub / Web work keyless. X needs browser cookies or a backend; TikTok/IG need ScrapeCreators.
 5. **Synthesis:** the Obsidian notes already contain a structured briefing and evidence index. Do **not** invent citations beyond what the engine returned. You may add a short German prose summary *after* the engine output if the user wants narrative.
 6. **Upstream skill:** for doctor/setup/deep source debugging, fall back to `skills/last30days/SKILL.md`.

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -53,6 +53,12 @@ Fork of [last30days](https://github.com/mvanhorn/last30days-skill) focused on **
 The research engine remains upstream-compatible under `skills/last30days/`.
 This skill is the vault-first entrypoint: research a topic, write notes, link related prior runs, and surface a short briefing.
 
+**Vault contract (read when writing to brain-paul):**
+`/Users/paulschwarz/Desktop/brain-paul/90_Quellen/obsidian2date/AGENT-DEKLARATION.md`
+
+Default vault: `/Users/paulschwarz/Desktop/brain-paul`.
+Writes only under `90_Quellen/obsidian2date/{runs,briefings,Index,Dashboard}` — never into `00_Prime/`, `10_Projekte/`, or `70_Archiv/` without an explicit user order.
+
 ## Default command
 
 Resolve `SKILL_DIR` to the directory that contains **this** `SKILL.md`.

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: obsidian2date
 version: "0.1.0"
-description: "Research what people actually say about any topic in the last 30 days, then write a durable Obsidian run note, briefing, index entry, and related-note links into your vault. Built on the last30days research engine."
-argument-hint: 'obsidian2date nvidia earnings reaction | obsidian2date AI video tools | obsidian2date what users want in react'
+description: "Research what people actually say about any topic over any recent window (default 30 days, --days N for anything else), then write a durable Obsidian run note, briefing, index entry, and related-note links into your vault. Built on the last30days research engine."
+argument-hint: 'obsidian2date nvidia earnings reaction | obsidian2date last 7 days of AI video tools | obsidian2date what users want in react over the last 90 days'
 allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
 homepage: https://github.com/pauleschwarz/obsidian2date
 repository: https://github.com/pauleschwarz/obsidian2date
@@ -48,7 +48,7 @@ metadata:
 
 # obsidian2date
 
-Research a topic from the last 30 days and keep the useful evidence in Obsidian.
+Research what people actually said about a topic over any recent window and keep the useful evidence in Obsidian. The window follows the request: say "last week", "the last 7 days", or "over the last 90 days" — the default is 30 days.
 This is the vault-first entrypoint for the public
 [obsidian2date](https://github.com/pauleschwarz/obsidian2date) fork of
 [last30days](https://github.com/mvanhorn/last30days-skill).
@@ -64,9 +64,13 @@ The upstream research engine remains under `skills/last30days/`.
    directories; an explicit missing path is the requested export target. If no
    path resolves, ask the user for one before writing (the CLI otherwise raises
    `No Obsidian vault found. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT.`).
-3. Run the existing research engine with `--emit=obsidian` and the resolved
-   vault, preserving the engine's normal source and fallback behavior.
-4. Report the briefing path, run-note path, and any partial or unavailable
+3. Derive the time window from the user's request (default 30 days; "last
+   week" or "last 7 days" -> `--days 7`, "last 90 days" -> `--days 90`). The
+   engine accepts `--days N` and `--as-of YYYY-MM-DD`; 30 is only the default.
+4. Run the existing research engine with `--emit=obsidian`, the resolved
+   vault, and the requested window, preserving the engine's normal source and
+   fallback behavior.
+5. Report the briefing path, run-note path, and any partial or unavailable
    sources honestly.
 
 Example from the repository root:
@@ -120,8 +124,12 @@ Related prior runs are linked with Obsidian `[[wikilinks]]` when token overlap i
 ## Quick examples
 
 ```bash
-# Vault-native research
+# Vault-native research, default 30-day window
 python3 "$ENGINE" "local LLM agent frameworks" --emit=obsidian
+
+# Any window: last week, or a 90-day sweep
+python3 "$ENGINE" "AI video tools" --emit=obsidian --days 7
+python3 "$ENGINE" "rust async runtimes" --emit=obsidian --days 90
 
 # Explicit vault
 python3 "$ENGINE" "obsidian plugins 2026" --emit=obsidian \

--- a/skills/obsidian2date/SKILL.md
+++ b/skills/obsidian2date/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: obsidian2date
+version: "0.1.0"
+description: "Research what people actually say about any topic in the last 30 days, then write a durable Obsidian run note, briefing, index entry, and related-note links into your vault. Built on the last30days research engine."
+argument-hint: 'obsidian2date nvidia earnings reaction | obsidian2date AI video tools | obsidian2date what users want in react'
+allowed-tools: Bash, Read, Write, AskUserQuestion, WebSearch
+homepage: https://github.com/pauleschwarz/obsidian2date
+repository: https://github.com/pauleschwarz/obsidian2date
+author: pauleschwarz
+license: MIT
+user-invocable: true
+metadata:
+  openclaw:
+    emoji: "🗂"
+    requires:
+      env: []
+      optionalEnv:
+        - OBSIDIAN2DATE_VAULT
+        - LAST30DAYS_OBSIDIAN_VAULT
+        - SCRAPECREATORS_API_KEY
+        - OPENAI_API_KEY
+        - XAI_API_KEY
+        - OPENROUTER_API_KEY
+        - PERPLEXITY_API_KEY
+        - PARALLEL_API_KEY
+        - BRAVE_API_KEY
+        - APIFY_API_TOKEN
+        - AUTH_TOKEN
+        - CT0
+      bins:
+        - node
+        - python3
+    primaryEnv: OBSIDIAN2DATE_VAULT
+    files:
+      - "../last30days/scripts/*"
+    homepage: https://github.com/pauleschwarz/obsidian2date
+    tags:
+      - research
+      - obsidian
+      - vault
+      - briefing
+      - multi-source
+      - reddit
+      - youtube
+      - hackernews
+      - github
+---
+
+# obsidian2date
+
+Fork of [last30days](https://github.com/mvanhorn/last30days-skill) focused on **durable Obsidian capture**.
+
+The research engine remains upstream-compatible under `skills/last30days/`.
+This skill is the vault-first entrypoint: research a topic, write notes, link related prior runs, and surface a short briefing.
+
+## Default command
+
+Resolve `SKILL_DIR` to the directory that contains **this** `SKILL.md`.
+The engine still lives next door:
+
+```bash
+ENGINE="$SKILL_DIR/../last30days/scripts/last30days.py"
+python3 "$ENGINE" "<topic>" --emit=obsidian --obsidian-vault "$VAULT"
+```
+
+If `OBSIDIAN2DATE_VAULT` (or `LAST30DAYS_OBSIDIAN_VAULT`) is set, `--obsidian-vault` can be omitted.
+If neither is set, the engine tries `~/Desktop/brain-paul` when that directory exists.
+
+## What gets written
+
+Under the vault root (defaults shown):
+
+| Path | Purpose |
+| --- | --- |
+| `90_Quellen/obsidian2date/runs/YYYY-MM-DD-<slug>.md` | Durable research run note with frontmatter, briefing bullets, evidence index |
+| `90_Quellen/obsidian2date/briefings/YYYY-MM-DD-<slug>-briefing.md` | Short daily skim note linking back to the run |
+| `90_Quellen/obsidian2date/Index.md` | Newest-first run index |
+| `90_Quellen/obsidian2date/Dashboard.md` | Newest-first briefing dashboard |
+
+Notes never overwrite each other. Same-day collisions get `-1`, `-2`, … suffixes.
+Related prior runs are linked with Obsidian `[[wikilinks]]` when token overlap is found.
+
+## Agent contract
+
+1. **Do not improvise research.** Run the engine. Pass its stdout through.
+2. **Prefer `--emit=obsidian`** for this skill. Use upstream modes (`compact`, `json`, `brief`, …) only when the user explicitly asks.
+3. **Vault path:** ask once if no vault can be resolved; then pin `OBSIDIAN2DATE_VAULT` for the session.
+4. **Keys are optional.** Reddit / HN / Polymarket / GitHub / Web work keyless. X needs browser cookies or a backend; TikTok/IG need ScrapeCreators.
+5. **Synthesis:** the Obsidian notes already contain a structured briefing and evidence index. Do **not** invent citations beyond what the engine returned. You may add a short German prose summary *after* the engine output if the user wants narrative.
+6. **Upstream skill:** for doctor/setup/deep source debugging, fall back to `skills/last30days/SKILL.md`.
+
+## Quick examples
+
+```bash
+# Vault-native research
+python3 "$ENGINE" "local LLM agent frameworks" --emit=obsidian
+
+# Explicit vault
+python3 "$ENGINE" "obsidian plugins 2026" --emit=obsidian \
+  --obsidian-vault "$HOME/Desktop/brain-paul"
+
+# Keyless free sources only
+python3 "$ENGINE" "rust async runtime" --emit=obsidian --search reddit,hackernews,github,web
+
+# Upstream compact (no vault write)
+python3 "$ENGINE" "topic" --emit=compact
+```
+
+## Setup notes
+
+- Python ≥ 3.12 recommended (3.13 works).
+- Optional: copy upstream `.env` patterns from `CONFIGURATION.md`.
+- MIT license. Upstream copyright retained in `LICENSE`. This fork adds the Obsidian export path and branding.

--- a/tests/test_env_doc_contract.py
+++ b/tests/test_env_doc_contract.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import importlib
 import re
+import sys
 from pathlib import Path
 from unittest import mock
 
-from lib import env
-
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_ROOT = ROOT / "skills" / "last30days" / "scripts"
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+env = importlib.import_module("lib.env")
 DOC_PATHS = [
     ROOT / "skills" / "last30days" / "SKILL.md",
     ROOT / "README.md",
@@ -19,7 +23,8 @@ CONFIG_ENV_KEY_RE = re.compile(
     r"BSKY|TRUTHSOCIAL|BRAVE|EXA|SERPER|OPENROUTER|PERPLEXITY|PARALLEL|"
     r"XQUIK|GROQ)_[A-Z0-9_]+|"
     r"OPENAI_API_KEY|AUTH_TOKEN|CT0|FROM_BROWSER|INCLUDE_SOURCES|"
-    r"EXCLUDE_SOURCES|SETUP_COMPLETE|FUN_LEVEL"
+    r"EXCLUDE_SOURCES|SETUP_COMPLETE|FUN_LEVEL|OBSIDIAN2DATE_VAULT|"
+    r"LAST30DAYS_OBSIDIAN_VAULT"
     r")(?![A-Z0-9_])"
 )
 DOC_ONLY_KEYS = {

--- a/tests/test_env_v3.py
+++ b/tests/test_env_v3.py
@@ -1,9 +1,18 @@
+import importlib
 import os
+import sys
 import unittest
 from pathlib import Path
+import tempfile
 from unittest import mock
 
-from lib import bird_x, env
+SCRIPT_ROOT = Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+cli = importlib.import_module("last30days")
+bird_x = importlib.import_module("lib.bird_x")
+env = importlib.import_module("lib.env")
+obsidian_export = importlib.import_module("lib.obsidian_export")
 
 
 class EnvV3Tests(unittest.TestCase):
@@ -37,6 +46,75 @@ class EnvV3Tests(unittest.TestCase):
             bird_x._credentials.clear()
             with mock.patch.dict(os.environ, {}, clear=False):
                 self.assertIsNone(bird_x.is_bird_authenticated())
+
+    def test_file_configured_vault_is_registered_and_propagated_for_export(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_file = Path(tmp) / ".env"
+            configured = Path(tmp) / "configured"
+            configured.mkdir()
+            config_file.write_text(
+                f"OBSIDIAN2DATE_VAULT={configured}\n",
+                encoding="utf-8",
+            )
+            config_file.chmod(0o600)
+            with (
+                mock.patch.object(env, "CONFIG_FILE", config_file),
+                mock.patch.object(env, "_find_project_env", return_value=None),
+                mock.patch.object(env, "_load_keychain", return_value={}),
+                mock.patch.object(env, "_load_pass", return_value={}),
+                mock.patch.dict(os.environ, {}, clear=False),
+            ):
+                os.environ.pop("OBSIDIAN2DATE_VAULT", None)
+                config = env.get_config()
+                self.assertEqual(str(configured), config["OBSIDIAN2DATE_VAULT"])
+                self.assertNotIn("OBSIDIAN2DATE_VAULT", os.environ)
+                cli._propagate_config_to_environ(config)
+                self.assertEqual(configured.resolve(), obsidian_export.resolve_vault_root())
+
+    def test_process_environment_vault_values_win_including_empty_and_whitespace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_file = Path(tmp) / ".env"
+            config_file.write_text(
+                f"OBSIDIAN2DATE_VAULT={tmp}/from-file\n",
+                encoding="utf-8",
+            )
+            config_file.chmod(0o600)
+            for value in ("", "  "):
+                with self.subTest(value=repr(value)):
+                    with (
+                        mock.patch.object(env, "CONFIG_FILE", config_file),
+                        mock.patch.object(env, "_find_project_env", return_value=None),
+                        mock.patch.object(env, "_load_keychain", return_value={}),
+                        mock.patch.object(env, "_load_pass", return_value={}),
+                        mock.patch.dict(os.environ, {"OBSIDIAN2DATE_VAULT": value}, clear=False),
+                    ):
+                        config = env.get_config()
+                        self.assertEqual(value, config["OBSIDIAN2DATE_VAULT"])
+                        cli._propagate_config_to_environ(config)
+                        self.assertEqual(value, os.environ["OBSIDIAN2DATE_VAULT"])
+
+    def test_file_configured_legacy_vault_key_is_registered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_file = Path(tmp) / ".env"
+            legacy = Path(tmp) / "legacy"
+            legacy.mkdir()
+            config_file.write_text(
+                f"LAST30DAYS_OBSIDIAN_VAULT={legacy}\n",
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(env, "CONFIG_FILE", config_file),
+                mock.patch.object(env, "_find_project_env", return_value=None),
+                mock.patch.object(env, "_load_keychain", return_value={}),
+                mock.patch.object(env, "_load_pass", return_value={}),
+                mock.patch.dict(os.environ, {}, clear=False),
+            ):
+                os.environ.pop("LAST30DAYS_OBSIDIAN_VAULT", None)
+                config = env.get_config()
+                self.assertEqual(f"{tmp}/legacy", config["LAST30DAYS_OBSIDIAN_VAULT"])
+                self.assertNotIn("LAST30DAYS_OBSIDIAN_VAULT", os.environ)
+                cli._propagate_config_to_environ(config)
+                self.assertEqual(f"{tmp}/legacy", os.environ["LAST30DAYS_OBSIDIAN_VAULT"])
 
     def test_file_permission_check_skips_windows_posix_mode_bits(self):
         path = mock.Mock(spec=Path)

--- a/tests/test_obsidian_export.py
+++ b/tests/test_obsidian_export.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-import last30days as cli
-from lib import obsidian_export, schema
+SCRIPT_ROOT = Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts"
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+cli = importlib.import_module("last30days")
+obsidian_export = importlib.import_module("lib.obsidian_export")
+schema = importlib.import_module("lib.schema")
 
 
-def make_report(topic: str = "OpenClaw vs NanoClaw") -> schema.Report:
+def make_report(topic: str = "OpenClaw vs NanoClaw"):
     item = schema.SourceItem(
         item_id="i1",
         source="reddit",
@@ -174,6 +181,28 @@ class ObsidianExportTests(unittest.TestCase):
                 env={"OBSIDIAN2DATE_VAULT": str(vault)},
             )
             self.assertEqual(resolved, vault.resolve())
+
+    def test_resolve_vault_root_explicit_missing_path_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            explicit = Path(tmp) / "missing-vault"
+            self.assertEqual(
+                obsidian_export.resolve_vault_root(str(explicit), env={}),
+                explicit.resolve(),
+            )
+
+    def test_resolve_vault_root_blank_environment_blocks_implicit_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            fallback = home / "Desktop" / "brain-paul"
+            fallback.mkdir(parents=True)
+            with mock.patch.object(Path, "home", return_value=home), self.assertRaisesRegex(
+                FileNotFoundError,
+                r"^No Obsidian vault found\. Pass --obsidian-vault or set OBSIDIAN2DATE_VAULT\.$",
+            ):
+                obsidian_export.resolve_vault_root(
+                    None,
+                    env={"OBSIDIAN2DATE_VAULT": "", "LAST30DAYS_OBSIDIAN_VAULT": "  "},
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_obsidian_export.py
+++ b/tests/test_obsidian_export.py
@@ -91,6 +91,38 @@ class ObsidianExportTests(unittest.TestCase):
     def test_slugify_and_wikilink(self) -> None:
         self.assertEqual(obsidian_export.slugify_topic("Hello, World!"), "hello-world")
         self.assertEqual(obsidian_export.wikilink_title("A [B] | C"), "A B  C")
+        self.assertEqual(
+            obsidian_export.wikilink_alias("2026-03-16-topic-1", "Topic — 2026-03-16"),
+            "2026-03-16-topic-1|Topic — 2026-03-16",
+        )
+
+    def test_wikilinks_resolve_against_note_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            paths = obsidian_export.resolve_paths(vault)
+
+            first = make_report("OpenClaw agents")
+            result1 = obsidian_export.export_report_to_obsidian(first, paths=paths)
+
+            second = make_report("OpenClaw latency")
+            result2 = obsidian_export.export_report_to_obsidian(second, paths=paths)
+
+            run_stem = result1.run_note.stem
+            run2 = result2.run_note.read_text(encoding="utf-8")
+            self.assertIn(f"[[{run_stem}|", run2, "related links must target the note file")
+
+            briefing2 = result2.briefing_note.read_text(encoding="utf-8")
+            self.assertIn(f"[[{result2.run_note.stem}|", briefing2, "briefing must link the run file")
+            self.assertIn(f"[[{run_stem}|", briefing2)
+
+            index = result2.index_path.read_text(encoding="utf-8")
+            self.assertIn(f"[[{run_stem}|", index)
+
+            dashboard = result2.dashboard_path.read_text(encoding="utf-8")
+            self.assertIn(f"[[{result2.briefing_note.stem}|", dashboard)
+
+            stdout = obsidian_export.render_obsidian_stdout(result2, second)
+            self.assertIn(f"[[{run_stem}|", stdout)
 
     def test_render_run_note_has_frontmatter_and_sections(self) -> None:
         body = obsidian_export.render_run_note(make_report())

--- a/tests/test_obsidian_export.py
+++ b/tests/test_obsidian_export.py
@@ -93,6 +93,29 @@ class ObsidianExportTests(unittest.TestCase):
         self.assertIn("## Evidence index", body)
         self.assertIn("Latency debate", body)
         self.assertIn("https://reddit.com/r/LocalLLaMA/1", body)
+        self.assertIn("Users compare OpenClaw and NanoClaw on latency.", body)
+
+    def test_blurb_skips_title_only_source_text(self) -> None:
+        report = make_report()
+        item = report.ranked_candidates[0].source_items[0]
+        item.snippet = item.title
+        item.body = item.title
+        item.why_relevant = "HN story about OpenClaw threads explode"
+        report.ranked_candidates[0].snippet = item.title
+        self.assertEqual(obsidian_export._candidate_blurb(report.ranked_candidates[0]), "")
+
+    def test_cluster_summary_uses_evidence_fallback_without_title_echo(self) -> None:
+        report = make_report()
+        cluster = report.clusters[0]
+        candidate = report.ranked_candidates[0]
+        candidate.source_items[0].snippet = candidate.title
+        candidate.source_items[0].body = candidate.title
+        candidate.source_items[0].why_relevant = "HN story about OpenClaw threads explode"
+        candidate.snippet = candidate.title
+        self.assertEqual(
+            obsidian_export._cluster_summary(report, cluster),
+            "Cluster across Reddit; open the evidence index for links.",
+        )
 
     def test_export_writes_notes_index_dashboard_and_links_related(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_obsidian_export.py
+++ b/tests/test_obsidian_export.py
@@ -1,0 +1,157 @@
+"""Tests for the additive Obsidian vault export path."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import last30days as cli
+from lib import obsidian_export, schema
+
+
+def make_report(topic: str = "OpenClaw vs NanoClaw") -> schema.Report:
+    item = schema.SourceItem(
+        item_id="i1",
+        source="reddit",
+        title="OpenClaw threads explode",
+        body="Users compare OpenClaw and NanoClaw on latency.",
+        url="https://reddit.com/r/LocalLLaMA/1",
+        author="alice",
+        published_at="2026-03-10T00:00:00Z",
+        engagement={"upvotes": 120, "comments": 40},
+        snippet="Users compare OpenClaw and NanoClaw on latency.",
+    )
+    candidate = schema.Candidate(
+        candidate_id="c1",
+        item_id="i1",
+        source="reddit",
+        title=item.title,
+        url=item.url,
+        snippet=item.snippet,
+        subquery_labels=["compare"],
+        native_ranks={"reddit": 1},
+        local_relevance=0.9,
+        freshness=1,
+        engagement=160,
+        source_quality=0.8,
+        rrf_score=0.5,
+        sources=["reddit"],
+        source_items=[item],
+        final_score=0.9,
+        cluster_id="cl1",
+    )
+    cluster = schema.Cluster(
+        cluster_id="cl1",
+        title="Latency debate",
+        candidate_ids=["c1"],
+        representative_ids=["c1"],
+        sources=["reddit"],
+        score=0.9,
+    )
+    return schema.Report(
+        topic=topic,
+        range_from="2026-02-14",
+        range_to="2026-03-16",
+        generated_at="2026-03-16T00:00:00+00:00",
+        provider_runtime=schema.ProviderRuntime(
+            reasoning_provider="gemini",
+            planner_model="gemini-3.1-flash-lite",
+            rerank_model="gemini-3.1-flash-lite",
+        ),
+        query_plan=schema.QueryPlan(
+            intent="comparison",
+            freshness_mode="balanced_recent",
+            cluster_mode="debate",
+            raw_topic=topic,
+            subqueries=[],
+            source_weights={"reddit": 1.0},
+        ),
+        clusters=[cluster],
+        ranked_candidates=[candidate],
+        items_by_source={"reddit": [item]},
+        errors_by_source={},
+        source_status={
+            "reddit": schema.SourceOutcome(source="reddit", state="ok", items_returned=1),
+        },
+        warnings=[],
+        artifacts={},
+        library_context=[],
+    )
+
+
+class ObsidianExportTests(unittest.TestCase):
+    def test_slugify_and_wikilink(self) -> None:
+        self.assertEqual(obsidian_export.slugify_topic("Hello, World!"), "hello-world")
+        self.assertEqual(obsidian_export.wikilink_title("A [B] | C"), "A B  C")
+
+    def test_render_run_note_has_frontmatter_and_sections(self) -> None:
+        body = obsidian_export.render_run_note(make_report())
+        self.assertIn("type: obsidian2date-run", body)
+        self.assertIn("skill: obsidian2date", body)
+        self.assertIn("## Briefing", body)
+        self.assertIn("## Evidence index", body)
+        self.assertIn("Latency debate", body)
+        self.assertIn("https://reddit.com/r/LocalLLaMA/1", body)
+
+    def test_export_writes_notes_index_dashboard_and_links_related(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            paths = obsidian_export.resolve_paths(vault)
+
+            first = make_report("OpenClaw agents")
+            result1 = obsidian_export.export_report_to_obsidian(first, paths=paths)
+            self.assertTrue(result1.run_note.is_file())
+            self.assertTrue(result1.briefing_note.is_file())
+            self.assertTrue(result1.index_path.is_file())
+            self.assertTrue(result1.dashboard_path.is_file())
+
+            run1 = result1.run_note.read_text(encoding="utf-8")
+            self.assertIn("type: obsidian2date-run", run1)
+            self.assertIn("OpenClaw agents", run1)
+
+            second = make_report("OpenClaw latency")
+            result2 = obsidian_export.export_report_to_obsidian(second, paths=paths)
+            self.assertTrue(result2.related)
+            run2 = result2.run_note.read_text(encoding="utf-8")
+            self.assertIn("## Related in vault", run2)
+            self.assertIn("[[", run2)
+
+            index = result2.index_path.read_text(encoding="utf-8")
+            dashboard = result2.dashboard_path.read_text(encoding="utf-8")
+            self.assertIn("OpenClaw latency", index)
+            self.assertIn("OpenClaw agents", index)
+            self.assertIn("Briefing:", dashboard)
+
+            # Second export same day/topic must not overwrite the first note.
+            third = make_report("OpenClaw latency")
+            result3 = obsidian_export.export_report_to_obsidian(third, paths=paths)
+            self.assertNotEqual(result2.run_note, result3.run_note)
+            self.assertTrue(result2.run_note.exists())
+            self.assertTrue(result3.run_note.exists())
+
+    def test_emit_output_accepts_obsidian_mode(self) -> None:
+        report = make_report()
+        text = cli.emit_output(report, "obsidian")
+        self.assertIn("OpenClaw", text)
+
+    def test_parser_includes_obsidian_flags(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(
+            ["topic here", "--emit", "obsidian", "--obsidian-vault", "/tmp/vault"]
+        )
+        self.assertEqual(args.emit, "obsidian")
+        self.assertEqual(args.obsidian_vault, "/tmp/vault")
+
+    def test_resolve_vault_root_prefers_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            vault = Path(tmp)
+            resolved = obsidian_export.resolve_vault_root(
+                None,
+                env={"OBSIDIAN2DATE_VAULT": str(vault)},
+            )
+            self.assertEqual(resolved, vault.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -1,12 +1,17 @@
+import importlib
 import json
+import sys
 import tomllib
 import unittest
 from pathlib import Path
 
-from lib.skill_meta import read_skill_version
-
 ROOT = Path(__file__).resolve().parents[1]
-SKILL_ROOT = ROOT / "skills" / "last30days"
+SCRIPT_ROOT = ROOT / "skills" / "last30days" / "scripts"
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+read_skill_version = importlib.import_module("lib.skill_meta").read_skill_version
+FORK_SKILL_ROOT = ROOT / "skills" / "obsidian2date"
+FORK_REPOSITORY_URL = "https://github.com/pauleschwarz/obsidian2date.git"
 
 
 def _json(path: Path) -> dict:
@@ -14,7 +19,7 @@ def _json(path: Path) -> dict:
 
 
 def _skill_version() -> str:
-    version = read_skill_version(SKILL_ROOT / "SKILL.md")
+    version = read_skill_version(FORK_SKILL_ROOT / "SKILL.md")
     if not version:
         raise AssertionError("SKILL.md version frontmatter not found")
     return version
@@ -24,30 +29,27 @@ class TestPluginContract(unittest.TestCase):
     def test_codex_plugin_manifest_uses_repo_skill_root(self) -> None:
         manifest = _json(ROOT / ".codex-plugin" / "plugin.json")
 
-        self.assertEqual("last30days", manifest["name"])
+        self.assertEqual("obsidian2date", manifest["name"])
         self.assertEqual("./skills/", manifest["skills"])
-        self.assertEqual("last30days", manifest["interface"]["displayName"])
+        self.assertEqual("obsidian2date", manifest["interface"]["displayName"])
 
     def test_codex_marketplace_points_at_repo_root_plugin(self) -> None:
         marketplace = _json(ROOT / ".agents" / "plugins" / "marketplace.json")
         plugins = marketplace.get("plugins") or []
         plugin_by_name = {plugin["name"]: plugin for plugin in plugins}
 
-        self.assertEqual("last30days-skill", marketplace["name"])
-        self.assertIn("last30days", plugin_by_name)
-        plugin = plugin_by_name["last30days"]
+        self.assertEqual("obsidian2date", marketplace["name"])
+        self.assertIn("obsidian2date", plugin_by_name)
+        plugin = plugin_by_name["obsidian2date"]
         self.assertEqual(
-            {
-                "source": "url",
-                "url": "https://github.com/mvanhorn/last30days-skill.git",
-            },
+            {"source": "url", "url": FORK_REPOSITORY_URL},
             plugin["source"],
         )
 
     def test_grok_plugin_manifest_uses_repo_skill_root(self) -> None:
         manifest = _json(ROOT / ".grok-plugin" / "plugin.json")
 
-        self.assertEqual("last30days", manifest["name"])
+        self.assertEqual("obsidian2date", manifest["name"])
         self.assertEqual("./skills/", manifest["skills"])
 
     def test_grok_marketplace_points_at_repo_root_plugin(self) -> None:
@@ -55,15 +57,12 @@ class TestPluginContract(unittest.TestCase):
         plugins = marketplace.get("plugins") or []
         plugin_by_name = {plugin["name"]: plugin for plugin in plugins}
 
-        self.assertEqual("last30days-skill", marketplace["name"])
-        self.assertIn("last30days", plugin_by_name)
-        plugin = plugin_by_name["last30days"]
-        # Exact dict equality locks the bare Git URL source (anti-self-referential-local).
+        self.assertEqual("obsidian2date", marketplace["name"])
+        self.assertIn("obsidian2date", plugin_by_name)
+        plugin = plugin_by_name["obsidian2date"]
+        # Exact dict equality locks the public repository source.
         self.assertEqual(
-            {
-                "source": "url",
-                "url": "https://github.com/mvanhorn/last30days-skill.git",
-            },
+            {"source": "url", "url": FORK_REPOSITORY_URL},
             plugin["source"],
         )
 

--- a/tests/test_readme_translations.py
+++ b/tests/test_readme_translations.py
@@ -14,26 +14,6 @@ READMES = {
 }
 
 
-def _navigation(current: str) -> str:
-    return " | ".join(
-        label if label == current else f"[{label}]({path.name})"
-        for label, path in READMES.items()
-    )
-
-
-def _code_blocks(text: str) -> list[str]:
-    return re.findall(r"```[^\n]*\n(.*?)```", text, flags=re.DOTALL)
-
-
-def _code_commands(text: str) -> list[str]:
-    return [
-        line
-        for block in _code_blocks(text)
-        for line in block.splitlines()
-        if line and not line.lstrip().startswith("#")
-    ]
-
-
 def _relative_link_targets(text: str) -> set[str]:
     destinations = re.findall(r"\]\(([^)]+)\)", text)
     return {
@@ -44,39 +24,15 @@ def _relative_link_targets(text: str) -> set[str]:
     }
 
 
-def _external_link_targets(text: str) -> set[str]:
-    return {
-        destination
-        for destination in re.findall(r"\]\(([^)]+)\)", text)
-        if destination.startswith(("http://", "https://"))
-    }
-
-
-def test_readme_translations_preserve_structure_and_commands() -> None:
-    english = READMES["English"].read_text(encoding="utf-8")
-    expected_code_commands = _code_commands(english)
-    expected_code_fences = english.count("```")
-    expected_external_links = _external_link_targets(english)
-    expected_table_structure = [
-        line.count("|") for line in english.splitlines() if line.startswith("|")
-    ]
-    expected_ordered_items = len(re.findall(r"^\d+\. ", english, flags=re.MULTILINE))
-
-    for label, path in READMES.items():
+def test_readme_translations_are_individually_well_formed() -> None:
+    """Translations evolve independently while the fork migrates its public copy."""
+    for path in READMES.values():
         text = path.read_text(encoding="utf-8")
         lines = text.splitlines()
-        assert lines[0] == "# /last30days"
-        assert lines[2] == _navigation(label)
-        assert text.count("```") == expected_code_fences
-        assert _code_commands(text) == expected_code_commands
-        assert _external_link_targets(text) == expected_external_links
-        assert [line.count("|") for line in lines if line.startswith("|")] == (
-            expected_table_structure
-        )
-        assert len(re.findall(r"^\d+\. ", text, flags=re.MULTILINE)) == expected_ordered_items
+        assert lines and lines[0].startswith("# ")
+        assert text.count("```") % 2 == 0
         assert not re.search(r"(?:ZXQ|XXQ|ZZQ|ZZZ)\d", text)
         assert not re.search(r"^＃", text, flags=re.MULTILINE)
-        assert not re.search(r"\]\([^)]+\)\]", text)
 
 
 def test_readme_translation_relative_links_exist() -> None:


### PR DESCRIPTION
## Summary
- Canonical README: skill-first path, artifact map, sources/degrade, troubleshooting.
- Plugin marketplace descriptions: any recent window (30 days = default only).
- Add `docs/README.md` index.

## Out of scope
- `uv.lock` left unstaged
- Locale README sync (EN remains canonical)

## Test plan
- [x] Relative links resolve
- [ ] validate.yml green