### PR TITLE
fix(ci): restore scheduled OSV scanner startup

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -24,6 +24,7 @@ jobs:
   scan-scheduled:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
     permissions:
+      actions: read # Required by the pinned reusable workflow for SARIF upload.
       contents: read
       security-events: write
     with:


### PR DESCRIPTION
## Summary

Restore scheduled and manual OSV vulnerability scans, which currently fail before any job starts because the reusable workflow requires `actions: read`.

This is the final CI prerequisite before publishing the merged cleanup as v3.23.1. Only the scanner job gains read access; existing triggers, pinned code, and advisory policy stay unchanged.

## Testing

- [x] 28 workflow and plugin-contract tests passed.
- [x] `actionlint .github/workflows/osv-scanner.yml` passed.
- [x] Compared permissions against the exact pinned upstream reusable workflow.
- [ ] Full suite in PR CI and actual OSV dispatch.
- [x] No new unit test: Actions authorization must be verified by a real workflow run, not a duplicated string assertion.

## Changelog

- [x] Skip changelog — internal CI startup repair; `skip-changelog` label.

## Agent disclosure

### AI review

Completed ce-code-review with sequential inline correctness, project-standards, security, and testing passes as required by the user's AGENTS.md. No actionable findings; these are not independent reviewers. Receipt: `last30days-osv-review.KYy7ma`.

### Security

Job-scoped read-only permission matches the pinned callee. No new secrets, dependency changes, write scopes, untrusted PR triggers, or changes to vulnerability policy.

## Notes

The baseline failure predates the merged OSV version bump. Previous run: https://github.com/mvanhorn/last30days-skill/actions/runs/34177726904

### Relationship to this change

- [x] None — no vendor or promotional integration.

## Related issues

Related: #1079

## Post-Deploy Monitoring & Validation

Owner: release operator in this session. Dispatch OSV on the branch and again on main after merge; inspect startup, scanner/reporter, and SARIF upload during this release window. Healthy: jobs execute and code-scanning upload completes. Failure: permission rejection, missing results, or failed upload; stop release preparation and diagnose. Reverting this one line restores the known broken startup, so do not use it as an automatic mitigation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
