### PR TITLE
fix(cookies): anchor Safari cookie host matching to the domain

### DIFF
--- a/changelog.d/+safari-cookie-domain-match.security.md
+++ b/changelog.d/+safari-cookie-domain-match.security.md
@@ -1,0 +1,1 @@
+Safari cookie extraction now matches the cookie host exactly or as a true subdomain, so a session cookie stored for an unrelated host such as `x.com.evil.tld` is no longer picked up for `x.com`.

--- a/skills/last30days/scripts/lib/safari_cookies.py
+++ b/skills/last30days/scripts/lib/safari_cookies.py
@@ -98,7 +98,10 @@ def extract_safari_cookies_macos(
     Extract cookies from Safari on macOS.
 
     Args:
-        domain: Domain to match (substring match, e.g. "x.com")
+        domain: Registrable host to match, with or without a leading dot
+            (e.g. "x.com" or ".x.com"). A stored cookie host matches when it
+            equals the domain or is a subdomain of it; unrelated hosts that
+            merely contain the text (e.g. "x.com.evil.tld") do not.
         cookie_names: List of cookie names to extract (e.g. ["auth_token", "ct0"])
 
     Returns:
@@ -136,6 +139,19 @@ def extract_safari_cookies_macos(
         return None
 
     return _parse_binary_cookies(raw, domain, cookie_names)
+
+
+def _host_matches(stored_host: str, domain: str) -> bool:
+    """True when stored_host equals domain or is a subdomain of it.
+
+    Safari stores domain cookies with a leading dot (".x.com") and host-only
+    cookies without one ("x.com"); both spellings are accepted on either side.
+    """
+    host = stored_host.strip().lstrip(".").lower()
+    wanted = domain.strip().lstrip(".").lower()
+    if not host or not wanted:
+        return False
+    return host == wanted or host.endswith("." + wanted)
 
 
 def _parse_binary_cookies(
@@ -182,8 +198,7 @@ def _parse_binary_cookies(
         page_data = raw[offset : offset + ps]
         cookies = _parse_page(page_data)
         for c in cookies:
-            # Substring match on domain (handles leading dots like ".x.com")
-            if domain in c["url"] and c["name"] in names_set:
+            if _host_matches(c["url"], domain) and c["name"] in names_set:
                 result[c["name"]] = c["value"]
         offset += ps
 

--- a/tests/test_safari_cookies.py
+++ b/tests/test_safari_cookies.py
@@ -128,11 +128,68 @@ class TestParseValidCookies:
         result = _parse_binary_cookies(x_cookies_file, "x.com", ["bogus"])
         assert result is None
 
-    def test_domain_substring_match_with_leading_dot(self, x_cookies_file: bytes):
+    def test_leading_dot_stored_host_matches_bare_domain(self, x_cookies_file: bytes):
         """Domain '.x.com' in cookie should match search for 'x.com'."""
         result = _parse_binary_cookies(x_cookies_file, "x.com", ["auth_token"])
         assert result is not None
         assert result["auth_token"] == "test_auth_abc123"
+
+
+def _single_cookie_file(stored_host: str) -> bytes:
+    rec = _build_cookie_record(stored_host, "auth_token", "fake_value_for_" + stored_host)
+    return _build_binary_cookies_file([_build_page([rec])])
+
+
+class TestDomainMatching:
+    @pytest.mark.parametrize("wanted", ["x.com", ".x.com"])
+    def test_exact_host_match(self, wanted: str):
+        result = _parse_binary_cookies(_single_cookie_file("x.com"), wanted, ["auth_token"])
+        assert result == {"auth_token": "fake_value_for_x.com"}
+
+    @pytest.mark.parametrize("wanted", ["x.com", ".x.com"])
+    def test_leading_dot_stored_host_matches(self, wanted: str):
+        result = _parse_binary_cookies(_single_cookie_file(".x.com"), wanted, ["auth_token"])
+        assert result == {"auth_token": "fake_value_for_.x.com"}
+
+    @pytest.mark.parametrize("stored", ["api.x.com", ".api.x.com"])
+    @pytest.mark.parametrize("wanted", ["x.com", ".x.com"])
+    def test_subdomain_match(self, stored: str, wanted: str):
+        result = _parse_binary_cookies(_single_cookie_file(stored), wanted, ["auth_token"])
+        assert result == {"auth_token": "fake_value_for_" + stored}
+
+    def test_case_insensitive_host(self):
+        result = _parse_binary_cookies(_single_cookie_file(".X.com"), "x.com", ["auth_token"])
+        assert result == {"auth_token": "fake_value_for_.X.com"}
+
+    @pytest.mark.parametrize(
+        "stored",
+        [
+            "notx.com",
+            ".notx.com",
+            "evilx.com",
+            "x.com.evil.tld",
+            ".x.com.evil.tld",
+            "api.x.com.evil.tld",
+            "xcom",
+            "com",
+        ],
+    )
+    @pytest.mark.parametrize("wanted", ["x.com", ".x.com"])
+    def test_rejects_hosts_that_merely_contain_domain(self, stored: str, wanted: str):
+        result = _parse_binary_cookies(_single_cookie_file(stored), wanted, ["auth_token"])
+        assert result is None
+
+    def test_rejects_parent_domain_when_subdomain_requested(self):
+        result = _parse_binary_cookies(_single_cookie_file(".com"), "x.com", ["auth_token"])
+        assert result is None
+
+    def test_empty_stored_host_never_matches(self):
+        result = _parse_binary_cookies(_single_cookie_file(""), "x.com", ["auth_token"])
+        assert result is None
+
+    def test_empty_requested_domain_never_matches(self):
+        result = _parse_binary_cookies(_single_cookie_file(".x.com"), "", ["auth_token"])
+        assert result is None
 
 
 class TestMultiplePages:


### PR DESCRIPTION
## Summary

Safari cookie extraction matched hosts with an unanchored substring test, `domain in c["url"]`. Callers pass the dotted form (`env.COOKIE_DOMAINS`: `.x.com`, `.truthsocial.com`), so a stored cookie on an attacker-registrable host such as `x.com.evil.tld` or `api.x.com.evil.tld` satisfied a request for `.x.com`, while a legitimate host-only `x.com` cookie was **missed**. Both directions are fixed by matching on host equality or a true subdomain suffix.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Probed old versus new against the real caller value `.x.com` rather than the docstring's undotted example:

| stored host | old | new |
|---|---|---|
| `x.com` (legitimate host-only) | no match | match |
| `.x.com` (legitimate domain cookie) | match | match |
| `api.x.com` (legitimate subdomain) | match | match |
| `.x.com.evil.tld` | match | no match |
| `api.x.com.evil.tld` | match | no match |

28 parametrized cases in `TestDomainMatching` cover exact host, leading-dot storage on either side, subdomain, case folding, empty host or empty requested domain, parent-domain rejection, and eight hosts that merely contain the domain text. Negative control: restoring `domain in c["url"]` fails 11 of them.

`test_domain_substring_match_with_leading_dot` was renamed to `test_leading_dot_stored_host_matches_bare_domain` since "substring" no longer describes the contract; its assertions are unchanged.

## Changelog

- [x] Added `changelog.d/+safari-cookie-domain-match.security.md` (`security`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Found during a full-codebase review. The matcher was probed in both directions against the real caller values, and the consumption path was traced to the end before rating it.

### Security

This is cookie **substitution**, not exfiltration, and the difference matters for how alarming it is. The domain is the lookup key and the destination is fixed per caller, so the user's real X cookie never travels anywhere new. What the old test allowed is the reverse: a cookie named `auth_token` or `ct0` sitting on a host the attacker can register gets read out of the local Safari store and sent to X as the user's credentials (`env.py:940-942` → `bird_x.py:75,82-86` → the vendored client's `cookie` header and `x-csrf-token`). Truth Social has the same shape via `_session_id` → `TRUTHSOCIAL_TOKEN` → `Authorization: Bearer`. The realistic outcomes are a failed auth or acting as the wrong session, and it requires a hostile cookie already in the user's Safari store.

The missed host-only cookie is the plainer bug: users whose Safari stored `x.com` without a leading dot silently got no credentials at all.

`notx.com` and `evilx.com` match only under the docstring's undotted `x.com` form, which no caller passes today. They are covered by tests anyway, because the docstring advertised that form and the next caller could use it.

No new input handling, command execution, or dependency change. Tests use obviously fake cookie values only.

## Notes

`_host_matches` strips a leading dot from both sides and lowercases before comparing, because Safari stores domain cookies as `.x.com` and host-only cookies as `x.com` and either spelling can arrive from either side. The docstring now states the real contract instead of promising a substring match.

### Scope rationale

Not addressed here: `extract_safari_cookies_macos` still takes the domain as a plain string, so nothing stops a future caller passing a public suffix such as `com` and matching everything. The fix rejects `com` for the current callers, but a typed or validated domain argument is a broader change and wants its own PR.

### Relationship to this change

- [x] None

## Related issues

N/A
