### PR TITLE
fix(release): bring mcp/manifest.json into the version lockstep

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -30,6 +30,7 @@ JSON_VERSION_FILES = (
     ROOT / ".codex-plugin" / "plugin.json",
     ROOT / ".grok-plugin" / "plugin.json",
     ROOT / "gemini-extension.json",
+    ROOT / "mcp" / "manifest.json",
 )
 
 MARKETPLACE_FILES = (

--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -98,6 +98,7 @@ jobs:
             .grok-plugin/plugin.json
             .grok-plugin/marketplace.json
             gemini-extension.json
+            mcp/manifest.json
           )
 
           bumps=()

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -91,7 +91,8 @@ jobs:
             .codex-plugin/plugin.json \
             .grok-plugin/plugin.json \
             .grok-plugin/marketplace.json \
-            gemini-extension.json
+            gemini-extension.json \
+            mcp/manifest.json
           git status --short
           if git diff --cached --quiet; then
             echo "No release changes staged (empty changelog.d?)."

--- a/changelog.d/+mcp-manifest-version-lockstep.fixed.md
+++ b/changelog.d/+mcp-manifest-version-lockstep.fixed.md
@@ -1,0 +1,1 @@
+Add `mcp/manifest.json` to the lockstep version set so the `.mcpb` manifest is bumped by release prep and guarded against drift in feature PRs.

--- a/tests/test_changelog_workflow.py
+++ b/tests/test_changelog_workflow.py
@@ -288,6 +288,35 @@ class TestChangelogWorkflow(unittest.TestCase):
         self.assertIn("mcp/manifest.json", guarded)
         self.assertEqual(bump_set, guarded)
 
+    def test_prepare_release_workflow_stages_every_bumped_file(self) -> None:
+        """A file prepare_release.py rewrites but the workflow never stages is
+        silently dropped from the release commit, so the bump is lost and any
+        test waiting on the new value keeps skipping."""
+        mod = _load_prepare_release()
+        bump_set = {
+            str(path.relative_to(ROOT))
+            for path in (
+                mod.PYPROJECT,
+                mod.UV_LOCK,
+                mod.SKILL_MD,
+                *mod.JSON_VERSION_FILES,
+                *mod.MARKETPLACE_FILES,
+            )
+        }
+        text = (ROOT / ".github" / "workflows" / "prepare-release.yml").read_text(
+            encoding="utf-8"
+        )
+        match = re.search(r"\n\s*git add \\\n(.*?)\n\s*git status", text, re.DOTALL)
+        if not match:
+            raise AssertionError("git add ... block not found in prepare-release.yml")
+        staged = {
+            line.strip().rstrip("\\").strip()
+            for line in match.group(1).splitlines()
+            if line.strip()
+        }
+        self.assertIn("mcp/manifest.json", staged)
+        self.assertEqual(set(), bump_set - staged)
+
     def test_bump_all_updates_lockstep_surfaces(self) -> None:
         mod = _load_prepare_release()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_changelog_workflow.py
+++ b/tests/test_changelog_workflow.py
@@ -221,6 +221,13 @@ class TestChangelogWorkflow(unittest.TestCase):
             ),
             "3.18.1",
         )
+        self.assertEqual(
+            mod.version_from(
+                "mcp/manifest.json",
+                json.dumps({"manifest_version": "0.3", "version": "3.18.1"}),
+            ),
+            "3.18.1",
+        )
         with self.assertRaises(SystemExit):
             mod.version_from(".claude-plugin/plugin.json", "{not-json")
 
@@ -254,6 +261,33 @@ class TestChangelogWorkflow(unittest.TestCase):
                 mod.main(["--version", "3.18.1"])
             self.assertIn("Refusing to re-release", str(ctx.exception))
 
+    def test_prepare_release_bumps_mcp_manifest(self) -> None:
+        mod = _load_prepare_release()
+        self.assertIn(ROOT / "mcp" / "manifest.json", mod.JSON_VERSION_FILES)
+
+    def test_changelog_guard_version_paths_match_release_bump_set(self) -> None:
+        """Every path prepare_release.py bumps must be guarded, and vice versa."""
+        mod = _load_prepare_release()
+        bump_set = {
+            str(path.relative_to(ROOT))
+            for path in (
+                mod.PYPROJECT,
+                mod.UV_LOCK,
+                mod.SKILL_MD,
+                *mod.JSON_VERSION_FILES,
+                *mod.MARKETPLACE_FILES,
+            )
+        }
+        text = (ROOT / ".github" / "workflows" / "changelog-guard.yml").read_text(
+            encoding="utf-8"
+        )
+        match = re.search(r"VERSION_PATHS=\(\n(.*?)\n\s*\)", text, re.DOTALL)
+        if not match:
+            raise AssertionError("VERSION_PATHS=( ... ) not found in changelog-guard.yml")
+        guarded = {line.strip() for line in match.group(1).splitlines() if line.strip()}
+        self.assertIn("mcp/manifest.json", guarded)
+        self.assertEqual(bump_set, guarded)
+
     def test_bump_all_updates_lockstep_surfaces(self) -> None:
         mod = _load_prepare_release()
         with tempfile.TemporaryDirectory() as tmp:
@@ -263,6 +297,7 @@ class TestChangelogWorkflow(unittest.TestCase):
             (tmp_path / ".claude-plugin").mkdir()
             (tmp_path / ".codex-plugin").mkdir()
             (tmp_path / ".grok-plugin").mkdir()
+            (tmp_path / "mcp").mkdir()
 
             (tmp_path / "pyproject.toml").write_text(
                 '[project]\nname = "last30days-skill"\nversion = "3.18.1"\n',
@@ -277,6 +312,7 @@ class TestChangelogWorkflow(unittest.TestCase):
                 ".codex-plugin/plugin.json",
                 ".grok-plugin/plugin.json",
                 "gemini-extension.json",
+                "mcp/manifest.json",
             ):
                 (tmp_path / rel).write_text(
                     json.dumps({"name": "last30days", "version": "3.18.1"}, indent=2)
@@ -314,6 +350,7 @@ class TestChangelogWorkflow(unittest.TestCase):
                 tmp_path / ".codex-plugin" / "plugin.json",
                 tmp_path / ".grok-plugin" / "plugin.json",
                 tmp_path / "gemini-extension.json",
+                tmp_path / "mcp" / "manifest.json",
             )
             mod.MARKETPLACE_FILES = (
                 tmp_path / ".claude-plugin" / "marketplace.json",
@@ -321,7 +358,7 @@ class TestChangelogWorkflow(unittest.TestCase):
             )
 
             touched = mod.bump_all("9.9.9")
-            self.assertEqual(len(touched), 9)
+            self.assertEqual(len(touched), 10)
 
             pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
             self.assertIn('version = "9.9.9"', pyproject)
@@ -337,6 +374,7 @@ class TestChangelogWorkflow(unittest.TestCase):
                 ".codex-plugin/plugin.json",
                 ".grok-plugin/plugin.json",
                 "gemini-extension.json",
+                "mcp/manifest.json",
             ):
                 data = json.loads((tmp_path / rel).read_text(encoding="utf-8"))
                 self.assertEqual(data["version"], "9.9.9", msg=rel)

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -87,6 +87,23 @@ class TestPluginContract(unittest.TestCase):
         self.assertEqual(1, len(grok_plugins))
         self.assertEqual(version, grok_plugins[0]["version"])
 
+    def test_mcp_manifest_version_matches_lockstep(self) -> None:
+        pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        version = pyproject["project"]["version"]
+        mcp_version = _json(ROOT / "mcp" / "manifest.json")["version"]
+
+        # mcp/manifest.json joined the lockstep set after it had already
+        # stalled at 3.6.0. Feature PRs may not bump it; only the next release
+        # PR (prepare_release.py) moves it off 3.6.0, at which point this
+        # branch is dead and the equality below is enforced unconditionally.
+        # Any other mismatch is fresh drift and fails.
+        if mcp_version == "3.6.0" and version != "3.6.0":
+            self.skipTest(
+                "mcp/manifest.json is at pre-lockstep 3.6.0; the next release PR "
+                "bumps it via prepare_release.py"
+            )
+        self.assertEqual(version, mcp_version)
+
     def test_claude_marketplace_has_current_schema_shape(self) -> None:
         marketplace = _json(ROOT / ".claude-plugin" / "marketplace.json")
 


### PR DESCRIPTION
## Summary

`mcp/manifest.json` carries a `version` that nothing bumps and nothing guards. It sits at `3.6.0` while `pyproject.toml` is at `3.23.1`. `release.yml:115,121` copies that file into every `.mcpb` artifact, so every release since v3.6.0 has shipped an extension manifest declaring `3.6.0` while the binary inside is built with the real tag (`release.yml:105`). This PR closes the mechanism without bumping the version, which a feature PR must not do.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

`pytest -q tests/test_plugin_contract.py tests/test_changelog_workflow.py`: 25 passed, 1 skipped (baseline before the change: 23 passed).

Verified facts, each read directly: `mcp/manifest.json:5` is `3.6.0`, last touched by `1b832a2` (#606); `pyproject.toml:3` is `3.23.1`; `changelog-guard.yml:91-101` lists 9 paths and not this one; `test_versions_match_across_manifests` (`test_plugin_contract.py:70-88`) covers 8 files and not this one; `prepare_release.py:28-33` `JSON_VERSION_FILES` did not include it, so `bump_all` never touched it.

End-to-end check: `prepare_release.py --bump patch --skip-towncrier` against a temp copy of the ten lockstep files printed `- mcp/manifest.json` and wrote `3.23.2`, with the file byte-identical apart from the version line.

Negative controls, each mutation reverted afterwards: manifest set to `3.7.0` fails the lockstep test; set to `3.23.1` it passes and does not skip; removing the path from `JSON_VERSION_FILES` fails both new workflow tests; removing it from `VERSION_PATHS` fails the bump-set test.

## Changelog

- [x] Added `changelog.d/+mcp-manifest-version-lockstep.fixed.md` (`fixed`)
- [ ] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Found during a full-codebase review. The review's framing was "add it to the lockstep test", which turns out to be the one thing that cannot be done on its own: the test would fail immediately, and making it pass requires editing a version string, which `AGENTS.md` forbids outside a release PR. So the fix is the three mechanisms rather than the assertion.

### Security

`N/A` for the change itself. It touches `changelog-guard.yml`, an advisory workflow, but only adds a path to its `VERSION_PATHS` list, so the guard becomes stricter, never weaker. No job, permission, trigger, or pinned action is modified. `read_manifest_version.py` already handles a generic JSON `version` field through its fallthrough branch, so no helper change was needed.

## Notes

Three changes, none of them a version edit:

1. `changelog-guard.yml`: added `mcp/manifest.json` to `VERSION_PATHS`, so a future feature PR that changes its version is caught.
2. `prepare_release.py`: added it to `JSON_VERSION_FILES`, so the next release PR carries it to the correct version automatically.
3. `test_plugin_contract.py`: a new `test_mcp_manifest_version_matches_lockstep` asserting `pyproject == mcp`, skipping only when the manifest reads exactly `3.6.0`, with the reason naming the release PR that clears it.

`test_versions_match_across_manifests` is byte-for-byte unchanged; the new assertion is a separate method, so nothing existing was relaxed to accommodate this.

On the skip specifically, since a test that skips today deserves justification: a strict `xfail` would XPASS on the auto-generated release PR and fail its CI, requiring a manual test edit in the middle of a release. This form self-converts to an unconditional assertion the moment the version moves off `3.6.0`, and `prepare_release.py` refuses downgrades, so the skip branch is dead afterwards. The gates that do work today are the guard list, the release bump set, and a new test asserting those two sets are equal in both directions.

### Scope rationale

Not addressed here: `uv.lock` is in the guard's `VERSION_PATHS` but not in the lockstep test, because `read_manifest_version.py:26` extracts only the `last30days-skill` package version from it. That asymmetry is pre-existing and unrelated to this manifest.

### Relationship to this change

- [x] None

## Related issues

N/A
