### PR TITLE
fix(tests): make the both-mode outcome fixture date relative

### DIFF
--- a/tests/test_source_outcomes.py
+++ b/tests/test_source_outcomes.py
@@ -1,5 +1,6 @@
 import socket
 import urllib.error
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -362,7 +363,9 @@ def test_pipeline_records_both_mode_semantic_leg_failure_as_partial():
         "title": "Search result",
         "url": "https://example.com/result",
         "snippet": "Raw search evidence",
-        "date": "2026-08-10",
+        # Relative so the item stays inside the run window; a fixed date fell out
+        # of the 30-day window and turned PARTIAL into ERROR once the calendar moved.
+        "date": (datetime.now(timezone.utc) - timedelta(days=5)).date().isoformat(),
         "relevance": 0.8,
         "why_relevant": "Perplexity Search result",
         "engagement": {},


### PR DESCRIPTION
## Summary

`test_pipeline_records_both_mode_semantic_leg_failure_as_partial` hardcodes `"date": "2026-08-10"` on its fixture item. Once that date falls outside the 30-day window the item is dropped, the pipeline reports ERROR instead of PARTIAL, and the test fails on every branch on the same calendar day. It has been red since 2026-09-10. This PR makes the fixture date relative to today so the test keeps asserting the intended behavior.

## Testing

- [x] `uv run pytest`
- [x] Added or updated tests that would catch a regression, or explained why not below

Verified against current `main` (`ca9d415`): the test fails with the fixed date and passes with the relative one; the rest of `tests/test_source_outcomes.py` (55 tests) is green, and a full-suite failure-list diff before and after shows this test as the only change. The date is computed as five days before today in UTC, so it stays well inside the window regardless of the runner's timezone.

## Changelog

- [ ] Added `changelog.d/<pr-or-issue>.<type>.md`
- [x] Skip changelog — chore/internal only (also add the `skip-changelog` label)

## Agent disclosure

### AI review

Prepared with Claude Code. Risk checked: that the relative date still lands inside the window under every timezone the test could run in (it uses a fixed offset of a few days, not the boundary). No other files touched.

### Security

N/A

## Notes

Test-only change. A maintainer will need to add the `skip-changelog` label; a fork contributor cannot set labels on this repo.

### Relationship to this change

- [x] None
- [ ] Yes — disclosure:

## Related issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
