### PR TITLE
fix(keychain): check presence without requesting passwords

### DIFF
--- a/changelog.d/+keychain-presence.security.md
+++ b/changelog.d/+keychain-presence.security.md
@@ -1,0 +1,1 @@
+Keychain setup and listing now check existence without requesting plaintext passwords, and count existing entries by exit status. Selectively retains the safe presence-check changes from #1061; the existing credential writer is unchanged and its command-line exposure remains a separate follow-up.

--- a/skills/last30days/scripts/setup-keychain.sh
+++ b/skills/last30days/scripts/setup-keychain.sh
@@ -72,7 +72,8 @@ case "$ACTION" in
   list)
     echo "Stored last30days-* keychain items:"
     for key in "${ALL_KEYS[@]}"; do
-      if security find-generic-password -a "$USER" -s "${PREFIX}${key}" -w >/dev/null 2>&1; then
+      # Existence checks do not need to decrypt or return the password.
+      if security find-generic-password -a "$USER" -s "${PREFIX}${key}" >/dev/null 2>&1; then
         echo "  $key"
       fi
     done
@@ -99,8 +100,12 @@ fi
 
 added=0; skipped=0; replaced=0
 for key in "${TARGETS[@]}"; do
-  existing="$(security find-generic-password -a "$USER" -s "${PREFIX}${key}" -w 2>/dev/null || true)"
-  if [[ -n "$existing" && "$REPLACE" -eq 0 ]]; then
+  if security find-generic-password -a "$USER" -s "${PREFIX}${key}" >/dev/null 2>&1; then
+    existed=1
+  else
+    existed=0
+  fi
+  if [[ "$existed" -eq 1 && "$REPLACE" -eq 0 ]]; then
     printf "  %-28s (set, skipping — use --replace to overwrite)\n" "$key"
     skipped=$((skipped + 1))
     continue
@@ -113,7 +118,7 @@ for key in "${TARGETS[@]}"; do
     continue
   fi
   security add-generic-password -U -a "$USER" -s "${PREFIX}${key}" -w "$value"
-  if [[ -n "$existing" ]]; then
+  if [[ "$existed" -eq 1 ]]; then
     replaced=$((replaced + 1))
   else
     added=$((added + 1))

--- a/tests/test_env_keychain.py
+++ b/tests/test_env_keychain.py
@@ -10,7 +10,9 @@ Covers:
 
 from __future__ import annotations
 
+import os
 import re
+import shlex
 import subprocess
 from pathlib import Path
 from unittest import mock
@@ -20,6 +22,66 @@ import pytest
 from lib import env
 
 SETUP_KEYCHAIN_SH = Path(__file__).resolve().parents[1] / "skills" / "last30days" / "scripts" / "setup-keychain.sh"
+
+
+def _plaintext_presence_checks(script: str) -> list[str]:
+    # Join shell continuations before tokenizing so a split -w cannot hide.
+    logical = re.sub(r"\\\r?\n", " ", script)
+    offenders = []
+    for line in logical.splitlines():
+        code = " ".join(shlex.split(line, comments=True))
+        if re.search(r"find-generic-password\b.*\s-[wg](?=\s|[;>|&]|$)", code):
+            offenders.append(line)
+    return offenders
+
+
+def test_setup_presence_checks_do_not_request_plaintext():
+    assert not _plaintext_presence_checks(SETUP_KEYCHAIN_SH.read_text(encoding="utf-8"))
+
+
+def test_presence_guard_detects_multiline_password_flags():
+    script = (
+        "security find-generic-password \\\n"
+        '    -a "$USER" \\\n'
+        "    -w >/dev/null"
+    )
+    assert _plaintext_presence_checks(script)
+    assert not _plaintext_presence_checks('# security find-generic-password -w\n')
+
+
+@pytest.mark.parametrize("existed,replace,value,summary", [
+    (True, False, "", "added=0 replaced=0 skipped=1"),
+    (False, False, "DUMMY-VALUE\n", "added=1 replaced=0 skipped=0"),
+    (True, True, "DUMMY-VALUE\n", "added=0 replaced=1 skipped=0"),
+])
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shell fixture")
+def test_setup_presence_and_counters_use_stub_security(tmp_path, existed, replace, value, summary):
+    stub = tmp_path / "security"
+    stub.write_text(
+        '#!/bin/sh\n'
+        'printf "%s\\n" "$1" >> "$STUB_LOG"\n'
+        'case "$1" in\n'
+        '  find-generic-password) exit "$STUB_STATUS" ;;\n'
+        '  add-generic-password) exit 0 ;;\n'
+        '  *) exit 99 ;;\n'
+        'esac\n', encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    log_path = tmp_path / "calls"
+    command = ["/bin/bash", str(SETUP_KEYCHAIN_SH)]
+    if replace:
+        command.append("--replace")
+    command.append("OPENAI_API_KEY")
+    result = subprocess.run(
+        command, input=value, text=True, capture_output=True, timeout=5,
+        env={"PATH": str(tmp_path), "USER": "fixture-user", "OSTYPE": "darwin",
+             "STUB_LOG": str(log_path), "STUB_STATUS": "0" if existed else "44"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert summary in result.stdout
+    assert "DUMMY-VALUE" not in result.stdout + result.stderr
+    calls = log_path.read_text().splitlines()
+    assert calls == ["find-generic-password"] + ([] if existed and not replace else ["add-generic-password"])
 
 # ---------------------------------------------------------------------------
 # _load_keychain unit tests


### PR DESCRIPTION
## Summary

Keychain setup and listing now determine whether an entry exists without requesting its plaintext password. This is a selective port of Alan Livshin (@Comradery64)'s presence-check and counter fixes, not the full secret-writer change.

## Testing

- [ ] Full `uv run pytest` on this head: pending CI.
- [x] 28 keychain tests pass with all credential operations mocked or stubbed.
- [x] New regression tests cover existing-entry skip, new-entry add, replacement counters, and multiline password-output flags. Three cases failed before the fix.
- [x] Shell syntax and whitespace checks pass.

## Changelog

- [x] Added `changelog.d/+keychain-presence.security.md` with deliberately narrow claims.

## Agent disclosure

### AI review

ce-code-review complete, run `latest20-1061`: correctness, project standards, testing, security, and adversarial passes ran sequentially in the main thread. No actionable findings; no independent review claimed.

### Security

Retained from original head `6ef5a3e5697a345a349123859f73e8737a568752`: metadata-only existence lookups and exit-status-based skip/replacement accounting. The password writer and its command-line exposure are unchanged.

## Notes

The omitted writer pipes two copies into `security add-generic-password -w` without a value. That invokes a password prompt backed by `getpass`, which prefers `/dev/tty`; the pipe does not establish safe unattended behavior. A separate writer change must prove interactive and noninteractive macOS behavior without real user credentials. This PR does not resolve the entire secret-hygiene concern.

### Relationship to this change

- [x] None: no third-party product or service is introduced or promoted.

## Related issues

Related: #1061

## Post-Deploy Monitoring & Validation

Maintainer owns the first setup/list smoke check after merge, using an isolated dummy keychain fixture. Healthy: listing does not request a password, existing entries skip, and replacement counts remain correct. Revert this narrow port if an existing-entry lookup begins prompting or is miscounted. No real keychain was read or written during development.
