### PR TITLE
test(backends): isolate the grok off-PATH probe from the real filesystem

### DIFF
--- a/tests/test_backend_descriptors.py
+++ b/tests/test_backend_descriptors.py
@@ -19,6 +19,7 @@ Covers the plan's U2 scenarios:
      (env.x_backend_chain()[0]) across three config permutations.
 """
 
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -57,6 +58,7 @@ def _x_env(
     grok_installed=False,
     grok_authed=False,
     grok_expired=False,
+    grok_off_path=None,
 ):
     """Context managers configuring the X-chain probe environment.
 
@@ -67,6 +69,12 @@ def _x_env(
 
     ``grok_expired`` simulates an expired session: AUTH_EXPIRED status, but
     has_stored_auth/is_available still return True (refresh may work).
+
+    ``grok_off_path`` drives the off-PATH branch of the grok probe. It must be
+    patched rather than left to the real filesystem: ``_off_path_binary``
+    scans installer dirs like ~/.local/bin, so a developer who has grok
+    installed there would otherwise take that branch on every
+    ``grok_installed=False`` case and see failures CI never reproduces.
     """
     from datetime import datetime, timezone, timedelta
     stored = (
@@ -114,6 +122,12 @@ def _x_env(
             return_value=grok_installed and (grok_authed or grok_expired),
         ),
         mock.patch("lib.grok_x.is_available", return_value=grok_available),
+        mock.patch(
+            "lib.health._off_path_binary",
+            lambda name: (
+                Path(grok_off_path) if name == "grok" and grok_off_path else None
+            ),
+        ),
         mock.patch("lib.health.probe_dependency", _probe_dep({"node": node_status})),
         mock.patch("lib.xurl_x.stored_auth_status", return_value=stored),
         mock.patch(
@@ -398,6 +412,21 @@ class TestGrokExpiryStates:
         assert "not found on PATH" in grok.detail
         # Grok is opt-in, so even MISSING doesn't affect the resolution.
         # X is unconfigured (no auto-chain backends available).
+        assert res.active_backend is None
+
+    def test_grok_off_path_prescribes_a_path_edit_not_an_install(self):
+        """grok present in an installer dir but absent from PATH -> still
+        MISSING, but the prescription must be a PATH edit: installing again
+        would fix nothing. This branch had no coverage, so it only ever ran
+        on developer machines that happened to have grok in ~/.local/bin."""
+        res = _resolve_x({}, grok_installed=False,
+                         grok_off_path="/home/dev/.local/bin/grok")
+        grok = next(f for f in res.findings if f.name == "grok")
+        assert grok.status == health.MISSING
+        assert "not on this process's PATH" in grok.detail
+        assert "/home/dev/.local/bin/grok" in grok.detail
+        assert "/home/dev/.local/bin" in grok.prescription
+        assert "install" not in grok.prescription.lower()
         assert res.active_backend is None
 
     def test_grok_installed_never_logged_in_is_missing(self):


### PR DESCRIPTION
## Summary

`test_no_grok_cli_is_missing` failed on any machine with grok installed in an installer directory. `_x_env` patches `lib.backends.which` to simulate an absent CLI, but `backends._grok_finding` then calls `health._off_path_binary("grok")`, which scans real directories including `~/.local/bin`. On such a host the probe took the off-PATH branch and returned "grok is installed at ... but that directory is not on this process's PATH" instead of "not found on PATH", so the test failed locally while passing in CI.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

The failure reproduced on this host, which has `~/.local/bin/grok`. Negative control: with the new patch removed, both the original test and the new one fail; with it in place the file is green.

`_x_env` gains a `grok_off_path` parameter so the branch is driven explicitly, which also gives the off-PATH path its first deliberate coverage. Until now it only ever executed on developer machines that happened to have grok installed off PATH, where it made an unrelated test fail rather than asserting anything.

`test_backend_descriptors.py` was the only test file touching this code without isolating it; the other seven that reference `_off_path` or `installer_bin_dirs` already patch them.

## Changelog

- [ ] Added `changelog.d/<pr-or-issue>.<type>.md` (types: `added`, `changed`, `fixed`, `removed`, `deprecated`, `security`)
- [x] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Found while running the suite across several branches during a full-codebase review: the same test failed on every branch and on untouched `main`, which ruled out the branches as the cause. Both product branches were then read and confirmed correct; the defect is entirely in the test's isolation, so no product code changes here.

### Security

`N/A`. Test-only change. No input handling, command execution, path handling, or dependency change.

## Notes

Only `grok` is exposed to this: `backends.py` has an off-PATH branch for grok and not for `xurl`, so the neighbouring `xurl` assertions on "not found on PATH" cannot be affected by the filesystem.

### Scope rationale

Not addressed here: `health._off_path_binary` reads real directories by design, and other suites patch it individually rather than through a shared autouse fixture. A repo-wide fixture would be the durable answer to this class, but it changes every backend test's environment at once and wants its own PR.

### Relationship to this change

- [x] None

## Related issues

N/A
