### PR TITLE
docs: add Validate workflow status badge to README

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **Eine von einem KI-Agenten gesteuerte Suchmaschine, die nach Upvotes, Likes und echtem Geld gewichtet – nicht nach Redaktionen.**

--- a/README.es.md
+++ b/README.es.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **Un buscador dirigido por un agente de IA que puntúa por votos positivos, likes y dinero real, no por redacciones.**

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **Un moteur de recherche piloté par un agent IA, qui classe les résultats selon les upvotes, les likes et l'argent réel — pas selon des rédacteurs.**

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **編集者ではなく、アップボート・いいね・実際に動いたお金でランク付けする、AIエージェント主導の検索エンジンです。**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ English | [Français](README.fr.md) | [Deutsch](README.de.md) | [Español](READM
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **An AI agent-led search engine scored by upvotes, likes, and real money - not editors.**

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **Um buscador conduzido por um agente de IA, que pontua por votos positivos, curtidas e dinheiro de verdade — não por redações.**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,10 @@
   <a href="https://trendshift.io/repositories/21997" target="_blank">
     <img src="https://trendshift.io/api/badge/repositories/21997" alt="mvanhorn/last30days-skill | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
   </a>
+  <br/>
+  <a href="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml">
+    <img src="https://github.com/mvanhorn/last30days-skill/actions/workflows/validate.yml/badge.svg" alt="Validate status" />
+  </a>
 </p>
 
 **一个由 AI 智能体驱动的搜索引擎：按赞同票、点赞和真金白银评分，而不是由编辑决定。**


### PR DESCRIPTION
## Summary

The README now shows a live GitHub Actions status badge for the Validate workflow (which runs the full pytest suite on every push to main and every pull request), in the English README and all six translations. This closes issue #249's request for a visible CI pass/fail signal.

Note on scope: issue #249 was filed before `.github/workflows/validate.yml` existed and asked for a new `ci.yml`. That workflow now already covers the issue's core requirement — pytest on push and PR with a failing suite failing the job — so this PR adds the missing README badge rather than a second workflow that would run the same suite twice. Happy to add a thin `ci.yml` wrapper instead if you prefer the literal filename.

## Testing

- [x] `uv run pytest` — not run locally; the change is documentation-only markup, covered by the Validate CI on this PR itself
- [x] Badge URL verified: `curl` against the Validate workflow badge returns HTTP 200 with SVG
- [x] Badge line verified byte-identical across all seven READMEs
- [x] YAML of `.github/workflows/validate.yml` parses; triggers and no-failure-masking flags verified against the #249 Definition of Done
- [x] Latest main Validate runs confirmed green

## Changelog

- [x] Skip changelog — chore/internal only (badge addition with no release-notes content); `skip-changelog` label added

## Agent disclosure

### AI review

Code review ran via the agent pipeline: correctness and project-standards personas reviewed the diff against `AGENTS.md`. Result: no actionable findings, verdict ready to merge. Residual notes (advisory): the badge renders gray until the first post-merge Validate run, and contributor forks will display upstream main status (consistent with existing README badges). The translation-parity test's link regex does not match HTML anchors, so a future divergent edit to the badge block would not be caught by CI — noted as a follow-up, not fixed here.

### Security

N/A — documentation-only change; no input handling, command execution, path handling, auth, secrets, or dependency changes. The badge URL targets the repo's own public Actions workflow.

## Notes

The PR plan (issue #249's Definition of Done adapted to the repo as found) lives in the gitignored `docs/plans/` directory and is not part of this diff.

### Relationship to this change

- [x] None

## Related issues

Fixes #249
