### PR TITLE
fix(verify): run the pytest suite instead of unittest discover

### DIFF
--- a/changelog.d/+verify-v3-test-runner.fixed.md
+++ b/changelog.d/+verify-v3-test-runner.fixed.md
@@ -1,0 +1,1 @@
+`verify_v3.py` now runs the unit stage with pytest, so pytest-style test files (previously skipped by `unittest discover`) are verified.

--- a/skills/last30days/scripts/verify_v3.py
+++ b/skills/last30days/scripts/verify_v3.py
@@ -52,7 +52,7 @@ def run_command(cmd: list[str], *, env: dict[str, str] | None = None, timeout: i
 
 
 def verify_unit() -> dict[str, str]:
-    run_command([PYTHON, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py"], timeout=600)
+    run_command([PYTHON, "-m", "pytest", "tests"], timeout=600)
     run_command(
         [
             PYTHON,

--- a/tests/test_verify_v3.py
+++ b/tests/test_verify_v3.py
@@ -36,6 +36,18 @@ class VerifyV3Tests(unittest.TestCase):
         commands = [call.args[0] for call in run.call_args_list]
         self.assertTrue(all("--json-profile=raw" in command for command in commands))
 
+    def test_unit_stage_invokes_pytest_runner(self):
+        module = load_verify_module()
+        rg_files = mock.Mock(stdout="skills/last30days/scripts/verify_v3.py\n")
+        with mock.patch.object(module, "run_command") as run, mock.patch.object(
+            module.subprocess, "run", return_value=rg_files
+        ):
+            module.verify_unit()
+
+        runner_command = run.call_args_list[0].args[0]
+        self.assertEqual(runner_command, [module.PYTHON, "-m", "pytest", "tests"])
+        self.assertNotIn("unittest", runner_command)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`verify_v3.py`'s unit stage ran `python -m unittest discover -s tests -p 'test_*.py'`, which collects **2076** tests. The suite is pytest-based (`[tool.pytest.ini_options]` in `pyproject.toml`) and pytest collects **4321** across 215 files. 83 test files define only module-level `def test_*` functions with no `TestCase` subclass, and `unittest discover` cannot see any of them. The stage verified 48% of the suite and printed OK.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Both runners were executed to get the numbers rather than inferred: `unittest discover` reported `Ran 2076 tests in 277.419s / OK`, exit 0; `pytest --collect-only -q tests` reported 4321 tests across 215 files. The 83-file count comes from scanning `tests/test_*.py` for files with `^def test_` and no `TestCase` base.

The new test asserts on the constructed command, not on a live suite run, so it stays at 0.05s: a verification-tool test that shells out to the whole suite is the kind of thing that gets skipped later.

## Changelog

- [x] Added `changelog.d/+verify-v3-test-runner.fixed.md` (`fixed`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Found during a full-codebase review, then confirmed by running both runners and diffing their collection counts rather than reasoning about discovery rules.

One risk checked before switching: `python -m pytest tests` inherits `addopts` from `pyproject.toml`. If those carried `--cov`, the stage would newly be subject to the `fail_under` gate and could fail for reasons unrelated to test outcomes. `addopts` is `["-q", "--tb=short"]` only, so that does not happen.

### Security

`N/A`. No input handling, path handling, or dependency change. The subprocess argument list is still a fixed literal with no interpolation.

## Notes

`cwd=REPO_ROOT` is preserved so `pyproject.toml` config applies, and `check=True` keeps the existing raise-on-failure contract, so the script's exit-code behaviour and output format are unchanged.

One behavioural consequence worth stating: the stage now requires `pytest` importable from `sys.executable`. Under the project's `.venv` that holds. Run against a bare system python it will fail loudly with `CalledProcessError` instead of silently under-verifying, which is the better failure.

### Scope rationale

Not addressed here: whether all 4321 tests pass *through `verify_v3.py`* was not measured, only that they are now collected. The repo's own `uv run pytest` is green, so I have no reason to expect a difference, but I did not run the script end to end and am not claiming it.

### Relationship to this change

- [x] None

## Related issues

N/A
