### PR TITLE
harden: detected non-static command inside command in run.go

### DIFF
--- a/changelog.d/1109.security.md
+++ b/changelog.d/1109.security.md
@@ -1,0 +1,3 @@
+Require an absolute path for automatically discovered MCP Python interpreters,
+including when Go's built-in relative-path protection is explicitly disabled.
+Explicit interpreter overrides retain their existing behavior.

--- a/mcp/internal/engine/run.go
+++ b/mcp/internal/engine/run.go
@@ -121,7 +121,12 @@ func resolvePython(override string) (string, error) {
 		return override, nil
 	}
 	path, err := exec.LookPath(DefaultPythonBinary)
-	if err == nil {
+	// Reject relative results: on older Go runtimes (and PATH entries that
+	// include "."), LookPath can resolve to a file in the current working
+	// directory instead of a trusted install, letting an attacker who
+	// controls the CWD substitute an arbitrary binary for the interpreter
+	// exec.CommandContext then runs. Requiring an absolute path closes that.
+	if err == nil && filepath.IsAbs(path) {
 		return path, nil
 	}
 	return "", fmt.Errorf(

--- a/mcp/internal/engine/run.go
+++ b/mcp/internal/engine/run.go
@@ -121,11 +121,8 @@ func resolvePython(override string) (string, error) {
 		return override, nil
 	}
 	path, err := exec.LookPath(DefaultPythonBinary)
-	// Reject relative results: on older Go runtimes (and PATH entries that
-	// include "."), LookPath can resolve to a file in the current working
-	// directory instead of a trusted install, letting an attacker who
-	// controls the CWD substitute an arbitrary binary for the interpreter
-	// exec.CommandContext then runs. Requiring an absolute path closes that.
+	// Go normally rejects relative results with ErrDot. Keep this invariant
+	// even when that protection is disabled with GODEBUG=execerrdot=0.
 	if err == nil && filepath.IsAbs(path) {
 		return path, nil
 	}

--- a/mcp/internal/engine/run_test.go
+++ b/mcp/internal/engine/run_test.go
@@ -238,6 +238,45 @@ func TestRunMissingPython(t *testing.T) {
 	}
 }
 
+func TestResolvePythonRejectsRelativePATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX executable fixture")
+	}
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(DefaultPythonBinary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", ".")
+	// Exercise our own guard even when Go's ErrDot protection is disabled.
+	t.Setenv("GODEBUG", "execerrdot=0")
+	if path, err := resolvePython(""); err == nil || path != "" {
+		t.Fatalf("resolvePython accepted relative executable: path=%q err=%v", path, err)
+	}
+}
+
+func TestResolvePythonAcceptsAbsolutePATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX executable fixture")
+	}
+	dir := t.TempDir()
+	want := filepath.Join(dir, DefaultPythonBinary)
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	if path, err := resolvePython(""); err != nil || path != want {
+		t.Fatalf("resolvePython = %q, %v; want %q", path, err, want)
+	}
+}
+
+func TestResolvePythonPreservesExplicitOverride(t *testing.T) {
+	t.Setenv("PATH", "")
+	want := filepath.Join("explicit", "python")
+	if path, err := resolvePython(want); err != nil || path != want {
+		t.Fatalf("resolvePython = %q, %v; want trusted override %q", path, err, want)
+	}
+}
+
 func TestRunMissingScript(t *testing.T) {
 	stub := makeStubPython(t)
 	// CacheDir exists but contains no last30days.py.


### PR DESCRIPTION
## Summary
Harden input handling in `mcp/internal/engine/run.go` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | go.lang.security.audit.dangerous-exec-command.dangerous-exec-command |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `go.lang.security.audit.dangerous-exec-command.dangerous-exec-command` |
| **File** | `mcp/internal/engine/run.go:87` |
| **Assessment** | Defensive hardening |

**Description**: Detected non-static command inside Command. Audit the input to 'exec.Command'. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.

## Threat Model Context

This appears to be an internal/admin endpoint with restricted access. This is a Python library - vulnerabilities affect applications that import this code.

## Changes
- `mcp/internal/engine/run.go`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=go.lang.security.audit.dangerous-exec-command.dangerous-exec-command scanner=semgrep -->
