### PR TITLE
fix(reddit): clamp engagement before log10 so downvoted posts don't crash ranking

### DIFF
--- a/changelog.d/+reddit-negative-engagement.fixed.md
+++ b/changelog.d/+reddit-negative-engagement.fixed.md
@@ -1,0 +1,1 @@
+Reddit ranking no longer crashes with a `math domain error` when a downvoted post has a negative score; such posts now receive the minimum engagement bonus.

--- a/skills/last30days/scripts/lib/reddit.py
+++ b/skills/last30days/scripts/lib/reddit.py
@@ -264,7 +264,7 @@ def _relevance_rank_key(item: Dict[str, Any]) -> float:
     ~0) above an on-topic one (relevance >= RELEVANCE_FLOOR).
     """
     rel = item.get("relevance") or 0.0
-    eng_bonus = min(0.25, math.log10(_total_engagement(item) + 1) / 20.0)
+    eng_bonus = min(0.25, math.log10(max(0, _total_engagement(item)) + 1) / 20.0)
     return rel + eng_bonus
 
 

--- a/skills/last30days/scripts/lib/reddit_keyless.py
+++ b/skills/last30days/scripts/lib/reddit_keyless.py
@@ -51,7 +51,7 @@ def _relevance_rank_key(post: Dict[str, Any]) -> float:
     """
     eng = post.get("engagement", {})
     total = (eng.get("score", 0) or 0) + (eng.get("num_comments", 0) or 0)
-    return (post.get("relevance") or 0.0) + min(0.25, math.log10(total + 1) / 20.0)
+    return (post.get("relevance") or 0.0) + min(0.25, math.log10(max(0, total) + 1) / 20.0)
 
 
 def _log(msg: str) -> None:

--- a/tests/test_reddit_relevance_ranking.py
+++ b/tests/test_reddit_relevance_ranking.py
@@ -8,7 +8,10 @@ on-topic posts rank first and pure zero-overlap posts are dropped when anything
 relevant remains.
 """
 
+import math
 from unittest import mock
+
+import pytest
 
 from lib import reddit, reddit_keyless
 
@@ -35,6 +38,25 @@ class TestRelevanceRankKey:
         on_topic = {"relevance": 0.3, "engagement": {"score": 10, "num_comments": 5}}
         off_topic = {"relevance": 0.0, "engagement": {"score": 99999, "num_comments": 4000}}
         assert reddit_keyless._relevance_rank_key(on_topic) > reddit_keyless._relevance_rank_key(off_topic)
+
+    @pytest.mark.parametrize("key", [reddit._relevance_rank_key, reddit_keyless._relevance_rank_key])
+    def test_negative_engagement_scores_the_floor(self, key):
+        # Downvoted posts report a negative score; log10 of a non-positive total
+        # must not raise, and the bonus bottoms out at zero.
+        zero_total = {"relevance": 0.3, "engagement": {"score": -1, "num_comments": 0}}
+        negative_total = {"relevance": 0.3, "engagement": {"score": -10, "num_comments": 3}}
+        assert key(zero_total) == pytest.approx(0.3)
+        assert key(negative_total) == pytest.approx(0.3)
+
+    @pytest.mark.parametrize("key", [reddit._relevance_rank_key, reddit_keyless._relevance_rank_key])
+    def test_zero_engagement_adds_no_bonus(self, key):
+        item = {"relevance": 0.3, "engagement": {"score": 0, "num_comments": 0}}
+        assert key(item) == pytest.approx(0.3)
+
+    @pytest.mark.parametrize("key", [reddit._relevance_rank_key, reddit_keyless._relevance_rank_key])
+    def test_non_negative_engagement_bonus_unchanged(self, key):
+        item = {"relevance": 0.3, "engagement": {"score": 5, "num_comments": 2}}
+        assert key(item) == pytest.approx(0.3 + math.log10(8) / 20.0)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Reddit ranking crashed on downvoted posts. `_relevance_rank_key` computes `math.log10(total_engagement + 1)`, and Reddit reports negative scores for downvoted posts, so a post at score `-1` made the argument exactly `0` and anything below that made it negative. Both raise `ValueError: math domain error`. The key is used by `all_items.sort(key=_relevance_rank_key)` at `reddit.py:651` with no guard, so one downvoted post aborted the entire Reddit search.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Reproduced on unfixed code at both sites before fixing:

```
reddit          score=-1,c=0  -> ValueError: math domain error
reddit          score=-10,c=3 -> ValueError: math domain error
reddit_keyless  score=-1,c=0  -> ValueError: math domain error
reddit_keyless  score=-10,c=3 -> ValueError: math domain error
```

Producers pass negative scores through unclamped: `reddit.py:228` `_extract_score` returns `ups`/`score`/`votes` verbatim, `reddit_listing.py:126` uses `int(_attr(tag, "score") or 0)`, and `reddit_arctic.py:57` returns the archived score as-is. `reddit_public.py:184` clamps only inside its own relevance computation, not the stored score.

Three tests, each parametrized across both implementations. Negative control: with the clamp reverted, the negative-engagement cases fail on both. The zero and non-negative cases pass either way by design: they pin that scores for existing inputs are unchanged, asserting the exact value `0.3 + log10(8)/20`.

## Changelog

- [x] Added `changelog.d/+reddit-negative-engagement.fixed.md` (`fixed`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Found during a full-codebase review. Both call sites were traced to their producers to confirm negative values actually reach the log, and the crash was reproduced rather than inferred from the arithmetic. The blast radius was checked too: the unguarded `sort` is what turns a bad score into a failed search rather than a mis-ranked post.

### Security

`N/A`. No input handling, command execution, path handling, or dependency change.

## Notes

`max(0, ...)` clamps at the log call rather than at the producers, so a downvoted post scores the engagement floor and still ranks by relevance. Clamping in `_extract_score` instead would have discarded the sign everywhere it is read, including anywhere a caller legitimately wants to know a post was downvoted.

### Scope rationale

Not addressed here: there is no test at the `search_reddit` level proving a mixed result set with one downvoted post completes. The crash source is covered directly, and a search-level test would need the whole fetch path mocked for no additional signal about this defect.

### Relationship to this change

- [x] None

## Related issues

N/A
